### PR TITLE
fix(vscode): engines version

### DIFF
--- a/extension/vscode/package.json
+++ b/extension/vscode/package.json
@@ -6,7 +6,7 @@
   "version": "0.2.4",
   "private": true,
   "engines": {
-    "vscode": "*"
+    "vscode": "^1.67.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
## 📝 Description

fixes this, I set it to the same version as [astro](https://github.com/withastro/language-tools/blob/6057e81e758ffab1dee2a27082934ae4480d21f0/packages/vscode/package.json#L32) extension
![image](https://github.com/chakra-ui/panda/assets/47224540/d874a1eb-a096-453c-af44-e7573e2a5611)