### PR TITLE
docs(patterns): mention jsxElement

### DIFF
--- a/website/pages/docs/concepts/patterns.md
+++ b/website/pages/docs/concepts/patterns.md
@@ -337,8 +337,10 @@ function App() {
 To use the pattern in JSX, you need to set the `jsxFramework` property in the config. When this is set, Panda will emit
 files for JSX elements based on the framework.
 
-Every pattern can be used as a JSX element and imported from the `/jsx` entrypoint. The pattern name is the same as the
-function name, but in PascalCase.
+Every pattern can be used as a JSX element and imported from the `/jsx` entrypoint. By default, the pattern name is the
+function name in PascalCase. You can override both the component name (with the `jsx` config property) and the element rendered (with the `jsxElement` config property).
+
+Learn more about pattern customization [here](/docs/customization/patterns).
 
 ```tsx
 import { VStack, Center } from '../styled-system/jsx'

--- a/website/pages/docs/customization/patterns.mdx
+++ b/website/pages/docs/customization/patterns.mdx
@@ -13,8 +13,9 @@ A pattern accepts the following parameters:
 - `description` - The description of the pattern
 - `properties` - The list of properties that the pattern accepts.
 - `transform` - The function that accepts the properties and returns a css object
-- `jsx` - The JSX element that will be generated (when `jsxFramework` is set). Defaults to the pascal-case version of
+- `jsx` - The name of the JSX component that will be generated (when `jsxFramework` is set). Defaults to the pascal-case version of
   the pattern name.
+- `jsxElement` - The actual JSX element that will be rendered (when `jsxFramework` is set). Defaults to `div`.
 - `blocklist` - The list of properties that are not allowed to be used in the pattern. Can be used to ensure strict
   typings when using the pattern.
 


### PR DESCRIPTION
## 📝 Description

was missing from docs

## 💣 Is this a breaking change (Yes/No):

no
