### PR TITLE
Remove redundant word in the get started page

### DIFF
--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -24,7 +24,7 @@ Panda combines the developer experience of CSS-in-JS and the performance of atom
 
 ### Framework Guides
 
-Starting using Panda CSS in your framework JavaScript framework using our framework-specific guides that cover our recommended approach.
+Starting using Panda CSS in your JavaScript framework using our framework-specific guides that cover our recommended approach.
 
 <FrameworkCards />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

There is an extra "framework" word that seems to be redundant.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

The extra word is gone making the sentence more understandable.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
