### PR TITLE
feat: update dark and light selectors to target same element as well

### DIFF
--- a/packages/presets/src/conditions.ts
+++ b/packages/presets/src/conditions.ts
@@ -82,8 +82,8 @@ export const conditions = {
   landscape: '@media (orientation: landscape)',
   portrait: '@media (orientation: portrait)',
 
-  dark: '.dark &',
-  light: '.light &',
+  dark: ' &.dark, .dark &',
+  light: ' &.light, .light &',
   osDark: '@media (prefers-color-scheme: dark)',
   osLight: '@media (prefers-color-scheme: light)',
 


### PR DESCRIPTION
Motivated by this issue in ark: https://github.com/chakra-ui/ark/pull/341#discussion_r1059785025

> Should we update the `_dark` selector in panda to include `&.dark`?

