### PR TITLE
Fix redundant indents and empty lines in reset.css

### DIFF
--- a/packages/generator/__tests__/generate-reset.test.ts
+++ b/packages/generator/__tests__/generate-reset.test.ts
@@ -6,199 +6,197 @@ import type { PandaHooks } from '@pandacss/types'
 describe('generate reset', () => {
   test('should work', () => {
     expect(generateResetCss({ hooks: createHooks<PandaHooks>() } as any, '.pd-reset')).toMatchInlineSnapshot(`
-      "
-          @layer reset {
-            .pd-reset * {
-              margin: 0;
-              padding: 0;
-              font: inherit;
-            }
+      "@layer reset {
+        .pd-reset * {
+          margin: 0;
+          padding: 0;
+          font: inherit;
+        }
 
-            .pd-reset *,
-            .pd-reset *::before,
-            .pd-reset *::after {
-              box-sizing: border-box;
-              border-width: 0;
-              border-style: solid;
-              border-color: var(--global-color-border, currentColor);
-            }
+        .pd-reset *,
+        .pd-reset *::before,
+        .pd-reset *::after {
+          box-sizing: border-box;
+          border-width: 0;
+          border-style: solid;
+          border-color: var(--global-color-border, currentColor);
+        }
 
-            .pd-reset {
-              line-height: 1.5;
-              --font-fallback: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-                'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-                'Noto Color Emoji';
-              -webkit-text-size-adjust: 100%;
-              -webkit-text-size-adjust: 100%;
-              -webkit-font-smoothing: antialiased;
-              -moz-tab-size: 4;
-              tab-size: 4;
-              font-family: var(--global-font-body, var(--font-fallback));
-            }
+        .pd-reset {
+          line-height: 1.5;
+          --font-fallback: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+            'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+            'Noto Color Emoji';
+          -webkit-text-size-adjust: 100%;
+          -webkit-text-size-adjust: 100%;
+          -webkit-font-smoothing: antialiased;
+          -moz-tab-size: 4;
+          tab-size: 4;
+          font-family: var(--global-font-body, var(--font-fallback));
+        }
 
-            .pd-reset hr {
-              height: 0;
-              color: inherit;
-              border-top-width: 1px;
-            }
+        .pd-reset hr {
+          height: 0;
+          color: inherit;
+          border-top-width: 1px;
+        }
 
-            body {
-              height: 100%;
-              line-height: inherit;
-            }
+        body {
+          height: 100%;
+          line-height: inherit;
+        }
 
-            .pd-reset img {
-              border-style: none;
-            }
+        .pd-reset img {
+          border-style: none;
+        }
 
-            .pd-reset img,
-            .pd-reset svg,
-            .pd-reset video,
-            .pd-reset canvas,
-            .pd-reset audio,
-            .pd-reset iframe,
-            .pd-reset embed,
-            .pd-reset object {
-              display: block;
-              vertical-align: middle;
-            }
+        .pd-reset img,
+        .pd-reset svg,
+        .pd-reset video,
+        .pd-reset canvas,
+        .pd-reset audio,
+        .pd-reset iframe,
+        .pd-reset embed,
+        .pd-reset object {
+          display: block;
+          vertical-align: middle;
+        }
 
-            .pd-reset img,
-            .pd-reset video {
-              max-width: 100%;
-              height: auto;
-            }
+        .pd-reset img,
+        .pd-reset video {
+          max-width: 100%;
+          height: auto;
+        }
 
-            .pd-reset p,
-            .pd-reset h1,
-            .pd-reset h2,
-            .pd-reset h3,
-            .pd-reset h4,
-            .pd-reset h5,
-            .pd-reset h6 {
-              overflow-wrap: break-word;
-            }
+        .pd-reset p,
+        .pd-reset h1,
+        .pd-reset h2,
+        .pd-reset h3,
+        .pd-reset h4,
+        .pd-reset h5,
+        .pd-reset h6 {
+          overflow-wrap: break-word;
+        }
 
-            .pd-reset ol,
-            .pd-reset ul {
-              list-style: none;
-            }
+        .pd-reset ol,
+        .pd-reset ul {
+          list-style: none;
+        }
 
-            .pd-reset code,
-            .pd-reset kbd,
-            .pd-reset pre,
-            .pd-reset samp {
-              font-size: 1em;
-            }
+        .pd-reset code,
+        .pd-reset kbd,
+        .pd-reset pre,
+        .pd-reset samp {
+          font-size: 1em;
+        }
 
-            .pd-reset button,
-            .pd-reset [type='button'],
-            .pd-reset [type='reset'],
-            .pd-reset [type='submit'] {
-              -webkit-appearance: button;
-              background-color: transparent;
-              background-image: none;
-            }
+        .pd-reset button,
+        .pd-reset [type='button'],
+        .pd-reset [type='reset'],
+        .pd-reset [type='submit'] {
+          -webkit-appearance: button;
+          background-color: transparent;
+          background-image: none;
+        }
 
-            .pd-reset button,
-            .pd-reset select {
-              text-transform: none;
-            }
+        .pd-reset button,
+        .pd-reset select {
+          text-transform: none;
+        }
 
-            .pd-reset table {
-              text-indent: 0;
-              border-color: inherit;
-              border-collapse: collapse;
-            }
+        .pd-reset table {
+          text-indent: 0;
+          border-color: inherit;
+          border-collapse: collapse;
+        }
 
-            .pd-reset input::placeholder,
-            .pd-reset textarea::placeholder {
-              opacity: 1;
-              color: var(--global-color-placeholder, #9ca3af);
-            }
+        .pd-reset input::placeholder,
+        .pd-reset textarea::placeholder {
+          opacity: 1;
+          color: var(--global-color-placeholder, #9ca3af);
+        }
 
-            .pd-reset textarea {
-              resize: vertical;
-            }
+        .pd-reset textarea {
+          resize: vertical;
+        }
 
-            .pd-reset summary {
-              display: list-item;
-            }
+        .pd-reset summary {
+          display: list-item;
+        }
 
-            .pd-reset small {
-              font-size: 80%;
-            }
+        .pd-reset small {
+          font-size: 80%;
+        }
 
-            .pd-reset sub,
-            .pd-reset sup {
-              font-size: 75%;
-              line-height: 0;
-              position: relative;
-              vertical-align: baseline;
-            }
+        .pd-reset sub,
+        .pd-reset sup {
+          font-size: 75%;
+          line-height: 0;
+          position: relative;
+          vertical-align: baseline;
+        }
 
-            .pd-reset sub {
-              bottom: -0.25em;
-            }
+        .pd-reset sub {
+          bottom: -0.25em;
+        }
 
-            .pd-reset sup {
-              top: -0.5em;
-            }
+        .pd-reset sup {
+          top: -0.5em;
+        }
 
-            .pd-reset dialog {
-              padding: 0;
-            }
+        .pd-reset dialog {
+          padding: 0;
+        }
 
-            .pd-reset a {
-              color: inherit;
-              text-decoration: inherit;
-            }
+        .pd-reset a {
+          color: inherit;
+          text-decoration: inherit;
+        }
 
-            .pd-reset abbr:where([title]) {
-              text-decoration: underline dotted;
-            }
+        .pd-reset abbr:where([title]) {
+          text-decoration: underline dotted;
+        }
 
-            .pd-reset b,
-            .pd-reset strong {
-              font-weight: bolder;
-            }
+        .pd-reset b,
+        .pd-reset strong {
+          font-weight: bolder;
+        }
 
-            .pd-reset code,
-            .pd-reset kbd,
-            .pd-reset samp,
-            .pd-reset pre {
-              font-size: 1em;
-              --font-mono-fallback: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New';
-              font-family: var(--global-font-mono, var(--font-fallback));
-            }
+        .pd-reset code,
+        .pd-reset kbd,
+        .pd-reset samp,
+        .pd-reset pre {
+          font-size: 1em;
+          --font-mono-fallback: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New';
+          font-family: var(--global-font-mono, var(--font-fallback));
+        }
 
-            .pd-reset [type='search'] {
-              -webkit-appearance: textfield;
-              outline-offset: -2px;
-            }
+        .pd-reset [type='search'] {
+          -webkit-appearance: textfield;
+          outline-offset: -2px;
+        }
 
-            .pd-reset ::-webkit-search-decoration {
-              -webkit-appearance: none;
-            }
+        .pd-reset ::-webkit-search-decoration {
+          -webkit-appearance: none;
+        }
 
-            .pd-reset ::-webkit-file-upload-button {
-              -webkit-appearance: button;
-            }
+        .pd-reset ::-webkit-file-upload-button {
+          -webkit-appearance: button;
+        }
 
-            .pd-reset ::-webkit-inner-spin-button,
-            .pd-reset ::-webkit-outer-spin-button {
-              height: auto;
-            }
+        .pd-reset ::-webkit-inner-spin-button,
+        .pd-reset ::-webkit-outer-spin-button {
+          height: auto;
+        }
 
-            .pd-reset :-moz-ui-invalid {
-              box-shadow: none;
-            }
+        .pd-reset :-moz-ui-invalid {
+          box-shadow: none;
+        }
 
-            .pd-reset :-moz-focusring {
-              outline: auto;
-            }
-          }
-        "
+        .pd-reset :-moz-focusring {
+          outline: auto;
+        }
+      }"
     `)
   })
 })

