### PR TITLE
fix(node): extract files before bundling CSS into an outfile

### DIFF
--- a/.changeset/chilled-shrimps-flow.md
+++ b/.changeset/chilled-shrimps-flow.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Extract files to chunks before bundling them into a CSS out file

--- a/packages/node/src/extract.ts
+++ b/packages/node/src/extract.ts
@@ -80,6 +80,7 @@ export async function extractCss(ctx: PandaContext) {
 }
 
 export async function bundleCss(ctx: PandaContext, outfile: string) {
+  await extractFiles(ctx)
   const files = ctx.chunks.getFiles()
   await writeFile(outfile, ctx.getCss({ files, resolve: true }))
   return { files, msg: ctx.messages.buildComplete(files.length) }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #936.

## 📝 Description

This PR contains the fix for using `panda cssgen` with `--outfile`, which would not emit the files correctly.

## ⛳️ Current behavior (updates)

When using `cssgen` with `outfile` option, it would not emit CSS of files.

## 🚀 New behavior

It now extracts the files to chunks before bundling them into a CSS file.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
