### PR TITLE
feat(types): make RecipeVariantProps only optional for variants missing defaults

### DIFF
--- a/.changeset/gold-tips-suffer.md
+++ b/.changeset/gold-tips-suffer.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/types': patch
+---
+
+Utility type `RecipeVariantProps` now respects recipes `defaultVariant`s, making variants that have defaults optional, whilst keeping the required ones required.

--- a/packages/types/src/recipe.ts
+++ b/packages/types/src/recipe.ts
@@ -6,29 +6,37 @@ type StringToBoolean<T> = T extends 'true' | 'false' ? boolean : T
 
 export type RecipeVariantRecord = Record<any, Record<any, SystemStyleObject>>
 
-export type RecipeSelection<T extends RecipeVariantRecord> = keyof any extends keyof T
-  ? {}
-  : {
-      [K in keyof T]?: StringToBoolean<keyof T[K]>
+export type RecipeSelection<T extends RecipeVariantRecord, D extends RecipeSelection<T, any> = {}> = D extends Record<
+  string,
+  unknown
+>
+  ? { [K in keyof D]?: StringToBoolean<keyof T[K]> } & {
+      [K in Exclude<keyof T, keyof D>]-?: StringToBoolean<keyof T[K]>
     }
+  : any
 
-export type RecipeVariantFn<T extends RecipeVariantRecord> = (props?: RecipeSelection<T>) => string
+export type RecipeVariantFn<T extends RecipeVariantRecord, D extends RecipeSelection<T, any>> = (
+  props?: RecipeSelection<T, D>,
+) => string
 
-export type RecipeVariantProps<T extends RecipeVariantFn<RecipeVariantRecord>> = Pretty<Parameters<T>[0]>
+export type RecipeVariantProps<T extends RecipeVariantFn<any, any>> = Pretty<Parameters<T>[0]>
 
 type RecipeVariantMap<T extends RecipeVariantRecord> = {
   [K in keyof T]: Array<keyof T[K]>
 }
 
-export type RecipeRuntimeFn<T extends RecipeVariantRecord> = RecipeVariantFn<T> & {
-  __type: RecipeSelection<T>
+export type RecipeRuntimeFn<T extends RecipeVariantRecord, D extends RecipeSelection<T, any>> = RecipeVariantFn<
+  T,
+  D
+> & {
+  __type: RecipeSelection<T, D>
   variantKeys: (keyof T)[]
   variantMap: RecipeVariantMap<T>
-  resolve: (props: RecipeSelection<T>) => SystemStyleObject
+  resolve: (props: RecipeSelection<T, D>) => SystemStyleObject
   config: RecipeConfig<T>
-  splitVariantProps<Props extends RecipeSelection<T>>(
+  splitVariantProps<Props extends RecipeSelection<T, D>>(
     props: Props,
-  ): [RecipeSelection<T>, Pretty<Omit<Props, keyof RecipeVariantRecord>>]
+  ): [RecipeSelection<T, D>, Pretty<Omit<Props, keyof RecipeVariantRecord>>]
 }
 
 export type RecipeCompoundSelection<T extends RecipeVariantRecord> = {
@@ -39,7 +47,7 @@ export type RecipeCompoundVariant<T extends RecipeVariantRecord> = RecipeCompoun
   css: SystemStyleObject
 }
 
-export type RecipeDefinition<T extends RecipeVariantRecord> = {
+export type RecipeDefinition<T extends RecipeVariantRecord, D extends RecipeSelection<T, any>> = {
   /**
    * The base styles of the recipe.
    */
@@ -51,16 +59,21 @@ export type RecipeDefinition<T extends RecipeVariantRecord> = {
   /**
    * The default variants of the recipe.
    */
-  defaultVariants?: RecipeSelection<T>
+  defaultVariants?: D
   /**
    * The styles to apply when a combination of variants is selected.
    */
   compoundVariants?: Array<RecipeCompoundVariant<T>>
 }
 
-export type RecipeCreatorFn = <T extends RecipeVariantRecord>(config: RecipeDefinition<T>) => RecipeRuntimeFn<T>
+export type RecipeCreatorFn = <T extends RecipeVariantRecord, D extends RecipeSelection<T, any>>(
+  config: RecipeDefinition<T, D>,
+) => RecipeRuntimeFn<T, D>
 
-export type RecipeConfig<T extends RecipeVariantRecord = RecipeVariantRecord> = RecipeDefinition<T> & {
+export type RecipeConfig<
+  T extends RecipeVariantRecord = RecipeVariantRecord,
+  D extends RecipeSelection<T, any> = RecipeSelection<T, any>,
+> = RecipeDefinition<T, D> & {
   /**
    * The name of the recipe.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -1008,7 +1008,7 @@ importers:
         version: 4.0.2
       next:
         specifier: 13.4.7
-        version: 13.4.7(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.7(@babel/core@7.12.9)(react-dom@18.2.0)(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@13.4.7)(react-dom@18.2.0)(react@18.2.0)
@@ -21818,7 +21818,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 13.4.7(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.7(@babel/core@7.12.9)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -21853,49 +21853,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(@babel/core@7.12.9)(react@18.2.0)
-      watchpack: 2.4.0
-      zod: 3.21.4
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 13.4.7
-      '@next/swc-darwin-x64': 13.4.7
-      '@next/swc-linux-arm64-gnu': 13.4.7
-      '@next/swc-linux-arm64-musl': 13.4.7
-      '@next/swc-linux-x64-gnu': 13.4.7
-      '@next/swc-linux-x64-musl': 13.4.7
-      '@next/swc-win32-arm64-msvc': 13.4.7
-      '@next/swc-win32-ia32-msvc': 13.4.7
-      '@next/swc-win32-x64-msvc': 13.4.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
-  /next@13.4.7(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==}
-    engines: {node: '>=16.8.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      fibers: '>= 3.1.0'
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      fibers:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 13.4.7
-      '@swc/helpers': 0.5.1
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001505
-      postcss: 8.4.14
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
       watchpack: 2.4.0
       zod: 3.21.4
     optionalDependencies:
@@ -26506,23 +26463,6 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.12.9
-      client-only: 0.0.1
-      react: 18.2.0
-    dev: false
-
-  /styled-jsx@5.1.1(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
       client-only: 0.0.1
       react: 18.2.0
     dev: false


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description

This PR severely modifies types to achieve a specific outcome with `RecipeVariantProps`. It’s a bit of a challenge, but I believe it adds a significant bit of DX to the utility.

## ⛳️ Current behavior (updates)

`RecipeVariantProps` today returns all props as optional. Regardless of whether they have defaults or not.

## 🚀 New behavior

- Added default props generics to all the relevant utility type functions
- The resulting type of `RecipeVariantProps` now behaves as follows:
  - if the variant _is present_ in recipes `defaultVariants`, then it is optional
  - otherwise, it is required.
 This is not achievable without passing the generic for `defaultVariants` to it.

<img width="510" alt="CleanShot 2023-07-05 at 15 46 07@2x" src="https://github.com/chakra-ui/panda/assets/45042736/27320411-8624-4d20-aee7-1ae394cc2e35">
Example where `size` is optional, but `intent` isn’t, as there is no default.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
> **Warning**
> I’ve managed to make it all work _but_ intellisense in `defaultVariants` is no longer autocompleting. It seems to be an either or situation, and I’d love to have some help in making this work.