### PR TITLE
fix(website): edit page github url

### DIFF
--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -41,7 +41,7 @@ const config: DocsThemeConfig = {
       openGraph: { url, images: [{ url: images }] }
     }
   },
-  docsRepositoryBase: 'https://github.com/chakra-ui/panda/blob/website/pages',
+  docsRepositoryBase: 'https://github.com/chakra-ui/panda/tree/main/website',
   sidebar: {
     toggleButton: true
   },


### PR DESCRIPTION
When I try edit page link on docs doesn't work.
![CleanShot 2023-06-16 at 11 06 04](https://github.com/chakra-ui/panda/assets/38381517/d4be8d00-6a5e-40fb-83bb-ef9075ea2b53)
