### PR TITLE
fix(shared): walkObject set prop with nullish value

### DIFF
--- a/.changeset/new-islands-play.md
+++ b/.changeset/new-islands-play.md
@@ -1,0 +1,27 @@
+---
+'@pandacss/shared': patch
+---
+
+Fix issue where the `walkObject` shared helper would set an object key to a nullish value
+
+Example:
+
+```ts
+const shorthands = {
+  flexDir: 'flexDirection',
+}
+
+const obj = {
+  flexDir: 'row',
+  flexDirection: undefined,
+}
+
+const result = walkObject(obj, (value) => value, {
+  getKey(prop) {
+    return shorthands[prop] ?? prop
+  },
+})
+```
+
+This would set the `flexDirection` to `row` (using `getKey`) and then set the `flexDirection` property again, this time
+to `undefined`, since it existed in the original object

--- a/packages/shared/__tests__/walk-object.test.ts
+++ b/packages/shared/__tests__/walk-object.test.ts
@@ -75,4 +75,27 @@ describe('walk object', () => {
       }
     `)
   })
+
+  test('should not overwrite keys if next value is nullish', () => {
+    const shorthands = {
+      flexDir: 'flexDirection',
+    }
+
+    const obj = {
+      flexDir: 'row',
+      flexDirection: undefined,
+    }
+
+    const result = walkObject(obj, (value) => value, {
+      getKey(prop) {
+        return shorthands[prop] ?? prop
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "flexDirection": undefined,
+      }
+    `)
+  })
 })

--- a/packages/shared/__tests__/walk-object.test.ts
+++ b/packages/shared/__tests__/walk-object.test.ts
@@ -76,7 +76,7 @@ describe('walk object', () => {
     `)
   })
 
-  test('should not overwrite keys if next value is nullish', () => {
+  test('should not set prop with nullish value', () => {
     const shorthands = {
       flexDir: 'flexDirection',
     }
@@ -94,7 +94,7 @@ describe('walk object', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "flexDirection": undefined,
+        "flexDirection": "row",
       }
     `)
   })

--- a/packages/shared/__tests__/walk-object.test.ts
+++ b/packages/shared/__tests__/walk-object.test.ts
@@ -88,6 +88,7 @@ describe('walk object', () => {
 
     const result = walkObject(obj, (value) => value, {
       getKey(prop) {
+        // @ts-ignore
         return shorthands[prop] ?? prop
       },
     })

--- a/packages/shared/src/walk-object.ts
+++ b/packages/shared/src/walk-object.ts
@@ -17,6 +17,9 @@ export type WalkObjectOptions = {
   getKey?(prop: string): string
 }
 
+type Nullable<T> = T | null | undefined
+const isNotNullish = <T>(element: Nullable<T>): element is T => element != null
+
 export function walkObject<T, K>(
   target: T,
   predicate: Predicate<K>,
@@ -33,7 +36,11 @@ export function walkObject<T, K>(
         if (stop?.(value, childPath)) {
           return predicate(value, path)
         }
-        result[key] = inner(child, childPath)
+
+        const next = inner(child, childPath)
+        if (isNotNullish(next)) {
+          result[key] = next
+        }
       }
       return result
     }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/877

## 📝 Description

Fix issue where the `walkObject` shared helper would set an object key to a nullish value

## ⛳️ Current behavior (updates)


```ts
const shorthands = {
  flexDir: 'flexDirection',
}

const obj = {
  flexDir: 'row',
  flexDirection: undefined,
}

const result = walkObject(obj, (value) => value, {
  getKey(prop) {
    return shorthands[prop] ?? prop
  },
})
```

This would set the `flexDirection` to `row` (using `getKey`) and then set the `flexDirection` property again, this time
to `undefined`, since it existed in the original object

## 💣 Is this a breaking change (Yes/No):

I'm not sure ? @segunadebayo 
