### PR TITLE
fix(extension): prettier issue with 3.0 breaking change

### DIFF
--- a/.changeset/tidy-shirts-switch.md
+++ b/.changeset/tidy-shirts-switch.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/language-server': patch
+'panda-css-vscode': patch
+---
+
+Pin prettier version in LSP because prettier v3 is incompatible with prettier/parser-postcss
+https://github.com/prettier/prettier/issues/14814
+
+and also disable extension in astro/svelte/vue files until we figured out how to map transformed file AST nodes to their original positions

--- a/extension/language-server/package.json
+++ b/extension/language-server/package.json
@@ -36,7 +36,7 @@
     "color2k": "^2.0.2",
     "lil-fp": "1.4.5",
     "postcss": "^8.4.25",
-    "prettier": "^3.0.0",
+    "prettier": "2.8.8",
     "satori": "^0.10.1",
     "ts-morph": "18.0.0",
     "ts-pattern": "5.0.1",

--- a/extension/vscode/src/index.ts
+++ b/extension/vscode/src/index.ts
@@ -18,9 +18,10 @@ const docSelector: vscode.DocumentSelector = [
   'typescriptreact',
   'javascript',
   'javascriptreact',
-  'astro',
-  'svelte',
-  'vue',
+  // TODO re-enable whenever we figured out how to map transformed file AST nodes to their original positions
+  // 'astro',
+  // 'svelte',
+  // 'vue',
 ]
 
 let client: LanguageClient


### PR DESCRIPTION
## 📝 Description

prettier/parser-postcss can't be used anymore
https://github.com/prettier/prettier/issues/14814

and also disable extension in astro/svelte/vue files until we figured out how to map transformed file AST nodes to their original positions

## 💣 Is this a breaking change (Yes/No):

no
