### PR TITLE
fix(postcss): HMR when importing internal package in config

### DIFF
--- a/.changeset/wicked-coats-join.md
+++ b/.changeset/wicked-coats-join.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Fix issue where hot module reloading is inconsistent in the PostCSS plugin when another internal package is changed

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -4,7 +4,7 @@ import { ConfigNotFoundError } from '@pandacss/error'
 import { logger } from '@pandacss/logger'
 import { existsSync } from 'fs'
 import { statSync } from 'fs-extra'
-import { resolve } from 'path'
+import { dirname, resolve } from 'path'
 import type { Message, Root } from 'postcss'
 import { findConfig, loadConfigAndCreateContext } from './config'
 import { type PandaContext } from './create-context'
@@ -105,7 +105,10 @@ export class Builder {
         }
       }
     }
-    const { deps: configDeps } = getConfigDependencies(configPath, tsOptions)
+    const { deps: foundDeps } = getConfigDependencies(configPath, tsOptions)
+    const cwd = this.context?.config.cwd ?? dirname(configPath)
+
+    const configDeps = new Set([...foundDeps, ...(this.context?.dependencies ?? []).map((file) => resolve(cwd, file))])
     this.configDependencies = configDeps
 
     const deps = this.checkConfigDeps(configPath, configDeps)


### PR DESCRIPTION
## 📝 Description

in a monorepo, esbuild properly resolves symlinks from internal packages, we don't check those in the `getConfigDependencies` (cause we're not trying to recreate a node module resolution algo 😅 )

## ⛳️ Current behavior (updates)

the `deps.isModified` would be false, because the `ctx.dependencies` weren't checked

## 🚀 New behavior

also check if a file from esbuild dependencies was modified

## 💣 Is this a breaking change (Yes/No):

no
