### PR TITLE
feat(hooks): extractor:eval

### DIFF
--- a/.changeset/many-terms-give.md
+++ b/.changeset/many-terms-give.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+'@pandacss/types': patch
+---
+
+Add the `extractor:eval` config.hook:
+
+It lets users provide scope variables or functions definitions and make the extract process adaptable to their use-cases

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -6230,7 +6230,7 @@ it('handles root spread conditional', () => {
   `)
 })
 
-it.only('allows customizing eval', () => {
+it('allows customizing eval', () => {
   const isFunctionMadeFromDefineParts = (expr: Identifier) => {
     const declaration = findIdentifierValueDeclaration(expr, [], {})
     if (!Node.isVariableDeclaration(declaration)) return

--- a/packages/extractor/src/types.ts
+++ b/packages/extractor/src/types.ts
@@ -86,7 +86,7 @@ export type ComponentMatchers = {
 }
 
 export type BoxContext = {
-  getEvaluateOptions?: (node: Expression, stack: Node[]) => EvaluateOptions
+  getEvaluateOptions?: (node: Expression, stack: Node[]) => Partial<EvaluateOptions> | undefined
   canEval?: (node: Expression, stack: Node[]) => boolean
   flags?: {
     skipEvaluate?: boolean

--- a/packages/node/src/create-context.ts
+++ b/packages/node/src/create-context.ts
@@ -28,7 +28,7 @@ export const createContext = (conf: ConfigResultWithHooks) =>
         getFiles,
         readFile: fs.readFileSync,
         hooks: conf.hooks,
-        parserOptions,
+        parserOptions: Object.assign({}, parserOptions, { hooks: conf.hooks }),
       })
     }),
 

--- a/packages/parser/__tests__/fixture.ts
+++ b/packages/parser/__tests__/fixture.ts
@@ -45,29 +45,25 @@ const defaults: LoadConfigResult = {
 }
 
 function getProject(code: string, options?: <Conf extends UserConfig>(conf: Conf) => Conf) {
-  const config = options ? options(defaults.config) : defaults.config
-  const hooks = createHooks<PandaHooks>()
-  const generator = createGenerator({ ...defaults, config, hooks })
-
-  return createProject({
-    useInMemoryFileSystem: true,
-    getFiles: () => [staticFilePath],
-    readFile: () => code,
-    parserOptions: generator.parserOptions,
-    hooks,
-  })
+  return getFixtureProject(code, options).project
 }
 
 export function getFixtureProject(code: string, options?: <Conf extends UserConfig>(conf: Conf) => Conf) {
   const config = options ? options(defaults.config) : defaults.config
   const hooks = createHooks<PandaHooks>()
+
+  // Register user hooks
+  if (config.hooks) {
+    hooks.addHooks(config.hooks)
+  }
+
   const generator = createGenerator({ ...defaults, config, hooks })
 
   const project = createProject({
     useInMemoryFileSystem: true,
     getFiles: () => [staticFilePath],
     readFile: () => code,
-    parserOptions: generator.parserOptions,
+    parserOptions: Object.assign(generator.parserOptions, { hooks }),
     hooks,
   })
 

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -810,7 +810,7 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
-  test.only('extractor:eval hook', () => {
+  test('extractor:eval hook', () => {
     const isFunctionMadeFromDefineParts = (expr: Identifier) => {
       const declaration = findIdentifierValueDeclaration(expr, [], {})
       if (!Node.isVariableDeclaration(declaration)) return

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -1,9 +1,12 @@
+import type { BoxContext } from '@pandacss/extractor'
 import type { TokenDictionary } from '@pandacss/token-dictionary'
 import type { HookKeys, Hookable } from 'hookable'
 import type { LoadConfigResult, UserConfig } from './config'
 import type { ParserResultType } from './parser'
+import type { Node } from 'ts-morph'
 
 type MaybeAsyncReturn = Promise<void> | void
+type EvaluateOptions = ReturnType<NonNullable<BoxContext['getEvaluateOptions']>>
 
 export interface PandaHooks {
   /**
@@ -22,6 +25,10 @@ export interface PandaHooks {
    * Called after reading the file content but before parsing it.
    */
   'parser:before': (file: string, content: string) => void
+  /**
+   * Called before evaluating a node with ts-evaluator, can provide an object of EvaluateOptions
+   */
+  'extractor:eval': (node: Node) => EvaluateOptions
   /**
    * Called after the file styles are extracted and processed into the resulting ParserResult object.
    */

--- a/playground/src/components/usePanda.tsx
+++ b/playground/src/components/usePanda.tsx
@@ -48,7 +48,7 @@ export function usePanda(source: string, theme: string) {
   return useMemo(() => {
     const project = createProject({
       useInMemoryFileSystem: true,
-      parserOptions: generator.parserOptions,
+      parserOptions: Object.assign({}, generator.parserOptions, { hooks: generator.hooks }),
       getFiles: () => ['code.tsx'],
       readFile: (file) => (file === 'code.tsx' ? source : ''),
       hooks: generator.hooks,


### PR DESCRIPTION
## 📝 Description

Add the `extractor:eval` config.hook:
It lets users provide scope variables or functions definitions and make the extract process adaptable to their use-cases

this makes such code statically extractable in user-land:

```ts
const parts = defineParts(checkboxAnatomy.build());
const checkbox = cva({
  base: parts({
    root: {},
    control: {
      background: 'primary',
    },
  }),
});
```

using the `extractor:eval` hook, we can enhance the `CallExpression` evaluation by returning an `environment` that contains a function implementation for `parts`, even though we never actually run the `defineParts` or `parts` code:

```ts
hooks: {
  'extractor:eval': (node) => {
    if (!Node.isCallExpression(node)) return
    const expr = node.getExpression()
  
    if (!Node.isIdentifier(expr)) return
    if (!isFunctionMadeFromDefineParts(expr)) return
  
    return { environment: { extra: { parts: (obj: any) => obj } } }
  },
},
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

idea from https://discord.com/channels/1118988919804010566/1120305029056831548/1120791649887465482