### PR TITLE
Add `StyledRecipeVariantProps` type utility

### DIFF
--- a/.changeset/forty-llamas-sip.md
+++ b/.changeset/forty-llamas-sip.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': minor
+'@pandacss/studio': minor
+---
+
+Add `StyledRecipeVariantProps` type utility

--- a/packages/generator/src/artifacts/preact-jsx/types.ts
+++ b/packages/generator/src/artifacts/preact-jsx/types.ts
@@ -23,6 +23,10 @@ export type ${componentName}<T extends ElementType, P extends Dict = {}> = {
   displayName?: string
 }
 
+export type ${upperName}RecipeVariantProps<C> = C extends ${componentName}<any, infer P>
+  ? P
+  : never;
+
 type RecipeFn = { __type: any }
 
 interface JsxFactory {

--- a/packages/generator/src/artifacts/qwik-jsx/types.ts
+++ b/packages/generator/src/artifacts/qwik-jsx/types.ts
@@ -42,6 +42,10 @@ type Assign<T, U> = {
 
 export type ${componentName}<T extends ElementType, P extends Dict = {}> = FunctionComponent<Assign<ComponentProps<T>, _Assign<JsxStyleProps, P>>>
 
+export type  ${upperName}RecipeVariantProps<C> = C extends ${componentName}<any, infer P>
+  ? P
+  : never;
+
 type RecipeFn = { __type: any }
 
 interface JsxFactory {

--- a/packages/generator/src/artifacts/react-jsx/types.ts
+++ b/packages/generator/src/artifacts/react-jsx/types.ts
@@ -21,6 +21,10 @@ export type ${componentName}<T extends ElementType, P extends Dict = {}> = {
   displayName?: string
 }
 
+export type ${upperName}RecipeVariantProps<C> = C extends ${componentName}<any, infer P>
+  ? P
+  : never;
+
 type RecipeFn = { __type: any }
 
 interface JsxFactory {

--- a/packages/generator/src/artifacts/solid-jsx/types.ts
+++ b/packages/generator/src/artifacts/solid-jsx/types.ts
@@ -23,6 +23,10 @@ export type ${componentName}<T extends ElementType, P extends Dict = {}> = {
   displayName?: string
 }
 
+export type ${upperName}RecipeVariantProps<C> = C extends ${componentName}<any, infer P>
+  ? P
+  : never;
+
 type RecipeFn = { __type: any }
 
 interface JsxFactory {

--- a/packages/generator/src/artifacts/vue-jsx/types.ts
+++ b/packages/generator/src/artifacts/vue-jsx/types.ts
@@ -141,9 +141,13 @@ type IntrinsicElement =
     ? Props
     : never
 
-  type ${componentName}<T extends ElementType, P extends Dict = {}> = FunctionalComponent<
+  export type ${componentName}<T extends ElementType, P extends Dict = {}> = FunctionalComponent<
   JsxHTMLProps<ComponentProps<T>, Assign<JsxStyleProps, P>>
   >
+
+  export type ${upperName}RecipeVariantProps<C> = C extends ${componentName}<any, infer P>
+  ? P
+  : never;
 
   type RecipeFn = { __type: any }
 

--- a/packages/studio/styled-system/types/jsx.d.ts
+++ b/packages/studio/styled-system/types/jsx.d.ts
@@ -10,6 +10,10 @@ export type PandaComponent<T extends ElementType, P extends Dict = {}> = {
   displayName?: string
 }
 
+export type PandaRecipeVariantProps<C> = C extends PandaComponent<any, infer P>
+  ? P
+  : never;
+
 type RecipeFn = { __type: any }
 
 interface JsxFactory {

--- a/website/pages/docs/concepts/recipes.md
+++ b/website/pages/docs/concepts/recipes.md
@@ -236,6 +236,34 @@ export type ButtonVariants = RecipeVariantProps<typeof buttonStyle> // { size?: 
 export const Button = styled('button', buttonStyle)
 ```
 
+When using `styled` with a jsx factory that accepts variants, you can skip the intermediate use of `cva` with the `StyledRecipeVariantProps` type utility:
+
+```tsx
+import { styled, type StyledRecipeVariantProps } from '../styled-system/jsx'
+import { cva } from '../styled-system/css'
+
+export const Button = styled('button', {
+  base: {
+    color: 'red',
+    textAlign: 'center'
+  },
+  variants: {
+    size: {
+      small: {
+        fontSize: '1rem'
+      },
+      large: {
+        fontSize: '2rem'
+      }
+    }
+  }
+})
+
+export type ButtonVariants = StyledRecipeVariantProps<typeof Button> // { size?: 'small' | 'large' }
+```
+
+If you've modified your `jsxFactory` this type utility will be renamed.
+
 ### Usage in JSX
 
 You can create a JSX component from any existing atomic recipe by using the `styled` function from the `/jsx` entrypoint.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Does not close any issues.

## 📝 Description

The existing `RecipeVariantProps` type utility allows you to get the variant props for a style. The new `StyledRecipeVariantProps` type utility returns the same thing, but allows you to pass in a styled component, assuming you are using a jsx framework.

## ⛳️ Current behavior (updates)

```tsx
import { styled } from '../styled-system/jsx'
import { cva, type RecipeVariantProps } from '../styled-system/css'

const buttonStyle = cva({
  base: {
    color: 'red'
  },
  variants: {
    size: {
      small: {
        fontSize: '1rem'
      },
      large: {
        fontSize: '2rem'
      }
    }
  }
})

export type ButtonVariants = RecipeVariantProps<typeof buttonStyle> // { size?: 'small' | 'large' }

export const Button = styled('button', buttonStyle)
```

## 🚀 New behavior

The above could now optionally be re-written as:

```tsx
import { styled, type StyledRecipeVariantProps } from '../styled-system/jsx'
import { cva } from '../styled-system/css'

export const Button = styled('button', {
  base: {
    color: 'red'
  },
  variants: {
    size: {
      small: {
        fontSize: '1rem'
      },
      large: {
        fontSize: '2rem'
      }
    }
  }
})

export type ButtonVariants = StyledRecipeVariantProps<typeof Button> // { size?: 'small' | 'large' }
```

## 💣 Is this a breaking change (Yes/No):

No, this is a new type utility that doesn't remove or change existing code.

## 📝 Additional Information
