### PR TITLE
docs(storybook): mention the weird Storybook+Vite & HMR case

### DIFF
--- a/website/pages/docs/installation/storybook.mdx
+++ b/website/pages/docs/installation/storybook.mdx
@@ -60,6 +60,20 @@ Install panda and create your `panda.config.ts` file.
   </Tab>
 </Tabs>
 
+> If you are using Storybook with the Vite builder, you will have to update your
+> PostCSS config file to use the array syntax for the plugins instead of the
+> object syntax.
+> Simply change `postcss.config.[c]js`:
+>
+> ```diff {3} filename="postcss.config.js"
+> module.exports = {
+> -  plugins: {
+> -   '@pandacss/dev/postcss': {}
+> -  }
+> +  plugins: [require('@pandacss/dev/postcss')()]
+> }
+> ```
+
 ### Update package.json scripts
 
   Open your `package.json` file and update the `scripts` section as follows:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When using PandaCSS in Storybook with the Vite builder, HMR is not working when modifying a recipe.
This is only due to a PostCSS configuration format.

My guess is that the Vite builder is generating a Vite configuration on the fly based on the `vite.config.*` file and other auto-detected parameters.  
The thing is that when inlining the PostCSS config in the Vite config, you **must** use the array format to define the plugin (see https://v2.vitejs.dev/config/#css-postcss).

This PR only mention this point in the "Storybook" dedicated page.

## ⛳️ Current behavior (updates)

When you change a PandaCSS recipe, HMR in Storybook does not pick up the changes. You have to completely restart Storybook to see the changes.

## 🚀 New behavior

When properly configured, Vite & PostCSS pick up the changes in recipes and properly triggers the HMR in Storybook.

## 💣 Is this a breaking change (Yes/No):

No, it only changes the documentation.

## 📝 Additional Information

More information on [this Discord thread](https://discord.com/channels/1118988919804010566/1126869091790110792)
