### PR TITLE
fix broken link

### DIFF
--- a/website/pages/docs/concepts/style-props.mdx
+++ b/website/pages/docs/concepts/style-props.mdx
@@ -144,7 +144,7 @@ Patterns are common layout patterns like `stack`, `grid`, `circle` that can be u
 
 All the patterns provided by Panda are available as JSX components.
 
-> Learn more about the [patterns](/docs/patterns/00-intro.mdx) we provide.
+> Learn more about the [patterns](/docs/customization/patterns) we provide.
 
 ```jsx
 import { Stack, Circle } from '../styled-system/jsx'


### PR DESCRIPTION
Link to `patterns` in https://panda-css.com/docs/concepts/style-props goes to 404. Replaced with the path that is believed to be the correct.