### PR TITLE
fix(parser): imports matching with tsconfig baseUrl

### DIFF
--- a/.changeset/pretty-wasps-appear.md
+++ b/.changeset/pretty-wasps-appear.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/generator': patch
+'@pandacss/parser': patch
+'@pandacss/types': patch
+'@pandacss/node': patch
+---
+
+Fix issue where using a nested outdir like `src/styled-system` with a baseUrl like `./src` would result on parser NOT
+matching imports like `import { container } from "styled-system/patterns";` cause it would expect the full path
+`src/styled-system`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -48,7 +48,8 @@
     "postcss": "8.4.24",
     "preferred-pm": "^3.0.3",
     "ts-morph": "18.0.0",
-    "ts-pattern": "4.3.0"
+    "ts-pattern": "4.3.0",
+    "tsconfck": "^2.1.1"
   },
   "devDependencies": {
     "@pandacss/fixture": "workspace:*",

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -2,6 +2,7 @@ import { loadConfigFile } from '@pandacss/config'
 import type { Config, ConfigResultWithHooks, PandaHooks } from '@pandacss/types'
 import { createDebugger, createHooks } from 'hookable'
 import { lookItUpSync } from 'look-it-up'
+import { parse } from 'tsconfck'
 import { createContext } from './create-context'
 
 const configs = ['.ts', '.js', '.mjs', '.cjs']
@@ -26,6 +27,12 @@ export async function loadConfigAndCreateContext(options: { cwd?: string; config
   }
   if (options.cwd) {
     conf.config.cwd = options.cwd
+  }
+
+  const tsconfigResult = await parse(conf.path, { root: cwd, resolveWithEmptyIfConfigNotFound: true })
+  if (tsconfigResult) {
+    conf.tsconfig = tsconfigResult.tsconfig
+    conf.tsconfigFile = tsconfigResult.tsconfigFile
   }
 
   conf.config.outdir ??= 'styled-system'

--- a/packages/node/src/create-context.ts
+++ b/packages/node/src/create-context.ts
@@ -25,6 +25,7 @@ export const createContext = (conf: ConfigResultWithHooks) =>
 
     Obj.bind('project', ({ getFiles, runtime: { fs }, parserOptions }) => {
       return createProject({
+        ...conf.tsconfig,
         getFiles,
         readFile: fs.readFileSync,
         hooks: conf.hooks,

--- a/packages/parser/__tests__/fixture.ts
+++ b/packages/parser/__tests__/fixture.ts
@@ -9,13 +9,13 @@ import {
   utilities,
 } from '@pandacss/fixture'
 import { createGenerator } from '@pandacss/generator'
-import type { LoadConfigResult, PandaHooks } from '@pandacss/types'
+import type { LoadConfigResult, PandaHooks, TSConfig } from '@pandacss/types'
 import { type UserConfig } from '@pandacss/types'
 import { createProject } from '../src'
 import { getImportDeclarations } from '../src/import'
 import { createHooks } from 'hookable'
 
-const staticFilePath = 'test.tsx'
+const staticFilePath = 'app/src/test.tsx'
 
 const defaults: LoadConfigResult = {
   dependencies: [],
@@ -58,12 +58,17 @@ function getProject(code: string, options?: <Conf extends UserConfig>(conf: Conf
   })
 }
 
-export function getFixtureProject(code: string, options?: <Conf extends UserConfig>(conf: Conf) => Conf) {
+export function getFixtureProject(
+  code: string,
+  options?: <Conf extends UserConfig>(conf: Conf) => Conf,
+  tsconfig?: TSConfig,
+) {
   const config = options ? options(defaults.config) : defaults.config
   const hooks = createHooks<PandaHooks>()
-  const generator = createGenerator({ ...defaults, config, hooks })
+  const generator = createGenerator({ ...defaults, config, hooks, tsconfig })
 
   const project = createProject({
+    ...tsconfig,
     useInMemoryFileSystem: true,
     getFiles: () => [staticFilePath],
     readFile: () => code,

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from 'vitest'
 import { getFixtureProject } from './fixture'
+import { TSConfig, UserConfig } from '@pandacss/types'
 
-const run = (code: string) => {
-  const { parse, generator } = getFixtureProject(code)
+const run = (code: string, options?: <Conf extends UserConfig>(conf: Conf) => Conf, tsconfig?: TSConfig) => {
+  const { parse, generator } = getFixtureProject(code, options, tsconfig)
   const result = parse()!
   return {
     json: result?.toArray().map(({ box, ...item }) => item),
@@ -2643,6 +2644,169 @@ describe('preset patterns', () => {
         .text_blue\\\\.100 {
           color: var(--colors-blue-100)
           }
+      }"
+    `)
+  })
+
+  test('nested outdir + tsconfig.compilerOptions.baseUrl importMap behaviour', () => {
+    const code = `
+    import { css } from "../styled-system/css";
+    import { container } from "../styled-system/patterns";
+
+    export default function App() {
+      return (
+        <div
+          className={container({
+            page: "A4",
+            width: {
+              _print: "210mm",
+            },
+            height: {
+              _print: "297mm",
+              base: "600px",
+            },
+            display: "flex",
+            margin: "auto",
+            flexDir: {
+              _print: "row",
+              base: "column",
+              sm: "row",
+            },
+          })}
+        >
+          <div className={css({ flex: 2 })}>aaa</div>
+          <div className={css({ flex: 1 })}>bbb</div>
+        </div>
+      );
+    }
+
+     `
+    const result = run(code, (config) => ({ ...config, outdir: 'src/styled-system', cwd: 'app' }), {
+      compilerOptions: { baseUrl: 'app/src' },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "flex": 2,
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "flex": 1,
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "display": "flex",
+              "flexDir": {
+                "_print": "row",
+                "base": "column",
+                "sm": "row",
+              },
+              "height": {
+                "_print": "297mm",
+                "base": "600px",
+              },
+              "margin": "auto",
+              "page": "A4",
+              "width": {
+                "_print": "210mm",
+              },
+            },
+          ],
+          "name": "container",
+          "type": "pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .flex_2 {
+          flex: 2
+          }
+
+        .flex_1 {
+          flex: 1 1 0%
+          }
+
+        .pos_relative {
+          position: relative
+          }
+
+        .max-w_8xl {
+          max-width: var(--sizes-8xl)
+          }
+
+        .mx_auto {
+          margin-inline: auto
+          }
+
+        .px_4 {
+          padding-inline: var(--spacing-4)
+          }
+
+        .page_A4 {
+          page: A4
+          }
+
+        .h_600px {
+          height: 600px
+          }
+
+        .d_flex {
+          display: flex
+          }
+
+        .m_auto {
+          margin: auto
+          }
+
+        .flex_column {
+          flex-direction: column
+          }
+
+        @media screen and (min-width: 640px) {
+          .sm\\\\:flex_row {
+            flex-direction: row
+          }
+              }
+
+        @media screen and (min-width: 768px) {
+          .md\\\\:px_6 {
+            padding-inline: var(--spacing-6)
+          }
+              }
+
+        @media screen and (min-width: 1024px) {
+          .lg\\\\:px_8 {
+            padding-inline: var(--spacing-8)
+          }
+              }
+
+        @media print {
+          .print\\\\:w_210mm {
+            width: 210mm
+          }
+
+          .print\\\\:h_297mm {
+            height: 297mm
+          }
+
+          .print\\\\:flex_row {
+            flex-direction: row
+          }
+              }
       }"
     `)
   })

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -105,7 +105,7 @@ export function createParser(options: ParserOptions) {
     const isValidStyleFn = (name: string) => name === jsx?.factory
     const isFactory = (name: string) => jsx && name.startsWith(jsx.factory)
 
-    const jsxFactoryAlias = jsx ? imports.getAlias(jsx.factory) : 'panda'
+    const jsxFactoryAlias = jsx ? imports.getAlias(jsx.factory) : 'styled'
     const jsxPatternNodes = new RegExp(
       `^(${jsx?.nodes.map((node) => node.type === 'pattern' && node.name).join('|')})$`,
     )

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,6 +22,7 @@
     "@pandacss/token-dictionary": "workspace:*",
     "chokidar-cli": "^3.0.0",
     "csstype": "3.1.2",
-    "hookable": "5.5.3"
+    "hookable": "5.5.3",
+    "pkg-types": "1.0.3"
   }
 }

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1,3 +1,4 @@
+import type { TSConfig } from 'pkg-types'
 import type { Conditions } from './conditions'
 import type { PandaHooks } from './hooks'
 import type { PatternConfig } from './pattern'
@@ -6,6 +7,8 @@ import type { StaticCssOptions } from './static-css'
 import type { GlobalStyleObject } from './system-types'
 import type { Theme } from './theme'
 import type { UtilityConfig } from './utility'
+
+export type { TSConfig }
 
 type StudioOptions = {
   /**
@@ -230,8 +233,10 @@ export type Preset = ExtendableOptions & PresetOptions
 
 export type UserConfig = UnwrapExtend<RequiredBy<Config, 'outdir' | 'cwd' | 'include'>>
 
-export type LoadConfigResult = {
+export interface LoadConfigResult {
   path: string
   config: UserConfig
+  tsconfig?: TSConfig
+  tsconfigFile?: string
   dependencies: string[]
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,7 @@ export type {
 } from './analyze-report'
 export type { CompositionStyles, LayerStyles, TextStyles } from './composition'
 export type { ConditionDetails, ConditionType, Conditions, RawCondition } from './conditions'
-export type { Config, LoadConfigResult, Preset, UserConfig } from './config'
+export type { Config, LoadConfigResult, Preset, UserConfig, TSConfig } from './config'
 export type { ConfigResultWithHooks, PandaHooks, PandaHookable } from './hooks'
 export type { ParserResultType, ResultItem } from './parser'
 export type { Part, Parts } from './parts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
       ts-pattern:
         specifier: 4.3.0
         version: 4.3.0
+      tsconfck:
+        specifier: ^2.1.1
+        version: 2.1.1(typescript@5.1.3)
     devDependencies:
       '@pandacss/fixture':
         specifier: workspace:*
@@ -955,6 +958,9 @@ importers:
       hookable:
         specifier: 5.5.3
         version: 5.5.3
+      pkg-types:
+        specifier: 1.0.3
+        version: 1.0.3
 
   playground:
     dependencies:
@@ -21609,6 +21615,7 @@ packages:
       pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.1.2
+    dev: false
 
   /mlly@1.4.0:
     resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
@@ -21617,7 +21624,6 @@ packages:
       pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.1.2
-    dev: true
 
   /mocha@5.2.0:
     resolution: {integrity: sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==}
@@ -23165,7 +23171,7 @@ packages:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.3.0
+      mlly: 1.4.0
       pathe: 1.1.1
 
   /pkg-up@3.1.0:


### PR DESCRIPTION
## 📝 Description

Fix issue where using a nested `outdir` like `src/styled-system` with a tsconfig `baseUrl` like `./src` would result on parser NOT matching imports like: `import { container } from "styled-system/patterns";` cause it would expect the full path `src/styled-system` in the module specifier

## ⛳️ Current behavior (updates)

some imports using the baseUrl instead of a relative path are being ignored by the imports matching in the parser (and therefore skip generating the corresponding css)

we can see it here
https://github.com/maxswjeon/panda-css-patterns-missing-css thanks @maxswjeon for the minimal reproduction

## 🚀 New behavior

bundling the config will also load the tsconfig (if there's any), so we can use the tsconfig.baseUrl in our imports matching logic

## 💣 Is this a breaking change (Yes/No):

no
