### PR TITLE
fix(core): assert that styleObject is an object

### DIFF
--- a/.changeset/gold-apples-brush.md
+++ b/.changeset/gold-apples-brush.md
@@ -1,0 +1,21 @@
+---
+'@pandacss/core': patch
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+---
+
+Fix cases where Stitches `styled.withConfig` would be misinterpreted as a panda fn and lead to this error:
+
+```ts
+TypeError: Cannot read properties of undefined (reading 'startsWith')
+    at /panda/packages/shared/dist/index.js:433:16
+    at get (/panda/packages/shared/dist/index.js:116:20)
+    at Utility.setClassName (/panda/packages/core/dist/index.js:1682:66)
+    at inner (/panda/packages/core/dist/index.js:1705:14)
+    at Utility.getOrCreateClassName (/panda/packages/core/dist/index.js:1709:12)
+    at AtomicRule.transform (/panda/packages/core/dist/index.js:1729:23)
+    at /panda/packages/core/dist/index.js:323:32
+    at inner (/panda/packages/shared/dist/index.js:219:12)
+    at walkObject (/panda/packages/shared/dist/index.js:221:10)
+    at AtomicRule.process (/panda/packages/core/dist/index.js:317:35)
+```

--- a/packages/core/src/atomic-rule.ts
+++ b/packages/core/src/atomic-rule.ts
@@ -50,6 +50,8 @@ export class AtomicRule {
     const { conditions: cond } = this.context
 
     const styleObject = normalizeStyleObject(styles, this.context)
+    // shouldn't happen, but just in case
+    if (typeof styleObject !== 'object') return
 
     const rule = this.rule
 

--- a/packages/extractor/src/extract.ts
+++ b/packages/extractor/src/extract.ts
@@ -155,7 +155,8 @@ export const extract = ({ ast, ...ctx }: ExtractOptions) => {
     }
 
     if (functions && Node.isCallExpression(node)) {
-      const fnName = node.getExpression().getText()
+      const expr = node.getExpression()
+      const fnName = Node.isCallExpression(expr) ? expr.getExpression().getText() : expr.getText()
       if (!functions.matchFn({ fnNode: node, fnName })) return
 
       const matchProp = ({ propName, propNode }: MatchFnPropArgs) =>

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -56,11 +56,12 @@ function createImportMatcher(mod: string, values?: string[]) {
 const combineResult = (unboxed: Unboxed) => {
   return [...unboxed.conditions, unboxed.raw, ...unboxed.spreadConditions]
 }
-const fallback = (box: BoxNode) => ({
-  value: undefined,
-  getNode: () => box.getNode(),
-  getStack: () => box.getStack(),
-})
+const fallback = (box: BoxNode) =>
+  ({
+    value: undefined,
+    getNode: () => box.getNode(),
+    getStack: () => box.getStack(),
+  } as BoxNode)
 
 type GetEvaluateOptions = NonNullable<Parameters<typeof extract>['0']['getEvaluateOptions']>
 
@@ -304,11 +305,9 @@ export function createParser(options: ParserOptions) {
             result.queryList.forEach((query) => {
               if (query.kind === 'call-expression' && query.box.value[1]) {
                 const map = query.box.value[1]
-                const result: ResultItem = {
-                  name,
-                  box: (map as BoxNodeMap) ?? fallback(query.box),
-                  data: combineResult(unbox(map)),
-                }
+                const boxNode = box.isMap(map) ? map : fallback(query.box)
+                // ensure that data is always an object
+                const result = { name, box: boxNode, data: combineResult(unbox(boxNode)) } as ResultItem
 
                 // CallExpression factory inline recipe
                 // panda("span", { base: {}, variants: { ... } })
@@ -336,11 +335,9 @@ export function createParser(options: ParserOptions) {
             result.queryList.forEach((query) => {
               if (query.kind === 'call-expression') {
                 const map = query.box.value[0]
-                const result: ResultItem = {
-                  name,
-                  box: (map as BoxNodeMap) ?? fallback(query.box),
-                  data: combineResult(unbox(map)),
-                }
+                const boxNode = box.isMap(map) ? map : fallback(query.box)
+                // ensure that data is always an object
+                const result = { name, box: boxNode, data: combineResult(unbox(boxNode)) } as ResultItem
 
                 // PropertyAccess factory inline recipe
                 // panda.span({ base: {}, variants: { ... } })


### PR DESCRIPTION
Discord issue https://discord.com/channels/1118988919804010566/1131248934405279836/1131250656213213286
reproduction here: https://github.com/widgetbot-io/message-renderer/blob/15ad1d4faefa66c21a53be96ece3037750a5265b/src/markdown/render/elements/mentions/style.ts#L7-L35

## 📝 Description

Fix cases where Stitches `styled.withConfig` would be misinterpreted as a panda fn and lead to this error:

```ts
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at /panda/packages/shared/dist/index.js:433:16
    at get (/panda/packages/shared/dist/index.js:116:20)
    at Utility.setClassName (/panda/packages/core/dist/index.js:1682:66)
    at inner (/panda/packages/core/dist/index.js:1705:14)
    at Utility.getOrCreateClassName (/panda/packages/core/dist/index.js:1709:12)
    at AtomicRule.transform (/panda/packages/core/dist/index.js:1729:23)
    at /panda/packages/core/dist/index.js:323:32
    at inner (/panda/packages/shared/dist/index.js:219:12)
    at walkObject (/panda/packages/shared/dist/index.js:221:10)
    at AtomicRule.process (/panda/packages/core/dist/index.js:317:35)
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
