### PR TITLE
fix(generator): reset.css import order

### DIFF
--- a/.changeset/smart-mirrors-call.md
+++ b/.changeset/smart-mirrors-call.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix reset.css (generated when config has `preflight: true`) import order, always place it first so that it can be easily
+overriden

--- a/packages/generator/src/artifacts/css/flat-css.ts
+++ b/packages/generator/src/artifacts/css/flat-css.ts
@@ -11,9 +11,9 @@ export const generateFlattenedCss = (ctx: Context) => (options: { files: string[
 
   const unresolved = [
     '@layer reset, base, tokens, recipes, utilities;',
+    preflight && "@import './reset.css';",
     "@import './global.css';",
     staticCss && "@import './static.css';",
-    preflight && "@import './reset.css';",
     !ctx.tokens.isEmpty && "@import './tokens/index.css';",
     keyframes && "@import './tokens/keyframes.css';",
   ]

--- a/packages/studio/styled-system/helpers.mjs
+++ b/packages/studio/styled-system/helpers.mjs
@@ -7,7 +7,7 @@ function isObject(value) {
 var newRule = /(?:([\u0080-\uFFFF\w-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(}\s*)/g
 var ruleClean = /\/\*[^]*?\*\/|\s\s+|\n/g
 var astish = (val, tree = [{}]) => {
-  const block = newRule.exec(val.replace(ruleClean, ''))
+  const block = newRule.exec((val ?? '').replace(ruleClean, ''))
   if (!block) return tree[0]
   if (block[4]) tree.shift()
   else if (block[3]) tree.unshift((tree[0][block[3]] = tree[0][block[3]] || {}))
@@ -73,6 +73,7 @@ function mergeProps(...sources) {
 }
 
 // src/walk-object.ts
+var isNotNullish = (element) => element != null
 function walkObject(target, predicate, options = {}) {
   const { stop, getKey } = options
   function inner(value, path = []) {
@@ -84,7 +85,10 @@ function walkObject(target, predicate, options = {}) {
         if (stop?.(value, childPath)) {
           return predicate(value, path)
         }
-        result[key] = inner(child, childPath)
+        const next = inner(child, childPath)
+        if (isNotNullish(next)) {
+          result[key] = next
+        }
       }
       return result
     }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/899

## 📝 Description

Fix reset.css (generated when config has `preflight: true`) import order, always place it first so that it can be easily
overriden

## 💣 Is this a breaking change (Yes/No):

no

