### PR TITLE
docs: preset code examples

### DIFF
--- a/website/pages/docs/customization/presets.md
+++ b/website/pages/docs/customization/presets.md
@@ -29,15 +29,17 @@ your `panda.config.ts` file.
 import { definePreset } from "@pandacss/dev";
 
 export default definePreset({
-  tokens: {
-    colors: {
-      rose: {
-        50: { value: "#fff1f2" },
-        // ...
-        800: { value: "#9f2233" },
+  theme: {
+    tokens: {
+      colors: {
+        rose: {
+          50: { value: "#fff1f2" },
+          // ...
+          800: { value: "#9f2233" },
+        },
       },
     },
-  },
+  }
 });
 ```
 
@@ -63,11 +65,13 @@ export default async function myPreset() {
   const roseColors = await getRoseColors();
 
   return definePreset({
-    tokens: {
-      colors: {
-        rose: roseColors,
+    theme: {
+      tokens: {
+        colors: {
+          rose: roseColors,
+        },
       },
-    },
+    }
   });
 }
 ```


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

No GitHub issue

## 📝 Description

In current documentation, theme object passed to `definePreset` is not wrapped by `theme` key. It should be wrapped as shown in example below from `preset-panda`

https://github.com/chakra-ui/panda/blob/main/packages/preset-panda/src/index.ts#L10

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No

## 📝 Additional Information
