### PR TITLE
website:fix sidebar is always open when prefers-reduced-motion is available

### DIFF
--- a/website/src/nextra/sidebar/sidebar-container.tsx
+++ b/website/src/nextra/sidebar/sidebar-container.tsx
@@ -33,9 +33,6 @@ const sidebarContainerStyles = cva({
         maskImage: `linear-gradient(to bottom, transparent, #000 20px), linear-gradient(to left, #000 10px, transparent 10px)`
       }
     },
-    _motionReduce: {
-      transform: 'none'
-    },
     transform: 'translate3d(0,0,0)',
     transitionProperty: 'all',
     _print: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #830

## 📝 Description

This PR is for #830 .

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

The sidebar on the document page is always open on mobile when prefers-reduced-motion is available.
(The sidebar covers a whole screen.)

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The sidebar on the document page works fine on mobile when prefers-reduced-motion is available.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No

## 📝 Additional Information

https://github.com/chakra-ui/panda/assets/10266230/59102d67-d89f-41cb-896a-a0840e4419ff

I'm not sure this PR is the best way to fix #830 . So please check it. And close it if you don't need it.
Thanks.