### PR TITLE
fix(extractor): handle operation tokens

### DIFF
--- a/.changeset/famous-hotels-flash.md
+++ b/.changeset/famous-hotels-flash.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/extractor': patch
+---
+
+Handle operation tokens in extractor. This means that values such as `1 / 2`, `3*5`, `2 **4`, `8- 1` will now properly
+be extracted
+
+Fix: https://github.com/chakra-ui/panda/issues/801

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -6292,3 +6292,29 @@ it('handles root tagged template literals', () => {
     }
   `)
 })
+
+it('handles operation tokens', () => {
+  expect(
+    extractFromCode(
+      `<>
+  <AspectRatio ratio={1 / 2} asterisk={1 *5} exp={1**4} minus={5 -1} />
+  `,
+      { tagNameList: ['AspectRatio'] },
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "AspectRatio": [
+        {
+          "conditions": [],
+          "raw": {
+            "asterisk": "1 *5",
+            "exp": "1**4",
+            "minus": "5 -1",
+            "ratio": "1 / 2",
+          },
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/extractor/src/maybe-box-node.ts
+++ b/packages/extractor/src/maybe-box-node.ts
@@ -50,6 +50,13 @@ const isLogicalSyntax = (op: SyntaxKind) =>
   op === ts.SyntaxKind.InstanceOfKeyword ||
   op === ts.SyntaxKind.InKeyword
 
+const isOperationSyntax = (op: SyntaxKind) =>
+  op === ts.SyntaxKind.AsteriskToken ||
+  op === ts.SyntaxKind.SlashToken ||
+  op === ts.SyntaxKind.PercentToken ||
+  op === ts.SyntaxKind.AsteriskAsteriskToken ||
+  op === ts.SyntaxKind.MinusToken
+
 const canReturnWhenTrueInLogicalExpression = (op: ts.SyntaxKind) => {
   return op === ts.SyntaxKind.BarBarToken || op === ts.SyntaxKind.QuestionQuestionToken
 }
@@ -214,6 +221,9 @@ export function maybeBoxNode(
               canReturnWhenTrue: canReturnWhenTrueInLogicalExpression(op),
             } as const
             return cache(maybeResolveConditionalExpression(exprObject, ctx))
+          })
+          .when(isOperationSyntax, () => {
+            return cache(box.literal(node.getText(), node, stack))
           })
           .otherwise(() => undefined)
       })


### PR DESCRIPTION
Closes #801

## 📝 Description

`@pandacss/extractor` didnt handle operation tokens. This means that values such as `1 / 2`, `3*5`, `2 **4`, `8- 1` will now properly be extracted

## 💣 Is this a breaking change (Yes/No):

no
