### PR TITLE
fix(studio): dev/build outside of monorepo

### DIFF
--- a/.changeset/chilled-cheetahs-search.md
+++ b/.changeset/chilled-cheetahs-search.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/studio': patch
+---
+
+Fix studio usage outside of panda's monorepo

--- a/packages/studio/astro.config.mjs
+++ b/packages/studio/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config'
 import react from '@astrojs/react'
-import virtualPanda from './virtual-panda'
+import virtualPanda from './virtual-panda.mjs'
 
 // https://astro.build/config
 export default defineConfig({

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -24,7 +24,8 @@
     "src",
     "public",
     "styled-system",
-    "*.ts"
+    "*.ts",
+    "*.mjs"
   ],
   "keywords": [
     "panda",

--- a/packages/studio/virtual-panda.mjs
+++ b/packages/studio/virtual-panda.mjs
@@ -1,7 +1,5 @@
 import { analyzeTokens, findConfig, loadConfigAndCreateContext, writeAnalyzeJSON } from '@pandacss/node'
-import type { AstroIntegration } from 'astro'
 import { stringify } from 'javascript-stringify'
-import type { Plugin as VitePlugin } from 'vite'
 
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -13,8 +11,11 @@ const _dirname = dirname(fileURLToPath(import.meta.url))
 const analysisDataFilepath = 'src/lib/analysis.json'
 const jsonPath = resolve(_dirname, analysisDataFilepath)
 
-function vitePlugin(): VitePlugin {
-  let config: any
+/**
+ * @returns import('vite').VitePlugin
+ */
+function vitePlugin() {
+  let config
 
   return {
     name: 'vite:panda',
@@ -50,7 +51,10 @@ function vitePlugin(): VitePlugin {
   }
 }
 
-const virtualPanda = (): AstroIntegration => ({
+/**
+ * @returns import('astro').AstroIntegration
+ */
+const virtualPanda = () => ({
   name: 'virtual:panda',
   hooks: {
     'astro:config:setup': ({ updateConfig, addWatchFile }) => {


### PR DESCRIPTION
## 📝 Description

running `panda studio` (with or without `--build`) was not working when used outside of our monorepo

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

this was the stacktrace, tried updating `vite.external` but no luck

```sh
❯ pnpm panda studio 
serveStudio
  ➜  Build: use --build to build
11:55:43 PM [vite] Error when evaluating SSR module /@fs/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:
|- ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)

11:55:43 PM [vite] Error when evaluating SSR module /@fs/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.mjs: failed to import "/@fs/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js"
|- ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)

11:55:43 PM [vite] Error when evaluating SSR module /@fs/Users/astahmer/dev/open-source/panda/packages/core/dist/index.mjs: failed to import "/@fs/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.mjs"
|- ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)

11:55:43 PM [vite] Error when evaluating SSR module /@fs/Users/astahmer/dev/open-source/panda/packages/node/dist/index.mjs: failed to import "/@fs/Users/astahmer/dev/open-source/panda/packages/core/dist/index.mjs"
|- ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)

11:55:43 PM [vite] Error when evaluating SSR module /@fs/Users/astahmer/dev/open-source/panda/packages/studio/virtual-panda.ts: failed to import "/@fs/Users/astahmer/dev/open-source/panda/packages/node/dist/index.mjs"
|- ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)

11:55:43 PM [vite] Error when evaluating SSR module /Users/astahmer/dev/open-source/panda/packages/studio/astro.config.mjs: failed to import "/@fs/Users/astahmer/dev/open-source/panda/packages/studio/virtual-panda.ts"
|- ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)

11:55:43 PM [astro] Unable to load /Users/astahmer/dev/open-source/panda/packages/studio/astro.config.mjs

 error   require is not defined
  File:
    /Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22
  Code:
    4 | let Declaration = require('./declaration')
    > 5 | let LazyResult = require('./lazy-result')
        |                      ^
      6 | let Container = require('./container')
      7 | let Processor = require('./processor')
      8 | let stringify = require('./stringify')
  Stacktrace:
ReferenceError: require is not defined
    at eval (/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/postcss@8.4.24/node_modules/postcss/lib/postcss.js:5:22)
    at instantiateModule (file:///Users/astahmer/dev/open-source/panda/node_modules/.pnpm/vite@4.3.9_@types+node@20.3.1/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:54405:15)


Sourcemap for "/Users/astahmer/dev/open-source/panda/node_modules/.pnpm/crosspath@2.0.0/node_modules/crosspath/dist/esm/index.js" points to missing source files
```