### PR TITLE
docs: add how does it work visuals

### DIFF
--- a/website/pages/docs/guides/component-library.mdx
+++ b/website/pages/docs/guides/component-library.mdx
@@ -14,6 +14,10 @@ When creating a component library that uses Panda which can be used in a variety
 
 > In the examples below, we use `tsup` as the build tool. You can use any other build tool.
 
+# Decision machine
+
+<StatelyMachinePreview embedId="d30cb4f3-2279-41a6-ad95-13e72ccfe884" machineId="0ff5a34b-1d63-476d-ad2d-21c91dad9973" />
+
 ## Ship a Panda Preset
 
 This is the simplest approach. You can include the token, semantic tokens, text styles, etc. within a preset and consume them in your projects.

--- a/website/pages/docs/overview/getting-started.mdx
+++ b/website/pages/docs/overview/getting-started.mdx
@@ -67,6 +67,12 @@ You can use the [online playground](https://play.panda-css.com) to get a taste o
 - Inspect what panda can extract using static analysis from your code
 - Preview the statically generated `.css` files
 
+## How does it work ?
+
+<StatelyMachinePreview embedId="d30cb4f3-2279-41a6-ad95-13e72ccfe884" machineId="56c607fb-f05d-46e3-ab7d-f59342466341" />
+
+You can also check out the [more detailed version](https://stately.ai/registry/editor/d30cb4f3-2279-41a6-ad95-13e72ccfe884?mode=Simulate&machineId=0223298d-5951-46a5-82d5-ef379c701d07) with the actual names of the functions called if you want to dive in the code
+
 ## Acknowledgement
 
 The development of Panda was only possible due to the inspiration and ideas from these amazing projects.

--- a/website/src/mdx/stately-machine.tsx
+++ b/website/src/mdx/stately-machine.tsx
@@ -1,0 +1,91 @@
+'use client'
+import { css } from '@/styled-system/css'
+import { useTheme } from 'next-themes'
+import {
+  FunctionComponent,
+  useRef,
+  useState,
+  useEffect,
+  RefObject
+} from 'react'
+
+const baseUrl = 'https://stately.ai/registry/editor/embed'
+
+export const StatelyMachinePreview = ({
+  embedId,
+  machineId
+}: {
+  embedId?: string
+  machineId?: string
+}) => {
+  const { resolvedTheme } = useTheme()
+  const src = `${baseUrl}/${embedId}?mode=Simulate&machineId=${machineId}&colorMode=${resolvedTheme}`
+
+  return (
+    <GeneralObserver>
+      <iframe
+        loading="lazy"
+        src={src}
+        allowFullScreen
+        className={css({
+          display: 'block',
+          width: '100%',
+          aspectRatio: '6 / 4'
+        })}
+      >
+        <a href={src}>
+          View the <em>Embed feature machine</em> machine in Stately Studio{' '}
+        </a>
+      </iframe>
+    </GeneralObserver>
+  )
+}
+
+interface IGeneralObserverProps {
+  /** React Children */
+  children: React.ReactNode
+  /** Fires when IntersectionObserver enters viewport */
+  onEnter?: (id?: string) => void
+  /** The height of the placeholder div before the component renders in */
+  height?: number
+}
+
+/**
+ * @see https://github.com/PaulieScanlon/mdx-embed/blob/c93115daa96291f1a23f6acdf90e8897142f6b3a/packages/mdx-embed/src/components/youtube/youtube.tsx
+ */
+const GeneralObserver: FunctionComponent<IGeneralObserverProps> = ({
+  children,
+  onEnter,
+  height = 0
+}) => {
+  const ref = useRef<HTMLElement>(null)
+  const [isChildVisible, setIsChildVisible] = useState(false)
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.intersectionRatio > 0) {
+          setIsChildVisible(true)
+          onEnter && onEnter()
+        }
+      },
+      {
+        root: null,
+        rootMargin: '400px',
+        threshold: 0
+      }
+    )
+    if (ref && ref.current) {
+      observer.observe(ref.current)
+    }
+  }, [ref])
+
+  return (
+    <div
+      ref={ref as RefObject<HTMLDivElement>}
+      data-testid="general-observer"
+      className="mdx-embed"
+    >
+      {isChildVisible ? children : <div style={{ height, width: '100%' }} />}
+    </div>
+  )
+}

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -13,6 +13,7 @@ import {
 import { Steps } from './src/mdx/steps'
 import { css } from './styled-system/css'
 import { Icon } from './theme/icons'
+import { StatelyMachinePreview } from '@/mdx/stately-machine'
 
 const config: DocsThemeConfig = {
   components: {
@@ -22,6 +23,7 @@ const config: DocsThemeConfig = {
     Cards: Cards,
     Callout: Callout,
     FileTree: FileTree,
+    StatelyMachinePreview: StatelyMachinePreview,
     Steps: Steps,
     Tab: Tab,
     Tabs: Tabs


### PR DESCRIPTION
[simple version](https://stately.ai/registry/editor/d30cb4f3-2279-41a6-ad95-13e72ccfe884?mode=Simulate&colorMode=light&machineId=56c607fb-f05d-46e3-ab7d-f59342466341) as iframe preview and [detailed version](https://stately.ai/registry/editor/d30cb4f3-2279-41a6-ad95-13e72ccfe884?mode=Simulate&machineId=0223298d-5951-46a5-82d5-ef379c701d07) with a link

(and since we're using an intersection observer, the iframe won't load until scrolling near it)

EDIT: should be merged AFTER https://github.com/chakra-ui/panda/pull/1047