### PR TITLE
feat(pattern): add jsxElement

### DIFF
--- a/.changeset/proud-emus-jump.md
+++ b/.changeset/proud-emus-jump.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+'@pandacss/types': patch
+---
+
+Add `jsxElement` option to patterns, to allow specifying the jsx element rendered by the patterns.

--- a/packages/generator/src/artifacts/react-jsx/pattern.ts
+++ b/packages/generator/src/artifacts/react-jsx/pattern.ts
@@ -6,7 +6,7 @@ export function generateReactJsxPattern(ctx: Context) {
   const { typeName, factoryName } = ctx.jsx
   return ctx.patterns.details.map((pattern) => {
     const { upperName, styleFnName, dashName, jsxName, props, blocklistType } = pattern
-    const { description } = pattern.config
+    const { description, jsxElement = 'div' } = pattern.config
 
     return {
       name: dashName,
@@ -20,14 +20,14 @@ export function generateReactJsxPattern(ctx: Context) {
           .with(
             0,
             () => outdent`
-        return createElement(${factoryName}.div, { ref, ...props })
+        return createElement(${factoryName}.${jsxElement}, { ref, ...props })
           `,
           )
           .otherwise(
             () => outdent`
         const { ${props.join(', ')}, ...restProps } = props
         const styleProps = ${styleFnName}({${props.join(', ')}})
-        return createElement(${factoryName}.div, { ref, ...styleProps, ...restProps })
+        return createElement(${factoryName}.${jsxElement}, { ref, ...styleProps, ...restProps })
           `,
           )}
       })    

--- a/packages/types/src/pattern.ts
+++ b/packages/types/src/pattern.ts
@@ -18,6 +18,10 @@ export type PatternConfig = {
    */
   description?: string
   /**
+   * The JSX element rendered by the pattern
+   */
+  jsxElement?: string
+  /**
    * The properties of the pattern.
    */
   properties: Record<string, PatternProperty>


### PR DESCRIPTION
Add `jsxElement` option to patterns, to allow specifying the jsx element rendered by the patterns.