### PR TITLE
feat: add tailwind-converter

### DIFF
--- a/packages/cli/app/src/pages/index.astro
+++ b/packages/cli/app/src/pages/index.astro
@@ -5,5 +5,5 @@ import { customDocs } from '../utils/custom-docs'
 ---
 
 <Layout title={customDocs.pageTitle}>
-  <Overview client:load />
+  <Overview client:only />
 </Layout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,81 @@ importers:
       typescript: 4.9.5
       vite: 4.1.4
 
+  tailwind-converter:
+    specifiers:
+      '@astrojs/react': ^2.0.2
+      '@box-extractor/core': ^0.8.3
+      '@esbuild-plugins/node-globals-polyfill': ^0.2.3
+      '@monaco-editor/react': 4.4.6
+      '@pandacss/core': workspace:^0.0.1
+      '@pandacss/dev': workspace:^0.0.1
+      '@pandacss/presets': workspace:^0.0.1
+      '@types/postcss-js': ^4.0.0
+      '@types/prettier': 2.7.2
+      '@types/react': 18.0.17
+      '@types/react-dom': ^18.0.11
+      '@xstate/react': ^3.2.1
+      astro: ^2.0.18
+      lightningcss: ^1.19.0
+      magic-string: ^0.30.0
+      monaco-editor: 0.36.1
+      os-browserify: ^0.3.0
+      pastable: ^2.2.0
+      path-browserify: ^1.0.1
+      postcss: ^8.4.21
+      postcss-js: ^4.0.1
+      postcss-nested: 6.0.1
+      prettier: 2.8.4
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      react-resizable-panels: ^0.0.37
+      rollup: ^3.19.1
+      rollup-plugin-dts: ^5.3.0
+      tailwindcss: ^3.2.7
+      ts-morph: 17.0.1
+      ts-pattern: 4.2.1
+      type-fest: ^3.6.1
+      typescript: ^5.0.2
+      util: ^0.12.5
+      xstate: ^4.37.0
+    dependencies:
+      '@astrojs/react': 2.0.2_2oepqzzhxfmg6g4waudpbxyldi
+      '@box-extractor/core': 0.8.3_6dlx3raluflhz7qh66pgpewcte
+      '@monaco-editor/react': 4.4.6_waewrrayshn643ztij6zbniufy
+      '@pandacss/core': link:../packages/core
+      '@pandacss/dev': link:../packages/cli
+      '@pandacss/presets': link:../packages/presets
+      '@types/postcss-js': 4.0.0
+      '@xstate/react': 3.2.1_2pg7zsdx3vskuvx3b2bkgrzdju
+      astro: 2.1.3
+      lightningcss: 1.19.0
+      magic-string: 0.30.0
+      monaco-editor: 0.36.1
+      os-browserify: 0.3.0
+      pastable: 2.2.0_react@18.2.0+xstate@4.37.0
+      path-browserify: 1.0.1
+      postcss: 8.4.21
+      postcss-js: 4.0.1_postcss@8.4.21
+      postcss-nested: 6.0.1_postcss@8.4.21
+      prettier: 2.8.4
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-resizable-panels: 0.0.37_biqbaboplfbrettd7655fr4n2y
+      tailwindcss: 3.2.7_postcss@8.4.21
+      ts-morph: 17.0.1
+      ts-pattern: 4.2.1
+      util: 0.12.5
+      xstate: 4.37.0
+    devDependencies:
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3
+      '@types/prettier': 2.7.2
+      '@types/react': 18.0.17
+      '@types/react-dom': 18.0.11
+      rollup: 3.19.1
+      rollup-plugin-dts: 5.3.0_7iejawhbqmte5pthjozf4tfuqy
+      type-fest: 3.6.1
+      typescript: 5.0.2
+
 packages:
 
   /@ampproject/remapping/2.2.0:
@@ -869,7 +944,7 @@ packages:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
       '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.4
+      browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
 
@@ -2147,6 +2222,33 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
+  /@box-extractor/core/0.8.3_6dlx3raluflhz7qh66pgpewcte:
+    resolution: {integrity: sha512-ZnVjRez4bmfoMAJg4LSXmWttAmSMKdw0nBb37lj+sHoSI7K8Yh5tDZCbKsiyjfpkl522icyjRGE4OSEmbw+nlQ==}
+    peerDependencies:
+      vite: ^2.2.3 || ^3.0.0 || ^4.0.3
+    dependencies:
+      '@box-extractor/logger': 0.2.1
+      '@types/debug': 4.1.7
+      pastable: 2.2.0_react@18.2.0+xstate@4.37.0
+      ts-evaluator: 1.1.0_typescript@5.0.2
+      ts-morph: 17.0.1
+      ts-pattern: 4.2.1
+    transitivePeerDependencies:
+      - jsdom
+      - react
+      - supports-color
+      - typescript
+      - xstate
+    dev: false
+
+  /@box-extractor/logger/0.2.1:
+    resolution: {integrity: sha512-Pk4G03dB169BHj50LnJ/86zHBLDy0wWkIF5pjoSG2Yw+cjWrmvugJ1K3TH3SzXRQFvY7UUjcJLi2DaaHa3LfVg==}
+    dependencies:
+      callsites: 4.0.0
+      humanize-duration: 3.28.0
+      picocolors: 1.0.0
+    dev: false
+
   /@changesets/apply-release-plan/6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
@@ -2437,6 +2539,12 @@ packages:
       '@esbuild-kit/core-utils': 3.0.0
       get-tsconfig: 4.4.0
     dev: false
+
+  /@esbuild-plugins/node-globals-polyfill/0.2.3:
+    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
+    peerDependencies:
+      esbuild: '*'
+    dev: true
 
   /@esbuild-plugins/node-modules-polyfill/0.1.4_esbuild@0.16.3:
     resolution: {integrity: sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==}
