### PR TITLE
fix(parser): factory with prop access should be like `css`

### DIFF
--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -481,10 +481,8 @@ describe('extract to css output pipeline', () => {
       })
 
       const Input = panda.input({
-        base: {
-          color: "blue.100",
-          bg: "blue.900",
-        }
+        color: "blue.100",
+        bg: "blue.900",
       })
 
       function App () {
@@ -499,6 +497,16 @@ describe('extract to css output pipeline', () => {
     const result = run(code)
     expect(result.json).toMatchInlineSnapshot(`
       [
+        {
+          "data": [
+            {
+              "bg": "blue.900",
+              "color": "blue.100",
+            },
+          ],
+          "name": "panda.input",
+          "type": "object",
+        },
         {
           "data": [
             {
@@ -525,18 +533,6 @@ describe('extract to css output pipeline', () => {
         },
         {
           "data": [
-            {
-              "base": {
-                "bg": "blue.900",
-                "color": "blue.100",
-              },
-            },
-          ],
-          "name": "panda.input",
-          "type": "cva",
-        },
-        {
-          "data": [
             {},
           ],
           "name": "Button",
@@ -554,6 +550,14 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
+        .text_blue\\\\.100 {
+          color: var(--colors-blue-100)
+          }
+
+        .bg_blue\\\\.900 {
+          background: var(--colors-blue-900)
+          }
+
         .text_red\\\\.100 {
           color: var(--colors-red-100)
           }
@@ -568,14 +572,6 @@ describe('extract to css output pipeline', () => {
 
         .bg_green\\\\.900 {
           background: var(--colors-green-900)
-          }
-
-        .text_blue\\\\.100 {
-          color: var(--colors-blue-100)
-          }
-
-        .bg_blue\\\\.900 {
-          background: var(--colors-blue-900)
           }
       }"
     `)

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -269,7 +269,7 @@ export function createParser(options: ParserOptions) {
             (name) => jsx && name.startsWith(jsxFactoryAlias),
             (name) => {
               result.queryList.forEach((query) => {
-                collector.setCva({
+                collector.set('css', {
                   name,
                   box: (query.box.value[0] as BoxNodeMap) ?? fallback(query.box),
                   data: combineResult(unbox(query.box.value[0])),


### PR DESCRIPTION
my bad I misunderstood how the the `styled.div({ ... })` usage, it should be like `css` not like `cva`

fixes this one https://github.com/chakra-ui/panda/pull/787 