### PR TITLE
feat(conditions): add negative conditions for all basic conditions

### DIFF
--- a/packages/preset-base/src/conditions.ts
+++ b/packages/preset-base/src/conditions.ts
@@ -1,4 +1,4 @@
-export const conditions = {
+const positiveConditions = {
   hover: '&:is(:hover, [data-hover])',
   focus: '&:is(:focus, [data-focus])',
   focusWithin: '&:focus-within',
@@ -100,4 +100,31 @@ export const conditions = {
 
   horizontal: '&[data-orientation=horizontal]',
   vertical: '&[data-orientation=vertical]',
+}
+
+const negativeConditions = Object.entries(positiveConditions).reduce(
+  (notConditions, [key, condition]) => {
+    if (!condition.startsWith('&') || condition.includes(',')) {
+      return notConditions
+    }
+
+    const negativeCondition = `&:not(${condition.slice(1)})`
+
+    return {
+      ...notConditions,
+      [`not${key.charAt(0).toUpperCase() + key.slice(1)}`]: negativeCondition,
+    }
+  },
+  // Those are specific cases that can't be handled by the loop above.
+  {
+    notDark: '&:not(.dark), :not(.dark) &',
+    notLight: '&:not(.light), :not(.light) &',
+    notLtr: ':not([dir=ltr]) &',
+    notRtl: ':not([dir=rtl]) &',
+  },
+)
+
+export const conditions = {
+  ...positiveConditions,
+  ...negativeConditions,
 }

--- a/packages/studio/styled-system/css/conditions.mjs
+++ b/packages/studio/styled-system/css/conditions.mjs
@@ -78,7 +78,7 @@ const conditions = new Set([
   '_light',
   '_osDark',
   '_osLight',
-  '_highConstrast',
+  '_highContrast',
   '_lessContrast',
   '_moreContrast',
   '_ltr',

--- a/packages/studio/styled-system/global.css
+++ b/packages/studio/styled-system/global.css
@@ -7,24 +7,24 @@
   *::before,
   *::after,
   ::backdrop {
-    --blur:   ;
-    --brightness:   ;
-    --contrast:   ;
-    --grayscale:   ;
-    --hue-rotate:   ;
-    --invert:   ;
-    --saturate:   ;
-    --sepia:   ;
-    --drop-shadow:   ;
-    --backdrop-blur:   ;
-    --backdrop-brightness:   ;
-    --backdrop-contrast:   ;
-    --backdrop-grayscale:   ;
-    --backdrop-hue-rotate:   ;
-    --backdrop-invert:   ;
-    --backdrop-opacity:   ;
-    --backdrop-saturate:   ;
-    --backdrop-sepia:   ;
+    --blur: ;
+    --brightness: ;
+    --contrast: ;
+    --grayscale: ;
+    --hue-rotate: ;
+    --invert: ;
+    --saturate: ;
+    --sepia: ;
+    --drop-shadow: ;
+    --backdrop-blur: ;
+    --backdrop-brightness: ;
+    --backdrop-contrast: ;
+    --backdrop-grayscale: ;
+    --backdrop-hue-rotate: ;
+    --backdrop-invert: ;
+    --backdrop-opacity: ;
+    --backdrop-saturate: ;
+    --backdrop-sepia: ;
     --scroll-snap-strictness: proximity;
     --border-spacing-x: 0;
     --border-spacing-y: 0;

--- a/packages/studio/styled-system/jsx/is-valid-prop.mjs
+++ b/packages/studio/styled-system/jsx/is-valid-prop.mjs
@@ -436,7 +436,7 @@ var userGenerated = [
   '_light',
   '_osDark',
   '_osLight',
-  '_highConstrast',
+  '_highContrast',
   '_lessContrast',
   '_moreContrast',
   '_ltr',

--- a/packages/studio/styled-system/types/conditions.d.ts
+++ b/packages/studio/styled-system/types/conditions.d.ts
@@ -79,7 +79,7 @@ export type Conditions = {
 	"_light": string
 	"_osDark": string
 	"_osLight": string
-	"_highConstrast": string
+	"_highContrast": string
 	"_lessContrast": string
 	"_moreContrast": string
 	"_ltr": string


### PR DESCRIPTION
## 📝 Description

We have a lot of conditions shortcuts to use in the CSS (like `_hover`) but as soon as you want to define the opposite condition, you have to manually rewrite those conditions.

So I figured that it would be a nice thing to also have the negative conditions of the ones provided by PandaCSS.

## ⛳️ Current behavior (updates)

When you want to use opposite conditions of the one that have shortcuts, you have to manually rewrite those conditions

## 🚀 New behavior

All basic conditions provided by the base preset now have there negative counterpart.