@@ -3536,11 +3644,11 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/kit/3.2.0_rollup@3.15.0:
+  /@nuxt/kit/3.2.0_rollup@3.19.1:
     resolution: {integrity: sha512-Otb1S/08tDxbpeQYLMynjr2TX7ssU1ynbWDpVzFzLBdfHkGWHXpIhJr+0u3LdnPUBw6C/xPXe7fd7RuXI9avoA==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
-      '@nuxt/schema': 3.2.0_rollup@3.15.0
+      '@nuxt/schema': 3.2.0_rollup@3.19.1
       c12: 1.1.0
       consola: 2.15.3
       defu: 6.1.2
@@ -3556,7 +3664,7 @@ packages:
       scule: 1.0.0
       semver: 7.3.8
       unctx: 2.1.2
-      unimport: 2.2.4_rollup@3.15.0
+      unimport: 2.2.4_rollup@3.19.1
       untyped: 1.2.2
     transitivePeerDependencies:
       - rollup
@@ -3585,7 +3693,7 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/schema/3.2.0_rollup@3.15.0:
+  /@nuxt/schema/3.2.0_rollup@3.19.1:
     resolution: {integrity: sha512-tz9RandI5LgbT9BQ8dE8n4kItV7+4OUgbX42YemcGbtORVJAWJJvQyHGikJ5akUgiTFYTV8tjV6pRPH9Txx0Pg==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     dependencies:
@@ -3600,7 +3708,7 @@ packages:
       scule: 1.0.0
       std-env: 3.3.2
       ufo: 1.1.0
-      unimport: 2.2.4_rollup@3.15.0
+      unimport: 2.2.4_rollup@3.19.1
       untyped: 1.2.2
     transitivePeerDependencies:
       - rollup
@@ -3646,8 +3754,8 @@ packages:
     peerDependencies:
       vue: ^3.2.47
     dependencies:
-      '@nuxt/kit': 3.2.0_rollup@3.15.0
-      '@rollup/plugin-replace': 5.0.2_rollup@3.15.0
+      '@nuxt/kit': 3.2.0_rollup@3.19.1
+      '@rollup/plugin-replace': 5.0.2_rollup@3.19.1
       '@vitejs/plugin-vue': 4.0.0_vite@4.1.4+vue@3.2.47
       '@vitejs/plugin-vue-jsx': 3.0.0_vite@4.1.4+vue@3.2.47
       autoprefixer: 10.4.14_postcss@8.4.21
@@ -3671,8 +3779,8 @@ packages:
       postcss: 8.4.21
       postcss-import: 15.1.0_postcss@8.4.21
       postcss-url: 10.1.3_postcss@8.4.21
-      rollup: 3.15.0
-      rollup-plugin-visualizer: 5.9.0_rollup@3.15.0
+      rollup: 3.19.1
+      rollup-plugin-visualizer: 5.9.0_rollup@3.19.1
       ufo: 1.1.0
       unplugin: 1.0.1
       vite: 4.1.4
@@ -4070,7 +4178,7 @@ packages:
     dependencies:
       web-streams-polyfill: 3.2.1
 
-  /@rollup/plugin-alias/4.0.3_rollup@3.15.0:
+  /@rollup/plugin-alias/4.0.3_rollup@3.19.1:
     resolution: {integrity: sha512-ZuDWE1q4PQDhvm/zc5Prun8sBpLJy41DMptYrS6MhAy9s9kL/doN1613BWfEchGVfKxzliJ3BjbOPizXX38DbQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4079,11 +4187,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.15.0
+      rollup: 3.19.1
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs/24.0.1_rollup@3.15.0:
+  /@rollup/plugin-commonjs/24.0.1_rollup@3.19.1:
     resolution: {integrity: sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4092,16 +4200,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.15.0
+      rollup: 3.19.1
     dev: true
 
-  /@rollup/plugin-inject/5.0.3_rollup@3.15.0:
+  /@rollup/plugin-inject/5.0.3_rollup@3.19.1:
     resolution: {integrity: sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4110,13 +4218,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
       estree-walker: 2.0.2
       magic-string: 0.27.0
-      rollup: 3.15.0
+      rollup: 3.19.1
     dev: true
 
-  /@rollup/plugin-json/6.0.0_rollup@3.15.0:
+  /@rollup/plugin-json/6.0.0_rollup@3.19.1:
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4125,11 +4233,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
-      rollup: 3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
+      rollup: 3.19.1
     dev: true
 
-  /@rollup/plugin-node-resolve/15.0.1_rollup@3.15.0:
+  /@rollup/plugin-node-resolve/15.0.1_rollup@3.19.1:
     resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4138,16 +4246,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.19.1
     dev: true
 
-  /@rollup/plugin-replace/5.0.2_rollup@3.15.0:
+  /@rollup/plugin-replace/5.0.2_rollup@3.19.1:
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4156,12 +4264,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
       magic-string: 0.27.0
-      rollup: 3.15.0
+      rollup: 3.19.1
     dev: true
 
-  /@rollup/plugin-terser/0.4.0_rollup@3.15.0:
+  /@rollup/plugin-terser/0.4.0_rollup@3.19.1:
     resolution: {integrity: sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4170,13 +4278,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.15.0
+      rollup: 3.19.1
       serialize-javascript: 6.0.1
       smob: 0.0.6
       terser: 5.16.3
     dev: true
 
-  /@rollup/plugin-wasm/6.1.2_rollup@3.15.0:
+  /@rollup/plugin-wasm/6.1.2_rollup@3.19.1:
     resolution: {integrity: sha512-YdrQ7zfnZ54Y+6raCev3tR1PrhQGxYKSTajGylhyP0oBacouuNo6KcNCk+pYKw9M98jxRWLFFca/udi76IDXzg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4185,7 +4293,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.15.0
+      rollup: 3.19.1
     dev: true
 
   /@rollup/pluginutils/4.2.1:
@@ -4210,7 +4318,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/pluginutils/5.0.2_rollup@3.15.0:
+  /@rollup/pluginutils/5.0.2_rollup@3.19.1:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4222,7 +4330,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.15.0
+      rollup: 3.19.1
     dev: true
 
   /@rushstack/eslint-patch/1.2.0:
@@ -5687,6 +5795,10 @@ packages:
     resolution: {integrity: sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==}
     dev: true
 
+  /@types/node/17.0.45:
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
+
   /@types/node/18.11.18:
     resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
     dev: true
@@ -5712,6 +5824,12 @@ packages:
   /@types/pluralize/0.0.29:
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
     dev: true
+
+  /@types/postcss-js/4.0.0:
+    resolution: {integrity: sha512-ieu0u7T7jnUCFmXcf8JzoJ3/1U5NI3ZYpfX5zW2td0x/BqVQrpCQ6uOY9Ef/0WJuIjc9OCtdfYF/JE7MGax2TA==}
+    dependencies:
+      postcss: 8.4.21
+    dev: false
 
   /@types/prettier/2.7.2:
     resolution: {integrity: sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==}
@@ -6630,6 +6748,26 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
+  /@xstate/react/3.2.1_2pg7zsdx3vskuvx3b2bkgrzdju:
+    resolution: {integrity: sha512-L/mqYRxyBWVdIdSaXBHacfvS8NKn3sTKbPb31aRADbE9spsJ1p+tXil0GVQHPlzrmjGeozquLrxuYGiXsFNU7g==}
+    peerDependencies:
+      '@xstate/fsm': ^2.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      xstate: ^4.36.0
+    peerDependenciesMeta:
+      '@xstate/fsm':
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      use-isomorphic-layout-effect: 1.1.2_ug65io7jkbhmo4fihdmbrh3ina
+      use-sync-external-store: 1.2.0_react@18.2.0
+      xstate: 4.37.0
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
     dev: true
@@ -7150,10 +7288,17 @@ packages:
     dependencies:
       acorn: 8.8.2
 
+  /acorn-node/1.8.2:
+    resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
+    dependencies:
+      acorn: 7.4.1
+      acorn-walk: 7.2.0
+      xtend: 4.0.2
+    dev: false
+
   /acorn-walk/7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /acorn-walk/8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -7163,7 +7308,6 @@ packages:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /acorn/8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
@@ -7272,7 +7416,7 @@ packages:
     resolution: {integrity: sha512-IG23inYII3dWlU2EyiAiGj6Bwal5GzsgPMwjYGvc1HPE2dgbj4ZB5ToWBKSquKw74nB3TIuOwaI6/jSULzfgrw==}
     engines: {node: '>=14.16'}
     dependencies:
-      type-fest: 3.5.7
+      type-fest: 3.6.1
     dev: true
 
   /ansi-html-community/0.0.8:
@@ -7324,6 +7468,7 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: true
 
   /anymatch/3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -7331,7 +7476,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
 
   /app-root-dir/1.0.2:
     resolution: {integrity: sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==}
@@ -7388,7 +7532,6 @@ packages:
 
   /arg/5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-    dev: true
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -7638,7 +7781,7 @@ packages:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      typescript: 4.9.5
+      typescript: 5.0.2
       unist-util-visit: 4.1.1
       vfile: 5.3.5
       vite: 4.1.4
@@ -8219,6 +8362,11 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  /callsites/4.0.0:
+    resolution: {integrity: sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==}
+    engines: {node: '>=12.20'}
+    dev: false
+
   /camel-case/4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
@@ -8348,7 +8496,7 @@ packages:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
-      anymatch: 3.1.2
+      anymatch: 3.1.3
       braces: 3.0.2
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
@@ -8792,6 +8940,13 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  /crosspath/2.0.0:
+    resolution: {integrity: sha512-ju88BYCQ2uvjO2bR+SsgLSTwTSctU+6Vp2ePbKPgSCZyy4MWZxYsT738DlKVRE5utUjobjPRm1MkTYKJxCmpTA==}
+    engines: {node: '>=14.9.0'}
+    dependencies:
+      '@types/node': 17.0.45
+    dev: false
+
   /crypto-random-string/2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
@@ -9155,6 +9310,10 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
 
+  /defined/1.0.1:
+    resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
+    dev: false
+
   /defu/6.1.2:
     resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
     dev: true
@@ -9219,6 +9378,12 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  /detect-libc/1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: false
+
   /detect-libc/2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
@@ -9246,8 +9411,22 @@ packages:
       - supports-color
     dev: true
 
+  /detective/5.2.1:
+    resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+    dependencies:
+      acorn-node: 1.8.2
+      defined: 1.0.1
+      minimist: 1.2.6
+    dev: false
+
   /devalue/4.2.0:
     resolution: {integrity: sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==}
+    dev: false
+
+  /didyoumean/1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
     dev: false
 
   /diff/4.0.2:
@@ -12015,6 +12194,10 @@ packages:
     resolution: {integrity: sha512-zyzVyMjpGBX2+6cDVZeFPCdtOtdsxOeseRhB9tkQ6xXmGUNrcnBzdEKPy3VPNYz+4gy1oukVOXcrJCunSyc6QQ==}
     engines: {node: '>=14.18.0'}
 
+  /humanize-duration/3.28.0:
+    resolution: {integrity: sha512-jMAxraOOmHuPbffLVDKkEKi/NeG8dMqP8lGRd6Tbf7JgAeG33jjgPWDbXXU7ypCI0o+oNKJFgbSB9FKVdWNI2A==}
+    dev: false
+
   /husky/8.0.3:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
@@ -12938,6 +13121,94 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  /lightningcss-darwin-arm64/1.19.0:
+    resolution: {integrity: sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-darwin-x64/1.19.0:
+    resolution: {integrity: sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-arm-gnueabihf/1.19.0:
+    resolution: {integrity: sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-arm64-gnu/1.19.0:
+    resolution: {integrity: sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-arm64-musl/1.19.0:
+    resolution: {integrity: sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-x64-gnu/1.19.0:
+    resolution: {integrity: sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-linux-x64-musl/1.19.0:
+    resolution: {integrity: sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss-win32-x64-msvc/1.19.0:
+    resolution: {integrity: sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lightningcss/1.19.0:
+    resolution: {integrity: sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.19.0
+      lightningcss-darwin-x64: 1.19.0
+      lightningcss-linux-arm-gnueabihf: 1.19.0
+      lightningcss-linux-arm64-gnu: 1.19.0
+      lightningcss-linux-arm64-musl: 1.19.0
+      lightningcss-linux-x64-gnu: 1.19.0
+      lightningcss-linux-x64-musl: 1.19.0
+      lightningcss-win32-x64-msvc: 1.19.0
+    dev: false
+
   /lil-fp/1.2.5:
     resolution: {integrity: sha512-7NSMQwZaGq0lNF8ZU4Dhb/Z0DSnEEUcXGWNdN1HISgXUkn15re6UJoRjmhGgPMfMwgpZSEf/gpZZzsq4LD0iGA==}
     dev: false
@@ -13244,6 +13515,12 @@ packages:
 
   /magic-string/0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+
+  /magic-string/0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -14006,7 +14283,6 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-    dev: true
 
   /minipass-collect/1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
@@ -14230,15 +14506,15 @@ packages:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.0
       '@netlify/functions': 1.4.0
-      '@rollup/plugin-alias': 4.0.3_rollup@3.15.0
-      '@rollup/plugin-commonjs': 24.0.1_rollup@3.15.0
-      '@rollup/plugin-inject': 5.0.3_rollup@3.15.0
-      '@rollup/plugin-json': 6.0.0_rollup@3.15.0
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.15.0
-      '@rollup/plugin-replace': 5.0.2_rollup@3.15.0
-      '@rollup/plugin-terser': 0.4.0_rollup@3.15.0
-      '@rollup/plugin-wasm': 6.1.2_rollup@3.15.0
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/plugin-alias': 4.0.3_rollup@3.19.1
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.19.1
+      '@rollup/plugin-inject': 5.0.3_rollup@3.19.1
+      '@rollup/plugin-json': 6.0.0_rollup@3.19.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.19.1
+      '@rollup/plugin-replace': 5.0.2_rollup@3.19.1
+      '@rollup/plugin-terser': 0.4.0_rollup@3.19.1
+      '@rollup/plugin-wasm': 6.1.2_rollup@3.19.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
       '@vercel/nft': 0.22.6
       archiver: 5.3.1
       c12: 1.1.0
@@ -14274,8 +14550,8 @@ packages:
       pkg-types: 1.0.2
       pretty-bytes: 6.1.0
       radix3: 1.0.0
-      rollup: 3.15.0
-      rollup-plugin-visualizer: 5.9.0_rollup@3.15.0
+      rollup: 3.19.1
+      rollup-plugin-visualizer: 5.9.0_rollup@3.19.1
       scule: 1.0.0
       semver: 7.3.8
       serve-placeholder: 2.0.1
@@ -14284,7 +14560,7 @@ packages:
       std-env: 3.3.2
       ufo: 1.1.0
       unenv: 1.1.1
-      unimport: 2.2.4_rollup@3.15.0
+      unimport: 2.2.4_rollup@3.19.1
       unstorage: 1.1.4
     transitivePeerDependencies:
       - bufferutil
@@ -14528,6 +14804,11 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  /object-hash/3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
 
@@ -14545,6 +14826,11 @@ packages:
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  /object-path/0.11.8:
+    resolution: {integrity: sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==}
+    engines: {node: '>= 10.12.0'}
+    dev: false
 
   /object.assign/4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
@@ -14708,6 +14994,10 @@ packages:
       log-symbols: 5.1.0
       strip-ansi: 7.0.1
       wcwidth: 1.0.1
+
+  /os-browserify/0.3.0:
+    resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
+    dev: false
 
   /os-tmpdir/1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
@@ -14913,6 +15203,27 @@ packages:
       tslib: 2.4.0
     dev: true
 
+  /pastable/2.2.0_react@18.2.0+xstate@4.37.0:
+    resolution: {integrity: sha512-VW3BlFr4aqazNaHOdf2Yg/GY8JRiMDnGExFCHXN+dm6yz8b5uZk9WuJk3YwhRPyzFjuZPnoxt8aFe5fX4gAStw==}
+    engines: {node: '>=14.x'}
+    peerDependencies:
+      react: '>=17'
+      xstate: '>=4.32.1'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      react: 18.2.0
+      ts-toolbelt: 9.6.0
+      type-fest: 3.6.1
+      xstate: 4.37.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -15002,7 +15313,6 @@ packages:
   /pify/2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /pify/4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -15125,6 +15435,18 @@ packages:
       enhanced-resolve: 4.5.0
     dev: true
 
+  /postcss-import/14.1.0_postcss@8.4.21:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.21
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: false
+
   /postcss-import/15.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -15136,6 +15458,16 @@ packages:
       read-cache: 1.0.0
       resolve: 1.22.1
     dev: true
+
+  /postcss-js/4.0.1_postcss@8.4.21:
+    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.21
+    dev: false
 
   /postcss-load-config/3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -15150,6 +15482,23 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
+      yaml: 1.10.2
+    dev: false
+
+  /postcss-load-config/3.1.4_postcss@8.4.21:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      postcss: 8.4.21
       yaml: 1.10.2
     dev: false
 
@@ -15340,6 +15689,16 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.21
       string-hash: 1.1.3
     dev: true
+
+  /postcss-nested/6.0.0_postcss@8.4.21:
+    resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss: 8.4.21
+      postcss-selector-parser: 6.0.11
+    dev: false
 
   /postcss-nested/6.0.1_postcss@8.4.21:
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
@@ -15808,7 +16167,6 @@ packages:
   /quick-lru/5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-    dev: true
 
   /radix3/1.0.0:
     resolution: {integrity: sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==}
@@ -15967,6 +16325,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /react-resizable-panels/0.0.37_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-8aTW4xyd/TZfsiDi84OUUJvbepjcC46I/RZyveXsauL12IzyygsxhfY60YghKKhmeglQ6OJq41LKIlgMTntZOQ==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /react-router-dom/6.8.1_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==}
     engines: {node: '>=14'}
@@ -16000,7 +16368,6 @@ packages:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
       pify: 2.3.0
-    dev: true
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -16456,6 +16823,20 @@ packages:
     dependencies:
       glob: 7.2.3
 
+  /rollup-plugin-dts/5.3.0_7iejawhbqmte5pthjozf4tfuqy:
+    resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
+    engines: {node: '>=v14'}
+    peerDependencies:
+      rollup: ^3.0.0
+      typescript: ^4.1 || ^5.0
+    dependencies:
+      magic-string: 0.30.0
+      rollup: 3.19.1
+      typescript: 5.0.2
+    optionalDependencies:
+      '@babel/code-frame': 7.18.6
+    dev: true
+
   /rollup-plugin-inject/3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
@@ -16471,7 +16852,7 @@ packages:
       rollup-plugin-inject: 3.0.2
     dev: true
 
-  /rollup-plugin-visualizer/5.9.0_rollup@3.15.0:
+  /rollup-plugin-visualizer/5.9.0_rollup@3.19.1:
     resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
     engines: {node: '>=14'}
     hasBin: true
@@ -16483,7 +16864,7 @@ packages:
     dependencies:
       open: 8.4.0
       picomatch: 2.3.1
-      rollup: 3.15.0
+      rollup: 3.19.1
       source-map: 0.7.4
       yargs: 17.5.1
     dev: true
@@ -16501,8 +16882,8 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /rollup/3.15.0:
-    resolution: {integrity: sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==}
+  /rollup/3.19.1:
+    resolution: {integrity: sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -17313,6 +17694,40 @@ packages:
     resolution: {integrity: sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==}
     dev: false
 
+  /tailwindcss/3.2.7_postcss@8.4.21:
+    resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.21
+      postcss-import: 14.1.0_postcss@8.4.21
+      postcss-js: 4.0.1_postcss@8.4.21
+      postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-selector-parser: 6.0.11
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
   /tapable/1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
     engines: {node: '>=6'}
@@ -17550,6 +17965,22 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
+  /ts-evaluator/1.1.0_typescript@5.0.2:
+    resolution: {integrity: sha512-B7j9Gw7NisfV+vTjZgYBjPAyNj48CgjFhHLmxpvN24mwln6v4sumL4LaQJn5ZMwFAQx2gGrzRE4V1Xt/0B5tvA==}
+    engines: {node: '>=14.19.0'}
+    peerDependencies:
+      jsdom: '>=14.x'
+      typescript: '>=3.2.x || >= 4.x'
+    peerDependenciesMeta:
+      jsdom:
+        optional: true
+    dependencies:
+      ansi-colors: 4.1.3
+      crosspath: 2.0.0
+      object-path: 0.11.8
+      typescript: 5.0.2
+    dev: false
+
   /ts-interface-checker/0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
@@ -17605,6 +18036,10 @@ packages:
 
   /ts-toolbelt/6.15.5:
     resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
+    dev: false
+
+  /ts-toolbelt/9.6.0:
+    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
     dev: false
 
   /tsconfig-paths/3.14.1:
@@ -17668,7 +18103,7 @@ packages:
       joycon: 3.1.1
       postcss-load-config: 3.1.4
       resolve-from: 5.0.0
-      rollup: 3.15.0
+      rollup: 3.19.1
       source-map: 0.8.0-beta.0
       sucrase: 3.24.0
       tree-kill: 1.2.2
@@ -17774,10 +18209,9 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  /type-fest/3.5.7:
-    resolution: {integrity: sha512-6J4bYzb4sdkcLBty4XW7F18VPI66M4boXNE+CY40532oq2OJe6AVMB5NmjOp6skt/jw5mRjz/hLRpuglz0U+FA==}
+  /type-fest/3.6.1:
+    resolution: {integrity: sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==}
     engines: {node: '>=14.16'}
-    dev: true
 
   /type-is/1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -17806,6 +18240,11 @@ packages:
   /typescript/4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
 
   /ufo/1.0.1:
@@ -17928,10 +18367,10 @@ packages:
       - rollup
     dev: true
 
-  /unimport/2.2.4_rollup@3.15.0:
+  /unimport/2.2.4_rollup@3.19.1:
     resolution: {integrity: sha512-qMgmeEGqqrrmEtm0dqxMG37J6xBtrriqxq9hILvDb+e6l2F0yTnJomLoCCp0eghLR7bYGeBsUU5Y0oyiUYhViw==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.15.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.19.1
       escape-string-regexp: 5.0.0
       fast-glob: 3.2.12
       local-pkg: 0.4.3
@@ -18169,6 +18608,19 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
     dependencies:
+      react: 18.2.0
+    dev: false
+
+  /use-isomorphic-layout-effect/1.1.2_ug65io7jkbhmo4fihdmbrh3ina:
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.0.17
       react: 18.2.0
     dev: false
 
@@ -18456,7 +18908,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.19.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -18489,7 +18941,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.19.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
@@ -19096,10 +19548,13 @@ packages:
     resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}
     dev: true
 
+  /xstate/4.37.0:
+    resolution: {integrity: sha512-YC+JCerRclKS9ixQTuw8l3vs3iFqWzNzOGR0ID5XsSlieMXIV9nNPE43h9CGr7VdxA1QYhMwhCZA0EdpOd17Bg==}
+    dev: false
+
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
-    dev: true
 
   /xxhashjs/0.2.2:
     resolution: {integrity: sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
-  - 'packages/**'
-  - 'sandbox/**'
-  - 'playground'
+  - "packages/**"
+  - "sandbox/**"
+  - "playground"
+  - "tailwind-converter"

--- a/tailwind-converter/.gitignore
+++ b/tailwind-converter/.gitignore
@@ -1,0 +1,25 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+## Panda
+design-system
+design-system-static

--- a/tailwind-converter/README.md
+++ b/tailwind-converter/README.md
@@ -1,0 +1,47 @@
+# Astro Starter Kit: Minimal
+
+```
+npm create astro@latest -- --template minimal
+```
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
+[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
+
+> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+
+## 🚀 Project Structure
+
+Inside of your Astro project, you'll see the following folders and files:
+
+```
+/
+├── public/
+├── src/
+│   └── pages/
+│       └── index.astro
+└── package.json
+```
+
+Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+
+There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+
+Any static assets, like images, can be placed in the `public/` directory.
+
+## 🧞 Commands
+
+All commands are run from the root of the project, from a terminal:
+
+| Command                | Action                                           |
+| :--------------------- | :----------------------------------------------- |
+| `npm install`          | Installs dependencies                            |
+| `npm run dev`          | Starts local dev server at `localhost:3000`      |
+| `npm run build`        | Build your production site to `./dist/`          |
+| `npm run preview`      | Preview your build locally, before deploying     |
+| `npm run astro ...`    | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro --help` | Get help using the Astro CLI                     |
+
+## 👀 Want to learn more?
+
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/tailwind-converter/astro.config.mjs
+++ b/tailwind-converter/astro.config.mjs
@@ -1,0 +1,41 @@
+import { defineConfig } from 'astro/config'
+import react from '@astrojs/react'
+
+import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill'
+import path from 'node:path'
+import * as url from 'node:url'
+
+const dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [react()],
+  vite: {
+    ssr: {
+      external: [
+        'lodash.merge',
+        'postcss-nested',
+        'camelcase-css',
+        'postcss-discard-duplicates',
+        'postcss-discard-empty',
+        'postcss-merge-rules',
+        'postcss-normalize-whitespace',
+        'postcss-selector-parser',
+      ],
+    },
+    optimizeDeps: {
+      esbuildOptions: {
+        define: {
+          global: 'globalThis',
+        },
+        plugins: [NodeGlobalsPolyfillPlugin({ process: true })],
+      },
+    },
+    resolve: {
+      alias: {
+        module: path.join(dirname, './module.shim.ts'),
+        crosspath: 'path-browserify',
+      },
+    },
+  },
+})

--- a/tailwind-converter/fs.shim.ts
+++ b/tailwind-converter/fs.shim.ts
@@ -1,0 +1,7 @@
+export const fs = {
+  readFileSync: (path: string) => {
+    return "";
+  },
+};
+
+export default fs;

--- a/tailwind-converter/get-ts-declarations.ts
+++ b/tailwind-converter/get-ts-declarations.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { safeJSONParse } from "pastable";
+import { rollup } from "rollup";
+import dts from "rollup-plugin-dts";
+import type { PackageJson } from "type-fest";
+
+const getDeps = (pkg: PackageJson) =>
+  Object.keys(pkg.dependencies ?? {}).concat(
+    Object.keys(pkg.peerDependencies ?? {})
+  );
+
+const getPkg = async (name: string) =>
+  safeJSONParse<PackageJson>(
+    await fs.promises.readFile(`./node_modules/${name}/package.json`, "utf8")
+  );
+
+const getTypesDeclaration = async (name: string) => {
+  const pkg = await getPkg(name);
+  if (!pkg.types && !pkg.typings) return;
+
+  const types = (pkg.types ?? pkg.typings)!;
+
+  const bundle = await rollup({
+    input: path.resolve("./node_modules/", name, types),
+    plugins: [dts({ respectExternal: true })],
+    external: (id) => getDeps(pkg).includes(id),
+  });
+  const result = await bundle.generate({});
+
+  return result.output[0].code;
+};
+
+const getTsDeclarations = async () => {
+  const reactDeclaration = await getTypesDeclaration("@types/react");
+  fs.writeFileSync("./react.d.ts", reactDeclaration!);
+
+  return {
+    name: "@types/react",
+    code: `declare module '@types/react' { ${reactDeclaration} }`,
+  };
+};
+
+// eslint-disable-next-line import/no-unused-modules
+// export default getTsDeclarations;
+
+// uncomment to run with bun
+await getTsDeclarations();
+// console.log(await getTsDeclarations());

--- a/tailwind-converter/module.shim.ts
+++ b/tailwind-converter/module.shim.ts
@@ -1,0 +1,3 @@
+// Empty implementation for Rollup alias
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const createRequire = () => {};

--- a/tailwind-converter/package.json
+++ b/tailwind-converter/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "tailwind-converter",
+  "type": "module",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "gen:react-declaration": "tsx ./get-ts-declarations.ts",
+    "prepare": "panda && pnpm gen:react-declaration"
+  },
+  "dependencies": {
+    "@astrojs/react": "^2.0.2",
+    "@box-extractor/core": "^0.8.3",
+    "@monaco-editor/react": "4.4.6",
+    "@pandacss/core": "workspace:^0.0.1",
+    "@pandacss/dev": "workspace:^0.0.1",
+    "@pandacss/presets": "workspace:^0.0.1",
+    "@types/postcss-js": "^4.0.0",
+    "@xstate/react": "^3.2.1",
+    "astro": "^2.0.18",
+    "lightningcss": "^1.19.0",
+    "magic-string": "^0.30.0",
+    "monaco-editor": "0.36.1",
+    "os-browserify": "^0.3.0",
+    "pastable": "^2.2.0",
+    "path-browserify": "^1.0.1",
+    "postcss": "^8.4.21",
+    "postcss-js": "^4.0.1",
+    "postcss-nested": "6.0.1",
+    "prettier": "2.8.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-resizable-panels": "^0.0.37",
+    "tailwindcss": "^3.2.7",
+    "ts-morph": "17.0.1",
+    "ts-pattern": "4.2.1",
+    "util": "^0.12.5",
+    "xstate": "^4.37.0"
+  },
+  "devDependencies": {
+    "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+    "@types/prettier": "2.7.2",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "rollup": "^3.19.1",
+    "rollup-plugin-dts": "^5.3.0",
+    "type-fest": "^3.6.1",
+    "typescript": "^5.0.2"
+  }
+}

--- a/tailwind-converter/panda.config.ts
+++ b/tailwind-converter/panda.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@pandacss/dev'
+import { config } from '@pandacss/presets'
+
+export default defineConfig({
+  preflight: true,
+  jsxFramework: 'react',
+  include: ['./src/**/*.{tsx,jsx}', './pages/**/*.{jsx,tsx}'],
+  exclude: [],
+  outdir: 'design-system',
+  strictTokens: false,
+  conditions: {
+    resizeHandleActive: '[data-resize-handle-active] &',
+    panelHorizontalActive: '[data-panel-group-direction="horizontal"] &',
+    panelVerticalActive: '[data-panel-group-direction="vertical"] &',
+  },
+  utilities: {
+    boxSize: {
+      // @ts-ignore
+      values: config.utilities?.width?.values,
+      transform: (value) => {
+        return {
+          width: value,
+          height: value,
+        }
+      },
+    },
+  },
+})

--- a/tailwind-converter/postcss.config.cjs
+++ b/tailwind-converter/postcss.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: { '@pandacss/dev/postcss': {} },
+}

--- a/tailwind-converter/public/favicon.svg
+++ b/tailwind-converter/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 36 36">
+  <path fill="#000" d="M22.25 4h-8.5a1 1 0 0 0-.96.73l-5.54 19.4a.5.5 0 0 0 .62.62l5.05-1.44a2 2 0 0 0 1.38-1.4l3.22-11.66a.5.5 0 0 1 .96 0l3.22 11.67a2 2 0 0 0 1.38 1.39l5.05 1.44a.5.5 0 0 0 .62-.62l-5.54-19.4a1 1 0 0 0-.96-.73Z"/>
+  <path fill="url(#gradient)" d="M18 28a7.63 7.63 0 0 1-5-2c-1.4 2.1-.35 4.35.6 5.55.14.17.41.07.47-.15.44-1.8 2.93-1.22 2.93.6 0 2.28.87 3.4 1.72 3.81.34.16.59-.2.49-.56-.31-1.05-.29-2.46 1.29-3.25 3-1.5 3.17-4.83 2.5-6-.67.67-2.6 2-5 2Z"/>
+  <defs>
+    <linearGradient id="gradient" x1="16" x2="16" y1="32" y2="24" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#000"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+	<style>
+    @media (prefers-color-scheme:dark){:root{filter:invert(100%)}}
+  </style>
+</svg>

--- a/tailwind-converter/react.d.ts
+++ b/tailwind-converter/react.d.ts
@@ -1,0 +1,3288 @@
+/// <reference path="global.d.ts" />
+import * as CSS from 'csstype';
+import * as PropTypes from 'prop-types';
+import { Interaction } from 'scheduler/tracing';
+
+// Type definitions for React 18.0
+
+
+type NativeAnimationEvent = AnimationEvent;
+type NativeClipboardEvent = ClipboardEvent;
+type NativeCompositionEvent = CompositionEvent;
+type NativeDragEvent = DragEvent;
+type NativeFocusEvent = FocusEvent;
+type NativeKeyboardEvent = KeyboardEvent;
+type NativeMouseEvent = MouseEvent;
+type NativeTouchEvent = TouchEvent;
+type NativePointerEvent = PointerEvent;
+type NativeTransitionEvent = TransitionEvent;
+type NativeUIEvent = UIEvent;
+type NativeWheelEvent = WheelEvent;
+type Booleanish = boolean | 'true' | 'false';
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// Destructors are only allowed to return void.
+type Destructor = () => void | { [UNDEFINED_VOID_ONLY]: never };
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+
+declare namespace React {
+    //
+    // React Elements
+    // ----------------------------------------------------------------------
+
+    type ElementType<P = any> =
+        {
+            [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
+        }[keyof JSX.IntrinsicElements] |
+        ComponentType<P>;
+    type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+
+    type JSXElementConstructor<P> =
+        | ((props: P) => ReactElement<any, any> | null)
+        | (new (props: P) => Component<any, any>);
+
+    interface RefObject<T> {
+        readonly current: T | null;
+    }
+    // Bivariance hack for consistent unsoundness with RefObject
+    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
+    type Ref<T> = RefCallback<T> | RefObject<T> | null;
+    type LegacyRef<T> = string | Ref<T>;
+    /**
+     * Gets the instance type for a React element. The instance will be different for various component types:
+     *
+     * - React class components will be the class instance. So if you had `class Foo extends React.Component<{}> {}`
+     *   and used `React.ElementRef<typeof Foo>` then the type would be the instance of `Foo`.
+     * - React stateless functional components do not have a backing instance and so `React.ElementRef<typeof Bar>`
+     *   (when `Bar` is `function Bar() {}`) will give you the `undefined` type.
+     * - JSX intrinsics like `div` will give you their DOM instance. For `React.ElementRef<'div'>` that would be
+     *   `HTMLDivElement`. For `React.ElementRef<'input'>` that would be `HTMLInputElement`.
+     * - React stateless functional components that forward a `ref` will give you the `ElementRef` of the forwarded
+     *   to component.
+     *
+     * `C` must be the type _of_ a React component so you need to use typeof as in React.ElementRef<typeof MyComponent>.
+     *
+     * @todo In Flow, this works a little different with forwarded refs and the `AbstractComponent` that
+     *       `React.forwardRef()` returns.
+     */
+    type ElementRef<
+        C extends
+            | ForwardRefExoticComponent<any>
+            | { new (props: any): Component<any> }
+            | ((props: any, context?: any) => ReactElement | null)
+            | keyof JSX.IntrinsicElements
+    > =
+        // need to check first if `ref` is a valid prop for ts@3.0
+        // otherwise it will infer `{}` instead of `never`
+        "ref" extends keyof ComponentPropsWithRef<C>
+            ? NonNullable<ComponentPropsWithRef<C>["ref"]> extends Ref<
+                infer Instance
+            >
+                ? Instance
+                : never
+            : never;
+
+    type ComponentState = any;
+
+    type Key = string | number;
+
+    /**
+     * @internal You shouldn't need to use this type since you never see these attributes
+     * inside your component or have to validate them.
+     */
+    interface Attributes {
+        key?: Key | null | undefined;
+    }
+    interface RefAttributes<T> extends Attributes {
+        ref?: Ref<T> | undefined;
+    }
+    interface ClassAttributes<T> extends Attributes {
+        ref?: LegacyRef<T> | undefined;
+    }
+
+    interface ReactElement<P = any, T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>> {
+        type: T;
+        props: P;
+        key: Key | null;
+    }
+
+    interface ReactComponentElement<
+        T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
+        P = Pick<ComponentProps<T>, Exclude<keyof ComponentProps<T>, 'key' | 'ref'>>
+    > extends ReactElement<P, Exclude<T, number>> { }
+
+    interface FunctionComponentElement<P> extends ReactElement<P, FunctionComponent<P>> {
+        ref?: ('ref' extends keyof P ? P extends { ref?: infer R | undefined } ? R : never : never) | undefined;
+    }
+
+    type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
+    interface ComponentElement<P, T extends Component<P, ComponentState>> extends ReactElement<P, ComponentClass<P>> {
+        ref?: LegacyRef<T> | undefined;
+    }
+
+    type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
+
+    // string fallback for custom web-components
+    interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element> extends ReactElement<P, string> {
+        ref: LegacyRef<T>;
+    }
+
+    // ReactHTML for ReactHTMLElement
+    interface ReactHTMLElement<T extends HTMLElement> extends DetailedReactHTMLElement<AllHTMLAttributes<T>, T> { }
+
+    interface DetailedReactHTMLElement<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMElement<P, T> {
+        type: keyof ReactHTML;
+    }
+
+    // ReactSVG for ReactSVGElement
+    interface ReactSVGElement extends DOMElement<SVGAttributes<SVGElement>, SVGElement> {
+        type: keyof ReactSVG;
+    }
+
+    interface ReactPortal extends ReactElement {
+        key: Key | null;
+        children: ReactNode;
+    }
+
+    //
+    // Factories
+    // ----------------------------------------------------------------------
+
+    type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
+
+    /**
+     * @deprecated Please use `FunctionComponentFactory`
+     */
+    type SFCFactory<P> = FunctionComponentFactory<P>;
+
+    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => FunctionComponentElement<P>;
+
+    type ComponentFactory<P, T extends Component<P, ComponentState>> =
+        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
+
+    type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
+    type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
+
+    type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
+
+    interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
+
+    interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
+        (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+    }
+
+    interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
+        (props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null, ...children: ReactNode[]): ReactSVGElement;
+    }
+
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
+    type ReactText = string | number;
+    /**
+     * @deprecated - This type is not relevant when using React. Inline the type instead to make the intent clear.
+     */
+    type ReactChild = ReactElement | string | number;
+
+    /**
+     * @deprecated Use either `ReactNode[]` if you need an array or `Iterable<ReactNode>` if its passed to a host component.
+     */
+    interface ReactNodeArray extends ReadonlyArray<ReactNode> {}
+    type ReactFragment = Iterable<ReactNode>;
+    type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
+
+    //
+    // Top Level API
+    // ----------------------------------------------------------------------
+
+    // DOM Elements
+    function createFactory<T extends HTMLElement>(
+        type: keyof ReactHTML): HTMLFactory<T>;
+    function createFactory(
+        type: keyof ReactSVG): SVGFactory;
+    function createFactory<P extends DOMAttributes<T>, T extends Element>(
+        type: string): DOMFactory<P, T>;
+
+    // Custom components
+    function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
+    function createFactory<P>(
+        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
+    function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
+        type: ClassType<P, T, C>): CFactory<P, T>;
+    function createFactory<P>(type: ComponentClass<P>): Factory<P>;
+
+    // DOM Elements
+    // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
+    function createElement(
+        type: "input",
+        props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
+        ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+    function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+        type: keyof ReactHTML,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+    function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
+        type: keyof ReactSVG,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): ReactSVGElement;
+    function createElement<P extends DOMAttributes<T>, T extends Element>(
+        type: string,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): DOMElement<P, T>;
+
+    // Custom components
+
+    function createElement<P extends {}>(
+        type: FunctionComponent<P>,
+        props?: Attributes & P | null,
+        ...children: ReactNode[]): FunctionComponentElement<P>;
+    function createElement<P extends {}>(
+        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
+        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
+        ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
+    function createElement<P extends {}, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
+        type: ClassType<P, T, C>,
+        props?: ClassAttributes<T> & P | null,
+        ...children: ReactNode[]): CElement<P, T>;
+    function createElement<P extends {}>(
+        type: FunctionComponent<P> | ComponentClass<P> | string,
+        props?: Attributes & P | null,
+        ...children: ReactNode[]): ReactElement<P>;
+
+    // DOM Elements
+    // ReactHTMLElement
+    function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+        element: DetailedReactHTMLElement<P, T>,
+        props?: P,
+        ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
+    // ReactHTMLElement, less specific
+    function cloneElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
+        element: ReactHTMLElement<T>,
+        props?: P,
+        ...children: ReactNode[]): ReactHTMLElement<T>;
+    // SVGElement
+    function cloneElement<P extends SVGAttributes<T>, T extends SVGElement>(
+        element: ReactSVGElement,
+        props?: P,
+        ...children: ReactNode[]): ReactSVGElement;
+    // DOM Element (has to be the last, because type checking stops at first overload that fits)
+    function cloneElement<P extends DOMAttributes<T>, T extends Element>(
+        element: DOMElement<P, T>,
+        props?: DOMAttributes<T> & P,
+        ...children: ReactNode[]): DOMElement<P, T>;
+
+    // Custom components
+    function cloneElement<P>(
+        element: FunctionComponentElement<P>,
+        props?: Partial<P> & Attributes,
+        ...children: ReactNode[]): FunctionComponentElement<P>;
+    function cloneElement<P, T extends Component<P, ComponentState>>(
+        element: CElement<P, T>,
+        props?: Partial<P> & ClassAttributes<T>,
+        ...children: ReactNode[]): CElement<P, T>;
+    function cloneElement<P>(
+        element: ReactElement<P>,
+        props?: Partial<P> & Attributes,
+        ...children: ReactNode[]): ReactElement<P>;
+
+    // Context via RenderProps
+    interface ProviderProps<T> {
+        value: T;
+        children?: ReactNode | undefined;
+    }
+
+    interface ConsumerProps<T> {
+        children: (value: T) => ReactNode;
+    }
+
+    // TODO: similar to how Fragment is actually a symbol, the values returned from createContext,
+    // forwardRef and memo are actually objects that are treated specially by the renderer; see:
+    // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/ReactContext.js#L35-L48
+    // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/forwardRef.js#L42-L45
+    // https://github.com/facebook/react/blob/v16.6.0/packages/react/src/memo.js#L27-L31
+    // However, we have no way of telling the JSX parser that it's a JSX element type or its props other than
+    // by pretending to be a normal component.
+    //
+    // We don't just use ComponentType or FunctionComponent types because you are not supposed to attach statics to this
+    // object, but rather to the original function.
+    interface ExoticComponent<P = {}> {
+        /**
+         * **NOTE**: Exotic components are not callable.
+         */
+        (props: P): (ReactElement|null);
+        readonly $$typeof: symbol;
+    }
+
+    interface NamedExoticComponent<P = {}> extends ExoticComponent<P> {
+        displayName?: string | undefined;
+    }
+
+    interface ProviderExoticComponent<P> extends ExoticComponent<P> {
+        propTypes?: WeakValidationMap<P> | undefined;
+    }
+
+    type ContextType<C extends Context<any>> = C extends Context<infer T> ? T : never;
+
+    // NOTE: only the Context object itself can get a displayName
+    // https://github.com/facebook/react-devtools/blob/e0b854e4c/backend/attachRendererFiber.js#L310-L325
+    type Provider<T> = ProviderExoticComponent<ProviderProps<T>>;
+    type Consumer<T> = ExoticComponent<ConsumerProps<T>>;
+    interface Context<T> {
+        Provider: Provider<T>;
+        Consumer: Consumer<T>;
+        displayName?: string | undefined;
+    }
+    function createContext<T>(
+        // If you thought this should be optional, see
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382213106
+        defaultValue: T,
+    ): Context<T>;
+
+    function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
+
+    // Sync with `ReactChildren` until `ReactChildren` is removed.
+    const Children: {
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
+        count(children: any): number;
+        only<C>(children: C): C extends any[] ? never : C;
+        toArray(children: ReactNode | ReactNode[]): Array<Exclude<ReactNode, boolean | null | undefined>>;
+    };
+    const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
+    const StrictMode: ExoticComponent<{ children?: ReactNode | undefined }>;
+
+    interface SuspenseProps {
+        children?: ReactNode | undefined;
+
+        /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
+        fallback?: ReactNode;
+    }
+
+    const Suspense: ExoticComponent<SuspenseProps>;
+    const version: string;
+
+    /**
+     * {@link https://reactjs.org/docs/profiler.html#onrender-callback Profiler API}
+     */
+    type ProfilerOnRenderCallback = (
+        id: string,
+        phase: "mount" | "update",
+        actualDuration: number,
+        baseDuration: number,
+        startTime: number,
+        commitTime: number,
+        interactions: Set<Interaction>,
+    ) => void;
+    interface ProfilerProps {
+        children?: ReactNode | undefined;
+        id: string;
+        onRender: ProfilerOnRenderCallback;
+    }
+
+    const Profiler: ExoticComponent<ProfilerProps>;
+
+    //
+    // Component API
+    // ----------------------------------------------------------------------
+
+    type ReactInstance = Component<any> | Element;
+
+    // Base component for plain JS classes
+    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
+    class Component<P, S> {
+        // tslint won't let me format the sample code in a way that vscode likes it :(
+        /**
+         * If set, `this.context` will be set at runtime to the current value of the given Context.
+         *
+         * Usage:
+         *
+         * ```ts
+         * type MyContext = number
+         * const Ctx = React.createContext<MyContext>(0)
+         *
+         * class Foo extends React.Component {
+         *   static contextType = Ctx
+         *   context!: React.ContextType<typeof Ctx>
+         *   render () {
+         *     return <>My context's value: {this.context}</>;
+         *   }
+         * }
+         * ```
+         *
+         * @see https://reactjs.org/docs/context.html#classcontexttype
+         */
+        static contextType?: Context<any> | undefined;
+
+        /**
+         * If using the new style context, re-declare this in your class to be the
+         * `React.ContextType` of your `static contextType`.
+         * Should be used with type annotation or static contextType.
+         *
+         * ```ts
+         * static contextType = MyContext
+         * // For TS pre-3.7:
+         * context!: React.ContextType<typeof MyContext>
+         * // For TS 3.7 and above:
+         * declare context: React.ContextType<typeof MyContext>
+         * ```
+         *
+         * @see https://reactjs.org/docs/context.html
+         */
+        context: unknown;
+
+        constructor(props: Readonly<P> | P);
+        /**
+         * @deprecated
+         * @see https://reactjs.org/docs/legacy-context.html
+         */
+        constructor(props: P, context: any);
+
+        // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
+        // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
+        // Also, the ` | S` allows intellisense to not be dumbisense
+        setState<K extends keyof S>(
+            state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+            callback?: () => void
+        ): void;
+
+        forceUpdate(callback?: () => void): void;
+        render(): ReactNode;
+
+        readonly props: Readonly<P>;
+        state: Readonly<S>;
+        /**
+         * @deprecated
+         * https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
+         */
+        refs: {
+            [key: string]: ReactInstance
+        };
+    }
+
+    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
+
+    interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
+        replaceState(nextState: S, callback?: () => void): void;
+        isMounted(): boolean;
+        getInitialState?(): S;
+    }
+
+    interface ChildContextProvider<CC> {
+        getChildContext(): CC;
+    }
+
+    //
+    // Class Interfaces
+    // ----------------------------------------------------------------------
+
+    type FC<P = {}> = FunctionComponent<P>;
+
+    interface FunctionComponent<P = {}> {
+        (props: P, context?: any): ReactElement<any, any> | null;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
+    }
+
+    /**
+     * @deprecated - Equivalent with `React.FC`.
+     */
+    type VFC<P = {}> = VoidFunctionComponent<P>;
+
+    /**
+     * @deprecated - Equivalent with `React.FunctionComponent`.
+     */
+    interface VoidFunctionComponent<P = {}> {
+        (props: P, context?: any): ReactElement<any, any> | null;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
+    }
+
+    type ForwardedRef<T> = ((instance: T | null) => void) | MutableRefObject<T | null> | null;
+
+    interface ForwardRefRenderFunction<T, P = {}> {
+        (props: P, ref: ForwardedRef<T>): ReactElement | null;
+        displayName?: string | undefined;
+        // explicit rejected with `never` required due to
+        // https://github.com/microsoft/TypeScript/issues/36826
+        /**
+         * defaultProps are not supported on render functions
+         */
+        defaultProps?: never | undefined;
+        /**
+         * propTypes are not supported on render functions
+         */
+        propTypes?: never | undefined;
+    }
+
+    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
+        new (props: P, context?: any): Component<P, S>;
+        propTypes?: WeakValidationMap<P> | undefined;
+        contextType?: Context<any> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        childContextTypes?: ValidationMap<any> | undefined;
+        defaultProps?: Partial<P> | undefined;
+        displayName?: string | undefined;
+    }
+
+    interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
+        new (props: P, context?: any): ClassicComponent<P, ComponentState>;
+        getDefaultProps?(): P;
+    }
+
+    /**
+     * We use an intersection type to infer multiple type parameters from
+     * a single argument, which is useful for many top-level API defs.
+     * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
+     */
+    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
+        C &
+        (new (props: P, context?: any) => T);
+
+    //
+    // Component Specs and Lifecycle
+    // ----------------------------------------------------------------------
+
+    // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
+    // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
+    // methods are present.
+    interface ComponentLifecycle<P, S, SS = any> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
+        /**
+         * Called immediately after a component is mounted. Setting state here will trigger re-rendering.
+         */
+        componentDidMount?(): void;
+        /**
+         * Called to determine whether the change in props and state should trigger a re-render.
+         *
+         * `Component` always returns true.
+         * `PureComponent` implements a shallow comparison on props and state and returns true if any
+         * props or states have changed.
+         *
+         * If false is returned, `Component#render`, `componentWillUpdate`
+         * and `componentDidUpdate` will not be called.
+         */
+        shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): boolean;
+        /**
+         * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
+         * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
+         */
+        componentWillUnmount?(): void;
+        /**
+         * Catches exceptions generated in descendant components. Unhandled exceptions will cause
+         * the entire component tree to unmount.
+         */
+        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+    }
+
+    // Unfortunately, we have no way of declaring that the component constructor must implement this
+    interface StaticLifecycle<P, S> {
+        getDerivedStateFromProps?: GetDerivedStateFromProps<P, S> | undefined;
+        getDerivedStateFromError?: GetDerivedStateFromError<P, S> | undefined;
+    }
+
+    type GetDerivedStateFromProps<P, S> =
+        /**
+         * Returns an update to a component's state based on its new props and old state.
+         *
+         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+         */
+        (nextProps: Readonly<P>, prevState: S) => Partial<S> | null;
+
+    type GetDerivedStateFromError<P, S> =
+        /**
+         * This lifecycle is invoked after an error has been thrown by a descendant component.
+         * It receives the error that was thrown as a parameter and should return a value to update state.
+         *
+         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+         */
+        (error: any) => Partial<S> | null;
+
+    // This should be "infer SS" but can't use it yet
+    interface NewLifecycle<P, S, SS> {
+        /**
+         * Runs before React applies the result of `render` to the document, and
+         * returns an object to be given to componentDidUpdate. Useful for saving
+         * things such as scroll position before `render` causes changes to it.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
+         * lifecycle events from running.
+         */
+        getSnapshotBeforeUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>): SS | null;
+        /**
+         * Called immediately after updating occurs. Not called for the initial render.
+         *
+         * The snapshot is only present if getSnapshotBeforeUpdate is present and returns non-null.
+         */
+        componentDidUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>, snapshot?: SS): void;
+    }
+
+    interface DeprecatedLifecycle<P, S> {
+        /**
+         * Called immediately before mounting occurs, and before `Component#render`.
+         * Avoid introducing any side-effects or subscriptions in this method.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use componentDidMount or the constructor instead; will stop working in React 17
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillMount?(): void;
+        /**
+         * Called immediately before mounting occurs, and before `Component#render`.
+         * Avoid introducing any side-effects or subscriptions in this method.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use componentDidMount or the constructor instead
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillMount?(): void;
+        /**
+         * Called when the component may be receiving new props.
+         * React may call this even if props have not changed, so be sure to compare new and existing
+         * props if you only want to handle changes.
+         *
+         * Calling `Component#setState` generally does not trigger this method.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use static getDerivedStateFromProps instead; will stop working in React 17
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+        /**
+         * Called when the component may be receiving new props.
+         * React may call this even if props have not changed, so be sure to compare new and existing
+         * props if you only want to handle changes.
+         *
+         * Calling `Component#setState` generally does not trigger this method.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use static getDerivedStateFromProps instead
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+        /**
+         * Called immediately before rendering when new props or state is received. Not called for the initial render.
+         *
+         * Note: You cannot call `Component#setState` here.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use getSnapshotBeforeUpdate instead; will stop working in React 17
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
+        /**
+         * Called immediately before rendering when new props or state is received. Not called for the initial render.
+         *
+         * Note: You cannot call `Component#setState` here.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use getSnapshotBeforeUpdate instead
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
+    }
+
+    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+        mixins?: Array<Mixin<P, S>> | undefined;
+        statics?: {
+            [key: string]: any;
+        } | undefined;
+
+        displayName?: string | undefined;
+        propTypes?: ValidationMap<any> | undefined;
+        contextTypes?: ValidationMap<any> | undefined;
+        childContextTypes?: ValidationMap<any> | undefined;
+
+        getDefaultProps?(): P;
+        getInitialState?(): S;
+    }
+
+    interface ComponentSpec<P, S> extends Mixin<P, S> {
+        render(): ReactNode;
+
+        [propertyName: string]: any;
+    }
+
+    function createRef<T>(): RefObject<T>;
+
+    // will show `ForwardRef(${Component.displayName || Component.name})` in devtools by default,
+    // but can be given its own specific name
+    interface ForwardRefExoticComponent<P> extends NamedExoticComponent<P> {
+        defaultProps?: Partial<P> | undefined;
+        propTypes?: WeakValidationMap<P> | undefined;
+    }
+
+    function forwardRef<T, P = {}>(render: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+
+    /** Ensures that the props do not include ref at all */
+    type PropsWithoutRef<P> =
+        // Pick would not be sufficient for this. We'd like to avoid unnecessary mapping and need a distributive conditional to support unions.
+        // see: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+        // https://github.com/Microsoft/TypeScript/issues/28339
+        P extends any ? ('ref' extends keyof P ? Pick<P, Exclude<keyof P, 'ref'>> : P) : P;
+    /** Ensures that the props do not include string ref, which cannot be forwarded */
+    type PropsWithRef<P> =
+        // Just "P extends { ref?: infer R }" looks sufficient, but R will infer as {} if P is {}.
+        'ref' extends keyof P
+            ? P extends { ref?: infer R | undefined }
+                ? string extends R
+                    ? PropsWithoutRef<P> & { ref?: Exclude<R, string> | undefined }
+                    : P
+                : P
+            : P;
+
+    type PropsWithChildren<P = unknown> = P & { children?: ReactNode | undefined };
+
+    /**
+     * NOTE: prefer ComponentPropsWithRef, if the ref is forwarded,
+     * or ComponentPropsWithoutRef when refs are not supported.
+     */
+    type ComponentProps<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> =
+        T extends JSXElementConstructor<infer P>
+            ? P
+            : T extends keyof JSX.IntrinsicElements
+                ? JSX.IntrinsicElements[T]
+                : {};
+    type ComponentPropsWithRef<T extends ElementType> =
+        T extends (new (props: infer P) => Component<any, any>)
+            ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
+            : PropsWithRef<ComponentProps<T>>;
+    type ComponentPropsWithoutRef<T extends ElementType> =
+        PropsWithoutRef<ComponentProps<T>>;
+
+    type ComponentRef<T extends ElementType> = T extends NamedExoticComponent<
+        ComponentPropsWithoutRef<T> & RefAttributes<infer Method>
+    >
+        ? Method
+        : ComponentPropsWithRef<T> extends RefAttributes<infer Method>
+            ? Method
+            : never;
+
+    // will show `Memo(${Component.displayName || Component.name})` in devtools by default,
+    // but can be given its own specific name
+    type MemoExoticComponent<T extends ComponentType<any>> = NamedExoticComponent<ComponentPropsWithRef<T>> & {
+        readonly type: T;
+    };
+
+    function memo<P extends object>(
+        Component: FunctionComponent<P>,
+        propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
+    ): NamedExoticComponent<P>;
+    function memo<T extends ComponentType<any>>(
+        Component: T,
+        propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean
+    ): MemoExoticComponent<T>;
+
+    type LazyExoticComponent<T extends ComponentType<any>> = ExoticComponent<ComponentPropsWithRef<T>> & {
+        readonly _result: T;
+    };
+
+    function lazy<T extends ComponentType<any>>(
+        factory: () => Promise<{ default: T }>
+    ): LazyExoticComponent<T>;
+
+    //
+    // React Hooks
+    // ----------------------------------------------------------------------
+
+    // based on the code in https://github.com/facebook/react/pull/13968
+
+    // Unlike the class component setState, the updates are not allowed to be partial
+    type SetStateAction<S> = S | ((prevState: S) => S);
+    // this technically does accept a second argument, but it's already under a deprecation warning
+    // and it's not even released so probably better to not define it.
+    type Dispatch<A> = (value: A) => void;
+    // Since action _can_ be undefined, dispatch may be called without any parameters.
+    type DispatchWithoutAction = () => void;
+    // Unlike redux, the actions _can_ be anything
+    type Reducer<S, A> = (prevState: S, action: A) => S;
+    // If useReducer accepts a reducer without action, dispatch may be called without any parameters.
+    type ReducerWithoutAction<S> = (prevState: S) => S;
+    // types used to try and prevent the compiler from reducing S
+    // to a supertype common with the second argument to useReducer()
+    type ReducerState<R extends Reducer<any, any>> = R extends Reducer<infer S, any> ? S : never;
+    type ReducerAction<R extends Reducer<any, any>> = R extends Reducer<any, infer A> ? A : never;
+    // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
+    type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
+        R extends ReducerWithoutAction<infer S> ? S : never;
+    type DependencyList = ReadonlyArray<unknown>;
+
+    // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
+    type EffectCallback = () => (void | Destructor);
+
+    interface MutableRefObject<T> {
+        current: T;
+    }
+
+    // This will technically work if you give a Consumer<T> or Provider<T> but it's deprecated and warns
+    /**
+     * Accepts a context object (the value returned from `React.createContext`) and returns the current
+     * context value, as given by the nearest context provider for the given context.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usecontext
+     */
+    function useContext<T>(context: Context<T>/*, (not public API) observedBits?: number|boolean */): T;
+    /**
+     * Returns a stateful value, and a function to update it.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usestate
+     */
+    function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    // convenience overload when first argument is omitted
+    /**
+     * Returns a stateful value, and a function to update it.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usestate
+     */
+    function useState<S = undefined>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+     */
+    // overload where dispatch could accept 0 arguments.
+    function useReducer<R extends ReducerWithoutAction<any>, I>(
+        reducer: R,
+        initializerArg: I,
+        initializer: (arg: I) => ReducerStateWithoutAction<R>
+    ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+     */
+    // overload where dispatch could accept 0 arguments.
+    function useReducer<R extends ReducerWithoutAction<any>>(
+        reducer: R,
+        initializerArg: ReducerStateWithoutAction<R>,
+        initializer?: undefined
+    ): [ReducerStateWithoutAction<R>, DispatchWithoutAction];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+     */
+    // overload where "I" may be a subset of ReducerState<R>; used to provide autocompletion.
+    // If "I" matches ReducerState<R> exactly then the last overload will allow initializer to be omitted.
+    // the last overload effectively behaves as if the identity function (x => x) is the initializer.
+    function useReducer<R extends Reducer<any, any>, I>(
+        reducer: R,
+        initializerArg: I & ReducerState<R>,
+        initializer: (arg: I & ReducerState<R>) => ReducerState<R>
+    ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+     */
+    // overload for free "I"; all goes as long as initializer converts it into "ReducerState<R>".
+    function useReducer<R extends Reducer<any, any>, I>(
+        reducer: R,
+        initializerArg: I,
+        initializer: (arg: I) => ReducerState<R>
+    ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+    /**
+     * An alternative to `useState`.
+     *
+     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
+     * multiple sub-values. It also lets you optimize performance for components that trigger deep
+     * updates because you can pass `dispatch` down instead of callbacks.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usereducer
+     */
+
+    // I'm not sure if I keep this 2-ary or if I make it (2,3)-ary; it's currently (2,3)-ary.
+    // The Flow types do have an overload for 3-ary invocation with undefined initializer.
+
+    // NOTE: without the ReducerState indirection, TypeScript would reduce S to be the most common
+    // supertype between the reducer's return type and the initialState (or the initializer's return type),
+    // which would prevent autocompletion from ever working.
+
+    // TODO: double-check if this weird overload logic is necessary. It is possible it's either a bug
+    // in older versions, or a regression in newer versions of the typescript completion service.
+    function useReducer<R extends Reducer<any, any>>(
+        reducer: R,
+        initialState: ReducerState<R>,
+        initializer?: undefined
+    ): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useref
+     */
+    function useRef<T>(initialValue: T): MutableRefObject<T>;
+    // convenience overload for refs given as a ref prop as they typically start with a null value
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * Usage note: if you need the result of useRef to be directly mutable, include `| null` in the type
+     * of the generic argument.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useref
+     */
+    function useRef<T>(initialValue: T|null): RefObject<T>;
+    // convenience overload for potentially undefined initialValue / call with 0 arguments
+    // has a default to stop it from defaulting to {} instead
+    /**
+     * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
+     * (`initialValue`). The returned object will persist for the full lifetime of the component.
+     *
+     * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+     * value around similar to how you’d use instance fields in classes.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useref
+     */
+    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    /**
+     * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
+     * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
+     * `useLayoutEffect` will be flushed synchronously, before the browser has a chance to paint.
+     *
+     * Prefer the standard `useEffect` when possible to avoid blocking visual updates.
+     *
+     * If you’re migrating code from a class component, `useLayoutEffect` fires in the same phase as
+     * `componentDidMount` and `componentDidUpdate`.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#uselayouteffect
+     */
+    function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
+    /**
+     * Accepts a function that contains imperative, possibly effectful code.
+     *
+     * @param effect Imperative function that can return a cleanup function
+     * @param deps If present, effect will only activate if the values in the list change.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useeffect
+     */
+    function useEffect(effect: EffectCallback, deps?: DependencyList): void;
+    // NOTE: this does not accept strings, but this will have to be fixed by removing strings from type Ref<T>
+    /**
+     * `useImperativeHandle` customizes the instance value that is exposed to parent components when using
+     * `ref`. As always, imperative code using refs should be avoided in most cases.
+     *
+     * `useImperativeHandle` should be used with `React.forwardRef`.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#useimperativehandle
+     */
+    function useImperativeHandle<T, R extends T>(ref: Ref<T>|undefined, init: () => R, deps?: DependencyList): void;
+    // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
+    // useCallback(X) is identical to just using X, useMemo(() => Y) is identical to just using Y.
+    /**
+     * `useCallback` will return a memoized version of the callback that only changes if one of the `inputs`
+     * has changed.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usecallback
+     */
+    // A specific function type would not trigger implicit any.
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/52873#issuecomment-845806435 for a comparison between `Function` and more specific types.
+    // tslint:disable-next-line ban-types
+    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
+    /**
+     * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usememo
+     */
+    // allow undefined, but don't make it optional as that is very likely a mistake
+    function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+    /**
+     * `useDebugValue` can be used to display a label for custom hooks in React DevTools.
+     *
+     * NOTE: We don’t recommend adding debug values to every custom hook.
+     * It’s most valuable for custom hooks that are part of shared libraries.
+     *
+     * @version 16.8.0
+     * @see https://reactjs.org/docs/hooks-reference.html#usedebugvalue
+     */
+    // the name of the custom hook is itself derived from the function name at runtime:
+    // it's just the function name without the "use" prefix.
+    function useDebugValue<T>(value: T, format?: (value: T) => any): void;
+
+    // must be synchronous
+    export type TransitionFunction = () => VoidOrUndefinedOnly;
+    // strange definition to allow vscode to show documentation on the invocation
+    export interface TransitionStartFunction {
+        /**
+         * State updates caused inside the callback are allowed to be deferred.
+         *
+         * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**
+         *
+         * @param callback A _synchronous_ function which causes state updates that can be deferred.
+         */
+        (callback: TransitionFunction): void;
+    }
+
+    /**
+     * Returns a deferred version of the value that may “lag behind” it.
+     *
+     * This is commonly used to keep the interface responsive when you have something that renders immediately
+     * based on user input and something that needs to wait for a data fetch.
+     *
+     * A good example of this is a text input.
+     *
+     * @param value The value that is going to be deferred
+     *
+     * @see https://reactjs.org/docs/concurrent-mode-reference.html#usedeferredvalue
+     */
+    export function useDeferredValue<T>(value: T): T;
+
+    /**
+     * Allows components to avoid undesirable loading states by waiting for content to load
+     * before transitioning to the next screen. It also allows components to defer slower,
+     * data fetching updates until subsequent renders so that more crucial updates can be
+     * rendered immediately.
+     *
+     * The `useTransition` hook returns two values in an array.
+     *
+     * The first is a boolean, React’s way of informing us whether we’re waiting for the transition to finish.
+     * The second is a function that takes a callback. We can use it to tell React which state we want to defer.
+     *
+     * **If some state update causes a component to suspend, that state update should be wrapped in a transition.**`
+     *
+     * @see https://reactjs.org/docs/concurrent-mode-reference.html#usetransition
+     */
+    export function useTransition(): [boolean, TransitionStartFunction];
+
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback A _synchronous_ function which causes state updates that can be deferred.
+     */
+    export function startTransition(scope: TransitionFunction): void;
+
+    export function useId(): string;
+
+    /**
+     * @param effect Imperative function that can return a cleanup function
+     * @param deps If present, effect will only activate if the values in the list change.
+     *
+     * @see https://github.com/facebook/react/pull/21913
+     */
+     export function useInsertionEffect(effect: EffectCallback, deps?: DependencyList): void;
+
+    /**
+     * @param subscribe
+     * @param getSnapshot
+     *
+     * @see https://github.com/reactwg/react-18/discussions/86
+     */
+    // keep in sync with `useSyncExternalStore` from `use-sync-external-store`
+    export function useSyncExternalStore<Snapshot>(
+        subscribe: (onStoreChange: () => void) => () => void,
+        getSnapshot: () => Snapshot,
+        getServerSnapshot?: () => Snapshot,
+    ): Snapshot;
+
+    //
+    // Event System
+    // ----------------------------------------------------------------------
+    // TODO: change any to unknown when moving to TS v3
+    interface BaseSyntheticEvent<E = object, C = any, T = any> {
+        nativeEvent: E;
+        currentTarget: C;
+        target: T;
+        bubbles: boolean;
+        cancelable: boolean;
+        defaultPrevented: boolean;
+        eventPhase: number;
+        isTrusted: boolean;
+        preventDefault(): void;
+        isDefaultPrevented(): boolean;
+        stopPropagation(): void;
+        isPropagationStopped(): boolean;
+        persist(): void;
+        timeStamp: number;
+        type: string;
+    }
+
+    /**
+     * currentTarget - a reference to the element on which the event listener is registered.
+     *
+     * target - a reference to the element from which the event was originally dispatched.
+     * This might be a child element to the element on which the event listener is registered.
+     * If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11508#issuecomment-256045682
+     */
+    interface SyntheticEvent<T = Element, E = Event> extends BaseSyntheticEvent<E, EventTarget & T, EventTarget> {}
+
+    interface ClipboardEvent<T = Element> extends SyntheticEvent<T, NativeClipboardEvent> {
+        clipboardData: DataTransfer;
+    }
+
+    interface CompositionEvent<T = Element> extends SyntheticEvent<T, NativeCompositionEvent> {
+        data: string;
+    }
+
+    interface DragEvent<T = Element> extends MouseEvent<T, NativeDragEvent> {
+        dataTransfer: DataTransfer;
+    }
+
+    interface PointerEvent<T = Element> extends MouseEvent<T, NativePointerEvent> {
+        pointerId: number;
+        pressure: number;
+        tangentialPressure: number;
+        tiltX: number;
+        tiltY: number;
+        twist: number;
+        width: number;
+        height: number;
+        pointerType: 'mouse' | 'pen' | 'touch';
+        isPrimary: boolean;
+    }
+
+    interface FocusEvent<Target = Element, RelatedTarget = Element> extends SyntheticEvent<Target, NativeFocusEvent> {
+        relatedTarget: (EventTarget & RelatedTarget) | null;
+        target: EventTarget & Target;
+    }
+
+    interface FormEvent<T = Element> extends SyntheticEvent<T> {
+    }
+
+    interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
+        target: EventTarget & T;
+    }
+
+    interface ChangeEvent<T = Element> extends SyntheticEvent<T> {
+        target: EventTarget & T;
+    }
+
+    interface KeyboardEvent<T = Element> extends UIEvent<T, NativeKeyboardEvent> {
+        altKey: boolean;
+        /** @deprecated */
+        charCode: number;
+        ctrlKey: boolean;
+        code: string;
+        /**
+         * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+         */
+        getModifierState(key: string): boolean;
+        /**
+         * See the [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#named-key-attribute-values). for possible values
+         */
+        key: string;
+        /** @deprecated */
+        keyCode: number;
+        locale: string;
+        location: number;
+        metaKey: boolean;
+        repeat: boolean;
+        shiftKey: boolean;
+        /** @deprecated */
+        which: number;
+    }
+
+    interface MouseEvent<T = Element, E = NativeMouseEvent> extends UIEvent<T, E> {
+        altKey: boolean;
+        button: number;
+        buttons: number;
+        clientX: number;
+        clientY: number;
+        ctrlKey: boolean;
+        /**
+         * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+         */
+        getModifierState(key: string): boolean;
+        metaKey: boolean;
+        movementX: number;
+        movementY: number;
+        pageX: number;
+        pageY: number;
+        relatedTarget: EventTarget | null;
+        screenX: number;
+        screenY: number;
+        shiftKey: boolean;
+    }
+
+    interface TouchEvent<T = Element> extends UIEvent<T, NativeTouchEvent> {
+        altKey: boolean;
+        changedTouches: TouchList;
+        ctrlKey: boolean;
+        /**
+         * See [DOM Level 3 Events spec](https://www.w3.org/TR/uievents-key/#keys-modifier). for a list of valid (case-sensitive) arguments to this method.
+         */
+        getModifierState(key: string): boolean;
+        metaKey: boolean;
+        shiftKey: boolean;
+        targetTouches: TouchList;
+        touches: TouchList;
+    }
+
+    interface UIEvent<T = Element, E = NativeUIEvent> extends SyntheticEvent<T, E> {
+        detail: number;
+        view: AbstractView;
+    }
+
+    interface WheelEvent<T = Element> extends MouseEvent<T, NativeWheelEvent> {
+        deltaMode: number;
+        deltaX: number;
+        deltaY: number;
+        deltaZ: number;
+    }
+
+    interface AnimationEvent<T = Element> extends SyntheticEvent<T, NativeAnimationEvent> {
+        animationName: string;
+        elapsedTime: number;
+        pseudoElement: string;
+    }
+
+    interface TransitionEvent<T = Element> extends SyntheticEvent<T, NativeTransitionEvent> {
+        elapsedTime: number;
+        propertyName: string;
+        pseudoElement: string;
+    }
+
+    //
+    // Event Handler Types
+    // ----------------------------------------------------------------------
+
+    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }["bivarianceHack"];
+
+    type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
+
+    type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+    type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
+    type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
+    type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+    type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
+    type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
+    type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+    type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
+    type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
+    type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
+    type WheelEventHandler<T = Element> = EventHandler<WheelEvent<T>>;
+    type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent<T>>;
+    type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent<T>>;
+
+    //
+    // Props / DOM Attributes
+    // ----------------------------------------------------------------------
+
+    interface HTMLProps<T> extends AllHTMLAttributes<T>, ClassAttributes<T> {
+    }
+
+    type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = ClassAttributes<T> & E;
+
+    interface SVGProps<T> extends SVGAttributes<T>, ClassAttributes<T> {
+    }
+
+    interface DOMAttributes<T> {
+        children?: ReactNode | undefined;
+        dangerouslySetInnerHTML?: {
+            __html: string;
+        } | undefined;
+
+        // Clipboard Events
+        onCopy?: ClipboardEventHandler<T> | undefined;
+        onCopyCapture?: ClipboardEventHandler<T> | undefined;
+        onCut?: ClipboardEventHandler<T> | undefined;
+        onCutCapture?: ClipboardEventHandler<T> | undefined;
+        onPaste?: ClipboardEventHandler<T> | undefined;
+        onPasteCapture?: ClipboardEventHandler<T> | undefined;
+
+        // Composition Events
+        onCompositionEnd?: CompositionEventHandler<T> | undefined;
+        onCompositionEndCapture?: CompositionEventHandler<T> | undefined;
+        onCompositionStart?: CompositionEventHandler<T> | undefined;
+        onCompositionStartCapture?: CompositionEventHandler<T> | undefined;
+        onCompositionUpdate?: CompositionEventHandler<T> | undefined;
+        onCompositionUpdateCapture?: CompositionEventHandler<T> | undefined;
+
+        // Focus Events
+        onFocus?: FocusEventHandler<T> | undefined;
+        onFocusCapture?: FocusEventHandler<T> | undefined;
+        onBlur?: FocusEventHandler<T> | undefined;
+        onBlurCapture?: FocusEventHandler<T> | undefined;
+
+        // Form Events
+        onChange?: FormEventHandler<T> | undefined;
+        onChangeCapture?: FormEventHandler<T> | undefined;
+        onBeforeInput?: FormEventHandler<T> | undefined;
+        onBeforeInputCapture?: FormEventHandler<T> | undefined;
+        onInput?: FormEventHandler<T> | undefined;
+        onInputCapture?: FormEventHandler<T> | undefined;
+        onReset?: FormEventHandler<T> | undefined;
+        onResetCapture?: FormEventHandler<T> | undefined;
+        onSubmit?: FormEventHandler<T> | undefined;
+        onSubmitCapture?: FormEventHandler<T> | undefined;
+        onInvalid?: FormEventHandler<T> | undefined;
+        onInvalidCapture?: FormEventHandler<T> | undefined;
+
+        // Image Events
+        onLoad?: ReactEventHandler<T> | undefined;
+        onLoadCapture?: ReactEventHandler<T> | undefined;
+        onError?: ReactEventHandler<T> | undefined; // also a Media Event
+        onErrorCapture?: ReactEventHandler<T> | undefined; // also a Media Event
+
+        // Keyboard Events
+        onKeyDown?: KeyboardEventHandler<T> | undefined;
+        onKeyDownCapture?: KeyboardEventHandler<T> | undefined;
+        /** @deprecated */
+        onKeyPress?: KeyboardEventHandler<T> | undefined;
+        /** @deprecated */
+        onKeyPressCapture?: KeyboardEventHandler<T> | undefined;
+        onKeyUp?: KeyboardEventHandler<T> | undefined;
+        onKeyUpCapture?: KeyboardEventHandler<T> | undefined;
+
+        // Media Events
+        onAbort?: ReactEventHandler<T> | undefined;
+        onAbortCapture?: ReactEventHandler<T> | undefined;
+        onCanPlay?: ReactEventHandler<T> | undefined;
+        onCanPlayCapture?: ReactEventHandler<T> | undefined;
+        onCanPlayThrough?: ReactEventHandler<T> | undefined;
+        onCanPlayThroughCapture?: ReactEventHandler<T> | undefined;
+        onDurationChange?: ReactEventHandler<T> | undefined;
+        onDurationChangeCapture?: ReactEventHandler<T> | undefined;
+        onEmptied?: ReactEventHandler<T> | undefined;
+        onEmptiedCapture?: ReactEventHandler<T> | undefined;
+        onEncrypted?: ReactEventHandler<T> | undefined;
+        onEncryptedCapture?: ReactEventHandler<T> | undefined;
+        onEnded?: ReactEventHandler<T> | undefined;
+        onEndedCapture?: ReactEventHandler<T> | undefined;
+        onLoadedData?: ReactEventHandler<T> | undefined;
+        onLoadedDataCapture?: ReactEventHandler<T> | undefined;
+        onLoadedMetadata?: ReactEventHandler<T> | undefined;
+        onLoadedMetadataCapture?: ReactEventHandler<T> | undefined;
+        onLoadStart?: ReactEventHandler<T> | undefined;
+        onLoadStartCapture?: ReactEventHandler<T> | undefined;
+        onPause?: ReactEventHandler<T> | undefined;
+        onPauseCapture?: ReactEventHandler<T> | undefined;
+        onPlay?: ReactEventHandler<T> | undefined;
+        onPlayCapture?: ReactEventHandler<T> | undefined;
+        onPlaying?: ReactEventHandler<T> | undefined;
+        onPlayingCapture?: ReactEventHandler<T> | undefined;
+        onProgress?: ReactEventHandler<T> | undefined;
+        onProgressCapture?: ReactEventHandler<T> | undefined;
+        onRateChange?: ReactEventHandler<T> | undefined;
+        onRateChangeCapture?: ReactEventHandler<T> | undefined;
+        onSeeked?: ReactEventHandler<T> | undefined;
+        onSeekedCapture?: ReactEventHandler<T> | undefined;
+        onSeeking?: ReactEventHandler<T> | undefined;
+        onSeekingCapture?: ReactEventHandler<T> | undefined;
+        onStalled?: ReactEventHandler<T> | undefined;
+        onStalledCapture?: ReactEventHandler<T> | undefined;
+        onSuspend?: ReactEventHandler<T> | undefined;
+        onSuspendCapture?: ReactEventHandler<T> | undefined;
+        onTimeUpdate?: ReactEventHandler<T> | undefined;
+        onTimeUpdateCapture?: ReactEventHandler<T> | undefined;
+        onVolumeChange?: ReactEventHandler<T> | undefined;
+        onVolumeChangeCapture?: ReactEventHandler<T> | undefined;
+        onWaiting?: ReactEventHandler<T> | undefined;
+        onWaitingCapture?: ReactEventHandler<T> | undefined;
+
+        // MouseEvents
+        onAuxClick?: MouseEventHandler<T> | undefined;
+        onAuxClickCapture?: MouseEventHandler<T> | undefined;
+        onClick?: MouseEventHandler<T> | undefined;
+        onClickCapture?: MouseEventHandler<T> | undefined;
+        onContextMenu?: MouseEventHandler<T> | undefined;
+        onContextMenuCapture?: MouseEventHandler<T> | undefined;
+        onDoubleClick?: MouseEventHandler<T> | undefined;
+        onDoubleClickCapture?: MouseEventHandler<T> | undefined;
+        onDrag?: DragEventHandler<T> | undefined;
+        onDragCapture?: DragEventHandler<T> | undefined;
+        onDragEnd?: DragEventHandler<T> | undefined;
+        onDragEndCapture?: DragEventHandler<T> | undefined;
+        onDragEnter?: DragEventHandler<T> | undefined;
+        onDragEnterCapture?: DragEventHandler<T> | undefined;
+        onDragExit?: DragEventHandler<T> | undefined;
+        onDragExitCapture?: DragEventHandler<T> | undefined;
+        onDragLeave?: DragEventHandler<T> | undefined;
+        onDragLeaveCapture?: DragEventHandler<T> | undefined;
+        onDragOver?: DragEventHandler<T> | undefined;
+        onDragOverCapture?: DragEventHandler<T> | undefined;
+        onDragStart?: DragEventHandler<T> | undefined;
+        onDragStartCapture?: DragEventHandler<T> | undefined;
+        onDrop?: DragEventHandler<T> | undefined;
+        onDropCapture?: DragEventHandler<T> | undefined;
+        onMouseDown?: MouseEventHandler<T> | undefined;
+        onMouseDownCapture?: MouseEventHandler<T> | undefined;
+        onMouseEnter?: MouseEventHandler<T> | undefined;
+        onMouseLeave?: MouseEventHandler<T> | undefined;
+        onMouseMove?: MouseEventHandler<T> | undefined;
+        onMouseMoveCapture?: MouseEventHandler<T> | undefined;
+        onMouseOut?: MouseEventHandler<T> | undefined;
+        onMouseOutCapture?: MouseEventHandler<T> | undefined;
+        onMouseOver?: MouseEventHandler<T> | undefined;
+        onMouseOverCapture?: MouseEventHandler<T> | undefined;
+        onMouseUp?: MouseEventHandler<T> | undefined;
+        onMouseUpCapture?: MouseEventHandler<T> | undefined;
+
+        // Selection Events
+        onSelect?: ReactEventHandler<T> | undefined;
+        onSelectCapture?: ReactEventHandler<T> | undefined;
+
+        // Touch Events
+        onTouchCancel?: TouchEventHandler<T> | undefined;
+        onTouchCancelCapture?: TouchEventHandler<T> | undefined;
+        onTouchEnd?: TouchEventHandler<T> | undefined;
+        onTouchEndCapture?: TouchEventHandler<T> | undefined;
+        onTouchMove?: TouchEventHandler<T> | undefined;
+        onTouchMoveCapture?: TouchEventHandler<T> | undefined;
+        onTouchStart?: TouchEventHandler<T> | undefined;
+        onTouchStartCapture?: TouchEventHandler<T> | undefined;
+
+        // Pointer Events
+        onPointerDown?: PointerEventHandler<T> | undefined;
+        onPointerDownCapture?: PointerEventHandler<T> | undefined;
+        onPointerMove?: PointerEventHandler<T> | undefined;
+        onPointerMoveCapture?: PointerEventHandler<T> | undefined;
+        onPointerUp?: PointerEventHandler<T> | undefined;
+        onPointerUpCapture?: PointerEventHandler<T> | undefined;
+        onPointerCancel?: PointerEventHandler<T> | undefined;
+        onPointerCancelCapture?: PointerEventHandler<T> | undefined;
+        onPointerEnter?: PointerEventHandler<T> | undefined;
+        onPointerEnterCapture?: PointerEventHandler<T> | undefined;
+        onPointerLeave?: PointerEventHandler<T> | undefined;
+        onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
+        onPointerOver?: PointerEventHandler<T> | undefined;
+        onPointerOverCapture?: PointerEventHandler<T> | undefined;
+        onPointerOut?: PointerEventHandler<T> | undefined;
+        onPointerOutCapture?: PointerEventHandler<T> | undefined;
+        onGotPointerCapture?: PointerEventHandler<T> | undefined;
+        onGotPointerCaptureCapture?: PointerEventHandler<T> | undefined;
+        onLostPointerCapture?: PointerEventHandler<T> | undefined;
+        onLostPointerCaptureCapture?: PointerEventHandler<T> | undefined;
+
+        // UI Events
+        onScroll?: UIEventHandler<T> | undefined;
+        onScrollCapture?: UIEventHandler<T> | undefined;
+
+        // Wheel Events
+        onWheel?: WheelEventHandler<T> | undefined;
+        onWheelCapture?: WheelEventHandler<T> | undefined;
+
+        // Animation Events
+        onAnimationStart?: AnimationEventHandler<T> | undefined;
+        onAnimationStartCapture?: AnimationEventHandler<T> | undefined;
+        onAnimationEnd?: AnimationEventHandler<T> | undefined;
+        onAnimationEndCapture?: AnimationEventHandler<T> | undefined;
+        onAnimationIteration?: AnimationEventHandler<T> | undefined;
+        onAnimationIterationCapture?: AnimationEventHandler<T> | undefined;
+
+        // Transition Events
+        onTransitionEnd?: TransitionEventHandler<T> | undefined;
+        onTransitionEndCapture?: TransitionEventHandler<T> | undefined;
+    }
+
+    export interface CSSProperties extends CSS.Properties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
+
+    // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
+    interface AriaAttributes {
+        /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
+        'aria-activedescendant'?: string | undefined;
+        /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
+        'aria-atomic'?: Booleanish | undefined;
+        /**
+         * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+         * presented if they are made.
+         */
+        'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both' | undefined;
+        /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
+        'aria-busy'?: Booleanish | undefined;
+        /**
+         * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+         * @see aria-pressed @see aria-selected.
+         */
+        'aria-checked'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+        /**
+         * Defines the total number of columns in a table, grid, or treegrid.
+         * @see aria-colindex.
+         */
+        'aria-colcount'?: number | undefined;
+        /**
+         * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+         * @see aria-colcount @see aria-colspan.
+         */
+        'aria-colindex'?: number | undefined;
+        /**
+         * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+         * @see aria-colindex @see aria-rowspan.
+         */
+        'aria-colspan'?: number | undefined;
+        /**
+         * Identifies the element (or elements) whose contents or presence are controlled by the current element.
+         * @see aria-owns.
+         */
+        'aria-controls'?: string | undefined;
+        /** Indicates the element that represents the current item within a container or set of related elements. */
+        'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined;
+        /**
+         * Identifies the element (or elements) that describes the object.
+         * @see aria-labelledby
+         */
+        'aria-describedby'?: string | undefined;
+        /**
+         * Identifies the element that provides a detailed, extended description for the object.
+         * @see aria-describedby.
+         */
+        'aria-details'?: string | undefined;
+        /**
+         * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+         * @see aria-hidden @see aria-readonly.
+         */
+        'aria-disabled'?: Booleanish | undefined;
+        /**
+         * Indicates what functions can be performed when a dragged object is released on the drop target.
+         * @deprecated in ARIA 1.1
+         */
+        'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined;
+        /**
+         * Identifies the element that provides an error message for the object.
+         * @see aria-invalid @see aria-describedby.
+         */
+        'aria-errormessage'?: string | undefined;
+        /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
+        'aria-expanded'?: Booleanish | undefined;
+        /**
+         * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+         * allows assistive technology to override the general default of reading in document source order.
+         */
+        'aria-flowto'?: string | undefined;
+        /**
+         * Indicates an element's "grabbed" state in a drag-and-drop operation.
+         * @deprecated in ARIA 1.1
+         */
+        'aria-grabbed'?: Booleanish | undefined;
+        /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
+        'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined;
+        /**
+         * Indicates whether the element is exposed to an accessibility API.
+         * @see aria-disabled.
+         */
+        'aria-hidden'?: Booleanish | undefined;
+        /**
+         * Indicates the entered value does not conform to the format expected by the application.
+         * @see aria-errormessage.
+         */
+        'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined;
+        /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
+        'aria-keyshortcuts'?: string | undefined;
+        /**
+         * Defines a string value that labels the current element.
+         * @see aria-labelledby.
+         */
+        'aria-label'?: string | undefined;
+        /**
+         * Identifies the element (or elements) that labels the current element.
+         * @see aria-describedby.
+         */
+        'aria-labelledby'?: string | undefined;
+        /** Defines the hierarchical level of an element within a structure. */
+        'aria-level'?: number | undefined;
+        /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
+        'aria-live'?: 'off' | 'assertive' | 'polite' | undefined;
+        /** Indicates whether an element is modal when displayed. */
+        'aria-modal'?: Booleanish | undefined;
+        /** Indicates whether a text box accepts multiple lines of input or only a single line. */
+        'aria-multiline'?: Booleanish | undefined;
+        /** Indicates that the user may select more than one item from the current selectable descendants. */
+        'aria-multiselectable'?: Booleanish | undefined;
+        /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
+        'aria-orientation'?: 'horizontal' | 'vertical' | undefined;
+        /**
+         * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+         * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+         * @see aria-controls.
+         */
+        'aria-owns'?: string | undefined;
+        /**
+         * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+         * A hint could be a sample value or a brief description of the expected format.
+         */
+        'aria-placeholder'?: string | undefined;
+        /**
+         * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+         * @see aria-setsize.
+         */
+        'aria-posinset'?: number | undefined;
+        /**
+         * Indicates the current "pressed" state of toggle buttons.
+         * @see aria-checked @see aria-selected.
+         */
+        'aria-pressed'?: boolean | 'false' | 'mixed' | 'true' | undefined;
+        /**
+         * Indicates that the element is not editable, but is otherwise operable.
+         * @see aria-disabled.
+         */
+        'aria-readonly'?: Booleanish | undefined;
+        /**
+         * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+         * @see aria-atomic.
+         */
+        'aria-relevant'?: 'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined;
+        /** Indicates that user input is required on the element before a form may be submitted. */
+        'aria-required'?: Booleanish | undefined;
+        /** Defines a human-readable, author-localized description for the role of an element. */
+        'aria-roledescription'?: string | undefined;
+        /**
+         * Defines the total number of rows in a table, grid, or treegrid.
+         * @see aria-rowindex.
+         */
+        'aria-rowcount'?: number | undefined;
+        /**
+         * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+         * @see aria-rowcount @see aria-rowspan.
+         */
+        'aria-rowindex'?: number | undefined;
+        /**
+         * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+         * @see aria-rowindex @see aria-colspan.
+         */
+        'aria-rowspan'?: number | undefined;
+        /**
+         * Indicates the current "selected" state of various widgets.
+         * @see aria-checked @see aria-pressed.
+         */
+        'aria-selected'?: Booleanish | undefined;
+        /**
+         * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+         * @see aria-posinset.
+         */
+        'aria-setsize'?: number | undefined;
+        /** Indicates if items in a table or grid are sorted in ascending or descending order. */
+        'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other' | undefined;
+        /** Defines the maximum allowed value for a range widget. */
+        'aria-valuemax'?: number | undefined;
+        /** Defines the minimum allowed value for a range widget. */
+        'aria-valuemin'?: number | undefined;
+        /**
+         * Defines the current value for a range widget.
+         * @see aria-valuetext.
+         */
+        'aria-valuenow'?: number | undefined;
+        /** Defines the human readable text alternative of aria-valuenow for a range widget. */
+        'aria-valuetext'?: string | undefined;
+    }
+
+    // All the WAI-ARIA 1.1 role attribute values from https://www.w3.org/TR/wai-aria-1.1/#role_definitions
+    type AriaRole =
+        | 'alert'
+        | 'alertdialog'
+        | 'application'
+        | 'article'
+        | 'banner'
+        | 'button'
+        | 'cell'
+        | 'checkbox'
+        | 'columnheader'
+        | 'combobox'
+        | 'complementary'
+        | 'contentinfo'
+        | 'definition'
+        | 'dialog'
+        | 'directory'
+        | 'document'
+        | 'feed'
+        | 'figure'
+        | 'form'
+        | 'grid'
+        | 'gridcell'
+        | 'group'
+        | 'heading'
+        | 'img'
+        | 'link'
+        | 'list'
+        | 'listbox'
+        | 'listitem'
+        | 'log'
+        | 'main'
+        | 'marquee'
+        | 'math'
+        | 'menu'
+        | 'menubar'
+        | 'menuitem'
+        | 'menuitemcheckbox'
+        | 'menuitemradio'
+        | 'navigation'
+        | 'none'
+        | 'note'
+        | 'option'
+        | 'presentation'
+        | 'progressbar'
+        | 'radio'
+        | 'radiogroup'
+        | 'region'
+        | 'row'
+        | 'rowgroup'
+        | 'rowheader'
+        | 'scrollbar'
+        | 'search'
+        | 'searchbox'
+        | 'separator'
+        | 'slider'
+        | 'spinbutton'
+        | 'status'
+        | 'switch'
+        | 'tab'
+        | 'table'
+        | 'tablist'
+        | 'tabpanel'
+        | 'term'
+        | 'textbox'
+        | 'timer'
+        | 'toolbar'
+        | 'tooltip'
+        | 'tree'
+        | 'treegrid'
+        | 'treeitem'
+        | (string & {});
+
+    interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        // React-specific Attributes
+        defaultChecked?: boolean | undefined;
+        defaultValue?: string | number | ReadonlyArray<string> | undefined;
+        suppressContentEditableWarning?: boolean | undefined;
+        suppressHydrationWarning?: boolean | undefined;
+
+        // Standard HTML Attributes
+        accessKey?: string | undefined;
+        className?: string | undefined;
+        contentEditable?: Booleanish | "inherit" | undefined;
+        contextMenu?: string | undefined;
+        dir?: string | undefined;
+        draggable?: Booleanish | undefined;
+        hidden?: boolean | undefined;
+        id?: string | undefined;
+        lang?: string | undefined;
+        placeholder?: string | undefined;
+        slot?: string | undefined;
+        spellCheck?: Booleanish | undefined;
+        style?: CSSProperties | undefined;
+        tabIndex?: number | undefined;
+        title?: string | undefined;
+        translate?: 'yes' | 'no' | undefined;
+
+        // Unknown
+        radioGroup?: string | undefined; // <command>, <menuitem>
+
+        // WAI-ARIA
+        role?: AriaRole | undefined;
+
+        // RDFa Attributes
+        about?: string | undefined;
+        datatype?: string | undefined;
+        inlist?: any;
+        prefix?: string | undefined;
+        property?: string | undefined;
+        resource?: string | undefined;
+        typeof?: string | undefined;
+        vocab?: string | undefined;
+
+        // Non-standard Attributes
+        autoCapitalize?: string | undefined;
+        autoCorrect?: string | undefined;
+        autoSave?: string | undefined;
+        color?: string | undefined;
+        itemProp?: string | undefined;
+        itemScope?: boolean | undefined;
+        itemType?: string | undefined;
+        itemID?: string | undefined;
+        itemRef?: string | undefined;
+        results?: number | undefined;
+        security?: string | undefined;
+        unselectable?: 'on' | 'off' | undefined;
+
+        // Living Standard
+        /**
+         * Hints at the type of data that might be entered by the user while editing the element or its contents
+         * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+         */
+        inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search' | undefined;
+        /**
+         * Specify that a standard HTML element should behave like a defined custom built-in element
+         * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+         */
+        is?: string | undefined;
+    }
+
+    interface AllHTMLAttributes<T> extends HTMLAttributes<T> {
+        // Standard HTML Attributes
+        accept?: string | undefined;
+        acceptCharset?: string | undefined;
+        action?: string | undefined;
+        allowFullScreen?: boolean | undefined;
+        allowTransparency?: boolean | undefined;
+        alt?: string | undefined;
+        as?: string | undefined;
+        async?: boolean | undefined;
+        autoComplete?: string | undefined;
+        autoFocus?: boolean | undefined;
+        autoPlay?: boolean | undefined;
+        capture?: boolean | 'user' | 'environment' | undefined;
+        cellPadding?: number | string | undefined;
+        cellSpacing?: number | string | undefined;
+        charSet?: string | undefined;
+        challenge?: string | undefined;
+        checked?: boolean | undefined;
+        cite?: string | undefined;
+        classID?: string | undefined;
+        cols?: number | undefined;
+        colSpan?: number | undefined;
+        content?: string | undefined;
+        controls?: boolean | undefined;
+        coords?: string | undefined;
+        crossOrigin?: string | undefined;
+        data?: string | undefined;
+        dateTime?: string | undefined;
+        default?: boolean | undefined;
+        defer?: boolean | undefined;
+        disabled?: boolean | undefined;
+        download?: any;
+        encType?: string | undefined;
+        form?: string | undefined;
+        formAction?: string | undefined;
+        formEncType?: string | undefined;
+        formMethod?: string | undefined;
+        formNoValidate?: boolean | undefined;
+        formTarget?: string | undefined;
+        frameBorder?: number | string | undefined;
+        headers?: string | undefined;
+        height?: number | string | undefined;
+        high?: number | undefined;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        htmlFor?: string | undefined;
+        httpEquiv?: string | undefined;
+        integrity?: string | undefined;
+        keyParams?: string | undefined;
+        keyType?: string | undefined;
+        kind?: string | undefined;
+        label?: string | undefined;
+        list?: string | undefined;
+        loop?: boolean | undefined;
+        low?: number | undefined;
+        manifest?: string | undefined;
+        marginHeight?: number | undefined;
+        marginWidth?: number | undefined;
+        max?: number | string | undefined;
+        maxLength?: number | undefined;
+        media?: string | undefined;
+        mediaGroup?: string | undefined;
+        method?: string | undefined;
+        min?: number | string | undefined;
+        minLength?: number | undefined;
+        multiple?: boolean | undefined;
+        muted?: boolean | undefined;
+        name?: string | undefined;
+        nonce?: string | undefined;
+        noValidate?: boolean | undefined;
+        open?: boolean | undefined;
+        optimum?: number | undefined;
+        pattern?: string | undefined;
+        placeholder?: string | undefined;
+        playsInline?: boolean | undefined;
+        poster?: string | undefined;
+        preload?: string | undefined;
+        readOnly?: boolean | undefined;
+        rel?: string | undefined;
+        required?: boolean | undefined;
+        reversed?: boolean | undefined;
+        rows?: number | undefined;
+        rowSpan?: number | undefined;
+        sandbox?: string | undefined;
+        scope?: string | undefined;
+        scoped?: boolean | undefined;
+        scrolling?: string | undefined;
+        seamless?: boolean | undefined;
+        selected?: boolean | undefined;
+        shape?: string | undefined;
+        size?: number | undefined;
+        sizes?: string | undefined;
+        span?: number | undefined;
+        src?: string | undefined;
+        srcDoc?: string | undefined;
+        srcLang?: string | undefined;
+        srcSet?: string | undefined;
+        start?: number | undefined;
+        step?: number | string | undefined;
+        summary?: string | undefined;
+        target?: string | undefined;
+        type?: string | undefined;
+        useMap?: string | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        width?: number | string | undefined;
+        wmode?: string | undefined;
+        wrap?: string | undefined;
+    }
+
+    type HTMLAttributeReferrerPolicy =
+        | ''
+        | 'no-referrer'
+        | 'no-referrer-when-downgrade'
+        | 'origin'
+        | 'origin-when-cross-origin'
+        | 'same-origin'
+        | 'strict-origin'
+        | 'strict-origin-when-cross-origin'
+        | 'unsafe-url';
+
+    type HTMLAttributeAnchorTarget =
+        | '_self'
+        | '_blank'
+        | '_parent'
+        | '_top'
+        | (string & {});
+
+    interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
+        download?: any;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        media?: string | undefined;
+        ping?: string | undefined;
+        rel?: string | undefined;
+        target?: HTMLAttributeAnchorTarget | undefined;
+        type?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+    }
+
+    interface AudioHTMLAttributes<T> extends MediaHTMLAttributes<T> {}
+
+    interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
+        alt?: string | undefined;
+        coords?: string | undefined;
+        download?: any;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        media?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        rel?: string | undefined;
+        shape?: string | undefined;
+        target?: string | undefined;
+    }
+
+    interface BaseHTMLAttributes<T> extends HTMLAttributes<T> {
+        href?: string | undefined;
+        target?: string | undefined;
+    }
+
+    interface BlockquoteHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+    }
+
+    interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoFocus?: boolean | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        formAction?: string | undefined;
+        formEncType?: string | undefined;
+        formMethod?: string | undefined;
+        formNoValidate?: boolean | undefined;
+        formTarget?: string | undefined;
+        name?: string | undefined;
+        type?: 'submit' | 'reset' | 'button' | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
+        height?: number | string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface ColHTMLAttributes<T> extends HTMLAttributes<T> {
+        span?: number | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface ColgroupHTMLAttributes<T> extends HTMLAttributes<T> {
+        span?: number | undefined;
+    }
+
+    interface DataHTMLAttributes<T> extends HTMLAttributes<T> {
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
+        open?: boolean | undefined;
+        onToggle?: ReactEventHandler<T> | undefined;
+    }
+
+    interface DelHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+        dateTime?: string | undefined;
+    }
+
+    interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
+        onCancel?: ReactEventHandler<T> |  undefined;
+        onClose?: ReactEventHandler<T> |  undefined;
+        open?: boolean | undefined;
+    }
+
+    interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
+        height?: number | string | undefined;
+        src?: string | undefined;
+        type?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface FieldsetHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        name?: string | undefined;
+    }
+
+    interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
+        acceptCharset?: string | undefined;
+        action?: string | undefined;
+        autoComplete?: string | undefined;
+        encType?: string | undefined;
+        method?: string | undefined;
+        name?: string | undefined;
+        noValidate?: boolean | undefined;
+        target?: string | undefined;
+        rel?: string | undefined;
+    }
+
+    interface HtmlHTMLAttributes<T> extends HTMLAttributes<T> {
+        manifest?: string | undefined;
+    }
+
+    interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
+        allow?: string | undefined;
+        allowFullScreen?: boolean | undefined;
+        allowTransparency?: boolean | undefined;
+        /** @deprecated */
+        frameBorder?: number | string | undefined;
+        height?: number | string | undefined;
+        loading?: "eager" | "lazy" | undefined;
+        /** @deprecated */
+        marginHeight?: number | undefined;
+        /** @deprecated */
+        marginWidth?: number | undefined;
+        name?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        sandbox?: string | undefined;
+        /** @deprecated */
+        scrolling?: string | undefined;
+        seamless?: boolean | undefined;
+        src?: string | undefined;
+        srcDoc?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
+        alt?: string | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        decoding?: "async" | "auto" | "sync" | undefined;
+        height?: number | string | undefined;
+        loading?: "eager" | "lazy" | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        sizes?: string | undefined;
+        src?: string | undefined;
+        srcSet?: string | undefined;
+        useMap?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface InsHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+        dateTime?: string | undefined;
+    }
+
+    type HTMLInputTypeAttribute =
+        | 'button'
+        | 'checkbox'
+        | 'color'
+        | 'date'
+        | 'datetime-local'
+        | 'email'
+        | 'file'
+        | 'hidden'
+        | 'image'
+        | 'month'
+        | 'number'
+        | 'password'
+        | 'radio'
+        | 'range'
+        | 'reset'
+        | 'search'
+        | 'submit'
+        | 'tel'
+        | 'text'
+        | 'time'
+        | 'url'
+        | 'week'
+        | (string & {});
+
+    interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
+        accept?: string | undefined;
+        alt?: string | undefined;
+        autoComplete?: string | undefined;
+        autoFocus?: boolean | undefined;
+        capture?: boolean | 'user' | 'environment' | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+        checked?: boolean | undefined;
+        crossOrigin?: string | undefined;
+        disabled?: boolean | undefined;
+        enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send' | undefined;
+        form?: string | undefined;
+        formAction?: string | undefined;
+        formEncType?: string | undefined;
+        formMethod?: string | undefined;
+        formNoValidate?: boolean | undefined;
+        formTarget?: string | undefined;
+        height?: number | string | undefined;
+        list?: string | undefined;
+        max?: number | string | undefined;
+        maxLength?: number | undefined;
+        min?: number | string | undefined;
+        minLength?: number | undefined;
+        multiple?: boolean | undefined;
+        name?: string | undefined;
+        pattern?: string | undefined;
+        placeholder?: string | undefined;
+        readOnly?: boolean | undefined;
+        required?: boolean | undefined;
+        size?: number | undefined;
+        src?: string | undefined;
+        step?: number | string | undefined;
+        type?: HTMLInputTypeAttribute | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        width?: number | string | undefined;
+
+        onChange?: ChangeEventHandler<T> | undefined;
+    }
+
+    interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoFocus?: boolean | undefined;
+        challenge?: string | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        keyType?: string | undefined;
+        keyParams?: string | undefined;
+        name?: string | undefined;
+    }
+
+    interface LabelHTMLAttributes<T> extends HTMLAttributes<T> {
+        form?: string | undefined;
+        htmlFor?: string | undefined;
+    }
+
+    interface LiHTMLAttributes<T> extends HTMLAttributes<T> {
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
+        as?: string | undefined;
+        crossOrigin?: string | undefined;
+        href?: string | undefined;
+        hrefLang?: string | undefined;
+        integrity?: string | undefined;
+        media?: string | undefined;
+        imageSrcSet?: string | undefined;
+        imageSizes?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        rel?: string | undefined;
+        sizes?: string | undefined;
+        type?: string | undefined;
+        charSet?: string | undefined;
+    }
+
+    interface MapHTMLAttributes<T> extends HTMLAttributes<T> {
+        name?: string | undefined;
+    }
+
+    interface MenuHTMLAttributes<T> extends HTMLAttributes<T> {
+        type?: string | undefined;
+    }
+
+    interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoPlay?: boolean | undefined;
+        controls?: boolean | undefined;
+        controlsList?: string | undefined;
+        crossOrigin?: string | undefined;
+        loop?: boolean | undefined;
+        mediaGroup?: string | undefined;
+        muted?: boolean | undefined;
+        playsInline?: boolean | undefined;
+        preload?: string | undefined;
+        src?: string | undefined;
+    }
+
+    interface MetaHTMLAttributes<T> extends HTMLAttributes<T> {
+        charSet?: string | undefined;
+        content?: string | undefined;
+        httpEquiv?: string | undefined;
+        name?: string | undefined;
+        media?: string | undefined;
+    }
+
+    interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
+        form?: string | undefined;
+        high?: number | undefined;
+        low?: number | undefined;
+        max?: number | string | undefined;
+        min?: number | string | undefined;
+        optimum?: number | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface QuoteHTMLAttributes<T> extends HTMLAttributes<T> {
+        cite?: string | undefined;
+    }
+
+    interface ObjectHTMLAttributes<T> extends HTMLAttributes<T> {
+        classID?: string | undefined;
+        data?: string | undefined;
+        form?: string | undefined;
+        height?: number | string | undefined;
+        name?: string | undefined;
+        type?: string | undefined;
+        useMap?: string | undefined;
+        width?: number | string | undefined;
+        wmode?: string | undefined;
+    }
+
+    interface OlHTMLAttributes<T> extends HTMLAttributes<T> {
+        reversed?: boolean | undefined;
+        start?: number | undefined;
+        type?: '1' | 'a' | 'A' | 'i' | 'I' | undefined;
+    }
+
+    interface OptgroupHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        label?: string | undefined;
+    }
+
+    interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
+        disabled?: boolean | undefined;
+        label?: string | undefined;
+        selected?: boolean | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
+        form?: string | undefined;
+        htmlFor?: string | undefined;
+        name?: string | undefined;
+    }
+
+    interface ParamHTMLAttributes<T> extends HTMLAttributes<T> {
+        name?: string | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface ProgressHTMLAttributes<T> extends HTMLAttributes<T> {
+        max?: number | string | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+    }
+
+    interface SlotHTMLAttributes<T> extends HTMLAttributes<T> {
+        name?: string | undefined;
+    }
+
+    interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
+        async?: boolean | undefined;
+        /** @deprecated */
+        charSet?: string | undefined;
+        crossOrigin?: string | undefined;
+        defer?: boolean | undefined;
+        integrity?: string | undefined;
+        noModule?: boolean | undefined;
+        nonce?: string | undefined;
+        referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
+        src?: string | undefined;
+        type?: string | undefined;
+    }
+
+    interface SelectHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoComplete?: string | undefined;
+        autoFocus?: boolean | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        multiple?: boolean | undefined;
+        name?: string | undefined;
+        required?: boolean | undefined;
+        size?: number | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        onChange?: ChangeEventHandler<T> | undefined;
+    }
+
+    interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
+        height?: number | string | undefined;
+        media?: string | undefined;
+        sizes?: string | undefined;
+        src?: string | undefined;
+        srcSet?: string | undefined;
+        type?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+        media?: string | undefined;
+        nonce?: string | undefined;
+        scoped?: boolean | undefined;
+        type?: string | undefined;
+    }
+
+    interface TableHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: "left" | "center" | "right" | undefined;
+        bgcolor?: string | undefined;
+        border?: number | undefined;
+        cellPadding?: number | string | undefined;
+        cellSpacing?: number | string | undefined;
+        frame?: boolean | undefined;
+        rules?: "none" | "groups" | "rows" | "columns" | "all" | undefined;
+        summary?: string | undefined;
+        width?: number | string | undefined;
+    }
+
+    interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoComplete?: string | undefined;
+        autoFocus?: boolean | undefined;
+        cols?: number | undefined;
+        dirName?: string | undefined;
+        disabled?: boolean | undefined;
+        form?: string | undefined;
+        maxLength?: number | undefined;
+        minLength?: number | undefined;
+        name?: string | undefined;
+        placeholder?: string | undefined;
+        readOnly?: boolean | undefined;
+        required?: boolean | undefined;
+        rows?: number | undefined;
+        value?: string | ReadonlyArray<string> | number | undefined;
+        wrap?: string | undefined;
+
+        onChange?: ChangeEventHandler<T> | undefined;
+    }
+
+    interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+        colSpan?: number | undefined;
+        headers?: string | undefined;
+        rowSpan?: number | undefined;
+        scope?: string | undefined;
+        abbr?: string | undefined;
+        height?: number | string | undefined;
+        width?: number | string | undefined;
+        valign?: "top" | "middle" | "bottom" | "baseline" | undefined;
+    }
+
+    interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: "left" | "center" | "right" | "justify" | "char" | undefined;
+        colSpan?: number | undefined;
+        headers?: string | undefined;
+        rowSpan?: number | undefined;
+        scope?: string | undefined;
+        abbr?: string | undefined;
+    }
+
+    interface TimeHTMLAttributes<T> extends HTMLAttributes<T> {
+        dateTime?: string | undefined;
+    }
+
+    interface TrackHTMLAttributes<T> extends HTMLAttributes<T> {
+        default?: boolean | undefined;
+        kind?: string | undefined;
+        label?: string | undefined;
+        src?: string | undefined;
+        srcLang?: string | undefined;
+    }
+
+    interface VideoHTMLAttributes<T> extends MediaHTMLAttributes<T> {
+        height?: number | string | undefined;
+        playsInline?: boolean | undefined;
+        poster?: string | undefined;
+        width?: number | string | undefined;
+        disablePictureInPicture?: boolean | undefined;
+        disableRemotePlayback?: boolean | undefined;
+    }
+
+    // this list is "complete" in that it contains every SVG attribute
+    // that React supports, but the types can be improved.
+    // Full list here: https://facebook.github.io/react/docs/dom-elements.html
+    //
+    // The three broad type categories are (in order of restrictiveness):
+    //   - "number | string"
+    //   - "string"
+    //   - union of string literals
+    interface SVGAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+        // Attributes which also defined in HTMLAttributes
+        // See comment in SVGDOMPropertyConfig.js
+        className?: string | undefined;
+        color?: string | undefined;
+        height?: number | string | undefined;
+        id?: string | undefined;
+        lang?: string | undefined;
+        max?: number | string | undefined;
+        media?: string | undefined;
+        method?: string | undefined;
+        min?: number | string | undefined;
+        name?: string | undefined;
+        style?: CSSProperties | undefined;
+        target?: string | undefined;
+        type?: string | undefined;
+        width?: number | string | undefined;
+
+        // Other HTML properties supported by SVG elements in browsers
+        role?: AriaRole | undefined;
+        tabIndex?: number | undefined;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+
+        // SVG Specific attributes
+        accentHeight?: number | string | undefined;
+        accumulate?: "none" | "sum" | undefined;
+        additive?: "replace" | "sum" | undefined;
+        alignmentBaseline?: "auto" | "baseline" | "before-edge" | "text-before-edge" | "middle" | "central" | "after-edge" |
+        "text-after-edge" | "ideographic" | "alphabetic" | "hanging" | "mathematical" | "inherit" | undefined;
+        allowReorder?: "no" | "yes" | undefined;
+        alphabetic?: number | string | undefined;
+        amplitude?: number | string | undefined;
+        arabicForm?: "initial" | "medial" | "terminal" | "isolated" | undefined;
+        ascent?: number | string | undefined;
+        attributeName?: string | undefined;
+        attributeType?: string | undefined;
+        autoReverse?: Booleanish | undefined;
+        azimuth?: number | string | undefined;
+        baseFrequency?: number | string | undefined;
+        baselineShift?: number | string | undefined;
+        baseProfile?: number | string | undefined;
+        bbox?: number | string | undefined;
+        begin?: number | string | undefined;
+        bias?: number | string | undefined;
+        by?: number | string | undefined;
+        calcMode?: number | string | undefined;
+        capHeight?: number | string | undefined;
+        clip?: number | string | undefined;
+        clipPath?: string | undefined;
+        clipPathUnits?: number | string | undefined;
+        clipRule?: number | string | undefined;
+        colorInterpolation?: number | string | undefined;
+        colorInterpolationFilters?: "auto" | "sRGB" | "linearRGB" | "inherit" | undefined;
+        colorProfile?: number | string | undefined;
+        colorRendering?: number | string | undefined;
+        contentScriptType?: number | string | undefined;
+        contentStyleType?: number | string | undefined;
+        cursor?: number | string | undefined;
+        cx?: number | string | undefined;
+        cy?: number | string | undefined;
+        d?: string | undefined;
+        decelerate?: number | string | undefined;
+        descent?: number | string | undefined;
+        diffuseConstant?: number | string | undefined;
+        direction?: number | string | undefined;
+        display?: number | string | undefined;
+        divisor?: number | string | undefined;
+        dominantBaseline?: number | string | undefined;
+        dur?: number | string | undefined;
+        dx?: number | string | undefined;
+        dy?: number | string | undefined;
+        edgeMode?: number | string | undefined;
+        elevation?: number | string | undefined;
+        enableBackground?: number | string | undefined;
+        end?: number | string | undefined;
+        exponent?: number | string | undefined;
+        externalResourcesRequired?: Booleanish | undefined;
+        fill?: string | undefined;
+        fillOpacity?: number | string | undefined;
+        fillRule?: "nonzero" | "evenodd" | "inherit" | undefined;
+        filter?: string | undefined;
+        filterRes?: number | string | undefined;
+        filterUnits?: number | string | undefined;
+        floodColor?: number | string | undefined;
+        floodOpacity?: number | string | undefined;
+        focusable?: Booleanish | "auto" | undefined;
+        fontFamily?: string | undefined;
+        fontSize?: number | string | undefined;
+        fontSizeAdjust?: number | string | undefined;
+        fontStretch?: number | string | undefined;
+        fontStyle?: number | string | undefined;
+        fontVariant?: number | string | undefined;
+        fontWeight?: number | string | undefined;
+        format?: number | string | undefined;
+        fr?: number | string | undefined;
+        from?: number | string | undefined;
+        fx?: number | string | undefined;
+        fy?: number | string | undefined;
+        g1?: number | string | undefined;
+        g2?: number | string | undefined;
+        glyphName?: number | string | undefined;
+        glyphOrientationHorizontal?: number | string | undefined;
+        glyphOrientationVertical?: number | string | undefined;
+        glyphRef?: number | string | undefined;
+        gradientTransform?: string | undefined;
+        gradientUnits?: string | undefined;
+        hanging?: number | string | undefined;
+        horizAdvX?: number | string | undefined;
+        horizOriginX?: number | string | undefined;
+        href?: string | undefined;
+        ideographic?: number | string | undefined;
+        imageRendering?: number | string | undefined;
+        in2?: number | string | undefined;
+        in?: string | undefined;
+        intercept?: number | string | undefined;
+        k1?: number | string | undefined;
+        k2?: number | string | undefined;
+        k3?: number | string | undefined;
+        k4?: number | string | undefined;
+        k?: number | string | undefined;
+        kernelMatrix?: number | string | undefined;
+        kernelUnitLength?: number | string | undefined;
+        kerning?: number | string | undefined;
+        keyPoints?: number | string | undefined;
+        keySplines?: number | string | undefined;
+        keyTimes?: number | string | undefined;
+        lengthAdjust?: number | string | undefined;
+        letterSpacing?: number | string | undefined;
+        lightingColor?: number | string | undefined;
+        limitingConeAngle?: number | string | undefined;
+        local?: number | string | undefined;
+        markerEnd?: string | undefined;
+        markerHeight?: number | string | undefined;
+        markerMid?: string | undefined;
+        markerStart?: string | undefined;
+        markerUnits?: number | string | undefined;
+        markerWidth?: number | string | undefined;
+        mask?: string | undefined;
+        maskContentUnits?: number | string | undefined;
+        maskUnits?: number | string | undefined;
+        mathematical?: number | string | undefined;
+        mode?: number | string | undefined;
+        numOctaves?: number | string | undefined;
+        offset?: number | string | undefined;
+        opacity?: number | string | undefined;
+        operator?: number | string | undefined;
+        order?: number | string | undefined;
+        orient?: number | string | undefined;
+        orientation?: number | string | undefined;
+        origin?: number | string | undefined;
+        overflow?: number | string | undefined;
+        overlinePosition?: number | string | undefined;
+        overlineThickness?: number | string | undefined;
+        paintOrder?: number | string | undefined;
+        panose1?: number | string | undefined;
+        path?: string | undefined;
+        pathLength?: number | string | undefined;
+        patternContentUnits?: string | undefined;
+        patternTransform?: number | string | undefined;
+        patternUnits?: string | undefined;
+        pointerEvents?: number | string | undefined;
+        points?: string | undefined;
+        pointsAtX?: number | string | undefined;
+        pointsAtY?: number | string | undefined;
+        pointsAtZ?: number | string | undefined;
+        preserveAlpha?: Booleanish | undefined;
+        preserveAspectRatio?: string | undefined;
+        primitiveUnits?: number | string | undefined;
+        r?: number | string | undefined;
+        radius?: number | string | undefined;
+        refX?: number | string | undefined;
+        refY?: number | string | undefined;
+        renderingIntent?: number | string | undefined;
+        repeatCount?: number | string | undefined;
+        repeatDur?: number | string | undefined;
+        requiredExtensions?: number | string | undefined;
+        requiredFeatures?: number | string | undefined;
+        restart?: number | string | undefined;
+        result?: string | undefined;
+        rotate?: number | string | undefined;
+        rx?: number | string | undefined;
+        ry?: number | string | undefined;
+        scale?: number | string | undefined;
+        seed?: number | string | undefined;
+        shapeRendering?: number | string | undefined;
+        slope?: number | string | undefined;
+        spacing?: number | string | undefined;
+        specularConstant?: number | string | undefined;
+        specularExponent?: number | string | undefined;
+        speed?: number | string | undefined;
+        spreadMethod?: string | undefined;
+        startOffset?: number | string | undefined;
+        stdDeviation?: number | string | undefined;
+        stemh?: number | string | undefined;
+        stemv?: number | string | undefined;
+        stitchTiles?: number | string | undefined;
+        stopColor?: string | undefined;
+        stopOpacity?: number | string | undefined;
+        strikethroughPosition?: number | string | undefined;
+        strikethroughThickness?: number | string | undefined;
+        string?: number | string | undefined;
+        stroke?: string | undefined;
+        strokeDasharray?: string | number | undefined;
+        strokeDashoffset?: string | number | undefined;
+        strokeLinecap?: "butt" | "round" | "square" | "inherit" | undefined;
+        strokeLinejoin?: "miter" | "round" | "bevel" | "inherit" | undefined;
+        strokeMiterlimit?: number | string | undefined;
+        strokeOpacity?: number | string | undefined;
+        strokeWidth?: number | string | undefined;
+        surfaceScale?: number | string | undefined;
+        systemLanguage?: number | string | undefined;
+        tableValues?: number | string | undefined;
+        targetX?: number | string | undefined;
+        targetY?: number | string | undefined;
+        textAnchor?: string | undefined;
+        textDecoration?: number | string | undefined;
+        textLength?: number | string | undefined;
+        textRendering?: number | string | undefined;
+        to?: number | string | undefined;
+        transform?: string | undefined;
+        u1?: number | string | undefined;
+        u2?: number | string | undefined;
+        underlinePosition?: number | string | undefined;
+        underlineThickness?: number | string | undefined;
+        unicode?: number | string | undefined;
+        unicodeBidi?: number | string | undefined;
+        unicodeRange?: number | string | undefined;
+        unitsPerEm?: number | string | undefined;
+        vAlphabetic?: number | string | undefined;
+        values?: string | undefined;
+        vectorEffect?: number | string | undefined;
+        version?: string | undefined;
+        vertAdvY?: number | string | undefined;
+        vertOriginX?: number | string | undefined;
+        vertOriginY?: number | string | undefined;
+        vHanging?: number | string | undefined;
+        vIdeographic?: number | string | undefined;
+        viewBox?: string | undefined;
+        viewTarget?: number | string | undefined;
+        visibility?: number | string | undefined;
+        vMathematical?: number | string | undefined;
+        widths?: number | string | undefined;
+        wordSpacing?: number | string | undefined;
+        writingMode?: number | string | undefined;
+        x1?: number | string | undefined;
+        x2?: number | string | undefined;
+        x?: number | string | undefined;
+        xChannelSelector?: string | undefined;
+        xHeight?: number | string | undefined;
+        xlinkActuate?: string | undefined;
+        xlinkArcrole?: string | undefined;
+        xlinkHref?: string | undefined;
+        xlinkRole?: string | undefined;
+        xlinkShow?: string | undefined;
+        xlinkTitle?: string | undefined;
+        xlinkType?: string | undefined;
+        xmlBase?: string | undefined;
+        xmlLang?: string | undefined;
+        xmlns?: string | undefined;
+        xmlnsXlink?: string | undefined;
+        xmlSpace?: string | undefined;
+        y1?: number | string | undefined;
+        y2?: number | string | undefined;
+        y?: number | string | undefined;
+        yChannelSelector?: string | undefined;
+        z?: number | string | undefined;
+        zoomAndPan?: string | undefined;
+    }
+
+    interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
+        allowFullScreen?: boolean | undefined;
+        allowpopups?: boolean | undefined;
+        autoFocus?: boolean | undefined;
+        autosize?: boolean | undefined;
+        blinkfeatures?: string | undefined;
+        disableblinkfeatures?: string | undefined;
+        disableguestresize?: boolean | undefined;
+        disablewebsecurity?: boolean | undefined;
+        guestinstance?: string | undefined;
+        httpreferrer?: string | undefined;
+        nodeintegration?: boolean | undefined;
+        partition?: string | undefined;
+        plugins?: boolean | undefined;
+        preload?: string | undefined;
+        src?: string | undefined;
+        useragent?: string | undefined;
+        webpreferences?: string | undefined;
+    }
+
+    //
+    // React.DOM
+    // ----------------------------------------------------------------------
+
+    interface ReactHTML {
+        a: DetailedHTMLFactory<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+        abbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        address: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        area: DetailedHTMLFactory<AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement>;
+        article: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        aside: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        audio: DetailedHTMLFactory<AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
+        b: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        base: DetailedHTMLFactory<BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement>;
+        bdi: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        bdo: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        big: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        blockquote: DetailedHTMLFactory<BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+        body: DetailedHTMLFactory<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+        br: DetailedHTMLFactory<HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
+        button: DetailedHTMLFactory<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+        canvas: DetailedHTMLFactory<CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement>;
+        caption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        cite: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        code: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        col: DetailedHTMLFactory<ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+        colgroup: DetailedHTMLFactory<ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+        data: DetailedHTMLFactory<DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
+        datalist: DetailedHTMLFactory<HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
+        dd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        del: DetailedHTMLFactory<DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+        details: DetailedHTMLFactory<DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement>;
+        dfn: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        dialog: DetailedHTMLFactory<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
+        div: DetailedHTMLFactory<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+        dl: DetailedHTMLFactory<HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
+        dt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        em: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        embed: DetailedHTMLFactory<EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>;
+        fieldset: DetailedHTMLFactory<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
+        figcaption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        figure: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        footer: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        form: DetailedHTMLFactory<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
+        h1: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h2: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h3: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h4: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h5: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        h6: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+        head: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLHeadElement>;
+        header: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        hgroup: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        hr: DetailedHTMLFactory<HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
+        html: DetailedHTMLFactory<HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>;
+        i: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        iframe: DetailedHTMLFactory<IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
+        img: DetailedHTMLFactory<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
+        input: DetailedHTMLFactory<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+        ins: DetailedHTMLFactory<InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
+        kbd: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        keygen: DetailedHTMLFactory<KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
+        label: DetailedHTMLFactory<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
+        legend: DetailedHTMLFactory<HTMLAttributes<HTMLLegendElement>, HTMLLegendElement>;
+        li: DetailedHTMLFactory<LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
+        link: DetailedHTMLFactory<LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement>;
+        main: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        map: DetailedHTMLFactory<MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
+        mark: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        menu: DetailedHTMLFactory<MenuHTMLAttributes<HTMLElement>, HTMLElement>;
+        menuitem: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        meta: DetailedHTMLFactory<MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
+        meter: DetailedHTMLFactory<MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement>;
+        nav: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        noscript: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        object: DetailedHTMLFactory<ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
+        ol: DetailedHTMLFactory<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
+        optgroup: DetailedHTMLFactory<OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
+        option: DetailedHTMLFactory<OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
+        output: DetailedHTMLFactory<OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement>;
+        p: DetailedHTMLFactory<HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
+        param: DetailedHTMLFactory<ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
+        picture: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        pre: DetailedHTMLFactory<HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
+        progress: DetailedHTMLFactory<ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement>;
+        q: DetailedHTMLFactory<QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+        rp: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        rt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        ruby: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        s: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        samp: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        slot: DetailedHTMLFactory<SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement>;
+        script: DetailedHTMLFactory<ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement>;
+        section: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        select: DetailedHTMLFactory<SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
+        small: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        source: DetailedHTMLFactory<SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement>;
+        span: DetailedHTMLFactory<HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
+        strong: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        style: DetailedHTMLFactory<StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement>;
+        sub: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        summary: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        sup: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        table: DetailedHTMLFactory<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
+        template: DetailedHTMLFactory<HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement>;
+        tbody: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+        td: DetailedHTMLFactory<TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>;
+        textarea: DetailedHTMLFactory<TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>;
+        tfoot: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+        th: DetailedHTMLFactory<ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
+        thead: DetailedHTMLFactory<HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+        time: DetailedHTMLFactory<TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement>;
+        title: DetailedHTMLFactory<HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
+        tr: DetailedHTMLFactory<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+        track: DetailedHTMLFactory<TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
+        u: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        ul: DetailedHTMLFactory<HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
+        "var": DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        video: DetailedHTMLFactory<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
+        wbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        webview: DetailedHTMLFactory<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
+    }
+
+    interface ReactSVG {
+        animate: SVGFactory;
+        circle: SVGFactory;
+        clipPath: SVGFactory;
+        defs: SVGFactory;
+        desc: SVGFactory;
+        ellipse: SVGFactory;
+        feBlend: SVGFactory;
+        feColorMatrix: SVGFactory;
+        feComponentTransfer: SVGFactory;
+        feComposite: SVGFactory;
+        feConvolveMatrix: SVGFactory;
+        feDiffuseLighting: SVGFactory;
+        feDisplacementMap: SVGFactory;
+        feDistantLight: SVGFactory;
+        feDropShadow: SVGFactory;
+        feFlood: SVGFactory;
+        feFuncA: SVGFactory;
+        feFuncB: SVGFactory;
+        feFuncG: SVGFactory;
+        feFuncR: SVGFactory;
+        feGaussianBlur: SVGFactory;
+        feImage: SVGFactory;
+        feMerge: SVGFactory;
+        feMergeNode: SVGFactory;
+        feMorphology: SVGFactory;
+        feOffset: SVGFactory;
+        fePointLight: SVGFactory;
+        feSpecularLighting: SVGFactory;
+        feSpotLight: SVGFactory;
+        feTile: SVGFactory;
+        feTurbulence: SVGFactory;
+        filter: SVGFactory;
+        foreignObject: SVGFactory;
+        g: SVGFactory;
+        image: SVGFactory;
+        line: SVGFactory;
+        linearGradient: SVGFactory;
+        marker: SVGFactory;
+        mask: SVGFactory;
+        metadata: SVGFactory;
+        path: SVGFactory;
+        pattern: SVGFactory;
+        polygon: SVGFactory;
+        polyline: SVGFactory;
+        radialGradient: SVGFactory;
+        rect: SVGFactory;
+        stop: SVGFactory;
+        svg: SVGFactory;
+        switch: SVGFactory;
+        symbol: SVGFactory;
+        text: SVGFactory;
+        textPath: SVGFactory;
+        tspan: SVGFactory;
+        use: SVGFactory;
+        view: SVGFactory;
+    }
+
+    interface ReactDOM extends ReactHTML, ReactSVG { }
+
+    //
+    // React.PropTypes
+    // ----------------------------------------------------------------------
+
+    type Validator<T> = PropTypes.Validator<T>;
+
+    type Requireable<T> = PropTypes.Requireable<T>;
+
+    type ValidationMap<T> = PropTypes.ValidationMap<T>;
+
+    type WeakValidationMap<T> = {
+        [K in keyof T]?: null extends T[K]
+            ? Validator<T[K] | null | undefined>
+            : undefined extends T[K]
+            ? Validator<T[K] | null | undefined>
+            : Validator<T[K]>
+    };
+
+    interface ReactPropTypes {
+        any: typeof PropTypes.any;
+        array: typeof PropTypes.array;
+        bool: typeof PropTypes.bool;
+        func: typeof PropTypes.func;
+        number: typeof PropTypes.number;
+        object: typeof PropTypes.object;
+        string: typeof PropTypes.string;
+        node: typeof PropTypes.node;
+        element: typeof PropTypes.element;
+        instanceOf: typeof PropTypes.instanceOf;
+        oneOf: typeof PropTypes.oneOf;
+        oneOfType: typeof PropTypes.oneOfType;
+        arrayOf: typeof PropTypes.arrayOf;
+        objectOf: typeof PropTypes.objectOf;
+        shape: typeof PropTypes.shape;
+        exact: typeof PropTypes.exact;
+    }
+
+    //
+    // React.Children
+    // ----------------------------------------------------------------------
+
+    /**
+     * @deprecated - Use `typeof React.Children` instead.
+     */
+    // Sync with type of `const Children`.
+    interface ReactChildren {
+        map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T):
+            C extends null | undefined ? C : Array<Exclude<T, boolean | null | undefined>>;
+        forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
+        count(children: any): number;
+        only<C>(children: C): C extends any[] ? never : C;
+        toArray(children: ReactNode | ReactNode[]): Array<Exclude<ReactNode, boolean | null | undefined>>;
+    }
+
+    //
+    // Browser Interfaces
+    // https://github.com/nikeee/2048-typescript/blob/master/2048/js/touch.d.ts
+    // ----------------------------------------------------------------------
+
+    interface AbstractView {
+        styleMedia: StyleMedia;
+        document: Document;
+    }
+
+    interface Touch {
+        identifier: number;
+        target: EventTarget;
+        screenX: number;
+        screenY: number;
+        clientX: number;
+        clientY: number;
+        pageX: number;
+        pageY: number;
+    }
+
+    interface TouchList {
+        [index: number]: Touch;
+        length: number;
+        item(index: number): Touch;
+        identifiedTouch(identifier: number): Touch;
+    }
+
+    //
+    // Error Interfaces
+    // ----------------------------------------------------------------------
+    interface ErrorInfo {
+        /**
+         * Captures which component contained the exception, and its ancestors.
+         */
+        componentStack: string;
+    }
+}
+
+// naked 'any' type in a conditional type will short circuit and union both the then/else branches
+// so boolean is only resolved for T = any
+type IsExactlyAny<T> = boolean extends (T extends never ? true : false) ? true : false;
+
+type ExactlyAnyPropertyKeys<T> = { [K in keyof T]: IsExactlyAny<T[K]> extends true ? K : never }[keyof T];
+type NotExactlyAnyPropertyKeys<T> = Exclude<keyof T, ExactlyAnyPropertyKeys<T>>;
+
+// Try to resolve ill-defined props like for JS users: props can be any, or sometimes objects with properties of type any
+type MergePropTypes<P, T> =
+    // Distribute over P in case it is a union type
+    P extends any
+        // If props is type any, use propTypes definitions
+        ? IsExactlyAny<P> extends true ? T :
+            // If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
+            string extends keyof P ? P :
+                // Prefer declared types which are not exactly any
+                & Pick<P, NotExactlyAnyPropertyKeys<P>>
+                // For props which are exactly any, use the type inferred from propTypes if present
+                & Pick<T, Exclude<keyof T, NotExactlyAnyPropertyKeys<P>>>
+                // Keep leftover props not specified in propTypes
+                & Pick<P, Exclude<keyof P, keyof T>>
+        : never;
+
+type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
+
+// Any prop that has a default prop becomes optional, but its type is unchanged
+// Undeclared default props are augmented into the resulting allowable attributes
+// If declared props have indexed properties, ignore default props entirely as keyof gets widened
+// Wrap in an outer-level conditional type to allow distribution over props that are unions
+type Defaultize<P, D> = P extends any
+    ? string extends keyof P ? P :
+        & Pick<P, Exclude<keyof P, keyof D>>
+        & InexactPartial<Pick<P, Extract<keyof P, keyof D>>>
+        & InexactPartial<Pick<D, Exclude<keyof D, keyof P>>>
+    : never;
+
+type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D; }
+    ? Defaultize<MergePropTypes<P, PropTypes.InferProps<T>>, D>
+    : C extends { propTypes: infer T; }
+        ? MergePropTypes<P, PropTypes.InferProps<T>>
+        : C extends { defaultProps: infer D; }
+            ? Defaultize<P, D>
+            : P;
+
+declare global {
+    namespace JSX {
+        interface Element extends React.ReactElement<any, any> { }
+        interface ElementClass extends React.Component<any> {
+            render(): React.ReactNode;
+        }
+        interface ElementAttributesProperty { props: {}; }
+        interface ElementChildrenAttribute { children: {}; }
+
+        // We can't recurse forever because `type` can't be self-referential;
+        // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
+        type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
+            ? T extends React.MemoExoticComponent<infer U> | React.LazyExoticComponent<infer U>
+                ? ReactManagedAttributes<U, P>
+                : ReactManagedAttributes<T, P>
+            : ReactManagedAttributes<C, P>;
+
+        interface IntrinsicAttributes extends React.Attributes { }
+        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
+
+        interface IntrinsicElements {
+            // HTML
+            a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+            abbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            address: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            area: React.DetailedHTMLProps<React.AreaHTMLAttributes<HTMLAreaElement>, HTMLAreaElement>;
+            article: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            aside: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            audio: React.DetailedHTMLProps<React.AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
+            b: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            base: React.DetailedHTMLProps<React.BaseHTMLAttributes<HTMLBaseElement>, HTMLBaseElement>;
+            bdi: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            bdo: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            big: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            blockquote: React.DetailedHTMLProps<React.BlockquoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+            body: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>;
+            br: React.DetailedHTMLProps<React.HTMLAttributes<HTMLBRElement>, HTMLBRElement>;
+            button: React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+            canvas: React.DetailedHTMLProps<React.CanvasHTMLAttributes<HTMLCanvasElement>, HTMLCanvasElement>;
+            caption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            cite: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            code: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            col: React.DetailedHTMLProps<React.ColHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+            colgroup: React.DetailedHTMLProps<React.ColgroupHTMLAttributes<HTMLTableColElement>, HTMLTableColElement>;
+            data: React.DetailedHTMLProps<React.DataHTMLAttributes<HTMLDataElement>, HTMLDataElement>;
+            datalist: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDataListElement>, HTMLDataListElement>;
+            dd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            del: React.DetailedHTMLProps<React.DelHTMLAttributes<HTMLModElement>, HTMLModElement>;
+            details: React.DetailedHTMLProps<React.DetailsHTMLAttributes<HTMLDetailsElement>, HTMLDetailsElement>;
+            dfn: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            dialog: React.DetailedHTMLProps<React.DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
+            div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
+            dl: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
+            dt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            em: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            embed: React.DetailedHTMLProps<React.EmbedHTMLAttributes<HTMLEmbedElement>, HTMLEmbedElement>;
+            fieldset: React.DetailedHTMLProps<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
+            figcaption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            figure: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            footer: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            form: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
+            h1: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h2: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h3: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h4: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h5: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            h6: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
+            head: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadElement>, HTMLHeadElement>;
+            header: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            hgroup: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            hr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHRElement>, HTMLHRElement>;
+            html: React.DetailedHTMLProps<React.HtmlHTMLAttributes<HTMLHtmlElement>, HTMLHtmlElement>;
+            i: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            iframe: React.DetailedHTMLProps<React.IframeHTMLAttributes<HTMLIFrameElement>, HTMLIFrameElement>;
+            img: React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
+            input: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+            ins: React.DetailedHTMLProps<React.InsHTMLAttributes<HTMLModElement>, HTMLModElement>;
+            kbd: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            keygen: React.DetailedHTMLProps<React.KeygenHTMLAttributes<HTMLElement>, HTMLElement>;
+            label: React.DetailedHTMLProps<React.LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>;
+            legend: React.DetailedHTMLProps<React.HTMLAttributes<HTMLLegendElement>, HTMLLegendElement>;
+            li: React.DetailedHTMLProps<React.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>;
+            link: React.DetailedHTMLProps<React.LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement>;
+            main: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            map: React.DetailedHTMLProps<React.MapHTMLAttributes<HTMLMapElement>, HTMLMapElement>;
+            mark: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            menu: React.DetailedHTMLProps<React.MenuHTMLAttributes<HTMLElement>, HTMLElement>;
+            menuitem: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            meta: React.DetailedHTMLProps<React.MetaHTMLAttributes<HTMLMetaElement>, HTMLMetaElement>;
+            meter: React.DetailedHTMLProps<React.MeterHTMLAttributes<HTMLMeterElement>, HTMLMeterElement>;
+            nav: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            noindex: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            noscript: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            object: React.DetailedHTMLProps<React.ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement>;
+            ol: React.DetailedHTMLProps<React.OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>;
+            optgroup: React.DetailedHTMLProps<React.OptgroupHTMLAttributes<HTMLOptGroupElement>, HTMLOptGroupElement>;
+            option: React.DetailedHTMLProps<React.OptionHTMLAttributes<HTMLOptionElement>, HTMLOptionElement>;
+            output: React.DetailedHTMLProps<React.OutputHTMLAttributes<HTMLOutputElement>, HTMLOutputElement>;
+            p: React.DetailedHTMLProps<React.HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>;
+            param: React.DetailedHTMLProps<React.ParamHTMLAttributes<HTMLParamElement>, HTMLParamElement>;
+            picture: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            pre: React.DetailedHTMLProps<React.HTMLAttributes<HTMLPreElement>, HTMLPreElement>;
+            progress: React.DetailedHTMLProps<React.ProgressHTMLAttributes<HTMLProgressElement>, HTMLProgressElement>;
+            q: React.DetailedHTMLProps<React.QuoteHTMLAttributes<HTMLQuoteElement>, HTMLQuoteElement>;
+            rp: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            rt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            ruby: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            s: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            samp: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            slot: React.DetailedHTMLProps<React.SlotHTMLAttributes<HTMLSlotElement>, HTMLSlotElement>;
+            script: React.DetailedHTMLProps<React.ScriptHTMLAttributes<HTMLScriptElement>, HTMLScriptElement>;
+            section: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            select: React.DetailedHTMLProps<React.SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>;
+            small: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            source: React.DetailedHTMLProps<React.SourceHTMLAttributes<HTMLSourceElement>, HTMLSourceElement>;
+            span: React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>;
+            strong: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            style: React.DetailedHTMLProps<React.StyleHTMLAttributes<HTMLStyleElement>, HTMLStyleElement>;
+            sub: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            summary: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            sup: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            table: React.DetailedHTMLProps<React.TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>;
+            template: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTemplateElement>, HTMLTemplateElement>;
+            tbody: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            td: React.DetailedHTMLProps<React.TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement>;
+            textarea: React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>;
+            tfoot: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            th: React.DetailedHTMLProps<React.ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement>;
+            thead: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement>;
+            time: React.DetailedHTMLProps<React.TimeHTMLAttributes<HTMLTimeElement>, HTMLTimeElement>;
+            title: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTitleElement>, HTMLTitleElement>;
+            tr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
+            track: React.DetailedHTMLProps<React.TrackHTMLAttributes<HTMLTrackElement>, HTMLTrackElement>;
+            u: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            ul: React.DetailedHTMLProps<React.HTMLAttributes<HTMLUListElement>, HTMLUListElement>;
+            "var": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            video: React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
+            wbr: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            webview: React.DetailedHTMLProps<React.WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
+
+            // SVG
+            svg: React.SVGProps<SVGSVGElement>;
+
+            animate: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateElement but is not in TypeScript's lib.dom.d.ts for now.
+            animateMotion: React.SVGProps<SVGElement>;
+            animateTransform: React.SVGProps<SVGElement>; // TODO: It is SVGAnimateTransformElement but is not in TypeScript's lib.dom.d.ts for now.
+            circle: React.SVGProps<SVGCircleElement>;
+            clipPath: React.SVGProps<SVGClipPathElement>;
+            defs: React.SVGProps<SVGDefsElement>;
+            desc: React.SVGProps<SVGDescElement>;
+            ellipse: React.SVGProps<SVGEllipseElement>;
+            feBlend: React.SVGProps<SVGFEBlendElement>;
+            feColorMatrix: React.SVGProps<SVGFEColorMatrixElement>;
+            feComponentTransfer: React.SVGProps<SVGFEComponentTransferElement>;
+            feComposite: React.SVGProps<SVGFECompositeElement>;
+            feConvolveMatrix: React.SVGProps<SVGFEConvolveMatrixElement>;
+            feDiffuseLighting: React.SVGProps<SVGFEDiffuseLightingElement>;
+            feDisplacementMap: React.SVGProps<SVGFEDisplacementMapElement>;
+            feDistantLight: React.SVGProps<SVGFEDistantLightElement>;
+            feDropShadow: React.SVGProps<SVGFEDropShadowElement>;
+            feFlood: React.SVGProps<SVGFEFloodElement>;
+            feFuncA: React.SVGProps<SVGFEFuncAElement>;
+            feFuncB: React.SVGProps<SVGFEFuncBElement>;
+            feFuncG: React.SVGProps<SVGFEFuncGElement>;
+            feFuncR: React.SVGProps<SVGFEFuncRElement>;
+            feGaussianBlur: React.SVGProps<SVGFEGaussianBlurElement>;
+            feImage: React.SVGProps<SVGFEImageElement>;
+            feMerge: React.SVGProps<SVGFEMergeElement>;
+            feMergeNode: React.SVGProps<SVGFEMergeNodeElement>;
+            feMorphology: React.SVGProps<SVGFEMorphologyElement>;
+            feOffset: React.SVGProps<SVGFEOffsetElement>;
+            fePointLight: React.SVGProps<SVGFEPointLightElement>;
+            feSpecularLighting: React.SVGProps<SVGFESpecularLightingElement>;
+            feSpotLight: React.SVGProps<SVGFESpotLightElement>;
+            feTile: React.SVGProps<SVGFETileElement>;
+            feTurbulence: React.SVGProps<SVGFETurbulenceElement>;
+            filter: React.SVGProps<SVGFilterElement>;
+            foreignObject: React.SVGProps<SVGForeignObjectElement>;
+            g: React.SVGProps<SVGGElement>;
+            image: React.SVGProps<SVGImageElement>;
+            line: React.SVGProps<SVGLineElement>;
+            linearGradient: React.SVGProps<SVGLinearGradientElement>;
+            marker: React.SVGProps<SVGMarkerElement>;
+            mask: React.SVGProps<SVGMaskElement>;
+            metadata: React.SVGProps<SVGMetadataElement>;
+            mpath: React.SVGProps<SVGElement>;
+            path: React.SVGProps<SVGPathElement>;
+            pattern: React.SVGProps<SVGPatternElement>;
+            polygon: React.SVGProps<SVGPolygonElement>;
+            polyline: React.SVGProps<SVGPolylineElement>;
+            radialGradient: React.SVGProps<SVGRadialGradientElement>;
+            rect: React.SVGProps<SVGRectElement>;
+            stop: React.SVGProps<SVGStopElement>;
+            switch: React.SVGProps<SVGSwitchElement>;
+            symbol: React.SVGProps<SVGSymbolElement>;
+            text: React.SVGProps<SVGTextElement>;
+            textPath: React.SVGProps<SVGTextPathElement>;
+            tspan: React.SVGProps<SVGTSpanElement>;
+            use: React.SVGProps<SVGUseElement>;
+            view: React.SVGProps<SVGViewElement>;
+        }
+    }
+}
+
+export { React as default };

