### PR TITLE
fix(parser): never allow all JSX props to be extracted

### DIFF
--- a/.changeset/three-spiders-turn.md
+++ b/.changeset/three-spiders-turn.md
@@ -1,0 +1,22 @@
+---
+'@pandacss/parser': patch
+---
+
+Do not allow all JSX properties to be extracted if none provided, rely on the `isStyleProp` fn instead
+
+This fixes cases when :
+
+- `eject: true` and only the `@pandacss/preset-base` is used (or none)
+- some non-styling JSX prop is extracted leading to an incorrect CSS rule being generated, ex:
+
+```sh
+🐼 info [cli] Writing /Users/astahmer/dev/reproductions/remix-panda/styled-system/debug/app__routes___index.css
+🐼 error [serializer:css] Failed to serialize CSS: CssSyntaxError: <css input>:28:19: Missed semicolon
+
+  26 |     }
+  27 |     .src_https\:\/\/akmweb\.viztatech\.com\/web\/svnres\/file\/50_e4bb32c9ea75c5de397f2dc17a3cf186\.jpg {
+> 28 |         src: https://akmweb.viztatech.com/web/svnres/file/50_e4bb32c9ea75c5de397f2dc17a3cf186.jpg
+     |                   ^
+  29 |     }
+  30 | }
+```

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -174,8 +174,6 @@ export function createParser(options: ParserOptions) {
     })
 
     const matchTagProp = memo((tagName: string, propName: string) => {
-      if (propertiesMap.size === 0) return true // = allow all
-
       if (
         Boolean(components.get(tagName)?.has(propName)) ||
         options.jsx?.isStyleProp(propName) ||


### PR DESCRIPTION
Closes # discord issue https://discord.com/channels/1118988919804010566/1124374872345292913/1124383942552866846

## 📝 Description

Do not allow all JSX properties to be extracted if none provided, rely on the `isStyleProp` fn instead

## ⛳️ Current behavior (updates)

when:
- `eject: true` and only the `@pandacss/preset-base` is used (or none)
- some non-styling JSX prop is extracted leading to an incorrect CSS rule being generated, ex:

```sh
🐼 info [cli] Writing /Users/astahmer/dev/reproductions/remix-panda/styled-system/debug/app__routes___index.css
🐼 error [serializer:css] Failed to serialize CSS: CssSyntaxError: <css input>:28:19: Missed semicolon

  26 |     }
  27 |     .src_https\:\/\/akmweb\.viztatech\.com\/web\/svnres\/file\/50_e4bb32c9ea75c5de397f2dc17a3cf186\.jpg {
> 28 |         src: https://akmweb.viztatech.com/web/svnres/file/50_e4bb32c9ea75c5de397f2dc17a3cf186.jpg
     |                   ^
  29 |     }
  30 | }
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

minimal repro here https://github.com/lili21/remix-panda
