### PR TITLE
fix(shared): add fallback on astish value

### DIFF
--- a/.changeset/nasty-planes-rhyme.md
+++ b/.changeset/nasty-planes-rhyme.md
@@ -1,0 +1,12 @@
+---
+'@pandacss/shared': patch
+---
+
+Fix the `astish` shared function when using `config.syntax: 'template-literal'`
+
+ex: css`${someVar}`
+
+if a value is unresolvable in the static analysis step, it would be interpreted as `undefined`, and `astish` would
+throw:
+
+> TypeError: Cannot read properties of undefined (reading 'replace')

--- a/packages/shared/__tests__/astish.test.ts
+++ b/packages/shared/__tests__/astish.test.ts
@@ -31,4 +31,9 @@ describe('astish', () => {
       }
     `)
   })
+
+  // @ts-ignore
+  // can happen if a value is unresolvable in the static analysis step
+  // ex: css`${someVar}`
+  astish(undefined)
 })

--- a/packages/shared/src/astish.ts
+++ b/packages/shared/src/astish.ts
@@ -2,7 +2,7 @@ const newRule = /(?:([\u0080-\uFFFF\w-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(}\s*
 const ruleClean = /\/\*[^]*?\*\/|\s\s+|\n/g
 
 export const astish = (val: string, tree: any[] = [{}]): Record<string, any> => {
-  const block = newRule.exec(val.replace(ruleClean, ''))
+  const block = newRule.exec((val ?? '').replace(ruleClean, ''))
   if (!block) return tree[0]
   if (block[4]) tree.shift()
   else if (block[3]) tree.unshift((tree[0][block[3]] = tree[0][block[3]] || {}))


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/855

## 📝 Description

Fix the `astish` shared function when using `config.syntax: 'template-literal'`

ex:

```ts
css`${someVar}`
```

if a value is unresolvable in the static analysis step, it would be interpreted as `undefined`, and `astish` would
throw:

> TypeError: Cannot read properties of undefined (reading 'replace')

## 💣 Is this a breaking change (Yes/No):

no
