### PR TITLE
docs: add stately preview for component library

### DIFF
--- a/website/pages/docs/guides/component-library.mdx
+++ b/website/pages/docs/guides/component-library.mdx
@@ -14,9 +14,19 @@ When creating a component library that uses Panda which can be used in a variety
 
 > In the examples below, we use `tsup` as the build tool. You can use any other build tool.
 
-# Decision machine
+## Recommendations
+
+- **App** code might **not** use Panda, use the **[static css](#ship-a-static-css-file)** file approach
+- **App** code **uses** Panda and Library code **doesn't ship components** but only ships tokens, patterns or recipes, use the **[ship preset](#ship-a-panda-preset)** approach
+- **App** code **uses** Panda and lives in your **internal monorepo**, use the **[include src files](#include-the-src-files)** approach
+- **App** code **uses** Panda and Library Code source files **shouldn't be published on npm**, use **[ship build info](#ship-the-build-info-file)** approach
+
+> ⚠️ If you use the `include src files` or `ship build info` approach, you might also need to ship a `preset` if your library code has any custom tokens, patterns or recipes.
+
+You can use the visual decision machine below to help you choose the best approach for your use case.
 
 <StatelyMachinePreview embedId="d30cb4f3-2279-41a6-ad95-13e72ccfe884" machineId="0ff5a34b-1d63-476d-ad2d-21c91dad9973" />
+
 
 ## Ship a Panda Preset
 
@@ -256,15 +266,6 @@ export default defineConfig({
   outdir: '@acme-org/styled-system'
 })
 ```
-
-## Recommendations
-
-- Library Code shouldn't be published on npm and App code uses Panda, use [ship build info](#ship-the-build-info-file) approach
-- App code might not use Panda, use the [static css](#ship-a-static-css-file) file approach
-- App code lives in an internal monorepo, use the [include src files](#include-the-src-files) approach
-- Library code doesn't ship components but only ships tokens, patterns or recipes, use the [ship preset](#ship-a-panda-preset) approach
-
-> ⚠️ If you use the `include src files` or `ship build info` approach, you might also need to ship a `preset` if your library code has any custom tokens, patterns or recipes.
 
 ## Troubleshooting
 

--- a/website/pages/docs/guides/component-library.mdx
+++ b/website/pages/docs/guides/component-library.mdx
@@ -14,6 +14,10 @@ When creating a component library that uses Panda which can be used in a variety
 
 > In the examples below, we use `tsup` as the build tool. You can use any other build tool.
 
+# Decision machine
+
+<StatelyMachinePreview embedId="d30cb4f3-2279-41a6-ad95-13e72ccfe884" machineId="0ff5a34b-1d63-476d-ad2d-21c91dad9973" />
+
 ## Ship a Panda Preset
 
 This is the simplest approach. You can include the token, semantic tokens, text styles, etc. within a preset and consume them in your projects.

--- a/website/src/mdx/stately-machine.tsx
+++ b/website/src/mdx/stately-machine.tsx
@@ -1,0 +1,91 @@
+'use client'
+import { css } from '@/styled-system/css'
+import { useTheme } from 'next-themes'
+import {
+  FunctionComponent,
+  useRef,
+  useState,
+  useEffect,
+  RefObject
+} from 'react'
+
+const baseUrl = 'https://stately.ai/registry/editor/embed'
+
+export const StatelyMachinePreview = ({
+  embedId,
+  machineId
+}: {
+  embedId?: string
+  machineId?: string
+}) => {
+  const { resolvedTheme } = useTheme()
+  const src = `${baseUrl}/${embedId}?mode=Simulate&machineId=${machineId}&colorMode=${resolvedTheme}`
+
+  return (
+    <GeneralObserver>
+      <iframe
+        loading="lazy"
+        src={src}
+        allowFullScreen
+        className={css({
+          display: 'block',
+          width: '100%',
+          aspectRatio: '6 / 4'
+        })}
+      >
+        <a href={src}>
+          View the <em>Embed feature machine</em> machine in Stately Studio{' '}
+        </a>
+      </iframe>
+    </GeneralObserver>
+  )
+}
+
+interface IGeneralObserverProps {
+  /** React Children */
+  children: React.ReactNode
+  /** Fires when IntersectionObserver enters viewport */
+  onEnter?: (id?: string) => void
+  /** The height of the placeholder div before the component renders in */
+  height?: number
+}
+
+/**
+ * @see https://github.com/PaulieScanlon/mdx-embed/blob/c93115daa96291f1a23f6acdf90e8897142f6b3a/packages/mdx-embed/src/components/youtube/youtube.tsx
+ */
+const GeneralObserver: FunctionComponent<IGeneralObserverProps> = ({
+  children,
+  onEnter,
+  height = 0
+}) => {
+  const ref = useRef<HTMLElement>(null)
+  const [isChildVisible, setIsChildVisible] = useState(false)
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.intersectionRatio > 0) {
+          setIsChildVisible(true)
+          onEnter && onEnter()
+        }
+      },
+      {
+        root: null,
+        rootMargin: '400px',
+        threshold: 0
+      }
+    )
+    if (ref && ref.current) {
+      observer.observe(ref.current)
+    }
+  }, [ref])
+
+  return (
+    <div
+      ref={ref as RefObject<HTMLDivElement>}
+      data-testid="general-observer"
+      className="mdx-embed"
+    >
+      {isChildVisible ? children : <div style={{ height, width: '100%' }} />}
+    </div>
+  )
+}

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -13,6 +13,7 @@ import {
 import { Steps } from './src/mdx/steps'
 import { css } from './styled-system/css'
 import { Icon } from './theme/icons'
+import { StatelyMachinePreview } from '@/mdx/stately-machine'
 
 const config: DocsThemeConfig = {
   components: {
@@ -22,6 +23,7 @@ const config: DocsThemeConfig = {
     Cards: Cards,
     Callout: Callout,
     FileTree: FileTree,
+    StatelyMachinePreview: StatelyMachinePreview,
     Steps: Steps,
     Tab: Tab,
     Tabs: Tabs


### PR DESCRIPTION
## 📝 Description

use an iframe to embed the stately studio preview to the component library decision helper
https://stately.ai/registry/editor/embed/d30cb4f3-2279-41a6-ad95-13e72ccfe884?mode=Simulate&colorMode=light&machineId=0ff5a34b-1d63-476d-ad2d-21c91dad9973