--- a/packages/generator/src/artifacts/css/reset-css.ts
+++ b/packages/generator/src/artifacts/css/reset-css.ts
@@ -4,199 +4,198 @@ const css = String.raw
 
 export function generateResetCss(ctx: Context, scope = '') {
   const selector = scope ? `${scope} ` : ''
-  const output = css`
-    @layer reset {
-      ${selector}* {
-        margin: 0;
-        padding: 0;
-        font: inherit;
-      }
+  // prettier-ignore
+  const output = css`@layer reset {
+  ${selector}* {
+    margin: 0;
+    padding: 0;
+    font: inherit;
+  }
 
-      ${selector}*,
-      ${selector}*::before,
-      ${selector}*::after {
-        box-sizing: border-box;
-        border-width: 0;
-        border-style: solid;
-        border-color: var(--global-color-border, currentColor);
-      }
+  ${selector}*,
+  ${selector}*::before,
+  ${selector}*::after {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+    border-color: var(--global-color-border, currentColor);
+  }
 
-      ${scope || 'html'} {
-        line-height: 1.5;
-        --font-fallback: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-          'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-          'Noto Color Emoji';
-        -webkit-text-size-adjust: 100%;
-        -webkit-text-size-adjust: 100%;
-        -webkit-font-smoothing: antialiased;
-        -moz-tab-size: 4;
-        tab-size: 4;
-        font-family: var(--global-font-body, var(--font-fallback));
-      }
+  ${scope || 'html'} {
+    line-height: 1.5;
+    --font-fallback: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+      'Noto Color Emoji';
+    -webkit-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%;
+    -webkit-font-smoothing: antialiased;
+    -moz-tab-size: 4;
+    tab-size: 4;
+    font-family: var(--global-font-body, var(--font-fallback));
+  }
 
-      ${selector}hr {
-        height: 0;
-        color: inherit;
-        border-top-width: 1px;
-      }
+  ${selector}hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
 
-      body {
-        height: 100%;
-        line-height: inherit;
-      }
+  body {
+    height: 100%;
+    line-height: inherit;
+  }
 
-      ${selector}img {
-        border-style: none;
-      }
+  ${selector}img {
+    border-style: none;
+  }
 
-      ${selector}img,
-      ${selector}svg,
-      ${selector}video,
-      ${selector}canvas,
-      ${selector}audio,
-      ${selector}iframe,
-      ${selector}embed,
-      ${selector}object {
-        display: block;
-        vertical-align: middle;
-      }
+  ${selector}img,
+  ${selector}svg,
+  ${selector}video,
+  ${selector}canvas,
+  ${selector}audio,
+  ${selector}iframe,
+  ${selector}embed,
+  ${selector}object {
+    display: block;
+    vertical-align: middle;
+  }
 
-      ${selector}img,
-      ${selector}video {
-        max-width: 100%;
-        height: auto;
-      }
+  ${selector}img,
+  ${selector}video {
+    max-width: 100%;
+    height: auto;
+  }
 
-      ${selector}p,
-      ${selector}h1,
-      ${selector}h2,
-      ${selector}h3,
-      ${selector}h4,
-      ${selector}h5,
-      ${selector}h6 {
-        overflow-wrap: break-word;
-      }
+  ${selector}p,
+  ${selector}h1,
+  ${selector}h2,
+  ${selector}h3,
+  ${selector}h4,
+  ${selector}h5,
+  ${selector}h6 {
+    overflow-wrap: break-word;
+  }
 
-      ${selector}ol,
-      ${selector}ul {
-        list-style: none;
-      }
+  ${selector}ol,
+  ${selector}ul {
+    list-style: none;
+  }
 
-      ${selector}code,
-      ${selector}kbd,
-      ${selector}pre,
-      ${selector}samp {
-        font-size: 1em;
-      }
+  ${selector}code,
+  ${selector}kbd,
+  ${selector}pre,
+  ${selector}samp {
+    font-size: 1em;
+  }
 
-      ${selector}button,
-      ${selector}[type='button'],
-      ${selector}[type='reset'],
-      ${selector}[type='submit'] {
-        -webkit-appearance: button;
-        background-color: transparent;
-        background-image: none;
-      }
+  ${selector}button,
+  ${selector}[type='button'],
+  ${selector}[type='reset'],
+  ${selector}[type='submit'] {
+    -webkit-appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
 
-      ${selector}button,
-      ${selector}select {
-        text-transform: none;
-      }
+  ${selector}button,
+  ${selector}select {
+    text-transform: none;
+  }
 
-      ${selector}table {
-        text-indent: 0;
-        border-color: inherit;
-        border-collapse: collapse;
-      }
+  ${selector}table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
 
-      ${selector}input::placeholder,
-      ${selector}textarea::placeholder {
-        opacity: 1;
-        color: var(--global-color-placeholder, #9ca3af);
-      }
+  ${selector}input::placeholder,
+  ${selector}textarea::placeholder {
+    opacity: 1;
+    color: var(--global-color-placeholder, #9ca3af);
+  }
 
-      ${selector}textarea {
-        resize: vertical;
-      }
+  ${selector}textarea {
+    resize: vertical;
+  }
 
-      ${selector}summary {
-        display: list-item;
-      }
+  ${selector}summary {
+    display: list-item;
+  }
 
-      ${selector}small {
-        font-size: 80%;
-      }
+  ${selector}small {
+    font-size: 80%;
+  }
 
-      ${selector}sub,
-      ${selector}sup {
-        font-size: 75%;
-        line-height: 0;
-        position: relative;
-        vertical-align: baseline;
-      }
+  ${selector}sub,
+  ${selector}sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
 
-      ${selector}sub {
-        bottom: -0.25em;
-      }
+  ${selector}sub {
+    bottom: -0.25em;
+  }
 
-      ${selector}sup {
-        top: -0.5em;
-      }
+  ${selector}sup {
+    top: -0.5em;
+  }
 
-      ${selector}dialog {
-        padding: 0;
-      }
+  ${selector}dialog {
+    padding: 0;
+  }
 
-      ${selector}a {
-        color: inherit;
-        text-decoration: inherit;
-      }
+  ${selector}a {
+    color: inherit;
+    text-decoration: inherit;
+  }
 
-      ${selector}abbr:where([title]) {
-        text-decoration: underline dotted;
-      }
+  ${selector}abbr:where([title]) {
+    text-decoration: underline dotted;
+  }
 
-      ${selector}b,
-      ${selector}strong {
-        font-weight: bolder;
-      }
+  ${selector}b,
+  ${selector}strong {
+    font-weight: bolder;
+  }
 
-      ${selector}code,
-      ${selector}kbd,
-      ${selector}samp,
-      ${selector}pre {
-        font-size: 1em;
-        --font-mono-fallback: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New';
-        font-family: var(--global-font-mono, var(--font-fallback));
-      }
+  ${selector}code,
+  ${selector}kbd,
+  ${selector}samp,
+  ${selector}pre {
+    font-size: 1em;
+    --font-mono-fallback: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New';
+    font-family: var(--global-font-mono, var(--font-fallback));
+  }
 
-      ${selector}[type='search'] {
-        -webkit-appearance: textfield;
-        outline-offset: -2px;
-      }
+  ${selector}[type='search'] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px;
+  }
 
-      ${selector}::-webkit-search-decoration {
-        -webkit-appearance: none;
-      }
+  ${selector}::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
 
-      ${selector}::-webkit-file-upload-button {
-        -webkit-appearance: button;
-      }
+  ${selector}::-webkit-file-upload-button {
+    -webkit-appearance: button;
+  }
 
-      ${selector}::-webkit-inner-spin-button,
-      ${selector}::-webkit-outer-spin-button {
-        height: auto;
-      }
+  ${selector}::-webkit-inner-spin-button,
+  ${selector}::-webkit-outer-spin-button {
+    height: auto;
+  }
 
-      ${selector}:-moz-ui-invalid {
-        box-shadow: none;
-      }
+  ${selector}:-moz-ui-invalid {
+    box-shadow: none;
+  }
 
-      ${selector}:-moz-focusring {
-        outline: auto;
-      }
-    }
-  `
+  ${selector}:-moz-focusring {
+    outline: auto;
+  }
+}`
 
   ctx.hooks.callHook('generator:css', 'reset.css', output)
   return output

--- a/packages/studio/styled-system/helpers.mjs
+++ b/packages/studio/styled-system/helpers.mjs
@@ -206,11 +206,12 @@ var memo = (fn) => {
   return get
 }
 
-// src/hypenate.ts
-var dashCaseRegex = /[A-Z]/g
+// src/hypenate-property.ts
+var wordRegex = /([A-Z])/g
+var msRegex = /^ms-/
 var hypenateProperty = memo((property) => {
   if (property.startsWith('--')) return property
-  return property.replace(dashCaseRegex, (match) => `-${match.toLowerCase()}`)
+  return property.replace(wordRegex, '-$1').replace(msRegex, '-ms-').toLowerCase()
 })
 
 // src/normalize-html.ts


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

The generated reset.css has redundant indents and empty lines because template literals is formatted by prettier.
This causes the formatter(prettier) detects the diffs every time running `panda codegen`.

So, I added `prettier-ignore` at the reset.css string definition.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

The generated reset.css likes below
```css
/* reset.css */

    @layer reset {
      * {
        margin: 0;
        padding: 0;
        font: inherit;
      }
      ...
    }
  
```

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

```css
/* reset.css */
@layer reset {
  * {
    margin: 0;
    padding: 0;
    font: inherit;
  }
  ...
}
```

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
