### PR TITLE
docs: fix missing astro extension

### DIFF
--- a/website/pages/docs/getting-started/astro.mdx
+++ b/website/pages/docs/getting-started/astro.mdx
@@ -60,7 +60,7 @@ import { defineConfig } from '@pandacss/dev'
 export default defineConfig({
   preflight: true,
   // define the content to scan 👇🏻
-  include: ['./src/**/*.{tsx,jsx}', './pages/**/*.{jsx,tsx}'],
+  include: ['./src/**/*.{tsx,jsx,astro}', './pages/**/*.{jsx,tsx,astro}'],
   exclude: [],
   outdir: 'styled-system'
 })


### PR DESCRIPTION
astro extension was missed here in https://panda-css.com/docs/getting-started/astro#configure-the-content
