### PR TITLE
fix(parser): match on import name+alias & include fn patterns

### DIFF
--- a/packages/parser/__tests__/fixture.ts
+++ b/packages/parser/__tests__/fixture.ts
@@ -72,8 +72,8 @@ export function importParser(code: string, option: { name: string; module: strin
   const project = getProject(code)
   const sourceFile = project.getSourceFile(staticFilePath)!
   const imports = getImportDeclarations(sourceFile, {
-    match({ id, mod }) {
-      return id === option.name && mod === option.module
+    match({ name, mod }) {
+      return name === option.name && mod === option.module
     },
   })
   return imports.value
@@ -115,7 +115,7 @@ export function jsxParser(code: string) {
   return data.jsx
 }
 
-export function jsxPatternParser(code: string) {
+export function patternParser(code: string) {
   const project = getProject(code, (conf) => ({
     ...conf,
     patterns: {

--- a/packages/parser/__tests__/jsx-pattern.test.ts
+++ b/packages/parser/__tests__/jsx-pattern.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { jsxPatternParser } from './fixture'
+import { patternParser } from './fixture'
 
 describe('pattern jsx', () => {
   test('should extract', () => {
@@ -15,7 +15,7 @@ describe('pattern jsx', () => {
        }
      `
 
-    expect(jsxPatternParser(code)).toMatchInlineSnapshot(`
+    expect(patternParser(code)).toMatchInlineSnapshot(`
       Map {
         "Stack" => Set {
           {

--- a/packages/parser/__tests__/patterns.test.ts
+++ b/packages/parser/__tests__/patterns.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from 'vitest'
+import { patternParser } from './fixture'
+
+describe('pattern jsx', () => {
+  test('should extract', () => {
+    const code = `
+       import { stack, hstack as aliased } from ".panda/patterns"
+
+       function Button() {
+         return (
+            <div>
+               <div className={stack({ align: "center" })}>Click me</div>
+               <div className={aliased({ justify: "flex-end" })}>Click me</div>
+            </div>
+        )
+       }
+     `
+
+    expect(patternParser(code)).toMatchInlineSnapshot(`
+      Map {
+        "stack" => Set {
+          {
+            "box": BoxNodeMap {
+              "node": CallExpression,
+              "spreadConditions": undefined,
+              "stack": [
+                CallExpression,
+                ObjectLiteralExpression,
+              ],
+              "type": "map",
+              "value": Map {
+                "align" => BoxNodeLiteral {
+                  "kind": "string",
+                  "node": StringLiteral,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    StringLiteral,
+                  ],
+                  "type": "literal",
+                  "value": "center",
+                },
+              },
+            },
+            "data": [
+              {
+                "align": "center",
+              },
+            ],
+            "name": "stack",
+            "type": "pattern",
+          },
+        },
+        "hstack" => Set {
+          {
+            "box": BoxNodeMap {
+              "node": CallExpression,
+              "spreadConditions": undefined,
+              "stack": [
+                CallExpression,
+                ObjectLiteralExpression,
+              ],
+              "type": "map",
+              "value": Map {
+                "justify" => BoxNodeLiteral {
+                  "kind": "string",
+                  "node": StringLiteral,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    StringLiteral,
+                  ],
+                  "type": "literal",
+                  "value": "flex-end",
+                },
+              },
+            },
+            "data": [
+              {
+                "justify": "flex-end",
+              },
+            ],
+            "name": "hstack",
+            "type": "pattern",
+          },
+        },
+      }
+    `)
+  })
+})

--- a/packages/parser/src/import.ts
+++ b/packages/parser/src/import.ts
@@ -10,7 +10,7 @@ type ImportResult = {
 export function getImportDeclarations(
   file: SourceFile,
   options: {
-    match: (value: { id: string; mod: string }) => boolean
+    match: (value: ImportResult) => boolean
   },
 ) {
   const { match } = options
@@ -26,7 +26,7 @@ export function getImportDeclarations(
       const name = specifier.getNameNode().getText()
       const alias = specifier.getAliasNode()?.getText() || name
 
-      if (!match({ id: name, mod: source })) return
+      if (!match({ name, alias, mod: source })) return
 
       result.push({ name, alias, mod: source })
     })
@@ -42,7 +42,7 @@ export function getImportDeclarations(
     },
     createMatch(mod: string) {
       const mods = result.filter((o) => o.mod.includes(mod))
-      return memo((id: string) => !!mods.find((mod) => mod.alias === id))
+      return memo((id: string) => !!mods.find((mod) => mod.alias === id || mod.name === id))
     },
     match(id: string) {
       return !!this.find(id)


### PR DESCRIPTION
I noticed we didnt always catch aliases for recipe/patterns, and sometimes woud only catch jsx pattern (= no fn pattern)