--- a/tailwind-converter/src/components/Home.tsx
+++ b/tailwind-converter/src/components/Home.tsx
@@ -1,0 +1,12 @@
+import { Flex } from '../../design-system/jsx'
+import PlaygroundWithMachine from './Playground/PlaygroundWithMachine'
+
+import '../styles.css'
+
+export const Home = () => {
+  return (
+    <Flex w="100%" direction="column" padding="3" height="100vh">
+      <PlaygroundWithMachine />;
+    </Flex>
+  )
+}

--- a/tailwind-converter/src/components/Playground/Playground.constants.ts
+++ b/tailwind-converter/src/components/Playground/Playground.constants.ts
@@ -1,0 +1,45 @@
+const defaultCode = `
+ const App = () => {
+  return <>
+    <figure class="md:flex bg-slate-100 rounded-xl p-8 md:p-0 dark:bg-slate-800">
+    <img class="w-24 h-24 md:w-48 md:h-auto md:rounded-none rounded-full mx-auto" src="/sarah-dayan.jpg" alt="" width="384" height="512">
+    <div class="pt-6 md:p-8 text-center md:text-left space-y-4">
+      <blockquote>
+        <p class="text-lg font-medium">
+          “Tailwind CSS is the only framework that I've seen scale
+          on large teams. It’s easy to customize, adapts to any design,
+          and the build size is tiny.”
+        </p>
+      </blockquote>
+      <figcaption class="font-medium">
+        <div class="text-sky-500 dark:text-sky-400">
+          Sarah Dayan
+        </div>
+        <div class="text-slate-700 dark:text-slate-500">
+          Staff Engineer, Algolia
+        </div>
+      </figcaption>
+    </div>
+  </figure>
+  </>
+}
+`.trim();
+
+const themeCode = `
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  theme: {
+    extend: {},
+  },
+}
+`.trim();
+
+export const initialInputList = {
+  "tw-App.tsx": defaultCode,
+  "theme.ts": themeCode,
+};
+
+export const initialOutputList = {
+  "panda-App.tsx": "",
+  "transformed.md": "",
+};

