### PR TITLE
Remove instruction about autoprefixer

### DIFF
--- a/website/pages/docs/getting-started/postcss.mdx
+++ b/website/pages/docs/getting-started/postcss.mdx
@@ -35,7 +35,7 @@ Install panda and create your `panda.config.ts` file.
 
 ### Add Panda to your PostCSS config
 
-Add panda and autoprefixer to your `postcss.config.cjs` file, or wherever PostCSS is configured in your project.
+Add panda to your `postcss.config.cjs` file, or wherever PostCSS is configured in your project.
 
 ```js
 module.exports = {


### PR DESCRIPTION
## 📝 Description

Removes instruction about `autoprefixer`

## ⛳️ Current behavior (updates)

Mentions adding `autoprefixer `

## 🚀 New behavior

Does not mention `autoprefixer `

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
If `autoprefixer` is suggested, it should be added to the added to the code snippet