### PR TITLE
fix(website): ThemeSwitch/Select component hydration error

### DIFF
--- a/website/src/components/select.tsx
+++ b/website/src/components/select.tsx
@@ -35,40 +35,38 @@ export function Select({
     <ArkSelect onChange={onChange}>
       {({ isOpen }) => (
         <>
-          <SelectTrigger>
-            <button
-              className={cx(
-                css({
-                  height: 7,
-                  borderRadius: 'md',
-                  px: 2,
-                  textAlign: 'left',
-                  fontSize: 'xs',
-                  fontWeight: 'medium',
-                  color: 'gray.600',
-                  transitionProperty: 'colors',
-                  _dark: { color: 'gray.400' },
-                  _expanded: {
-                    bg: 'gray.200',
-                    color: 'gray.900',
-                    // _dark: { bg: 'primary.100/10', color: 'gray.50' } // opacity modifier
-                    _dark: { bg: 'rgb(219 234 254 / 0.1)', color: 'gray.50' }
-                  },
-                  _hover: {
-                    bg: 'gray.100',
-                    color: 'gray.900',
-                    // _dark: { bg: 'primary.100/5', color: 'gray.50' }
-                    _dark: {
-                      bg: 'rgb(219 234 254 / 0.1)',
-                      color: 'gray.50'
-                    } // opacity modifier
-                  }
-                }),
-                className
-              )}
-            >
-              {(selected?.label as any) ?? title}
-            </button>
+          <SelectTrigger
+            className={cx(
+              css({
+                height: 7,
+                borderRadius: 'md',
+                px: 2,
+                textAlign: 'left',
+                fontSize: 'xs',
+                fontWeight: 'medium',
+                color: 'gray.600',
+                transitionProperty: 'colors',
+                _dark: { color: 'gray.400' },
+                _expanded: {
+                  bg: 'gray.200',
+                  color: 'gray.900',
+                  // _dark: { bg: 'primary.100/10', color: 'gray.50' } // opacity modifier
+                  _dark: { bg: 'rgb(219 234 254 / 0.1)', color: 'gray.50' }
+                },
+                _hover: {
+                  bg: 'gray.100',
+                  color: 'gray.900',
+                  // _dark: { bg: 'primary.100/5', color: 'gray.50' }
+                  _dark: {
+                    bg: 'rgb(219 234 254 / 0.1)',
+                    color: 'gray.50'
+                  } // opacity modifier
+                }
+              }),
+              className
+            )}
+          >
+            {(selected?.label as any) ?? title}
           </SelectTrigger>
           <Portal>
             <div


### PR DESCRIPTION
`ThemeSwitch` component was causing hydration error on docs page.
I'm not sure why exactly this change fixed the error, but after inspecting `SelectTrigger` ([here](https://github.com/chakra-ui/ark/blob/main/packages/react/src/select/select-trigger.tsx)) component I figured out it's already a `button` so I removed inned button component. I guess it's not a valid HTML when button is rendered inside another button 🤷‍♂️.

<img width="819" alt="ssr-error" src="https://github.com/chakra-ui/panda/assets/4128883/2af7163b-5dcc-49e3-a144-4cd97d352410">
