### PR TITLE
docs: fix typo global.css to globals.css

### DIFF
--- a/website/pages/docs/getting-started/nextjs.mdx
+++ b/website/pages/docs/getting-started/nextjs.mdx
@@ -174,7 +174,7 @@ If you don't have Next.js app installed, you can follow the [Create a Next.js ap
   ### Configure the entry CSS with layers
 
   <RouteSwitchContent value="app-dir">
-    In your Next.js project, navigate to the `src/app` folder and open `global.css` file. Replace all the content with the following code:
+    In your Next.js project, navigate to the `src/app` folder and open `globals.css` file. Replace all the content with the following code:
   </RouteSwitchContent>
   <RouteSwitchContent value="pages-dir">
     In your Next.js project, navigate to the `src/styles` folder and open `globals.css` file. Replace all the content with the following code:
@@ -194,7 +194,7 @@ If you don't have Next.js app installed, you can follow the [Create a Next.js ap
   ### Import the entry CSS in your app
 
   <RouteSwitchContent value="app-dir">
-  Make sure that you import the `global.css` file in your `src/app/layout.tsx` file as follows:
+  Make sure that you import the `globals.css` file in your `src/app/layout.tsx` file as follows:
 
   ```tsx {1} filename="./src/app/layout.tsx"
     import './globals.css'


### PR DESCRIPTION
Fix typo "global.css" to "globals.css" in nextjs.mdx