### PR TITLE
feat(generator): export isCssProperty from /jsx

### DIFF
--- a/.changeset/mean-carpets-fly.md
+++ b/.changeset/mean-carpets-fly.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Export `isCssProperty` helper function from styled-system/jsx

--- a/packages/generator/src/artifacts/index.ts
+++ b/packages/generator/src/artifacts/index.ts
@@ -182,7 +182,7 @@ function setupJsx(ctx: Context): Artifact {
   `,
     dts: outdent`
   export * from './factory'
-  ${isValidProp?.ts ? `export * from './is-valid-prop'` : ''}
+  ${isValidProp?.dts ? `export * from './is-valid-prop'` : ''}
   ${outdent.string(patterns.map((file) => `export * from './${file.name}'`).join('\n'))}
   export type { ${ctx.jsx.typeName} } from '../types/jsx'
     `,
@@ -194,7 +194,7 @@ function setupJsx(ctx: Context): Artifact {
       ...patterns.map((file) => ({ file: ctx.file.ext(file.name), code: file.js })),
       ...patterns.map((file) => ({ file: `${file.name}.d.ts`, code: file.dts })),
       { file: ctx.file.ext('is-valid-prop'), code: isValidProp?.js },
-      { file: 'is-valid-prop.d.ts', code: isValidProp?.ts },
+      { file: 'is-valid-prop.d.ts', code: isValidProp?.dts },
       { file: 'factory.d.ts', code: types.jsxFactory },
       { file: ctx.file.ext('factory'), code: factory?.js },
       { file: 'index.d.ts', code: index.dts },

--- a/packages/generator/src/artifacts/index.ts
+++ b/packages/generator/src/artifacts/index.ts
@@ -177,10 +177,12 @@ function setupJsx(ctx: Context): Artifact {
   const index = {
     js: outdent`
   ${ctx.file.export('./factory')}
+  ${isValidProp?.js ? ctx.file.export('./is-valid-prop') : ''}
   ${outdent.string(patterns.map((file) => ctx.file.export(`./${file.name}`)).join('\n'))}
   `,
     dts: outdent`
   export * from './factory'
+  ${isValidProp?.ts ? `export * from './is-valid-prop'` : ''}
   ${outdent.string(patterns.map((file) => `export * from './${file.name}'`).join('\n'))}
   export type { ${ctx.jsx.typeName} } from '../types/jsx'
     `,
@@ -192,6 +194,7 @@ function setupJsx(ctx: Context): Artifact {
       ...patterns.map((file) => ({ file: ctx.file.ext(file.name), code: file.js })),
       ...patterns.map((file) => ({ file: `${file.name}.d.ts`, code: file.dts })),
       { file: ctx.file.ext('is-valid-prop'), code: isValidProp?.js },
+      { file: 'is-valid-prop.d.ts', code: isValidProp?.ts },
       { file: 'factory.d.ts', code: types.jsxFactory },
       { file: ctx.file.ext('factory'), code: factory?.js },
       { file: 'index.d.ts', code: index.dts },

--- a/packages/generator/src/artifacts/js/is-valid-prop.ts
+++ b/packages/generator/src/artifacts/js/is-valid-prop.ts
@@ -1,5 +1,6 @@
 import isValidPropJson from '../generated/is-valid-prop.mjs.json' assert { type: 'json' }
 import type { Context } from '../../engines'
+import { outdent } from 'outdent'
 
 export function generateisValidProp(ctx: Context) {
   if (ctx.isTemplateLiteralSyntax) return
@@ -10,5 +11,11 @@ export function generateisValidProp(ctx: Context) {
   )
   return {
     js: content,
+    ts: outdent`
+    declare const allCssProperties: string[];
+    declare const isCssProperty: (value: string) => boolean;
+
+    export { allCssProperties, isCssProperty };
+    `,
   }
 }

--- a/packages/generator/src/artifacts/js/is-valid-prop.ts
+++ b/packages/generator/src/artifacts/js/is-valid-prop.ts
@@ -12,10 +12,9 @@ export function generateisValidProp(ctx: Context) {
   return {
     js: content,
     dts: outdent`
-    declare const allCssProperties: string[];
     declare const isCssProperty: (value: string) => boolean;
 
-    export { allCssProperties, isCssProperty };
+    export { isCssProperty };
     `,
   }
 }

--- a/packages/generator/src/artifacts/js/is-valid-prop.ts
+++ b/packages/generator/src/artifacts/js/is-valid-prop.ts
@@ -11,7 +11,7 @@ export function generateisValidProp(ctx: Context) {
   )
   return {
     js: content,
-    ts: outdent`
+    dts: outdent`
     declare const allCssProperties: string[];
     declare const isCssProperty: (value: string) => boolean;
 

--- a/packages/studio/styled-system/jsx/index.d.ts
+++ b/packages/studio/styled-system/jsx/index.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 export * from './factory'
+export * from './is-valid-prop'
 export * from './box'
 export * from './flex'
 export * from './stack'

--- a/packages/studio/styled-system/jsx/index.mjs
+++ b/packages/studio/styled-system/jsx/index.mjs
@@ -1,4 +1,5 @@
 export * from './factory.mjs'
+export * from './is-valid-prop.mjs'
 export * from './box.mjs'
 export * from './flex.mjs'
 export * from './stack.mjs'

--- a/packages/studio/styled-system/jsx/is-valid-prop.d.ts
+++ b/packages/studio/styled-system/jsx/is-valid-prop.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable */
+declare const allCssProperties: string[];
+declare const isCssProperty: (value: string) => boolean;
+
+export { allCssProperties, isCssProperty };

--- a/packages/studio/styled-system/jsx/is-valid-prop.d.ts
+++ b/packages/studio/styled-system/jsx/is-valid-prop.d.ts
@@ -1,5 +1,4 @@
 /* eslint-disable */
-declare const allCssProperties: string[];
 declare const isCssProperty: (value: string) => boolean;
 
-export { allCssProperties, isCssProperty };
+export { isCssProperty };


### PR DESCRIPTION
## 📝 Description

Export `isCssProperty` helper function from styled-system/jsx
It is mostly useful to make a wrapper around `styled` factory function, so split properties between style props & custom ones

## 💣 Is this a breaking change (Yes/No):

no
