### PR TITLE
refactor(cli): debug/analyze, use simple glob arg

### DIFF
--- a/packages/cli/app/design-system/types/global.d.ts
+++ b/packages/cli/app/design-system/types/global.d.ts
@@ -1,4 +1,5 @@
 import { RecipeVariantRecord, RecipeConfig } from './recipe'
+import { Parts } from './parts'
 import { AnyPatternConfig, PatternConfig } from './pattern'
 import { GlobalStyleObject, SystemStyleObject } from './system-types'
 import { CompositionStyles } from './composition'

--- a/packages/node/src/analyze-tokens.ts
+++ b/packages/node/src/analyze-tokens.ts
@@ -16,7 +16,8 @@ export function analyzeTokens(
   const parserResultByFilepath = new Map<string, ParserResult>()
   const extractTimeByFilepath = new Map<string, number>()
 
-  ctx.getFiles().map((file) => {
+  const includedFiles = ctx.getFiles()
+  includedFiles.map((file) => {
     const start = performance.now()
     const result = ctx.project.parseSourceFile(file)
 
@@ -33,16 +34,16 @@ export function analyzeTokens(
   })
 
   const totalMs = Array.from(extractTimeByFilepath.values()).reduce((a, b) => a + b, 0)
-  logger.debug('analyze', `Analyzed ${ctx.getFiles().length} files in ${totalMs.toFixed(2)}ms`)
+  logger.debug('analyze', `Analyzed ${includedFiles.length} files in ${totalMs.toFixed(2)}ms`)
 
   const minify = ctx.config.minify
-  const files = ctx.chunks.getFiles()
+  const chunkFiles = ctx.chunks.getFiles()
 
   ctx.config.minify = false
-  const css = ctx.getCss({ files })
+  const css = ctx.getCss({ files: chunkFiles })
 
   ctx.config.minify = true
-  const minifiedCss = ctx.getCss({ files })
+  const minifiedCss = ctx.getCss({ files: chunkFiles })
 
   // restore minify config
   ctx.config.minify = minify


### PR DESCRIPTION
strip out any "smart logic" that ended up causing more problems than it solved :
- we would try to avoid loading the config twice in exchange for needing a valid file path (= not a glob), it's better to let the user have the freedom to pass any valid glob instead
- we would also try to avoid needing the user to write `**` after a glob, this would sometimes lead to invalid globs

& re-use/rename some variables