### PR TITLE
fix(config): ts.compilerOptions.moduleResolution in browser

### DIFF
--- a/.changeset/mighty-pianos-know.md
+++ b/.changeset/mighty-pianos-know.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/config': patch
+---
+
+Fix module resolution issue when using panda from a browser environment


### PR DESCRIPTION
## 📝 Description

value "Node" doesn't exist in browser, which crashed the playground, omit it when passing options to TS and use a try/catch to make this part safer

## 💣 Is this a breaking change (Yes/No):

no
