### PR TITLE
fix(extractor): eval nodes with operation tokens

### DIFF
--- a/.changeset/healthy-llamas-turn.md
+++ b/.changeset/healthy-llamas-turn.md
@@ -1,0 +1,31 @@
+---
+'@pandacss/extractor': patch
+---
+
+Fix extractor behaviour when encoutering operation tokens, try to evaluate them instead of resolving them as string
+
+before:
+
+```tsx
+<AspectRatio ratio={1 / 2} asterisk={1 * 5} exp={1 ** 4} minus={5 - 1} />
+```
+
+would be extracted to:
+
+````json
+{
+    "asterisk": "1 *5",
+    "exp": "1**4",
+    "minus": "5 -1",
+    "ratio": "1 / 2",
+}
+
+now, it will be extracted to the actual values:
+```json
+{
+    "asterisk": 5,
+    "exp": 1,
+    "minus": 4,
+    "ratio": 0.5,
+}
+````

--- a/.changeset/healthy-llamas-turn.md
+++ b/.changeset/healthy-llamas-turn.md
@@ -12,20 +12,22 @@ before:
 
 would be extracted to:
 
-````json
-{
-    "asterisk": "1 *5",
-    "exp": "1**4",
-    "minus": "5 -1",
-    "ratio": "1 / 2",
-}
-
-now, it will be extracted to the actual values:
 ```json
 {
-    "asterisk": 5,
-    "exp": 1,
-    "minus": 4,
-    "ratio": 0.5,
+  "asterisk": "1 *5",
+  "exp": "1**4",
+  "minus": "5 -1",
+  "ratio": "1 / 2"
 }
-````
+```
+
+now, it will be extracted to the actual values:
+
+```json
+{
+  "asterisk": 5,
+  "exp": 1,
+  "minus": 4,
+  "ratio": 0.5
+}
+```

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5595,10 +5595,10 @@ it('handles operation tokens', () => {
         {
           "conditions": [],
           "raw": {
-            "asterisk": "1 *5",
-            "exp": "1**4",
-            "minus": "5 -1",
-            "ratio": "1 / 2",
+            "asterisk": 5,
+            "exp": 1,
+            "minus": 4,
+            "ratio": 0.5,
           },
           "spreadConditions": [],
         },

--- a/packages/extractor/src/maybe-box-node.ts
+++ b/packages/extractor/src/maybe-box-node.ts
@@ -223,7 +223,7 @@ export function maybeBoxNode(
             return cache(maybeResolveConditionalExpression(exprObject, ctx))
           })
           .when(isOperationSyntax, () => {
-            return cache(box.literal(node.getText(), node, stack))
+            return cache(box.literal(safeEvaluateNode(node, stack, ctx), node, stack))
           })
           .otherwise(() => undefined)
       })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1008

## 📝 Description


Fix extractor behaviour when encoutering operation tokens, try to evaluate them instead of resolving them as string

before:

```tsx
<AspectRatio ratio={1 / 2} asterisk={1 * 5} exp={1 ** 4} minus={5 - 1} />
```

would be extracted to:

```json
{
    "asterisk": "1 *5",
    "exp": "1**4",
    "minus": "5 -1",
    "ratio": "1 / 2",
}
```

now, it will be extracted to the actual values:
```json
{
    "asterisk": 5,
    "exp": 1,
    "minus": 4,
    "ratio": 0.5,
}
````


## 💣 Is this a breaking change (Yes/No):

no
