### PR TITLE
fix(parser): don't skip file if no known imports are found

### DIFF
--- a/packages/cli/app/design-system/types/global.d.ts
+++ b/packages/cli/app/design-system/types/global.d.ts
@@ -1,4 +1,5 @@
 import { RecipeVariantRecord, RecipeConfig } from './recipe'
+import { Parts } from './parts'
 import { AnyPatternConfig, PatternConfig } from './pattern'
 import { GlobalStyleObject, SystemStyleObject } from './system-types'
 import { CompositionStyles } from './composition'

--- a/packages/parser/__tests__/css-2.test.ts
+++ b/packages/parser/__tests__/css-2.test.ts
@@ -18,7 +18,170 @@ describe('ast parser', () => {
 
     expect(cssParser(code)).toMatchInlineSnapshot(`
       {
-        "css": Set {},
+        "css": Set {
+          {
+            "box": BoxNodeMap {
+              "node": CallExpression,
+              "spreadConditions": undefined,
+              "stack": [
+                CallExpression,
+                ObjectLiteralExpression,
+              ],
+              "type": "map",
+              "value": Map {
+                "color" => BoxNodeLiteral {
+                  "kind": "string",
+                  "node": StringLiteral,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    StringLiteral,
+                  ],
+                  "type": "literal",
+                  "value": "red",
+                },
+                "fontSize" => BoxNodeLiteral {
+                  "kind": "string",
+                  "node": StringLiteral,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    StringLiteral,
+                  ],
+                  "type": "literal",
+                  "value": "12px",
+                },
+              },
+            },
+            "data": [
+              {
+                "color": "red",
+                "fontSize": "12px",
+              },
+            ],
+            "name": "css",
+            "type": "object",
+          },
+          {
+            "box": BoxNodeMap {
+              "node": CallExpression,
+              "spreadConditions": undefined,
+              "stack": [
+                CallExpression,
+                ObjectLiteralExpression,
+              ],
+              "type": "map",
+              "value": Map {
+                "bg" => BoxNodeLiteral {
+                  "kind": "string",
+                  "node": StringLiteral,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    StringLiteral,
+                  ],
+                  "type": "literal",
+                  "value": "red.300",
+                },
+                "margin" => BoxNodeMap {
+                  "node": ObjectLiteralExpression,
+                  "spreadConditions": undefined,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    ObjectLiteralExpression,
+                  ],
+                  "type": "map",
+                  "value": Map {
+                    "xs" => BoxNodeLiteral {
+                      "kind": "string",
+                      "node": StringLiteral,
+                      "stack": [
+                        CallExpression,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        StringLiteral,
+                      ],
+                      "type": "literal",
+                      "value": "0",
+                    },
+                    "lg" => BoxNodeLiteral {
+                      "kind": "string",
+                      "node": StringLiteral,
+                      "stack": [
+                        CallExpression,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        StringLiteral,
+                      ],
+                      "type": "literal",
+                      "value": "40px",
+                    },
+                  },
+                },
+                "padding" => BoxNodeArray {
+                  "node": ArrayLiteralExpression,
+                  "stack": [
+                    CallExpression,
+                    ObjectLiteralExpression,
+                    PropertyAssignment,
+                    ArrayLiteralExpression,
+                  ],
+                  "type": "array",
+                  "value": [
+                    BoxNodeLiteral {
+                      "kind": "number",
+                      "node": NumericLiteral,
+                      "stack": [
+                        CallExpression,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        ArrayLiteralExpression,
+                      ],
+                      "type": "literal",
+                      "value": 12,
+                    },
+                    BoxNodeLiteral {
+                      "kind": "number",
+                      "node": NumericLiteral,
+                      "stack": [
+                        CallExpression,
+                        ObjectLiteralExpression,
+                        PropertyAssignment,
+                        ArrayLiteralExpression,
+                      ],
+                      "type": "literal",
+                      "value": 50,
+                    },
+                  ],
+                },
+              },
+            },
+            "data": [
+              {
+                "bg": "red.300",
+                "margin": {
+                  "lg": "40px",
+                  "xs": "0",
+                },
+                "padding": [
+                  12,
+                  50,
+                ],
+              },
+            ],
+            "name": "css",
+            "type": "object",
+          },
+        },
       }
     `)
   })

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -90,12 +90,10 @@ export function createParser(options: ParserOptions) {
 
     const collector = createParserResult()
 
-    if (!imports.value.length) {
-      logger.debug('ast:import', `No import found in ${filePath}`)
-      return collector
-    }
-
-    logger.debug('ast:import', `Found import { ${imports} } in ${filePath}`)
+    logger.debug(
+      'ast:import',
+      imports.value.length ? `Found import { ${imports} } in ${filePath}` : `No import found in ${filePath}`,
+    )
 
     const [css] = importRegex
     const isValidPattern = imports.createMatch(importMap.pattern)


### PR DESCRIPTION
we still need to parse a file without known imports because it could contain imported JSX components that use panda style props

```ts
// App.ts
import { useState } from "react";
import reactLogo from "./assets/react.svg";
import viteLogo from "/vite.svg";
import "./App.css";
import "./styles.css";
import { StyledCheckbox } from "../lib/styled-checkbox";

function App() {
  return (
    <div className="App">
      <StyledCheckbox color="yellow.200" size="md">
        Styled checkbox
      </StyledCheckbox>
      <p className="read-the-docs">
        Click on the Vite and React logos to learn more
      </p>
    </div>
  );
}
```


```ts
// lib/styled-checkbox.tsx
export const StyledCheckbox = ({
  size,
  label,
  ...props
}: CheckboxVariants & SystemStyleObject & { label?: string }) => {
  return (
    <Checkbox className={cx(checkbox({ size }), css(props))}>
      {label ? <CheckboxLabel>{label}</CheckboxLabel> : null}
      <CheckboxInput />
      <CheckboxControl />
    </Checkbox>
  );
};
```

before that PR, we would just skip the extract process on the file entirely (as an optimization), but this was missing the fact that we can just have some unknown component that will spread its panda style props