### PR TITLE
fix(extractor): resolve identifier default value

### DIFF
--- a/.changeset/purple-ads-hammer.md
+++ b/.changeset/purple-ads-hammer.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/extractor': patch
+---
+
+Resolve identifier default value from parameter, code like `position` and `inset` here:
+
+```tsx
+export const Positioned: React.FC<PositionedProps> = ({ children, position = 'absolute', inset = 0, ...rest }) => (
+  <styled.div position={position} inset={inset} {...rest}>
+    {children}
+  </styled.div>
+)
+```

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5630,3 +5630,41 @@ it('resolves shorthands identifier ShorthandPropertyAssignment', () => {
     }
   `)
 })
+
+it('resolves identifier pointing to default value on parameters JsxExpression > Identifier > BindingElement > StringLiteral', () => {
+  expect(
+    extractFromCode(
+      `import { styled, HTMLStyledProps } from "../styled-system/jsx";
+
+      type PositionedProps = HTMLStyledProps<"div">;
+
+      export const Positioned: React.FC<PositionedProps> = ({
+        children,
+        position = "absolute",
+        inset = 0,
+        ...rest
+      }) => (
+        <styled.div position={position} inset={inset} {...rest}>
+          {children}
+        </styled.div>
+      );
+
+      export default Positioned;
+      `,
+      { tagNameList: ['styled.div'] },
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "styled.div": [
+        {
+          "conditions": [],
+          "raw": {
+            "inset": 0,
+            "position": "absolute",
+          },
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/extractor/src/maybe-box-node.ts
+++ b/packages/extractor/src/maybe-box-node.ts
@@ -800,6 +800,12 @@ const maybeDefinitionValue = (def: Node, stack: Node[], ctx: BoxContext): BoxNod
       // since ts-evaluator will throw an error
       return box.unresolvable(def, stack)
     }
+
+    // { position = "absolute", ...props }
+    const initializer = unwrapExpression(init)
+    const innerStack = [...stack, initializer]
+    const maybeValue = maybeBoxNode(initializer, innerStack, ctx)
+    if (maybeValue) return maybeValue
   }
 }
 

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -19,10 +19,12 @@ describe('extract to css output pipeline', () => {
 
       const color = "red.100";
 
-       function Button() {
+       function Button({ position = "relative", inset: aliasedInset = 0, ...props }) {
          return (
             <div marginTop="55555px">
               <div className={css({
+                position,
+                inset: aliasedInset,
                 color: "blue.100",
                 backgroundImage: \`url("https://raw.githubusercontent.com/chakra-ui/chakra-ui/main/media/logo-colored@2x.png?raw=true")\`,
                 border: "1px solid token(colors.yellow.100)",
@@ -64,7 +66,9 @@ describe('extract to css output pipeline', () => {
               "border": "1px solid token(colors.yellow.100)",
               "boxShadow": "0 0 0 4px var(--shadow)",
               "color": "blue.100",
+              "inset": 0,
               "outlineColor": "var(--colors-pink-200)",
+              "position": "relative",
             },
           ],
           "name": "css",
@@ -104,6 +108,14 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
+        .pos_relative {
+          position: relative
+          }
+
+        .inset_0 {
+          inset: var(--spacing-0)
+          }
+
         .text_blue\\\\.100 {
           color: var(--colors-blue-100)
           }

--- a/packages/studio/styled-system/helpers.mjs
+++ b/packages/studio/styled-system/helpers.mjs
@@ -206,11 +206,12 @@ var memo = (fn) => {
   return get
 }
 
-// src/hypenate.ts
-var dashCaseRegex = /[A-Z]/g
+// src/hypenate-property.ts
+var wordRegex = /([A-Z])/g
+var msRegex = /^ms-/
 var hypenateProperty = memo((property) => {
   if (property.startsWith('--')) return property
-  return property.replace(dashCaseRegex, (match) => `-${match.toLowerCase()}`)
+  return property.replace(wordRegex, '-$1').replace(msRegex, '-ms-').toLowerCase()
 })
 
 // src/normalize-html.ts


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/970

## 📝 Description

Resolve identifier default value from parameter, code like `position` and `inset` here:

```tsx
export const Positioned: React.FC<PositionedProps> = ({ children, position = 'absolute', inset = 0, ...rest }) => (
  <styled.div position={position} inset={inset} {...rest}>
    {children}
  </styled.div>
)
```


## 💣 Is this a breaking change (Yes/No):

no