### PR TITLE
Fix/868 ts alias

### DIFF
--- a/.changeset/purple-snakes-jump.md
+++ b/.changeset/purple-snakes-jump.md
@@ -1,0 +1,11 @@
+---
+'@pandacss/preset-base': patch
+'@pandacss/generator': patch
+'@pandacss/config': patch
+'@pandacss/parser': patch
+'@pandacss/studio': patch
+'@pandacss/types': patch
+'@pandacss/node': patch
+---
+
+Fix parser issue with TS path mappings

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "husky install && pnpm build-fast",
     "dev": "pnpm -r --parallel --filter=./packages/** --filter=./extension/** dev",
     "build-fast": "pnpm -r --parallel --filter=./packages/** build-fast",
-    "build": "pnpm -r --parallel --filter=./packages/** --filter=./extension/** build",
+    "build": "pnpm -r --filter=./packages/** --filter=./extension/** build",
     "check": "pnpm build && pnpm typecheck && pnpm lint && pnpm test run",
     "clean": "pnpm -r --parallel exec rimraf dist .turbo *.log",
     "reset": "pnpm -r --parallel exec rimraf node_modules && rimraf node_modules",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,6 @@
 export { findConfigFile } from './find-config'
-export { getConfigDependencies, type GetConfigDependenciesTsOptions, type GetDepsOptions } from './get-mod-deps'
+export { getConfigDependencies, type GetDepsOptions } from './get-mod-deps'
 export { getResolvedConfig } from './get-resolved-config'
 export { bundleConfigFile, loadConfigFile, resolveConfigFile } from './load-config'
 export { mergeConfigs } from './merge-config'
-export { convertTsPathsToRegexes } from './ts-config-paths'
+export { convertTsPathsToRegexes, resolveTsPathPattern } from './ts-config-paths'

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -18,10 +18,10 @@ const defaults = (conf: ConfigResultWithHooks): ConfigResultWithHooks => ({
 })
 
 const getImportMap = (outdir: string) => ({
-  css: `${outdir}/css`,
-  recipe: `${outdir}/recipes`,
-  pattern: `${outdir}/patterns`,
-  jsx: `${outdir}/jsx`,
+  css: [outdir, 'css'],
+  recipe: [outdir, 'recipes'],
+  pattern: [outdir, 'patterns'],
+  jsx: [outdir, 'jsx'],
 })
 
 export const createGenerator = (conf: ConfigResultWithHooks) => {
@@ -32,7 +32,7 @@ export const createGenerator = (conf: ConfigResultWithHooks) => {
   const baseUrl = compilerOptions.baseUrl ?? ''
 
   const cwd = conf.config.cwd
-  const relativeBaseUrl = baseUrl ? baseUrl.replace(cwd, '').slice(1) + '/' : cwd
+  const relativeBaseUrl = baseUrl !== cwd ? baseUrl.replace(cwd, '').slice(1) + '/' : cwd
 
   return {
     ...ctx,
@@ -48,6 +48,8 @@ export const createGenerator = (conf: ConfigResultWithHooks) => {
         nodes: [...patterns.nodes, ...recipes.nodes],
       },
       getRecipesByJsxName: recipes.filter,
+      compilerOptions: compilerOptions as any,
+      tsOptions: conf.tsOptions,
     },
   }
 }

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -1,4 +1,4 @@
-import { getConfigDependencies, type GetConfigDependenciesTsOptions, convertTsPathsToRegexes } from '@pandacss/config'
+import { getConfigDependencies } from '@pandacss/config'
 import { discardDuplicate, mergeCss } from '@pandacss/core'
 import { ConfigNotFoundError } from '@pandacss/error'
 import { logger } from '@pandacss/logger'
