### PR TITLE
refactor(parser): matchFnProp => true

### DIFF
--- a/packages/parser/__tests__/css-2.test.ts
+++ b/packages/parser/__tests__/css-2.test.ts
@@ -422,10 +422,61 @@ console.log(
                 ObjectLiteralExpression,
               ],
               "type": "map",
-              "value": Map {},
+              "value": Map {
+                "selectors" => BoxNodeMap {
+                  "node": ObjectLiteralExpression,
+                  "spreadConditions": undefined,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    ObjectLiteralExpression,
+                  ],
+                  "type": "map",
+                  "value": Map {
+                    "&:hover" => BoxNodeMap {
+                      "node": ObjectLiteralExpression,
+                      "spreadConditions": undefined,
+                      "stack": [
+                        CallExpression,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        ObjectLiteralExpression,
+                      ],
+                      "type": "map",
+                      "value": Map {
+                        "background" => BoxNodeLiteral {
+                          "kind": "string",
+                          "node": StringLiteral,
+                          "stack": [
+                            CallExpression,
+                            ObjectLiteralExpression,
+                            PropertyAssignment,
+                            ObjectLiteralExpression,
+                            PropertyAssignment,
+                            ObjectLiteralExpression,
+                            PropertyAssignment,
+                            StringLiteral,
+                          ],
+                          "type": "literal",
+                          "value": "red.200",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
             "data": [
-              {},
+              {
+                "selectors": {
+                  "&:hover": {
+                    "background": "red.200",
+                  },
+                },
+              },
             ],
             "name": "css",
             "type": "object",

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -182,17 +182,6 @@ export function createParser(options: ParserOptions) {
       if (fnName === cvaAlias || fnName === cssAlias || fnName.startsWith(jsxFactoryAlias)) return true
       return Boolean(functions.get(fnName))
     })
-    const matchFnProp = memo((fnName: string, propName: string) => {
-      if (propertiesMap.size === 0) return true // = allow all
-
-      if (recipes.has(fnName) || patterns.has(fnName)) return true
-      if (fnName === cvaAlias) return true
-      if (fnName.startsWith(jsxFactoryAlias)) return true
-      if (fnName === cssAlias)
-        return Boolean(propertiesMap.get(propName) || propName[0] === '&' || propName.startsWith('['))
-      return Boolean(functions.get(fnName)?.get(propName))
-    })
-
     const measure = logger.time.debug(`Tokens extracted from ${filePath}`)
     const extractResultByName = extract({
       ast: sourceFile,
@@ -202,7 +191,7 @@ export function createParser(options: ParserOptions) {
       },
       functions: {
         matchFn: (prop) => matchFn(prop.fnName),
-        matchProp: (prop) => matchFnProp(prop.fnName, prop.propName),
+        matchProp: () => true,
         matchArg: (prop) => {
           // skip resolving `badge` here: `panda("span", badge)`
           if (prop.fnName === jsxFactoryAlias && prop.index === 1 && Node.isIdentifier(prop.argNode)) return false


### PR DESCRIPTION
```ts
import { css } from '../design-system/css'

const welcome = css({
  '&[data-state=closed]': {
    animation: 'exit',
    fadeOut: '0.2',
  },
})
```

this wasn't caught anymore, probably because of an assumption of mine that selectors were under a `selectors` key