### PR TITLE
feat(config): eject option to opt-out of the defaults config presets

### DIFF
--- a/packages/config/src/load-config.ts
+++ b/packages/config/src/load-config.ts
@@ -28,11 +28,11 @@ export async function loadConfigFile(options: ConfigFileOptions) {
 
 export async function resolveConfigFile(result: Awaited<ReturnType<typeof bundleConfigFile>>, cwd: string) {
   const presets = new Set<any>()
-  presets.add(presetBase)
+  if (!result.config.eject) {
+    presets.add(presetBase)
+  }
 
-  if (!result.config.presets) {
-    presets.add(presetPanda)
-  } else {
+  if (result.config.presets) {
     result.config.presets.forEach((preset: any) => {
       if (typeof preset === 'string' && isBundledPreset(preset)) {
         presets.add(bundledPresets[preset])
@@ -40,6 +40,8 @@ export async function resolveConfigFile(result: Awaited<ReturnType<typeof bundle
         presets.add(preset)
       }
     })
+  } else if (!result.config.eject) {
+    presets.add(presetPanda)
   }
 
   result.config.presets = Array.from(presets)

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -201,6 +201,11 @@ type PresetOptions = {
    * Used to create reusable config presets for your project or team.
    */
   presets?: (string | Preset | Promise<Preset>)[]
+  /**
+   * Whether to opt-out of the defaults config presets: [`@pandacss/preset-base`, `@pandacss/preset-panda`]
+   * @default 'false'
+   */
+  eject?: boolean
 }
 
 type HooksOptions = {

--- a/website/pages/docs/references/config.md
+++ b/website/pages/docs/references/config.md
@@ -21,7 +21,7 @@ export default defineConfig({
 
 **Type**: `string[]`
 
-**Default**: `['@pandacss/dev/presets']`
+**Default**: `['@pandacss/preset-base', '@pandacss/preset-panda']`
 
 The set of reusable and shareable configuration presets.
 
@@ -30,7 +30,21 @@ as a set of overrides and extensions.
 
 ```json
 {
-  "presets": ["@pandacss/dev/presets"]
+  "presets": ["@pandacss/preset-base", "@pandacss/preset-panda"]
+}
+```
+
+### eject
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+Whether to opt-out of the defaults config presets: [`@pandacss/preset-base`, `@pandacss/preset-panda`]
+
+```json
+{
+  "eject": true
 }
 ```
 


### PR DESCRIPTION
Closes # https://github.com/chakra-ui/panda/issues/716

## 📝 Description

Whether to opt-out of the defaults config presets: [`@pandacss/preset-base`, `@pandacss/preset-panda`]

## 💣 Is this a breaking change (Yes/No):

no
