### PR TITLE
Make pattern.properties optional

### DIFF
--- a/packages/generator/src/engines/pattern.ts
+++ b/packages/generator/src/engines/pattern.ts
@@ -42,7 +42,7 @@ export const getPatternEngine = (config: UserConfig) => {
       return Object.entries(patterns).map(([name, pattern]) => ({
         type: 'pattern' as const,
         name: pattern.jsx ?? capitalize(name),
-        props: Object.keys(pattern.properties),
+        props: Object.keys(pattern?.properties ?? {}),
         baseName: name,
       }))
     }),


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/782

## 📝 Description

> Allows pattern.properties to be optional

## ⛳️ Current behavior (updates)

> `panda codegen` errors if a pattern doesn't have a properties object
## 🚀 New behavior

> `panda codegen` works as expected when a pattern doesn't have a properties object 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
