### PR TITLE
feat(vscode): enable extension in astro/svelte/vue files

### DIFF
--- a/.changeset/smooth-dragons-check.md
+++ b/.changeset/smooth-dragons-check.md
@@ -1,0 +1,5 @@
+---
+'panda-css-vscode': patch
+---
+
+Enable extension in .astro/svelte/vue files

--- a/extension/vscode/src/index.ts
+++ b/extension/vscode/src/index.ts
@@ -13,7 +13,15 @@ import { defaultSettings, getFlattenedSettings } from '@pandacss/extension-share
 import { type TsLanguageFeaturesApiV0, getTsApi } from './typescript-language-features'
 
 // Client entrypoint
-const docSelector: vscode.DocumentSelector = ['typescript', 'typescriptreact', 'javascript', 'javascriptreact']
+const docSelector: vscode.DocumentSelector = [
+  'typescript',
+  'typescriptreact',
+  'javascript',
+  'javascriptreact',
+  'astro',
+  'svelte',
+  'vue',
+]
 
 let client: LanguageClient
 const debug = false


### PR DESCRIPTION
## 📝 Description

> Add a brief description

Enable extension in .astro/svelte/vue files

## 💣 Is this a breaking change (Yes/No):

no

--- 

thanks @pawelblaszczyk5 for catching this