--- a/tailwind-converter/src/components/Playground/Playground.machine.ts
+++ b/tailwind-converter/src/components/Playground/Playground.machine.ts
@@ -1,0 +1,255 @@
+import { extract, ExtractedComponentInstance, ExtractResultByName } from '@box-extractor/core'
+import type { Monaco } from '@monaco-editor/react'
+import type { editor } from 'monaco-editor'
+import type { Config } from 'tailwindcss'
+import resolveConfig from 'tailwindcss/resolveConfig'
+import { Node, Project, SourceFile, ts } from 'ts-morph'
+import { assign, createMachine } from 'xstate'
+import { choose } from 'xstate/lib/actions'
+import { createTwParser } from '../../converter/tw'
+import { initialInputList, initialOutputList } from './Playground.constants'
+
+import { optimizeCss } from '@pandacss/core'
+import MagicString from 'magic-string'
+import postcss, { Root } from 'postcss'
+import postcssJS from 'postcss-js'
+import { createProject } from './createProject'
+import { evalTheme } from './evalTheme'
+import { maybePretty } from './maybePretty'
+
+type TwResultItem = {
+  classList: Set<string>
+  css: string
+  js: postcssJS.CssInJs
+  query: ExtractedComponentInstance
+  ast: Root
+}
+
+type PlaygroundContext = {
+  monaco: Monaco | null
+  inputEditor: editor.IStandaloneCodeEditor | null
+  outputEditor: editor.IStandaloneCodeEditor | null
+  sourceFile: SourceFile | null
+  extracted: ExtractResultByName | null
+  resultList: TwResultItem[]
+  inputList: Record<string, string>
+  selectedInput: string
+  outputList: Record<string, string>
+  selectedOutput: string
+  decorations: string[]
+}
+
+type PlaygroundEvent =
+  | {
+      type: 'Editor Loaded'
+      editor: editor.IStandaloneCodeEditor
+      monaco: Monaco
+      kind: 'input' | 'output'
+    }
+  | { type: 'Select input tab'; name: string }
+  | { type: 'Select output tab'; name: string }
+  | { type: 'Update input'; value: string }
+
+const project: Project = createProject()
+
+const initialContext: PlaygroundContext = {
+  monaco: null,
+  inputEditor: null,
+  outputEditor: null,
+  sourceFile: null,
+  extracted: null,
+  resultList: [],
+  inputList: initialInputList,
+  selectedInput: 'tw-App.tsx',
+  outputList: initialOutputList,
+  selectedOutput: 'panda-App.tsx',
+  decorations: [],
+}
+
+globalThis.__dirname = '/'
+
+export const playgroundMachine = createMachine(
+  {
+    predictableActionArguments: true,
+    id: 'playground',
+    tsTypes: {} as import('./Playground.machine.typegen').Typegen0,
+    schema: {
+      context: {} as PlaygroundContext,
+      events: {} as PlaygroundEvent,
+    },
+    context: initialContext,
+    initial: 'loading',
+    states: {
+      loading: {
+        on: {
+          'Editor Loaded': [
+            {
+              cond: 'willBeReady',
+              target: 'ready',
+              actions: ['assignEditorRef', 'extractClassList'],
+            },
+            { actions: 'assignEditorRef' },
+          ],
+        },
+      },
+      ready: {
+        initial: 'Playing',
+        entry: ['updateInput'],
+        states: {
+          Playing: {
+            on: {
+              'Select input tab': {
+                actions: ['selectInputTab', 'updateInput'],
+              },
+              'Select output tab': { actions: ['selectOutputTab'] },
+              'Update input': { actions: ['updateInput'] },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    actions: {
+      assignEditorRef: assign((ctx, event) => {
+        if (event.kind === 'input') {
+          return { ...ctx, inputEditor: event.editor, monaco: event.monaco }
+        }
+
+        return { ...ctx, outputEditor: event.editor, monaco: event.monaco }
+      }),
+      selectInputTab: assign((ctx, event) => {
+        return { ...ctx, selectedInput: event.name }
+      }),
+      selectOutputTab: assign((ctx, event) => {
+        return { ...ctx, selectedOutput: event.name }
+      }),
+      updateSelectedInput: assign((ctx, event) => {
+        if (event.type !== 'Update input') return ctx
+
+        // if (ctx.inputEditor) {
+        // ctx.inputEditor.setValue(event.value);
+        // }
+
+        const { inputList, selectedInput } = ctx
+        if (inputList[selectedInput]) {
+          inputList[selectedInput] = event.value
+        }
+        return { ...ctx, inputList }
+      }),
+      updateInput: choose([
+        {
+          cond: 'isAppFile',
+          actions: ['updateSelectedInput', 'extractClassList'],
+        },
+        { actions: ['updateSelectedInput'] },
+      ]),
+      extractClassList: assign((ctx, event) => {
+        const value = event.type === 'Update input' ? event.value : ctx.inputEditor?.getValue() ?? ''
+        const sourceFile = project.createSourceFile('App.tsx', value, {
+          scriptKind: ts.ScriptKind.TSX,
+          overwrite: true,
+        })
+        console.time('extract')
+        const extracted = extract({
+          ast: sourceFile,
+          components: {
+            matchTag: () => true,
+            matchProp: ({ propName }) => ['class', 'className'].includes(propName),
+          },
+        })
+        console.timeEnd('extract')
+
+        console.time('resolveConfig')
+        const themeContent = ctx.inputList['theme.ts'] ?? 'module.exports = {}'
+        const evaluatedTheme = evalTheme(themeContent) ?? {}
+        const userTheme = {
+          ...evaluatedTheme,
+          corePlugins: {
+            ...evaluatedTheme.corePlugins,
+            preflight: false,
+          },
+        }
+
+        const config = resolveConfig(userTheme)
+        console.timeEnd('resolveConfig')
+
+        const parser = createTwParser(config as Config)
+        const classListByInstance = new Map<ExtractedComponentInstance, { classList: Set<string>; node: Node }>()
+
+        extracted.forEach((entry) => {
+          ;(entry.queryList as ExtractedComponentInstance[]).forEach((query) => {
+            const classList = new Set<string>()
+            const classLiteral = query.box.value.get('className') ?? query.box.value.get('class')
+            if (!classLiteral) return
+            if (!classLiteral.isLiteral()) return
+            if (typeof classLiteral.value !== 'string') return
+
+            const classes = classLiteral.value.split(' ')
+            classes.forEach((c) => classList.add(c))
+
+            classListByInstance.set(query, {
+              classList,
+              node: classLiteral.getNode(),
+            })
+          })
+        })
+
+        const resultList = [] as TwResultItem[]
+        const code = sourceFile.getFullText()
+        const magicStr = new MagicString(code)
+
+        console.time('tw parsing')
+        classListByInstance.forEach(({ classList, node }, query) => {
+          const parsed = parser(classList)
+          const css = parsed.toString()
+          const js = postcssJS.objectify(postcss.parse(css))
+
+          resultList.push({ classList, css, js, query, ast: parsed })
+          magicStr.update(
+            node.getStart(),
+            node.getEnd(),
+            `{css(${JSON.stringify(postcssJS.objectify(postcss.parse(optimizeCss(css))), null, 2)})}`,
+          )
+        })
+        console.timeEnd('tw parsing')
+
+        const output = maybePretty(magicStr.toString())
+        const outputList = {
+          ['panda-App.tsx']: output,
+          'transformed.md': resultList
+            .map((result) => {
+              return `// ${Array.from(result.classList).join(' ')}\n\`\`\`json\n${JSON.stringify(
+                postcssJS.objectify(postcss.parse(optimizeCss(result.css))),
+                null,
+                2,
+              )}\n\`\`\``
+            })
+            .join('\n\n//------------------------------------\n'),
+        }
+        console.log({
+          extracted,
+          config,
+          resultList,
+          output,
+          editor: ctx.outputEditor,
+          outputList,
+        })
+
+        // if (ctx.monaco && ctx.outputEditor) {
+        //   ctx.outputEditor.setValue(output);
+        // }
+
+        return { ...ctx, sourceFile, extracted, resultList, outputList }
+      }),
+    },
+    guards: {
+      willBeReady: (ctx) => {
+        return Boolean(ctx.inputEditor || ctx.outputEditor)
+      },
+      isAppFile: (ctx) => {
+        return ctx.selectedInput === 'tw-App.tsx'
+      },
+    },
+  },
+)

--- a/tailwind-converter/src/components/Playground/Playground.machine.typegen.ts
+++ b/tailwind-converter/src/components/Playground/Playground.machine.typegen.ts
@@ -1,0 +1,31 @@
+// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  '@@xstate/typegen': true
+  internalEvents: {
+    'xstate.init': { type: 'xstate.init' }
+  }
+  invokeSrcNameMap: {}
+  missingImplementations: {
+    actions: never
+    delays: never
+    guards: never
+    services: never
+  }
+  eventsCausingActions: {
+    assignEditorRef: 'Editor Loaded'
+    extractClassList: 'Editor Loaded' | 'Select input tab' | 'Update input'
+    selectInputTab: 'Select input tab'
+    selectOutputTab: 'Select output tab'
+    updateInput: 'Editor Loaded' | 'Select input tab' | 'Update input'
+    updateSelectedInput: 'Editor Loaded' | 'Select input tab' | 'Update input'
+  }
+  eventsCausingDelays: {}
+  eventsCausingGuards: {
+    isAppFile: 'Editor Loaded' | 'Select input tab' | 'Update input'
+    willBeReady: 'Editor Loaded'
+  }
+  eventsCausingServices: {}
+  matchesStates: 'loading' | 'ready' | 'ready.Playing' | { ready?: 'Playing' }
+  tags: never
+}

--- a/tailwind-converter/src/components/Playground/Playground.tsx
+++ b/tailwind-converter/src/components/Playground/Playground.tsx
@@ -1,0 +1,148 @@
+import Editor from '@monaco-editor/react'
+import { useActor } from '@xstate/react'
+import { Panel, PanelGroup } from 'react-resizable-panels'
+import { css } from '../../../design-system/css'
+import { Flex, panda } from '../../../design-system/jsx'
+import { usePlaygroundContext } from './PlaygroundMachineProvider'
+import { ResizeHandle } from './ResizeHandle'
+import ReactDeclaration from '../../../react.d.ts?raw'
+
+export const Playground = () => {
+  const service = usePlaygroundContext()
+  const [state, send] = useActor(service)
+  console.log(state.value, state.context)
+
+  // TODO
+  const colorMode = 'light'
+
+  return (
+    <panda.div display="flex" w="100%" h="100%" pos="relative">
+      <PanelGroup direction="horizontal">
+        <Panel className={css({ display: 'flex', flexDirection: 'column' })} minSize={20}>
+          <Flex px="2" bg="var(--sp-colors-surface1)" borderBottom="1px solid var(--sp-colors-surface2)" role="tablist">
+            {Object.entries(state.context.inputList).map(([fileName]) => (
+              <panda.button
+                role="tab"
+                key={fileName}
+                onClick={() => send({ type: 'Select input tab', name: fileName })}
+                fontSize="sm"
+                fontWeight="medium"
+                borderRadius="0"
+                p="2"
+                color="blue.400"
+                opacity={0.8}
+                transition="color opacity 150ms ease"
+                bg="none"
+                cursor="pointer"
+                borderBottom="solid 1px transparent"
+                data-active={state.context.selectedInput === fileName ? '' : undefined}
+                _active={{
+                  color: 'blue.600',
+                  opacity: 1,
+                  borderBottom: 'solid 1px token(colors.blue.500, red)',
+                }}
+                _hover={{ color: 'blue.600' }}
+              >
+                {fileName}
+              </panda.button>
+            ))}
+          </Flex>
+          <panda.div
+            boxSize="full"
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="center"
+            overflow="hidden"
+          >
+            <Editor
+              theme={colorMode === 'dark' ? 'vs-dark' : 'vs-light'}
+              language="typescript"
+              path="tw-App.tsx"
+              value={state.context.inputList[state.context.selectedInput]}
+              beforeMount={(monaco) => {
+                monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+                  target: monaco.languages.typescript.ScriptTarget.Latest,
+                  allowNonTsExtensions: true,
+                  moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+                  module: monaco.languages.typescript.ModuleKind.CommonJS,
+                  noEmit: true,
+                  esModuleInterop: true,
+                  jsx: monaco.languages.typescript.JsxEmit.Preserve,
+                  // reactNamespace: "React",
+                  allowJs: true,
+                  typeRoots: ['node_modules/@types'],
+                })
+
+                monaco.languages.typescript.typescriptDefaults.addExtraLib(ReactDeclaration, '@types/react')
+
+                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSemanticValidation: true })
+              }}
+              onMount={(editor, monaco) => {
+                console.log('editor mounted', editor, monaco)
+                send({ type: 'Editor Loaded', editor, monaco, kind: 'input' })
+                // editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+                //     send({ type: "Save" });
+                // });
+              }}
+              onChange={(content) => send({ type: 'Update input', value: content ?? '' })}
+            />
+          </panda.div>
+        </Panel>
+        <ResizeHandle />
+        <Panel className={css({ display: 'flex', flexDirection: 'column' })} minSize={20}>
+          <Flex px="2" bg="var(--sp-colors-surface1)" borderBottom="1px solid var(--sp-colors-surface2)" role="tablist">
+            {Object.entries(state.context.outputList).map(([fileName]) => (
+              <panda.button
+                role="tab"
+                key={fileName}
+                onClick={() => send({ type: 'Select output tab', name: fileName })}
+                fontSize="sm"
+                fontWeight="medium"
+                borderRadius="0"
+                p="2"
+                color="blue.400"
+                opacity={0.8}
+                transition="color opacity 150ms ease"
+                bg="none"
+                cursor="pointer"
+                borderBottom="solid 1px transparent"
+                data-active={state.context.selectedOutput === fileName ? '' : undefined}
+                _active={{
+                  color: 'blue.600',
+                  opacity: 1,
+                  borderBottom: 'solid 1px token(colors.blue.500, red)',
+                }}
+                _hover={{ color: 'blue.600' }}
+              >
+                {fileName}
+              </panda.button>
+            ))}
+          </Flex>
+          <panda.div
+            boxSize="full"
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="center"
+            overflow="hidden"
+          >
+            <Editor
+              // options={{ fontSize: 15, minimap: { enabled: false } }}
+              theme={colorMode === 'dark' ? 'vs-dark' : 'vs-light'}
+              language="typescript"
+              path="panda-App.tsx"
+              value={state.context.outputList[state.context.selectedOutput] ?? ''}
+              beforeMount={(monaco) => {
+                monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSemanticValidation: true })
+              }}
+              onMount={(editor, monaco) => {
+                send({ type: 'Editor Loaded', editor, monaco, kind: 'output' })
+              }}
+            />
+          </panda.div>
+        </Panel>
+      </PanelGroup>
+    </panda.div>
+  )
+}

