### PR TITLE
Remove 'value' key from breakpoints

### DIFF
--- a/website/pages/docs/customization/theme.mdx
+++ b/website/pages/docs/customization/theme.mdx
@@ -18,7 +18,7 @@ export default defineConfig({
   theme: {
     extend: {
       breakpoints: {
-        '3xl': { value: '1800px' }
+        '3xl': '1800px'
       }
     }
   }


### PR DESCRIPTION
## 📝 Description

Removes `value` key from `breakpoints` in theme config

## ⛳️ Current behavior (updates)

Docs suggest a `value` key for extending `breakpoints`

## 🚀 New behavior

`value` key is not used for `breakpoints` 

## 💣 Is this a breaking change (Yes/No):

No
