### PR TITLE
fix(recipes): multiple recipes on 1 JSX element

### DIFF
--- a/.changeset/rotten-kids-develop.md
+++ b/.changeset/rotten-kids-develop.md
@@ -1,0 +1,55 @@
+---
+'@pandacss/generator': patch
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Fix JSX recipe extraction when multiple recipes were used on the same component, ex:
+
+```tsx
+const ComponentWithMultipleRecipes = ({ variant }) => {
+  return (
+    <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+  )
+}
+```
+
+Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
+
+```ts
+recipes: {
+    pinkRecipe: {
+        name: 'pinkRecipe',
+        jsx: ['ComponentWithMultipleRecipes'],
+        base: { color: 'pink.100' },
+        variants: {
+            variant: {
+            small: { fontSize: 'sm' },
+            },
+        },
+    },
+    greenRecipe: {
+        name: 'greenRecipe',
+        jsx: ['ComponentWithMultipleRecipes'],
+        base: { color: 'green.100' },
+        variants: {
+            variant: {
+            small: { fontSize: 'sm' },
+            },
+        },
+    },
+    blueRecipe: {
+        name: 'blueRecipe',
+        jsx: ['ComponentWithMultipleRecipes'],
+        base: { color: 'blue.100' },
+        variants: {
+            variant: {
+            small: { fontSize: 'sm' },
+            },
+        },
+    },
+},
+```
+
+Only the first matching recipe would be noticed and have its CSS generated, now this will properly generate the CSS for
+each of them

--- a/packages/core/src/recipes.ts
+++ b/packages/core/src/recipes.ts
@@ -1,4 +1,4 @@
-import { capitalize, dashCase, memo, splitProps, uncapitalize } from '@pandacss/shared'
+import { capitalize, dashCase, memo, splitProps } from '@pandacss/shared'
 import type { RecipeConfig, Dict, SystemStyleObject } from '@pandacss/types'
 import merge from 'lodash.merge'
 import { AtomicRule, type ProcessOptions } from './atomic-rule'
@@ -105,15 +105,12 @@ export class Recipes {
     return this.recipes[name]
   })
 
-  find = memo((name: string) => {
-    for (const node of sharedState.configs.values()) {
-      if (node.match.test(name)) return node
-    }
+  find = memo((jsxName: string) => {
+    return this.details.find((node) => node.match.test(jsxName))
   })
 
-  getFnName = memo((jsxName: string) => {
-    const recipe = this.find(jsxName)
-    return recipe?.name ?? uncapitalize(jsxName)
+  filter = memo((jsxName: string) => {
+    return this.details.filter((node) => node.match.test(jsxName))
   })
 
   get details() {

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -47,8 +47,7 @@ export const createGenerator = (conf: ConfigResultWithHooks) => {
         isStyleProp: isValidProperty,
         nodes: [...patterns.nodes, ...recipes.nodes],
       },
-      getRecipeName: recipes.getFnName,
-      getRecipeByName: recipes.getConfig,
+      getRecipesByJsxName: recipes.filter,
     },
   }
 }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -260,10 +260,28 @@ describe('extract to css output pipeline', () => {
         },
         {
           "data": [
+            {
+              "variant": "sm",
+            },
+          ],
+          "name": "ComponentWithMultipleRecipes",
+          "type": "jsx-recipe",
+        },
+        {
+          "data": [
             {},
           ],
           "name": "blueRecipe",
           "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "variant": "sm",
+            },
+          ],
+          "name": "ComponentWithMultipleRecipes",
+          "type": "jsx-recipe",
         },
       ]
     `)

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -179,6 +179,114 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
+  test('multiple recipes on 1 component', () => {
+    const code = `
+    import { button, pinkRecipe, greenRecipe, blueRecipe } from ".panda/recipes"
+
+    const ComponentWithMultipleRecipes = ({ variant }) => {
+      return <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    }
+
+
+    export default function Page() {
+      return (
+        <>
+          <ComponentWithMultipleRecipes variant="sm" />
+        </>
+      )
+    }
+     `
+    const result = run(code, (conf) => ({
+      ...conf,
+      theme: {
+        recipes: {
+          pinkRecipe: {
+            name: 'pinkRecipe',
+            jsx: ['ComponentWithMultipleRecipes'],
+            base: { color: 'pink.100' },
+            variants: {
+              variant: {
+                small: { fontSize: 'sm' },
+              },
+            },
+          },
+          greenRecipe: {
+            name: 'greenRecipe',
+            jsx: ['ComponentWithMultipleRecipes'],
+            base: { color: 'green.100' },
+            variants: {
+              variant: {
+                small: { fontSize: 'sm' },
+              },
+            },
+          },
+          blueRecipe: {
+            name: 'blueRecipe',
+            jsx: ['ComponentWithMultipleRecipes'],
+            base: { color: 'blue.100' },
+            variants: {
+              variant: {
+                small: { fontSize: 'sm' },
+              },
+            },
+          },
+        },
+      },
+    }))
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "pinkRecipe",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "variant": "sm",
+            },
+          ],
+          "name": "ComponentWithMultipleRecipes",
+          "type": "jsx-recipe",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "greenRecipe",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "blueRecipe",
+          "type": "recipe",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes {
+        @layer _base {
+          .pinkRecipe {
+            color: pink.100
+              }
+
+          .greenRecipe {
+            color: green.100
+              }
+
+          .blueRecipe {
+            color: blue.100
+              }
+          }
+      }"
+    `)
+  })
+
   test('empty rules', () => {
     const code = `
     import { SectionLearn } from '@/components/sections/learn'


### PR DESCRIPTION
originally issued on discord with this minimal repro repo https://github.com/snowball-tech/fractal

Closes #861

## 📝 Description

Fix JSX recipe extraction when multiple recipes were used on the same component, ex:

```tsx
const ComponentWithMultipleRecipes = ({ variant }) => {
  return (
    <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
  )
}
```

Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:

```ts
recipes: {
    pinkRecipe: {
        name: 'pinkRecipe',
        jsx: ['ComponentWithMultipleRecipes'],
        base: { color: 'pink.100' },
        variants: {
            variant: {
            small: { fontSize: 'sm' },
            },
        },
    },
    greenRecipe: {
        name: 'greenRecipe',
        jsx: ['ComponentWithMultipleRecipes'],
        base: { color: 'green.100' },
        variants: {
            variant: {
            small: { fontSize: 'sm' },
            },
        },
    },
    blueRecipe: {
        name: 'blueRecipe',
        jsx: ['ComponentWithMultipleRecipes'],
        base: { color: 'blue.100' },
        variants: {
            variant: {
            small: { fontSize: 'sm' },
            },
        },
    },
},
```

Only the first matching recipe would be noticed and have its CSS generated, now this will properly generate the CSS for
each of them


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

the test output will be clearer once https://github.com/chakra-ui/panda/pull/878 is merged
