### PR TITLE
refactor(recipes): always use the recipe.name

### DIFF
--- a/.changeset/strange-pugs-eat.md
+++ b/.changeset/strange-pugs-eat.md
@@ -1,0 +1,32 @@
+---
+'@pandacss/core': patch
+---
+
+Refactor the way recipes are found: Always use recipe.name instead of sometimes relying on the key used in the
+`theme.recipes` object
+
+Which means, this didn't work before and now it does:
+
+```ts panda.config.ts
+// ...
+theme: {
+    recipes: {
+        buttonRecipeWithKeyNotMatchingName: {
+        name: 'button',
+        description: 'The styles for the Button component',
+        base: {
+            display: 'flex',
+            bg: 'red.200',
+            color: 'white',
+        },
+        },
+    },
+},
+```
+
+```ts App.tsx
+import { button } from '.panda/recipes'
+
+// ...
+const App = () => <div className={button()} />
+```

--- a/packages/core/src/recipes.ts
+++ b/packages/core/src/recipes.ts
@@ -50,8 +50,8 @@ export class Recipes {
   }
 
   save = () => {
-    for (const [name, recipe] of Object.entries(this.recipes)) {
-      this.assignRecipe(name, this.normalize(recipe))
+    for (const recipe of Object.values(this.recipes)) {
+      this.assignRecipe(recipe.name, this.normalize(recipe))
     }
   }
 
@@ -80,7 +80,7 @@ export class Recipes {
 
   assignRules = () => {
     if (!this.context) return
-    for (const name of Object.keys(this.recipes)) {
+    for (const name of Object.values(this.recipes).map((recipe) => recipe.name)) {
       this.rules.set(name, this.createRule(name))
     }
   }
@@ -102,7 +102,7 @@ export class Recipes {
   })
 
   getConfig = memo((name: string): RecipeConfig | undefined => {
-    return this.recipes[name]
+    return Object.values(this.recipes).find((recipe) => recipe.name === name)
   })
 
   find = memo((name: string) => {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -217,6 +217,53 @@ describe('extract to css output pipeline', () => {
     expect(result.css).toMatchInlineSnapshot('""')
   })
 
+  test('recipe key shouldnt matter', () => {
+    const code = `
+    import { button } from ".panda/recipes"
+
+    <div className={button()} />
+     `
+    const result = run(code, (conf) => ({
+      ...conf,
+      theme: {
+        recipes: {
+          buttonRecipeWithKeyNotMatchingName: {
+            name: 'button',
+            description: 'The styles for the Button component',
+            base: {
+              display: 'flex',
+              bg: 'red.200',
+              color: 'white',
+            },
+          },
+        },
+      },
+    }))
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "button",
+          "type": "recipe",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes {
+        @layer _base {
+          .button {
+            display: flex;
+            background: red.200;
+            color: white
+              }
+          }
+      }"
+    `)
+  })
+
   test('string literal - factory', () => {
     const code = `
     import { panda } from ".panda/jsx"


### PR DESCRIPTION
## 📝 Description

Refactor the way recipes are found: Always use recipe.name instead of sometimes relying on the key used in the
`theme.recipes` object

## ⛳️ Current behavior (updates)

Which means, this didn't work before and now it does:

```ts panda.config.ts
// ...
theme: {
    recipes: {
        buttonRecipeWithKeyNotMatchingName: {
        name: 'button',
        description: 'The styles for the Button component',
        base: {
            display: 'flex',
            bg: 'red.200',
            color: 'white',
        },
        },
    },
},
```

```ts App.tsx
import { button } from '.panda/recipes'

// ...
const App = () => <div className={button()} />
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

related https://github.com/chakra-ui/panda/issues/814#issuecomment-1606176181
