### PR TITLE
fix(parser): svelte with TS / script context / multiple script

### DIFF
--- a/.changeset/popular-foxes-deny.md
+++ b/.changeset/popular-foxes-deny.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/parser': patch
+---
+
+Fix svelte parsing when using Typescript or <script context="module"> or multiple <script>

--- a/packages/parser/__tests__/svelte.test.ts
+++ b/packages/parser/__tests__/svelte.test.ts
@@ -12,10 +12,42 @@ const run = (code: string) => {
 }
 
 describe('extract svelte templates', () => {
-  test('svelte basic template', () => {
+  test('template with svelte-specific syntax + Typescript usage', () => {
     const code = `
-    <script lang="ts">
+
+    <script context="module">
+      let moduleStyle: string = css({ color: 'blue.400' })
+
+      type Something = "a" | "b" | "c";
+      type Another = Something | "d" | "e";
+
+      // the export keyword allows this function to imported with e.g.
+      export function getStyles() {
+        return style2
+      }
+
+      export let title;
+      export let person;
+
+      // this will update "document.title" whenever
+      // the "title" prop changes
+      $: document.title = title;
+
+      $: {
+        console.log("multiple statements can be combined");
+        css({ color: 'blue.100' })
+      }
+
+      // this will update "name" when 'person' changes
+      $: ({ name } = person);
+    </script>
+
+   <script lang="ts">
         import { css } from "styled-system/css";
+
+        export let variable: boolean;
+        type Something = "a" | "b" | "c";
+        type Another = Something | "d" | "e";
 
         let style = css({ color: 'green.400' })
         let style2 = css({ color: 'purple.400' })
@@ -24,24 +56,152 @@ describe('extract svelte templates', () => {
     <h1 class={style}>using class binding</h1>
     <p class={css({ color: 'red.500' })}>using inline styles</p>
     <span class="style3">using actual class</span>
+
+    {@html post.content}
+    {@debug}
+
+    <!-- this is a comment! --><h1>Hello world</h1>
+    <!-- svelte-ignore a11y-autofocus -->
+    <input bind:value={name} autofocus />
+
+    {#if porridge.temperature > 100}
+      <p class={css({ color: 'teal.100' })}>too hot!</p>
+    {:else if 80 > porridge.temperature}
+      <p class={css({ color: 'teal.200' })}>too cold!</p>
+    {:else}
+      <p className={css({ color: 'teal.300' })}>just right!</p>
+    {/if}
+
+    <ul>
+      {#each items as item}
+        <li class={css({ color: 'teal.400' })}>{item.name} x {item.qty}</li>
+      {/each}
+    </ul>
+
+    {#each items as { id, name, qty }, i (id)}
+      <li class={css({ color: 'teal.500' })}>{i + 1}: {name} x {qty}</li>
+    {/each}
+
+    {#await promise}
+      <!-- promise is pending -->
+      <p class={css({ color: 'teal.600' })}>waiting for the promise to resolve...</p>
+    {:then value}
+      <!-- promise was fulfilled -->
+      <p>The value is {value}</p>
+    {:catch error}
+      <!-- promise was rejected -->
+      <p class={css({ color: 'teal.700' })}>Something went wrong: {error.message}</p>
+    {/await}
+
+    <style>
+      p {
+        /* this will only affect <p> elements in this component */
+        color: burlywood;
+      }
+    </style>
     `
 
     const transformed = svelteToTsx(code)
     expect(transformed).toMatchInlineSnapshot(`
-      "import { css } from \\"styled-system/css\\";
+      "let moduleStyle: string = css({ color: 'blue.400' })
+
+            type Something = \\"a\\" | \\"b\\" | \\"c\\";
+            type Another = Something | \\"d\\" | \\"e\\";
+
+            // the export keyword allows this function to imported with e.g.
+            export function getStyles() {
+              return style2
+            }
+
+            export let title;
+            export let person;
+
+            // this will update \\"document.title\\" whenever
+            // the \\"title\\" prop changes
+            $: document.title = title;
+
+            $: {
+              console.log(\\"multiple statements can be combined\\");
+              css({ color: 'blue.100' })
+            }
+
+            // this will update \\"name\\" when 'person' changes
+            $: ({ name } = person);
+          
+              import { css } from \\"styled-system/css\\";
+
+              export let variable: boolean;
+              type Something = \\"a\\" | \\"b\\" | \\"c\\";
+              type Another = Something | \\"d\\" | \\"e\\";
 
               let style = css({ color: 'green.400' })
               let style2 = css({ color: 'purple.400' })
           
-
       const render = <div><h1 class={style}>using class binding</h1>
           <p class={css({ color: 'red.500' })}>using inline styles</p>
-          <span class=\\"style3\\">using actual class</span></div>"
+          <span class=\\"style3\\">using actual class</span>
+
+          {@html post.content}
+          {@debug}
+
+          <h1>Hello world</h1>
+          
+          <input bind:value={name} autofocus />
+
+          {#if porridge.temperature > 100}
+            <p class={css({ color: 'teal.100' })}>too hot!</p>
+          {:else if 80 > porridge.temperature}
+            <p class={css({ color: 'teal.200' })}>too cold!</p>
+          {:else}
+            <p className={css({ color: 'teal.300' })}>just right!</p>
+          {/if}
+
+          <ul>
+            {#each items as item}
+              <li class={css({ color: 'teal.400' })}>{item.name} x {item.qty}</li>
+            {/each}
+          </ul>
+
+          {#each items as { id, name, qty }, i (id)}
+            <li class={css({ color: 'teal.500' })}>{i + 1}: {name} x {qty}</li>
+          {/each}
+
+          {#await promise}
+            
+            <p class={css({ color: 'teal.600' })}>waiting for the promise to resolve...</p>
+          {:then value}
+            
+            <p>The value is {value}</p>
+          {:catch error}
+            
+            <p class={css({ color: 'teal.700' })}>Something went wrong: {error.message}</p>
+          {/await}
+
+          
+          </div>"
     `)
 
     const result = run(transformed)
     expect(result.json).toMatchInlineSnapshot(`
       [
+        {
+          "data": [
+            {
+              "color": "blue.400",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "blue.100",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
         {
           "data": [
             {
@@ -69,11 +229,82 @@ describe('extract svelte templates', () => {
           "name": "css",
           "type": "object",
         },
+        {
+          "data": [
+            {
+              "color": "teal.100",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "teal.200",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "teal.300",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "teal.400",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "teal.500",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "teal.600",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "color": "teal.700",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
       ]
     `)
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
+        .text_blue\\\\.400 {
+          color: var(--colors-blue-400)
+          }
+
+        .text_blue\\\\.100 {
+          color: var(--colors-blue-100)
+          }
+
         .text_green\\\\.400 {
           color: var(--colors-green-400)
           }
@@ -84,6 +315,34 @@ describe('extract svelte templates', () => {
 
         .text_red\\\\.500 {
           color: var(--colors-red-500)
+          }
+
+        .text_teal\\\\.100 {
+          color: var(--colors-teal-100)
+          }
+
+        .text_teal\\\\.200 {
+          color: var(--colors-teal-200)
+          }
+
+        .text_teal\\\\.300 {
+          color: var(--colors-teal-300)
+          }
+
+        .text_teal\\\\.400 {
+          color: var(--colors-teal-400)
+          }
+
+        .text_teal\\\\.500 {
+          color: var(--colors-teal-500)
+          }
+
+        .text_teal\\\\.600 {
+          color: var(--colors-teal-600)
+          }
+
+        .text_teal\\\\.700 {
+          color: var(--colors-teal-700)
           }
       }"
     `)

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -24,7 +24,6 @@
     "@vue/compiler-sfc": "^3.3.4",
     "lil-fp": "1.4.5",
     "magic-string": "^0.30.0",
-    "svelte": "^4.0.0",
     "ts-morph": "18.0.0",
     "ts-pattern": "4.3.0"
   },

--- a/packages/parser/src/svelte-to-tsx.ts
+++ b/packages/parser/src/svelte-to-tsx.ts
@@ -1,28 +1,28 @@
-import * as svelte from 'svelte/compiler'
 import MagicString from 'magic-string'
+
+/** @see https://github.com/sveltejs/svelte/blob/d3297e2a2595db08c85356d65fd5f953b04a681f/packages/svelte/src/compiler/preprocess/index.js#L255C1-L255C85 */
+const regex_style_tags = /<!--[^]*?-->|<style(\s[^]*?)?(?:>([^]*?)<\/style>|\/>)/gi
+
+/** @see https://github.com/sveltejs/svelte/blob/d3297e2a2595db08c85356d65fd5f953b04a681f/packages/svelte/src/compiler/preprocess/index.js#L256C1-L256C88 */
+const regex_script_tags = /<!--[^]*?-->|<script(\s[^]*?)?(?:>([^]*?)<\/script>|\/>)/gi
 
 export const svelteToTsx = (code: string) => {
   try {
-    const parsed = svelte.parse(code)
-    const fileStr = new MagicString(code)
+    const scripts = []
+    const original = new MagicString(code)
 
-    // remove the script tag
-    if (parsed.instance && parsed.instance.content) {
-      const content = parsed.instance.content as any as typeof parsed.instance // it's actually a `BaseNode` but the type isnt exported so..
-      fileStr.update(parsed.instance.start, parsed.instance.end, code.slice(content.start, content.end))
+    // Remove script tags & extract script content
+    let match: RegExpExecArray | null
+    while ((match = regex_script_tags.exec(code)) != null) {
+      const [fullMatch, _attributesStr, scriptContent] = match
+      if (scriptContent) {
+        scripts.push(scriptContent)
+        original.remove(match.index, match.index + fullMatch.length)
+      }
     }
 
-    const moduleContext = parsed.module ? fileStr.snip(parsed.module.start, parsed.module.end) : ''
-    const scriptContent = parsed.instance ? fileStr.snip(parsed.instance.start, parsed.instance.end) : ''
-    const templateContent =
-      parsed.html.children
-        ?.map((child) => fileStr.snip(child.start, child.end))
-        .join('')
-        .trimStart() ?? ''
-
-    const transformed = new MagicString(
-      `${moduleContext + '\n'}${scriptContent + '\n'}\nconst render = <div>${templateContent}</div>`,
-    )
+    const templateContent = original.toString().trimStart().replace(regex_style_tags, '').replace(regex_style_tags, '')
+    const transformed = `${scripts.join('')}\nconst render = <div>${templateContent}</div>`
 
     return transformed.toString().trim()
   } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -815,9 +815,6 @@ importers:
       magic-string:
         specifier: ^0.30.0
         version: 0.30.0
-      svelte:
-        specifier: ^4.0.0
-        version: 4.0.0
       ts-morph:
         specifier: 18.0.0
         version: 18.0.0
@@ -1979,26 +1976,6 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.0
 
-  /@babel/helper-create-class-features-plugin@7.22.1(@babel/core@7.22.1):
-    resolution: {integrity: sha512-SowrZ9BWzYFgzUMwUmowbPSGu6CXL5MSuuCkG3bejahSpSymioPmuLdhPxNOc9MjuNGjy7M/HaXvJ8G82Lywlw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.3
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.22.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.22.5
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-create-class-features-plugin@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==}
     engines: {node: '>=6.9.0'}
@@ -2006,6 +1983,26 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.21.8
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.5
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-create-class-features-plugin@7.22.5(@babel/core@7.22.1):
+    resolution: {integrity: sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.1
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
@@ -2109,13 +2106,6 @@ packages:
     dependencies:
       '@babel/types': 7.22.5
 
-  /@babel/helper-member-expression-to-functions@7.22.3:
-    resolution: {integrity: sha512-Gl7sK04b/2WOb6OPVeNy9eFKeD3L6++CzL3ykPOWqTn08xgYYK0wz4TUh2feIImDXxcVW3/9WQ1NMKY66/jfZA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: true
-
   /@babel/helper-member-expression-to-functions@7.22.5:
     resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
     engines: {node: '>=6.9.0'}
@@ -2155,13 +2145,6 @@ packages:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-optimise-call-expression@7.18.6:
-    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -2210,20 +2193,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helper-replace-supers@7.22.1:
-    resolution: {integrity: sha512-ut4qrkE4AuSfrwHSps51ekR1ZY/ygrP1tp0WFm8oVq6nzc/hvfV/22JylndIbsf2U2M9LOMwiSddr6y+78j+OQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.3
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-replace-supers@7.22.5:
     resolution: {integrity: sha512-aLdNM5I3kdI/V9xGNyKSF3X/gTyMUBohTZ+/3QdQKAA9vxIiy12E+8E2HoOP1/DjeqU+g6as35QHJNMDDYpuCg==}
     engines: {node: '>=6.9.0'}
@@ -2242,13 +2211,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
-
-  /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
-    resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-    dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
@@ -2822,6 +2784,16 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
 
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.1):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.1
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
     engines: {node: '>=6.9.0'}
@@ -2980,14 +2952,14 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-typescript@7.21.4(@babel/core@7.22.1):
-    resolution: {integrity: sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==}
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.1):
+    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.1
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.5):
@@ -3449,7 +3421,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.1
       '@babel/helper-module-transforms': 7.22.5
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -3969,17 +3941,17 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-typescript@7.22.3(@babel/core@7.22.1):
-    resolution: {integrity: sha512-pyjnCIniO5PNaEuGxT28h0HbMru3qCVrMqVgVOz/krComdIrY9W6FCLBq9NWHY8HDGaUlan+UhmZElDENIfCcw==}
+  /@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.1):
+    resolution: {integrity: sha512-SMubA9S7Cb5sGSFFUlqxyClTA9zWJ8qGQrppNUm05LtFuN1ELRFNndkix4zUJrC9F+YivWwa1dHMSyo0e0N9dA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.1
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.22.1(@babel/core@7.22.1)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.22.1)
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.22.1)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4293,11 +4265,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.1
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.1)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.1)
       '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.1)
-      '@babel/plugin-transform-typescript': 7.22.3(@babel/core@7.22.1)
+      '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.22.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13780,6 +13752,7 @@ packages:
       acorn: 8.9.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
+    dev: true
 
   /collapse-white-space@1.0.6:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
@@ -14346,6 +14319,7 @@ packages:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.0.2
+    dev: true
 
   /css-what@5.1.0:
     resolution: {integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==}
@@ -20252,6 +20226,7 @@ packages:
 
   /locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: true
 
   /locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -20933,6 +20908,7 @@ packages:
 
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+    dev: true
 
   /mdn-data@2.0.32:
     resolution: {integrity: sha512-dGzrfhOPm47P8qlChU77TGlCEcFNOCDAhCbHP53LST3FR5jSB5JSHaPjyYW2uFd2CV6D6z4tzCGW09pTxSn0aA==}
@@ -26663,6 +26639,7 @@ packages:
       locate-character: 3.0.0
       magic-string: 0.30.0
       periscopic: 3.1.0
+    dev: true
 
   /svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/813

## 📝 Description

Fix svelte parsing 

## ⛳️ Current behavior (updates)

- `<script context="module">` content would not be extracted properly
- Typescript usage in a `<script>` would make the `svelte.parse(code)` crash
- using multiple <script> wasn't working properly either

## 🚀 New behavior

fixed

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

implementation-wise, I removed the `svelte.parse` cause we can't use `svelte-preprocess` either because of its async-ness

surprisingly it seems ts-morph is parsing just fine in svelte-specific syntax such as `{#if xxx}` `{:catch}` etc, so we just remove the `<script xxx>` & `<style>` tags with regexes
