### PR TITLE
fix(postcss): use ts.resolveModuleName

### DIFF
--- a/.changeset/wild-deers-sin.md
+++ b/.changeset/wild-deers-sin.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/config': patch
+---
+
+Fix issue where hot module reloading is inconsistent in the PostCSS plugin when another internal typescript-only package is changed

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -41,7 +41,7 @@
     "escalade": "3.1.1",
     "jiti": "^1.19.1",
     "merge-anything": "^5.1.7",
-    "tsconfck": "^2.1.1"
+    "typescript": "^5.1.6"
   },
   "devDependencies": {
     "pkg-types": "1.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,9 +450,9 @@ importers:
       merge-anything:
         specifier: ^5.1.7
         version: 5.1.7
-      tsconfck:
-        specifier: ^2.1.1
-        version: 2.1.1(typescript@5.1.6)
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
     devDependencies:
       pkg-types:
         specifier: 1.0.3


### PR DESCRIPTION
Closes https://discord.com/channels/1118988919804010566/1126883096067850393/1129043920643424337

## 📝 Description

Fix issue where hot module reloading is inconsistent in the PostCSS plugin when another internal typescript-only package is changed
-> if a monorepo internal package only use TS files, without a dist folder, it seems esbuild can't properly resolve config dependencies.

## ⛳️ Current behavior (updates)

this kind of internal package with a package.json would be an issue:
```json
"main": "./src/index.ts",
"types": "./src/index.ts",
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

minimal repro here 
https://github.com/rcoedo/pandacss-pnpm-turbo