--- a/tailwind-converter/src/components/Playground/PlaygroundMachineProvider.ts
+++ b/tailwind-converter/src/components/Playground/PlaygroundMachineProvider.ts
@@ -1,0 +1,8 @@
+import { createContextWithHook } from "pastable/react";
+import { InterpreterFrom } from "xstate";
+import { playgroundMachine } from "./Playground.machine";
+
+export const [PlaygroundMachineProvider, usePlaygroundContext] =
+  createContextWithHook<InterpreterFrom<typeof playgroundMachine>>(
+    "PlaygroundMachineContext"
+  );

--- a/tailwind-converter/src/components/Playground/PlaygroundWithMachine.tsx
+++ b/tailwind-converter/src/components/Playground/PlaygroundWithMachine.tsx
@@ -1,0 +1,16 @@
+import { useInterpret } from "@xstate/react";
+import { Playground } from "./Playground";
+import { playgroundMachine } from "./Playground.machine";
+import { PlaygroundMachineProvider } from "./PlaygroundMachineProvider";
+
+export const PlaygroundWithMachine = () => {
+  const service = useInterpret(playgroundMachine);
+
+  return (
+    <PlaygroundMachineProvider value={service}>
+      <Playground />
+    </PlaygroundMachineProvider>
+  );
+};
+
+export default PlaygroundWithMachine;

