### PR TITLE
fix(postcss): HMR when importing files in config

### DIFF
--- a/.changeset/popular-hornets-press.md
+++ b/.changeset/popular-hornets-press.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Fix postcss HMR when importing files in the panda.config file

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -41,6 +41,8 @@ export class Builder {
    */
   context: PandaContext | undefined
 
+  configDependencies: Set<string> = new Set()
+
   writeFileCss(file: string, css: string) {
     const oldCss = this.fileCssMap?.get(file) ?? ''
     const newCss = mergeCss(oldCss, css)
@@ -104,6 +106,7 @@ export class Builder {
       }
     }
     const { deps: configDeps } = getConfigDependencies(configPath, tsOptions)
+    this.configDependencies = configDeps
 
     const deps = this.checkConfigDeps(configPath, configDeps)
 
@@ -243,6 +246,10 @@ export class Builder {
     }
 
     for (const file of ctx.dependencies) {
+      fn({ type: 'dependency', file: resolve(file) })
+    }
+
+    for (const file of this.configDependencies) {
       fn({ type: 'dependency', file: resolve(file) })
     }
   }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1025

## 📝 Description

Fix postcss HMR when importing files in the panda.config file

## ⛳️ Current behavior (updates)

We didnt register the dependencies found through the `getConfigDependencies` function to the postcss plugin process, sometimes it seems we find more file dependencies that esbuild (`ctx.dependencies`)

## 🚀 New behavior

Use both esbuild found dependencies `ctx.dependencies` and those found from our own `getConfigDependencies` function 

## 💣 Is this a breaking change (Yes/No):

no