@@ -93,19 +93,10 @@ export class Builder {
     logger.debug('builder', '🚧 Setup')
 
     const configPath = options.configPath ?? this.getConfigPath()
-    let tsOptions: GetConfigDependenciesTsOptions = { baseUrl: undefined, pathMappings: [] }
+    const tsOptions = this.context?.tsOptions ?? { baseUrl: undefined, pathMappings: [] }
+    const compilerOptions = this.context?.tsconfig?.compilerOptions ?? {}
 
-    if (this.context?.tsconfig) {
-      const options = this.context.tsconfig.compilerOptions
-      if (options?.paths) {
-        const baseUrl = options.baseUrl
-        tsOptions = {
-          baseUrl,
-          pathMappings: convertTsPathsToRegexes(options?.paths, baseUrl ?? this.context.config.cwd),
-        }
-      }
-    }
-    const { deps: foundDeps } = getConfigDependencies(configPath, tsOptions)
+    const { deps: foundDeps } = getConfigDependencies(configPath, tsOptions, compilerOptions)
     const cwd = this.context?.config.cwd ?? dirname(configPath)
 
     const configDeps = new Set([...foundDeps, ...(this.context?.dependencies ?? []).map((file) => resolve(cwd, file))])

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -1,4 +1,4 @@
-import { loadConfigFile } from '@pandacss/config'
+import { convertTsPathsToRegexes, loadConfigFile } from '@pandacss/config'
 import type { Config, ConfigResultWithHooks, PandaHooks } from '@pandacss/types'
 import { createDebugger, createHooks } from 'hookable'
 import { lookItUpSync } from 'look-it-up'
@@ -33,6 +33,12 @@ export async function loadConfigAndCreateContext(options: { cwd?: string; config
   if (tsconfigResult) {
     conf.tsconfig = tsconfigResult.tsconfig
     conf.tsconfigFile = tsconfigResult.tsconfigFile
+
+    const options = tsconfigResult.tsconfig?.compilerOptions
+    if (options?.paths) {
+      const baseUrl = options.baseUrl
+      conf.tsOptions = { baseUrl, pathMappings: convertTsPathsToRegexes(options.paths, baseUrl ?? cwd) }
+    }
   }
 
   conf.config.outdir ??= 'styled-system'

--- a/packages/node/src/create-context.ts
+++ b/packages/node/src/create-context.ts
@@ -2,41 +2,38 @@ import { createGenerator, type Generator } from '@pandacss/generator'
 import { createProject, type Project } from '@pandacss/parser'
 import type { ConfigResultWithHooks, PandaHookable } from '@pandacss/types'
 import type { Runtime } from '@pandacss/types/src/runtime'
-import { Obj, pipe, tap } from 'lil-fp'
 import { getChunkEngine } from './chunk-engine'
 import { nodeRuntime } from './node-runtime'
 import { getOutputEngine } from './output-engine'
 
-export const createContext = (conf: ConfigResultWithHooks) =>
-  pipe(
-    conf,
-    createGenerator,
+export const createContext = (conf: ConfigResultWithHooks) => {
+  const generator = createGenerator(conf)
+  const config = conf.config
+  const runtime = nodeRuntime
 
-    Obj.assign({ runtime: nodeRuntime, hooks: conf.hooks }),
+  config.cwd ||= runtime.cwd()
 
-    tap(({ config, runtime }) => {
-      config.cwd ||= runtime.cwd()
+  const { include, exclude, cwd } = config
+  const getFiles = () => runtime.fs.glob({ include, exclude, cwd })
+
+  const ctx = {
+    ...conf,
+    ...generator,
+    runtime: nodeRuntime,
+    hooks: conf.hooks,
+    getFiles,
+    project: createProject({
+      ...conf.tsconfig,
+      getFiles,
+      readFile: runtime.fs.readFileSync,
+      join: runtime.path.join as any,
+      hooks: conf.hooks,
+      parserOptions: generator.parserOptions,
     }),
+  }
 
-    Obj.bind('getFiles', ({ config, runtime: { fs } }) => () => {
-      const { include, exclude, cwd } = config
-      return fs.glob({ include, exclude, cwd })
-    }),
-
-    Obj.bind('project', ({ getFiles, runtime: { fs }, parserOptions }) => {
-      return createProject({
-        ...conf.tsconfig,
-        getFiles,
-        readFile: fs.readFileSync,
-        hooks: conf.hooks,
-        parserOptions,
-      })
-    }),
-
-    Obj.bind('chunks', getChunkEngine),
-
-    Obj.bind('output', getOutputEngine),
-  ) as PandaContext
+  return Object.assign(ctx, { chunks: getChunkEngine(ctx), output: getOutputEngine(ctx) }) as PandaContext
+}
 
 export type PandaContext = Generator & {
   runtime: Runtime

--- a/packages/parser/__tests__/fixture.ts
+++ b/packages/parser/__tests__/fixture.ts
@@ -53,6 +53,9 @@ function getProject(code: string, options?: <Conf extends UserConfig>(conf: Conf
     useInMemoryFileSystem: true,
     getFiles: () => [staticFilePath],
     readFile: () => code,
+    join(...paths) {
+      return paths.join('/')
+    },
     parserOptions: generator.parserOptions,
     hooks,
   })
@@ -72,6 +75,9 @@ export function getFixtureProject(
     useInMemoryFileSystem: true,
     getFiles: () => [staticFilePath],
     readFile: () => code,
+    join(...paths) {
+      return paths.join('/')
+    },
     parserOptions: generator.parserOptions,
     hooks,
   })

--- a/packages/parser/__tests__/import.test.ts
+++ b/packages/parser/__tests__/import.test.ts
@@ -13,6 +13,7 @@ describe('extract imports', () => {
       [
         {
           "alias": "nCss",
+          "importMapValue": true,
           "mod": "@panda/css",
           "name": "css",
         },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -16,6 +16,7 @@
     "dev": "pnpm build-fast --watch"
   },
   "dependencies": {
+    "@pandacss/config": "workspace:^",
     "@pandacss/extractor": "workspace:*",
     "@pandacss/is-valid-prop": "workspace:*",
     "@pandacss/logger": "workspace:*",

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -6,7 +6,9 @@ import { Node } from 'ts-morph'
 import { match } from 'ts-pattern'
 import { getImportDeclarations } from './import'
 import { createParserResult } from './parser-result'
-import type { RecipeConfig, ResultItem } from '@pandacss/types'
+import type { ConfigTsOptions, RecipeConfig, ResultItem } from '@pandacss/types'
+import { resolveTsPathPattern } from '@pandacss/config'
+import type { ProjectOptions } from './project-types'
 
 type ParserPatternNode = {
   name: string
@@ -29,13 +31,14 @@ const cvaProps = ['compoundVariants', 'defaultVariants', 'variants', 'base']
 const isCva = (map: BoxNodeMap['value']) => cvaProps.some((prop) => map.has(prop))
 
 export type ParserOptions = {
-  importMap: Record<'css' | 'recipe' | 'pattern' | 'jsx', string>
+  importMap: Record<'css' | 'recipe' | 'pattern' | 'jsx', string[]>
   jsx?: {
     factory: string
     nodes: ParserNodeOptions[]
     isStyleProp: (prop: string) => boolean
   }
   getRecipesByJsxName: (jsxName: string) => RecipeConfig[]
+  tsOptions?: ConfigTsOptions
 }
 
 // create strict regex from array of strings
@@ -65,8 +68,9 @@ type EvalOptions = ReturnType<GetEvaluateOptions>
 
 const defaultEnv: EvalOptions['environment'] = { preset: 'NONE' }
 
-export function createParser(options: ParserOptions) {
-  const { jsx, importMap, getRecipesByJsxName } = options
+export function createParser(options: ParserOptions, { join }: Pick<ProjectOptions, 'join'>) {
+  const { jsx, getRecipesByJsxName, tsOptions } = options
+  const importMap = Object.fromEntries(Object.entries(options.importMap).map(([key, value]) => [key, join(...value)]))
 
   // Create regex for each import map
   const importRegex = [
@@ -87,7 +91,30 @@ export function createParser(options: ParserOptions) {
     // Get all import declarations
     const imports = getImportDeclarations(sourceFile, {
       match(value) {
-        return importRegex.some(({ regex, mod }) => regex.test(value.name) && value.mod.includes(mod))
+        let found: string | boolean = false
+
+        for (const { regex, mod } of importRegex) {
+          // if none of the imported values match the regex, skip
+          if (!regex.test(value.name)) continue
+
+          // this checks that `yyy` contains {outdir}/{folder} in `import xxx from yyy`
+          if (value.mod.includes(mod)) {
+            found = true
+            break
+          }
+
+          // that might be a TS path mapping, it could be completely different from the actual path
+          if (tsOptions?.pathMappings) {
+            const filename = resolveTsPathPattern(tsOptions.pathMappings, value.mod)
+
+            if (filename?.includes(mod)) {
+              found = mod
+              break
+            }
+          }
+        }
+
+        return found
       },
     })
 

--- a/packages/parser/src/project-types.ts
+++ b/packages/parser/src/project-types.ts
@@ -1,0 +1,12 @@
+import { type ProjectOptions as TsProjectOptions } from 'ts-morph'
+import { type ParserOptions } from './parser'
+import type { ConfigTsOptions, PandaHookable, Runtime } from '@pandacss/types'
+
+export type ProjectOptions = Partial<TsProjectOptions> & {
+  readFile: Runtime['fs']['readFileSync']
+  getFiles: () => string[]
+  join: Runtime['path']['join']
+  hooks: PandaHookable
+  parserOptions: ParserOptions
+  tsOptions?: ConfigTsOptions
+}

--- a/packages/parser/src/project.ts
+++ b/packages/parser/src/project.ts
@@ -1,17 +1,10 @@
 import { Obj, pipe, tap } from 'lil-fp'
 import { Project as TsProject, type ProjectOptions as TsProjectOptions, ScriptKind } from 'ts-morph'
-import { createParser, type ParserOptions } from './parser'
+import { createParser } from './parser'
 import { ParserResult } from './parser-result'
-import type { PandaHookable } from '@pandacss/types'
 import { vueToTsx } from './vue-to-tsx'
 import { svelteToTsx } from './svelte-to-tsx'
-
-export type ProjectOptions = Partial<TsProjectOptions> & {
-  readFile: (filePath: string) => string
-  getFiles: () => string[]
-  hooks: PandaHookable
-  parserOptions: ParserOptions
-}
+import type { ProjectOptions } from './project-types'
 
 const createTsProject = (options: Partial<TsProjectOptions>) =>
   new TsProject({
@@ -27,11 +20,11 @@ const createTsProject = (options: Partial<TsProjectOptions>) =>
     },
   })
 
-export const createProject = ({ getFiles, readFile, parserOptions, hooks, ...projectOptions }: ProjectOptions) =>
+export const createProject = ({ getFiles, readFile, parserOptions, hooks, join, ...projectOptions }: ProjectOptions) =>
   pipe(
     {
       project: createTsProject(projectOptions),
-      parser: createParser(parserOptions),
+      parser: createParser(parserOptions, { join }),
     },
 
     Obj.assign(({ project, parser }) => ({

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -233,10 +233,21 @@ export type Preset = ExtendableOptions & PresetOptions
 
 export type UserConfig = UnwrapExtend<RequiredBy<Config, 'outdir' | 'cwd' | 'include'>>
 
+export type PathMapping = {
+  pattern: RegExp
+  paths: string[]
+}
+
+export type ConfigTsOptions = {
+  baseUrl?: string | undefined
+  pathMappings: PathMapping[]
+}
+
 export interface LoadConfigResult {
   path: string
   config: UserConfig
   tsconfig?: TSConfig
+  tsOptions?: ConfigTsOptions
   tsconfigFile?: string
   dependencies: string[]
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,7 @@ export type {
 } from './analyze-report'
 export type { CompositionStyles, LayerStyles, TextStyles } from './composition'
 export type { ConditionDetails, ConditionType, Conditions, RawCondition } from './conditions'
-export type { Config, LoadConfigResult, Preset, UserConfig, TSConfig } from './config'
+export type { Config, ConfigTsOptions, LoadConfigResult, Preset, UserConfig, TSConfig } from './config'
 export type { ConfigResultWithHooks, PandaHooks, PandaHookable } from './hooks'
 export type { ParserResultType, ResultItem } from './parser'
 export type { Part, Parts } from './parts'

--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -56,6 +56,9 @@ export function usePanda(source: string, config: string) {
       parserOptions: generator.parserOptions,
       getFiles: () => ['code.tsx'],
       readFile: (file) => (file === 'code.tsx' ? source : ''),
+      join(...paths) {
+        return paths.join('/')
+      },
       hooks: generator.hooks,
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
 
   packages/parser:
     dependencies:
+      '@pandacss/config':
+        specifier: workspace:^
+        version: link:../config
       '@pandacss/extractor':
         specifier: workspace:*
         version: link:../extractor


### PR DESCRIPTION
Closes # https://github.com/chakra-ui/panda/issues/868

## 📝 Description

fix(generator): return import map as array
so that it can be joined later on using the specific runtime that can better handle it for the different OSs etc
this should be related https://github.com/chakra-ui/panda/discussions/980#discussioncomment-6387293

refactor(config): move the tsOptions (baseUrl+pathMappings)
earlier in the pipeline so it can be shared, from the builder (which is postcss-only) to the loadConfigAndCreateContext entrypoint function

fix(config): also pass compilerOptions to resolveModuleName

fix(parser): handle TS path mappings in import regexes as well
otherwise patterns etc wouldnt be recognized
minimal repro https://github.com/chakra-ui/panda/issues/868

refactor(node): rm lil-fp from createContext
cause of TS dts issues

## 💣 Is this a breaking change (Yes/No):

no