--- a/tailwind-converter/src/components/Playground/ResizeHandle.tsx
+++ b/tailwind-converter/src/components/Playground/ResizeHandle.tsx
@@ -1,0 +1,141 @@
+import { PanelResizeHandle } from 'react-resizable-panels'
+import { css } from '../../../design-system/css'
+import { panda } from '../../../design-system/jsx'
+
+// adapted from https://github.com/bvaughn/react-resizable-panels/blob/820f48f263407b6b78feecf975a6914c417107e6/packages/react-resizable-panels-website/src/components/ResizeHandle.tsx
+export function ResizeHandle({ className = '', id }: { className?: string; id?: string }) {
+  return (
+    <PanelResizeHandle
+      className={[
+        css({
+          position: 'relative',
+          outline: 'none',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'stretch',
+        }),
+        className,
+      ].join(' ')}
+      id={id ?? null}
+      style={{ flex: '0 0 1.5em', transition: 'background-color .2s linear' }}
+    >
+      <panda.div
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="sm"
+        flex={1}
+        backgroundColor="gray.100"
+      >
+        <Icon
+          className={css({
+            boxSize: '4',
+            _resizeHandleActive: { display: 'none' },
+            _panelVerticalActive: { display: 'none' },
+          })}
+          type="resize-horizontal"
+        />
+        <Icon
+          className={css({
+            boxSize: '4',
+            _resizeHandleActive: { display: 'none' },
+            _panelHorizontalActive: { display: 'none' },
+          })}
+          type="resize-vertical"
+        />
+      </panda.div>
+    </PanelResizeHandle>
+  )
+}
+
+export type IconType =
+  | 'chevron-down'
+  | 'close'
+  | 'css'
+  | 'files'
+  | 'horizontal-collapse'
+  | 'horizontal-expand'
+  | 'html'
+  | 'markdown'
+  | 'resize-horizontal'
+  | 'resize-vertical'
+  | 'search'
+  | 'typescript'
+
+function Icon({ className = '', type }: { className?: string; type: IconType }) {
+  let path = ''
+  switch (type) {
+    case 'chevron-down': {
+      path = 'M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z'
+      break
+    }
+
+    case 'close': {
+      path =
+        'M20 6.91L17.09 4L12 9.09L6.91 4L4 6.91L9.09 12L4 17.09L6.91 20L12 14.91L17.09 20L20 17.09L14.91 12L20 6.91Z'
+      break
+    }
+
+    case 'css': {
+      path =
+        'M5,3L4.35,6.34H17.94L17.5,8.5H3.92L3.26,11.83H16.85L16.09,15.64L10.61,17.45L5.86,15.64L6.19,14H2.85L2.06,18L9.91,21L18.96,18L20.16,11.97L20.4,10.76L21.94,3H5Z'
+      break
+    }
+
+    case 'files': {
+      path =
+        'M15,7H20.5L15,1.5V7M8,0H16L22,6V18A2,2 0 0,1 20,20H8C6.89,20 6,19.1 6,18V2A2,2 0 0,1 8,0M4,4V22H20V24H4A2,2 0 0,1 2,22V4H4Z'
+      break
+    }
+
+    case 'horizontal-collapse': {
+      path = 'M13,20V4H15.03V20H13M10,20V4H12.03V20H10M5,8L9.03,12L5,16V13H2V11H5V8M20,16L16,12L20,8V11H23V13H20V16Z'
+      break
+    }
+
+    case 'horizontal-expand': {
+      path = 'M9,11H15V8L19,12L15,16V13H9V16L5,12L9,8V11M2,20V4H4V20H2M20,20V4H22V20H20Z'
+      break
+    }
+
+    case 'html': {
+      path =
+        'M12,17.56L16.07,16.43L16.62,10.33H9.38L9.2,8.3H16.8L17,6.31H7L7.56,12.32H14.45L14.22,14.9L12,15.5L9.78,14.9L9.64,13.24H7.64L7.93,16.43L12,17.56M4.07,3H19.93L18.5,19.2L12,21L5.5,19.2L4.07,3Z'
+      break
+    }
+
+    case 'markdown': {
+      path =
+        'M20.56 18H3.44C2.65 18 2 17.37 2 16.59V7.41C2 6.63 2.65 6 3.44 6H20.56C21.35 6 22 6.63 22 7.41V16.59C22 17.37 21.35 18 20.56 18M6.81 15.19V11.53L8.73 13.88L10.65 11.53V15.19H12.58V8.81H10.65L8.73 11.16L6.81 8.81H4.89V15.19H6.81M19.69 12H17.77V8.81H15.85V12H13.92L16.81 15.28L19.69 12Z'
+      break
+    }
+
+    case 'resize-horizontal': {
+      path = 'M18,16V13H15V22H13V2H15V11H18V8L22,12L18,16M2,12L6,16V13H9V22H11V2H9V11H6V8L2,12Z'
+      break
+    }
+
+    case 'resize-vertical': {
+      path = 'M8,18H11V15H2V13H22V15H13V18H16L12,22L8,18M12,2L8,6H11V9H2V11H22V9H13V6H16L12,2Z'
+      break
+    }
+
+    case 'search': {
+      path =
+        'M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z'
+      break
+    }
+
+    case 'typescript': {
+      path =
+        'M3,3H21V21H3V3M13.71,17.86C14.21,18.84 15.22,19.59 16.8,19.59C18.4,19.59 19.6,18.76 19.6,17.23C19.6,15.82 18.79,15.19 17.35,14.57L16.93,14.39C16.2,14.08 15.89,13.87 15.89,13.37C15.89,12.96 16.2,12.64 16.7,12.64C17.18,12.64 17.5,12.85 17.79,13.37L19.1,12.5C18.55,11.54 17.77,11.17 16.7,11.17C15.19,11.17 14.22,12.13 14.22,13.4C14.22,14.78 15.03,15.43 16.25,15.95L16.67,16.13C17.45,16.47 17.91,16.68 17.91,17.26C17.91,17.74 17.46,18.09 16.76,18.09C15.93,18.09 15.45,17.66 15.09,17.06L13.71,17.86M13,11.25H8V12.75H9.5V20H11.25V12.75H13V11.25Z'
+      break
+    }
+  }
+
+  return (
+    <svg className={className} viewBox="0 0 24 24">
+      <path fill="currentColor" d={path} />
+    </svg>
+  )
+}

