### PR TITLE
fix: studio build adjustments with pnpm or linking

### DIFF
--- a/.changeset/mighty-ducks-mix.md
+++ b/.changeset/mighty-ducks-mix.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/studio': patch
+---
+
+Fix studio build while using pnpm or linking dependencies

--- a/packages/studio/scripts/studio.ts
+++ b/packages/studio/scripts/studio.ts
@@ -1,23 +1,28 @@
 import { colors, logger } from '@pandacss/logger'
 import { execa } from 'execa'
-import { join } from 'path'
+import { join } from 'node:path'
+import { createRequire } from 'node:module'
 
 export type BuildOpts = {
   outDir: string
 }
 
-const astroBin = join(__dirname, '../node_modules/.bin/astro')
+const require = createRequire(import.meta.url)
+const astroBin = require.resolve('astro')
 const appPath = join(__dirname, '..')
 
 export async function buildStudio({ outDir }: BuildOpts) {
   process.env.ASTRO_OUT_DIR = outDir
-  const { stdout } = await execa(astroBin, ['build', '--root', appPath])
+  const { stdout } = await execa(astroBin, ['build', '--root', appPath], {
+    cwd: appPath,
+  })
   logger.log(stdout)
 }
 
 export async function serveStudio() {
   const result = execa(astroBin, ['dev', '--root', appPath], {
     stdio: 'inherit',
+    cwd: appPath,
   })
   result.stdout?.pipe(process.stdout)
   result.stderr?.pipe(process.stderr)
@@ -27,6 +32,7 @@ export async function previewStudio({ outDir }: BuildOpts) {
   process.env.ASTRO_OUT_DIR = outDir
   const result = execa(astroBin, ['preview', '--root', appPath], {
     stdio: 'inherit',
+    cwd: appPath,
   })
   result.stdout?.pipe(process.stdout)
   result.stderr?.pipe(process.stderr)


### PR DESCRIPTION
## 📝 Description

This PR fixes issues regarding `studio --build` command in case of using `pnpm` or linking dependencies locally

@astahmer is aware of this issue and we were in contact while solving it

## ⛳️ Current behavior (updates)

Currently it throws errors about dependencies that it can't find, example error (shortened for brevity)

```
Cannot find package 'html-escaper' imported from /Users/pawelblaszczyk/dev/panda-studio-pnpm/styled-system-studio/src/pages/index.astro.mjs
  Did you mean to import html-escaper@3.0.3/node_modules/html-escaper/cjs/index.js?
Error: Cannot find package 'html-escaper' imported from /Users/pawelblaszczyk/dev/panda-studio-pnpm/styled-system-studio/src/pages/index.astro.mjs
```

## 🚀 New behavior

It should properly resolve the paths and cwd of the command now

## 💣 Is this a breaking change (Yes/No):

I think no

## 📝 Additional Information

I've tried to test it as far as it was possible for me locally. Linking and `pnpm` installing definitely works on MacOS. I also made sure that there is no regression while using standard `npm` or `yarn` setup on MacOS. I know this path issues are sometimes tricky on windows, so maybe it should get some extensive testing. Unfortunately, I couldn't get access to a Windows/Linux machine to check it myself, apologizes. I'm also not 100% sure about the changeset semver level