### PR TITLE
fix(extractor): Not working when I use SpreadSyntax and prop contains string that ends with ':'

### DIFF
--- a/.changeset/sour-months-melt.md
+++ b/.changeset/sour-months-melt.md
@@ -1,0 +1,6 @@
+---
+"@pandacss/extractor": patch
+"@pandacss/parser": patch
+---
+
+Fix issue where extraction does not work when the spread syntax is used or prop contains string that ends with ':'

--- a/packages/extractor/src/box.ts
+++ b/packages/extractor/src/box.ts
@@ -41,13 +41,21 @@ export const box = {
   unresolvable: (node: Node, stack: Node[]) => {
     return new BoxNodeUnresolvable({ type: 'unresolvable', node, stack })
   },
-  // asserts
+  /**
+   * box.type === “object” -> object that was resolved using ts-evaluator , most likely from a
+   * complex condition OR a simple CallExpression eval result, we don’t have access to individual
+   * AST nodes here so we need the distinction
+   */
   isObject(value: BoxNode | undefined): value is BoxNodeObject {
     return value?.type === 'object'
   },
   isLiteral(value: BoxNode | undefined): value is BoxNodeLiteral {
     return value?.type === 'literal'
   },
+  /**
+   * box.type === “map” -> basically any object that was statically analyzable, we store each
+   * prop+value in a Map
+   */
   isMap(value: BoxNode | undefined): value is BoxNodeMap {
     return value?.type === 'map'
   },

--- a/packages/extractor/src/box.ts
+++ b/packages/extractor/src/box.ts
@@ -42,7 +42,7 @@ export const box = {
     return new BoxNodeUnresolvable({ type: 'unresolvable', node, stack })
   },
   /**
-   * box.type === “object” -> object that was resolved using ts-evaluator , most likely from a
+   * box.type === “object” -> object that was resolved using ts-evaluator, most likely from a
    * complex condition OR a simple CallExpression eval result, we don’t have access to individual
    * AST nodes here so we need the distinction
    */
@@ -54,7 +54,7 @@ export const box = {
   },
   /**
    * box.type === “map” -> basically any object that was statically analyzable, we store each
-   * prop+value in a Map
+   * prop + value in a Map
    */
   isMap(value: BoxNode | undefined): value is BoxNodeMap {
     return value?.type === 'map'

--- a/packages/extractor/src/extract.ts
+++ b/packages/extractor/src/extract.ts
@@ -106,7 +106,7 @@ export const extract = ({ ast, ...ctx }: ExtractOptions) => {
           }
 
           mapValue.forEach((propValue, propName) => {
-            if (isMap ? true : matchProp({ propName, propNode: node as any })) {
+            if (matchProp({ propName, propNode: node as any })) {
               component.props.set(propName, propValue)
               boxByProp.set(propName, (boxByProp.get(propName) ?? []).concat(propValue))
             }

--- a/packages/parser/__tests__/css-2.test.ts
+++ b/packages/parser/__tests__/css-2.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { cssParser } from './fixture'
+import { cssParser, parseAndExtract } from './fixture'
 
 describe('ast parser', () => {
   test('[without import] should not parse', () => {
@@ -506,6 +506,49 @@ export function Card({ className }) {
           },
         },
       }
+    `)
+  })
+
+  test.only('issue #1022: should extract css when using spread syntax on the child', () => {
+    const result = parseAndExtract(
+      `import { css } from '../styled-system/jsx';
+
+      const meta: MetaProps = {
+        title: 'hello world:',
+      };
+
+      export const App = () => {
+        return (
+          <div
+            className={css({
+              color: 'red.400',
+              maxW: '1000px',
+            })}
+          >
+            <Meta {...meta} />
+          </div>
+        );
+      };
+
+      type MetaProps = {
+        title: string;
+      };
+      const Meta: React.FC<MetaProps> = ({ title }) => {
+        return <div>{title}</div>;
+      };
+      `,
+    )
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_red\\.400 {
+          color: var(--colors-red-400)
+        }
+
+        .max-w_1000px {
+          max-width: 1000px
+        }
+      }"
     `)
   })
 })

--- a/packages/parser/__tests__/css-2.test.ts
+++ b/packages/parser/__tests__/css-2.test.ts
@@ -509,7 +509,7 @@ export function Card({ className }) {
     `)
   })
 
-  test.only('issue #1022: should extract css when using spread syntax on the child', () => {
+  test('issue #1022: should extract css when using spread syntax on the child', () => {
     const result = parseAndExtract(
       `import { css } from '../styled-system/jsx';
 

--- a/packages/parser/__tests__/css-2.test.ts
+++ b/packages/parser/__tests__/css-2.test.ts
@@ -540,15 +540,15 @@ export function Card({ className }) {
     )
 
     expect(result.css).toMatchInlineSnapshot(`
-      "@layer utilities {
-        .text_red\\.400 {
-          color: var(--colors-red-400)
+    "@layer utilities {
+      .text_red\\\\.400 {
+        color: var(--colors-red-400)
         }
 
-        .max-w_1000px {
-          max-width: 1000px
+      .max-w_1000px {
+        max-width: 1000px
         }
-      }"
+    }"
     `)
   })
 })


### PR DESCRIPTION
Closes #1022

## 📝 Description
This is ~~WIP~~ fix for issue #1022.