--- a/tailwind-converter/src/components/Playground/createProject.ts
+++ b/tailwind-converter/src/components/Playground/createProject.ts
@@ -1,0 +1,23 @@
+import { Project, ts } from "ts-morph";
+
+export const createProject = () => {
+  return new Project({
+    compilerOptions: {
+      jsx: ts.JsxEmit.React,
+      jsxFactory: "React.createElement",
+      jsxFragmentFactory: "React.Fragment",
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+      noUnusedParameters: false,
+      declaration: false,
+      noEmit: true,
+      allowJs: true,
+      // useVirtualFileSystem: true,
+    },
+    // tsConfigFilePath: tsConfigPath,
+    skipAddingFilesFromTsConfig: true,
+    skipFileDependencyResolution: true,
+    skipLoadingLibFiles: true,
+    useInMemoryFileSystem: true,
+  });
+};

--- a/tailwind-converter/src/components/Playground/evalTheme.ts
+++ b/tailwind-converter/src/components/Playground/evalTheme.ts
@@ -1,0 +1,17 @@
+const evalCode = (code: string, scope: Record<string, unknown>) => {
+  const scopeKeys = Object.keys(scope);
+  const scopeValues = scopeKeys.map((key) => scope[key]);
+  return new Function(...scopeKeys, code)(...scopeValues);
+};
+export const evalTheme = (theme: string) => {
+  const codeTrimmed = theme
+    .replaceAll(/module.exports.*/g, "")
+    .trim()
+    .replace(/;$/, "");
+
+  try {
+    return evalCode(`return (() => {${codeTrimmed}; return theme})()`, {});
+  } catch (e) {
+    return null;
+  }
+};

