### PR TITLE
fix(pattern): add start token in regex

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -101,7 +101,9 @@ export function createParser(options: ParserOptions) {
     const isValidStyleFn = (name: string) => name === jsx?.factory
 
     const jsxFactoryAlias = jsx ? imports.getAlias(jsx.factory) : 'panda'
-    const jsxPatternNodes = new RegExp(`(${jsx?.nodes.map((node) => node.type === 'pattern' && node.name).join('|')})$`)
+    const jsxPatternNodes = new RegExp(
+      `^(${jsx?.nodes.map((node) => node.type === 'pattern' && node.name).join('|')})$`,
+    )
 
     const recipes = new Set<string>()
     const patterns = new Set<string>()


### PR DESCRIPTION
![image](https://github.com/chakra-ui/panda/assets/47224540/32ae1327-9c63-41e3-bc1e-d871763493b5)

found kinda the same issue with regex that we had with recipes
-> which means patterns regex also needs to have start/end tokens otherwise it will return false positives