### PR TITLE
fix(builder): isValidRoot

### DIFF
--- a/.changeset/cold-ladybugs-brake.md
+++ b/.changeset/cold-ladybugs-brake.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Fix postcss issue with less strict check on @layer reset, base, tokens, recipes, utilities

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -32,6 +32,9 @@ const contentFilesCache = new WeakMap<PandaContext, ContentData>()
 
 let setupCount = 0
 
+/** @layer reset, base, tokens, recipes, utilities */
+const layersName = ['reset', 'base', 'tokens', 'recipes', 'utilities']
+
 export class Builder {
   /**
    * The current panda context
@@ -202,14 +205,14 @@ export class Builder {
     })
   }
 
-  // ASSUMPTION: Layer structure is an exact match (no extra layers)
   isValidRoot(root: Root) {
-    const params = 'reset, base, tokens, recipes, utilities'
-
     let found = false
 
     root.walkAtRules('layer', (rule) => {
-      if (rule.params === params) {
+      const foundLayers = new Set<string>()
+      rule.params.split(',').forEach((name) => foundLayers.add(name.trim()))
+
+      if (foundLayers.size >= 5 && layersName.every((name) => foundLayers.has(name))) {
         found = true
       }
     })


### PR DESCRIPTION
## 📝 Description

Fix postcss issue with less strict check on @layer reset, base, tokens, recipes, utilities

## ⛳️ Current behavior (updates)

currently, when using postcss, we look for this exact match `reset, base, tokens, recipes, utilities`

## 🚀 New behavior

now we'll loop on each layer name and check that all the expected ones are found

## 💣 Is this a breaking change (Yes/No):

no