--- a/tailwind-converter/src/components/Playground/maybePretty.ts
+++ b/tailwind-converter/src/components/Playground/maybePretty.ts
@@ -1,0 +1,15 @@
+import prettier, { type Options } from "prettier";
+import parserTypescript from "prettier/parser-typescript";
+
+/** @see https://github.dev/stephenh/ts-poet/blob/5ea0dbb3c9f1f4b0ee51a54abb2d758102eda4a2/src/Code.ts#L231 */
+export function maybePretty(input: string, options?: Options | null): string {
+  try {
+    return prettier.format(input.trim(), {
+      parser: "typescript",
+      plugins: [parserTypescript],
+      ...options,
+    });
+  } catch {
+    return input; // assume it's invalid syntax and ignore
+  }
+}

--- a/tailwind-converter/src/converter/tw.ts
+++ b/tailwind-converter/src/converter/tw.ts
@@ -1,0 +1,84 @@
+import type * as P from 'postcss'
+import postcss from 'postcss'
+import type { Config } from 'tailwindcss'
+// @ts-expect-error Types added below
+import { resolveMatches as resolveMatchesRaw } from 'tailwindcss/lib/lib/generateRules'
+// @ts-expect-error Types added below
+import { createContext as createContextRaw } from 'tailwindcss/lib/lib/setupContextUtils'
+import type { TailwindContext, TailwindMatch } from './types'
+
+const createContext = createContextRaw as (config: Config) => TailwindContext
+const resolveMatches = resolveMatchesRaw as (candidate: string, context: TailwindContext) => Iterable<TailwindMatch>
+
+const cssVarRegex = /var\((--([\w-]+))\)/
+
+export const createTwParser = (config: Config) => {
+  const context = createContext(config)
+
+  const processClassName = (className: string, root: P.Root) => {
+    const matches = Array.from(resolveMatches(className, context))
+    matches.forEach((m) => {
+      let [infos, rule] = m
+      if (rule.type === 'decl') return
+
+      let container: P.Container = root
+      // console.log({
+      //   type: rule.type,
+      //   parent: rule.parent.type,
+      //   nodes: rule.nodes?.length,
+      //   css: rule.toString(),
+      //   json: rule.toJSON(),
+      // });
+      if (rule.type === 'atrule') {
+        const atRule = postcss.atRule({ name: rule.name, params: rule.params })
+        root.append(atRule)
+        container = atRule
+      }
+
+      const varMap = new Map()
+      if (infos.collectedFormats?.length) {
+        let modifierRule: P.Rule | undefined
+        infos.collectedFormats.reverse().forEach(({ format }) => {
+          const next = postcss.rule({ selector: format })
+          if (!modifierRule) {
+            container.append(next)
+          } else {
+            modifierRule.append(next)
+          }
+
+          modifierRule = next
+        })
+
+        if (modifierRule) {
+          container = modifierRule
+        }
+      }
+      rule.walkDecls((decl) => {
+        // console.log({
+        //   decl: decl.toString(),
+        //   prop: decl.prop.toString(),
+        //   value: decl.value.toString(),
+        //   startsWith: decl.prop.startsWith("--"),
+        // });
+        if (decl.prop.startsWith('--')) {
+          varMap.set(decl.prop, decl)
+        }
+
+        const match = decl.value.match(cssVarRegex)
+        if (match && varMap.has(match[1])) {
+          const cssVarDecl = varMap.get(match[1])
+          decl.value = decl.value.replace(cssVarRegex, cssVarDecl.value)
+          cssVarDecl.remove()
+        }
+
+        container!.append(decl)
+      })
+    })
+  }
+
+  return (classList: Set<string>) => {
+    const root = postcss.root()
+    classList.forEach((name) => processClassName(name, root))
+    return root
+  }
+}

--- a/tailwind-converter/src/converter/types.ts
+++ b/tailwind-converter/src/converter/types.ts
@@ -1,0 +1,53 @@
+import type * as P from "postcss";
+
+export type TailwindContext = {
+  getClassOrder: (
+    classes: string[]
+  ) => Array<[className: string, order: bigint]>;
+  candidateRuleMap: Array<[string, Candidate[]]>;
+  variantMap: Array<Record<string, never>>;
+};
+
+export type Candidate = [
+  data: { layer: string },
+  rule: P.Rule | P.AtRule | P.Declaration
+];
+
+export type TailwindMatchOptions = {
+  preserveSource?: boolean;
+  respectPrefix?: boolean;
+  respectImportant?: boolean;
+  values?: Record<string, string>;
+};
+export type TailwindMatch = [
+  TailwindMatchInfos,
+  P.Rule | P.AtRule | P.Declaration
+];
+
+interface TailwindMatchInfos {
+  sort: {
+    layer: string;
+    parentLayer: string;
+    arbitrary: number;
+    variants: number;
+    parallelIndex: number;
+    index: number;
+    options: Option[];
+  };
+  layer?: string;
+  options: TailwindMatchOptions;
+  collectedFormats: CollectedFormat[];
+}
+
+interface Option {
+  modifier: any;
+  value: any;
+  id: string;
+  sort: any[];
+  variant: number;
+}
+
+interface CollectedFormat {
+  format: string;
+  isArbitraryVariant: boolean;
+}

--- a/tailwind-converter/src/env.d.ts
+++ b/tailwind-converter/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/tailwind-converter/src/pages/index.astro
+++ b/tailwind-converter/src/pages/index.astro
@@ -1,0 +1,16 @@
+---
+import { Home } from "../components/Home";
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Tailwind to CSS-in-JS</title>
+	</head>
+	<body>
+		<Home client:load />
+	</body>
+</html>

--- a/tailwind-converter/src/styles.css
+++ b/tailwind-converter/src/styles.css
@@ -1,0 +1,9 @@
+@layer reset, base, tokens, recipes, utilities;
+
+:root {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans',
+    'Helvetica Neue', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  color: #333;
+  font-size: 16px;
+  min-width: 360px;
+}

--- a/tailwind-converter/tsconfig.json
+++ b/tailwind-converter/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## what is this

currently a tailwind to CSS-in-JS converter

##  in the future it could : 
- keep the theme token values

atm: `bg-slate-100`  -> background: "#12345"
future: `bg-slate-100` -> background: "slate.100" (given slate.100 is defined in the `theme.colors`)

- also convert the tailwind config to the panda config equivalent
- atm it extracts (using box-extractor) class/className jsx attributes but in the future there could be a Combobox or some kind of inputs to specify which fn args to extract (think `cx`, `clsx`, `cn`, etc etc)

![Screenshot 2023-03-18 at 23 34 15](https://user-images.githubusercontent.com/47224540/226143682-98c768e6-7daa-46b7-964d-10dc938df473.png)

## how does it work

using tailwind internals (1) we can directly use their config + function to convert to postcss AST and then walk this AST to convert to a CSS-in-JS object

```ts
// (1)
import { resolveMatches as resolveMatchesRaw } from 'tailwindcss/lib/lib/generateRules'
import { createContext as createContextRaw } from 'tailwindcss/lib/lib/setupContextUtils'
```

rough implementation is in `tailwind-converter/src/converter/tw.ts`


<hr />

as a side note, the current tailwind-converter directory was ported from a local PoC vite repo so some eslint/ts lint rules may throw, some logs might still be commented out, in summary this is not clean yet