### PR TITLE
docs: fix storybook typo

### DIFF
--- a/website/src/components/sections/works-everywhere.tsx
+++ b/website/src/components/sections/works-everywhere.tsx
@@ -45,7 +45,7 @@ export const SectionWorksEverywhere = () => {
             <HStack gap="12">
               <ProjectLogo icon="PostCSSLogo" title="PostCSS" height="45" />
               <ProjectLogo icon="AstroLogo" title="Astro" />
-              <ProjectLogo icon="StoryBookLogo" title="StoryBook" height="39" />
+              <ProjectLogo icon="StorybookLogo" title="Storybook" height="39" />
             </HStack>
           </Stack>
 

--- a/website/theme/icons.tsx
+++ b/website/theme/icons.tsx
@@ -428,7 +428,7 @@ const AstroLogo = (props: ComponentPropsWithoutRef<'svg'>) => (
   </svg>
 )
 
-const StoryBookLogo = (props: ComponentPropsWithoutRef<'svg'>) => (
+const StorybookLogo = (props: ComponentPropsWithoutRef<'svg'>) => (
   <svg
     width="33"
     height="40"
@@ -494,7 +494,7 @@ const icons = {
   PostCSSLogo,
   ViteLogo,
   NextJsLogo,
-  StoryBookLogo,
+  StorybookLogo,
   MagnifyingGlass
 }
 


### PR DESCRIPTION
Replace "StoryBook" with "Storybook" everywhere.