### PR TITLE
playground: use `styled-system` as outdir

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -36,4 +36,4 @@ yarn-error.log*
 next-env.d.ts
 ## Panda
 styled-system
-design-system-static
+styled-system-static

--- a/playground/src/components/usePanda.tsx
+++ b/playground/src/components/usePanda.tsx
@@ -37,7 +37,7 @@ export function usePanda(source: string, theme: string) {
       config: {
         cwd: '',
         include: [],
-        outdir: 'design-system',
+        outdir: 'styled-system',
         ...presetBase,
         preflight: true,
         theme,

--- a/playground/src/components/usePlayground.ts
+++ b/playground/src/components/usePlayground.ts
@@ -19,7 +19,7 @@ export const usePlayground = (props: UsePlayGroundProps) => {
     intialState
       ? intialState
       : {
-          code: `import { css } from 'design-system/css'
+          code: `import { css } from 'styled-system/css'
 
 export const App = () => {
   return (


### PR DESCRIPTION
 
Closes #778

use `styled-system` as outdir