### PR TITLE
feat(parser): `{fn}.raw` syntax

### DIFF
--- a/.changeset/real-maps-camp.md
+++ b/.changeset/real-maps-camp.md
@@ -1,0 +1,27 @@
+---
+'@pandacss/generator': minor
+'@pandacss/parser': minor
+---
+
+Introduce the new `{fn}.raw` method that allows for a super flexible usage and extraction :tada: :
+
+```tsx
+<Button rootProps={css.raw({ bg: "red.400" })} />
+
+// recipe in storybook
+export const Funky: Story = {
+	args: button.raw({
+		visual: "funky",
+		shape: "circle",
+		size: "sm",
+	}),
+};
+
+// mixed with pattern
+const stackProps = {
+  sm: stack.raw({ direction: "column" }),
+  md: stack.raw({ direction: "row" })
+}
+
+stack(stackProps[props.size]))
+```

--- a/packages/generator/__tests__/generate-pattern.test.ts
+++ b/packages/generator/__tests__/generate-pattern.test.ts
@@ -18,8 +18,13 @@ test('should generate pattern', () => {
 
     type BoxOptions = BoxProperties & Omit<SystemStyleObject, keyof BoxProperties >
 
+    interface BoxPatternFn {
+      (options?: BoxOptions): string
+      raw: (options: BoxOptions) => BoxOptions
+    }
 
-    export declare function box(options?: BoxOptions): string
+
+    export declare const box: BoxPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -31,7 +36,8 @@ test('should generate pattern', () => {
 
     export const getBoxStyle = (styles = {}) => boxConfig.transform(styles, { map: mapObject })
 
-    export const box = (styles) => css(getBoxStyle(styles))",
+    export const box = (styles) => css(getBoxStyle(styles))
+    box.raw = (styles) => styles",
         "name": "box",
       },
       {
@@ -53,8 +59,13 @@ test('should generate pattern', () => {
 
     type FlexOptions = FlexProperties & Omit<SystemStyleObject, keyof FlexProperties >
 
+    interface FlexPatternFn {
+      (options?: FlexOptions): string
+      raw: (options: FlexOptions) => FlexOptions
+    }
 
-    export declare function flex(options?: FlexOptions): string
+
+    export declare const flex: FlexPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -77,7 +88,8 @@ test('should generate pattern', () => {
 
     export const getFlexStyle = (styles = {}) => flexConfig.transform(styles, { map: mapObject })
 
-    export const flex = (styles) => css(getFlexStyle(styles))",
+    export const flex = (styles) => css(getFlexStyle(styles))
+    flex.raw = (styles) => styles",
         "name": "flex",
       },
       {
@@ -96,8 +108,13 @@ test('should generate pattern', () => {
 
     type StackOptions = StackProperties & Omit<SystemStyleObject, keyof StackProperties >
 
+    interface StackPatternFn {
+      (options?: StackOptions): string
+      raw: (options: StackOptions) => StackOptions
+    }
 
-    export declare function stack(options?: StackOptions): string
+
+    export declare const stack: StackPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -117,7 +134,8 @@ test('should generate pattern', () => {
 
     export const getStackStyle = (styles = {}) => stackConfig.transform(styles, { map: mapObject })
 
-    export const stack = (styles) => css(getStackStyle(styles))",
+    export const stack = (styles) => css(getStackStyle(styles))
+    stack.raw = (styles) => styles",
         "name": "stack",
       },
       {
@@ -134,8 +152,13 @@ test('should generate pattern', () => {
 
     type VstackOptions = VstackProperties & Omit<SystemStyleObject, keyof VstackProperties >
 
+    interface VstackPatternFn {
+      (options?: VstackOptions): string
+      raw: (options: VstackOptions) => VstackOptions
+    }
 
-    export declare function vstack(options?: VstackOptions): string
+
+    export declare const vstack: VstackPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -155,7 +178,8 @@ test('should generate pattern', () => {
 
     export const getVstackStyle = (styles = {}) => vstackConfig.transform(styles, { map: mapObject })
 
-    export const vstack = (styles) => css(getVstackStyle(styles))",
+    export const vstack = (styles) => css(getVstackStyle(styles))
+    vstack.raw = (styles) => styles",
         "name": "vstack",
       },
       {
@@ -172,8 +196,13 @@ test('should generate pattern', () => {
 
     type HstackOptions = HstackProperties & Omit<SystemStyleObject, keyof HstackProperties >
 
+    interface HstackPatternFn {
+      (options?: HstackOptions): string
+      raw: (options: HstackOptions) => HstackOptions
+    }
 
-    export declare function hstack(options?: HstackOptions): string
+
+    export declare const hstack: HstackPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -193,7 +222,8 @@ test('should generate pattern', () => {
 
     export const getHstackStyle = (styles = {}) => hstackConfig.transform(styles, { map: mapObject })
 
-    export const hstack = (styles) => css(getHstackStyle(styles))",
+    export const hstack = (styles) => css(getHstackStyle(styles))
+    hstack.raw = (styles) => styles",
         "name": "hstack",
       },
       {
@@ -209,8 +239,13 @@ test('should generate pattern', () => {
 
     type SpacerOptions = SpacerProperties & Omit<SystemStyleObject, keyof SpacerProperties >
 
+    interface SpacerPatternFn {
+      (options?: SpacerOptions): string
+      raw: (options: SpacerOptions) => SpacerOptions
+    }
 
-    export declare function spacer(options?: SpacerOptions): string
+
+    export declare const spacer: SpacerPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -228,7 +263,8 @@ test('should generate pattern', () => {
 
     export const getSpacerStyle = (styles = {}) => spacerConfig.transform(styles, { map: mapObject })
 
-    export const spacer = (styles) => css(getSpacerStyle(styles))",
+    export const spacer = (styles) => css(getSpacerStyle(styles))
+    spacer.raw = (styles) => styles",
         "name": "spacer",
       },
       {
@@ -244,8 +280,13 @@ test('should generate pattern', () => {
 
     type SquareOptions = SquareProperties & Omit<SystemStyleObject, keyof SquareProperties >
 
+    interface SquarePatternFn {
+      (options?: SquareOptions): string
+      raw: (options: SquareOptions) => SquareOptions
+    }
 
-    export declare function square(options?: SquareOptions): string
+
+    export declare const square: SquarePatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -266,7 +307,8 @@ test('should generate pattern', () => {
 
     export const getSquareStyle = (styles = {}) => squareConfig.transform(styles, { map: mapObject })
 
-    export const square = (styles) => css(getSquareStyle(styles))",
+    export const square = (styles) => css(getSquareStyle(styles))
+    square.raw = (styles) => styles",
         "name": "square",
       },
       {
@@ -282,8 +324,13 @@ test('should generate pattern', () => {
 
     type CircleOptions = CircleProperties & Omit<SystemStyleObject, keyof CircleProperties >
 
+    interface CirclePatternFn {
+      (options?: CircleOptions): string
+      raw: (options: CircleOptions) => CircleOptions
+    }
 
-    export declare function circle(options?: CircleOptions): string
+
+    export declare const circle: CirclePatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -305,7 +352,8 @@ test('should generate pattern', () => {
 
     export const getCircleStyle = (styles = {}) => circleConfig.transform(styles, { map: mapObject })
 
-    export const circle = (styles) => css(getCircleStyle(styles))",
+    export const circle = (styles) => css(getCircleStyle(styles))
+    circle.raw = (styles) => styles",
         "name": "circle",
       },
       {
@@ -321,8 +369,13 @@ test('should generate pattern', () => {
 
     type CenterOptions = CenterProperties & Omit<SystemStyleObject, keyof CenterProperties >
 
+    interface CenterPatternFn {
+      (options?: CenterOptions): string
+      raw: (options: CenterOptions) => CenterOptions
+    }
 
-    export declare function center(options?: CenterOptions): string
+
+    export declare const center: CenterPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -340,7 +393,8 @@ test('should generate pattern', () => {
 
     export const getCenterStyle = (styles = {}) => centerConfig.transform(styles, { map: mapObject })
 
-    export const center = (styles) => css(getCenterStyle(styles))",
+    export const center = (styles) => css(getCenterStyle(styles))
+    center.raw = (styles) => styles",
         "name": "center",
       },
       {
@@ -356,8 +410,13 @@ test('should generate pattern', () => {
 
     type LinkBoxOptions = LinkBoxProperties & Omit<SystemStyleObject, keyof LinkBoxProperties >
 
+    interface LinkBoxPatternFn {
+      (options?: LinkBoxOptions): string
+      raw: (options: LinkBoxOptions) => LinkBoxOptions
+    }
 
-    export declare function linkBox(options?: LinkBoxOptions): string
+
+    export declare const linkBox: LinkBoxPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -376,7 +435,8 @@ test('should generate pattern', () => {
 
     export const getLinkBoxStyle = (styles = {}) => linkBoxConfig.transform(styles, { map: mapObject })
 
-    export const linkBox = (styles) => css(getLinkBoxStyle(styles))",
+    export const linkBox = (styles) => css(getLinkBoxStyle(styles))
+    linkBox.raw = (styles) => styles",
         "name": "link-box",
       },
       {
@@ -392,8 +452,13 @@ test('should generate pattern', () => {
 
     type LinkOverlayOptions = LinkOverlayProperties & Omit<SystemStyleObject, keyof LinkOverlayProperties >
 
+    interface LinkOverlayPatternFn {
+      (options?: LinkOverlayOptions): string
+      raw: (options: LinkOverlayOptions) => LinkOverlayOptions
+    }
 
-    export declare function linkOverlay(options?: LinkOverlayOptions): string
+
+    export declare const linkOverlay: LinkOverlayPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -417,7 +482,8 @@ test('should generate pattern', () => {
 
     export const getLinkOverlayStyle = (styles = {}) => linkOverlayConfig.transform(styles, { map: mapObject })
 
-    export const linkOverlay = (styles) => css(getLinkOverlayStyle(styles))",
+    export const linkOverlay = (styles) => css(getLinkOverlayStyle(styles))
+    linkOverlay.raw = (styles) => styles",
         "name": "link-overlay",
       },
       {
@@ -433,8 +499,13 @@ test('should generate pattern', () => {
 
     type AspectRatioOptions = AspectRatioProperties & Omit<SystemStyleObject, keyof AspectRatioProperties | 'aspectRatio'>
 
+    interface AspectRatioPatternFn {
+      (options?: AspectRatioOptions): string
+      raw: (options: AspectRatioOptions) => AspectRatioOptions
+    }
 
-    export declare function aspectRatio(options?: AspectRatioOptions): string
+
+    export declare const aspectRatio: AspectRatioPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -469,7 +540,8 @@ test('should generate pattern', () => {
 
     export const getAspectRatioStyle = (styles = {}) => aspectRatioConfig.transform(styles, { map: mapObject })
 
-    export const aspectRatio = (styles) => css(getAspectRatioStyle(styles))",
+    export const aspectRatio = (styles) => css(getAspectRatioStyle(styles))
+    aspectRatio.raw = (styles) => styles",
         "name": "aspect-ratio",
       },
       {
@@ -489,8 +561,13 @@ test('should generate pattern', () => {
 
     type GridOptions = GridProperties & Omit<SystemStyleObject, keyof GridProperties >
 
+    interface GridPatternFn {
+      (options?: GridOptions): string
+      raw: (options: GridOptions) => GridOptions
+    }
 
-    export declare function grid(options?: GridOptions): string
+
+    export declare const grid: GridPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -510,7 +587,8 @@ test('should generate pattern', () => {
 
     export const getGridStyle = (styles = {}) => gridConfig.transform(styles, { map: mapObject })
 
-    export const grid = (styles) => css(getGridStyle(styles))",
+    export const grid = (styles) => css(getGridStyle(styles))
+    grid.raw = (styles) => styles",
         "name": "grid",
       },
       {
@@ -531,8 +609,13 @@ test('should generate pattern', () => {
 
     type GridItemOptions = GridItemProperties & Omit<SystemStyleObject, keyof GridItemProperties >
 
+    interface GridItemPatternFn {
+      (options?: GridItemOptions): string
+      raw: (options: GridItemOptions) => GridItemOptions
+    }
 
-    export declare function gridItem(options?: GridItemOptions): string
+
+    export declare const gridItem: GridItemPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -554,7 +637,8 @@ test('should generate pattern', () => {
 
     export const getGridItemStyle = (styles = {}) => gridItemConfig.transform(styles, { map: mapObject })
 
-    export const gridItem = (styles) => css(getGridItemStyle(styles))",
+    export const gridItem = (styles) => css(getGridItemStyle(styles))
+    gridItem.raw = (styles) => styles",
         "name": "grid-item",
       },
       {
@@ -574,8 +658,13 @@ test('should generate pattern', () => {
 
     type WrapOptions = WrapProperties & Omit<SystemStyleObject, keyof WrapProperties >
 
+    interface WrapPatternFn {
+      (options?: WrapOptions): string
+      raw: (options: WrapOptions) => WrapOptions
+    }
 
-    export declare function wrap(options?: WrapOptions): string
+
+    export declare const wrap: WrapPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -597,7 +686,8 @@ test('should generate pattern', () => {
 
     export const getWrapStyle = (styles = {}) => wrapConfig.transform(styles, { map: mapObject })
 
-    export const wrap = (styles) => css(getWrapStyle(styles))",
+    export const wrap = (styles) => css(getWrapStyle(styles))
+    wrap.raw = (styles) => styles",
         "name": "wrap",
       },
       {
@@ -613,8 +703,13 @@ test('should generate pattern', () => {
 
     type ContainerOptions = ContainerProperties & Omit<SystemStyleObject, keyof ContainerProperties >
 
+    interface ContainerPatternFn {
+      (options?: ContainerOptions): string
+      raw: (options: ContainerOptions) => ContainerOptions
+    }
 
-    export declare function container(options?: ContainerOptions): string
+
+    export declare const container: ContainerPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -632,7 +727,8 @@ test('should generate pattern', () => {
 
     export const getContainerStyle = (styles = {}) => containerConfig.transform(styles, { map: mapObject })
 
-    export const container = (styles) => css(getContainerStyle(styles))",
+    export const container = (styles) => css(getContainerStyle(styles))
+    container.raw = (styles) => styles",
         "name": "container",
       },
       {
@@ -650,8 +746,13 @@ test('should generate pattern', () => {
 
     type DividerOptions = DividerProperties & Omit<SystemStyleObject, keyof DividerProperties >
 
+    interface DividerPatternFn {
+      (options?: DividerOptions): string
+      raw: (options: DividerOptions) => DividerOptions
+    }
 
-    export declare function divider(options?: DividerOptions): string
+
+    export declare const divider: DividerPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -672,7 +773,8 @@ test('should generate pattern', () => {
 
     export const getDividerStyle = (styles = {}) => dividerConfig.transform(styles, { map: mapObject })
 
-    export const divider = (styles) => css(getDividerStyle(styles))",
+    export const divider = (styles) => css(getDividerStyle(styles))
+    divider.raw = (styles) => styles",
         "name": "divider",
       },
       {
@@ -691,8 +793,13 @@ test('should generate pattern', () => {
 
     type FloatOptions = FloatProperties & Omit<SystemStyleObject, keyof FloatProperties >
 
+    interface FloatPatternFn {
+      (options?: FloatOptions): string
+      raw: (options: FloatOptions) => FloatOptions
+    }
 
-    export declare function float(options?: FloatOptions): string
+
+    export declare const float: FloatPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
     import { css } from '../css/index.mjs';
@@ -737,7 +844,8 @@ test('should generate pattern', () => {
 
     export const getFloatStyle = (styles = {}) => floatConfig.transform(styles, { map: mapObject })
 
-    export const float = (styles) => css(getFloatStyle(styles))",
+    export const float = (styles) => css(getFloatStyle(styles))
+    float.raw = (styles) => styles",
         "name": "float",
       },
     ]

--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -66,6 +66,7 @@ describe('generate recipes', () => {
       interface TextStyleRecipe {
         __type: TextStyleVariantProps
         (props?: TextStyleVariantProps): string
+        raw: (props?: TextStyleVariantProps) => TextStyleVariantProps
         variantMap: TextStyleVariantMap
         variantKeys: Array<keyof TextStyleVariant>
         splitVariantProps<Props extends TextStyleVariantProps>(props: Props): [TextStyleVariantProps, Pretty<Omit<Props, keyof TextStyleVariantProps>>]
@@ -116,6 +117,7 @@ describe('generate recipes', () => {
       interface TooltipStyleRecipe {
         __type: TooltipStyleVariantProps
         (props?: TooltipStyleVariantProps): string
+        raw: (props?: TooltipStyleVariantProps) => TooltipStyleVariantProps
         variantMap: TooltipStyleVariantMap
         variantKeys: Array<keyof TooltipStyleVariant>
         splitVariantProps<Props extends TooltipStyleVariantProps>(props: Props): [TooltipStyleVariantProps, Pretty<Omit<Props, keyof TooltipStyleVariantProps>>]
@@ -158,6 +160,7 @@ describe('generate recipes', () => {
       interface ButtonStyleRecipe {
         __type: ButtonStyleVariantProps
         (props?: ButtonStyleVariantProps): string
+        raw: (props?: ButtonStyleVariantProps) => ButtonStyleVariantProps
         variantMap: ButtonStyleVariantMap
         variantKeys: Array<keyof ButtonStyleVariant>
         splitVariantProps<Props extends ButtonStyleVariantProps>(props: Props): [ButtonStyleVariantProps, Pretty<Omit<Props, keyof ButtonStyleVariantProps>>]

--- a/packages/generator/src/artifacts/js/css-fn.ts
+++ b/packages/generator/src/artifacts/js/css-fn.ts
@@ -15,16 +15,22 @@ export function generateCssFn(ctx: Context) {
   return {
     dts: outdent`
     import type { SystemStyleObject } from '../types'
-    export declare function css(styles: SystemStyleObject): string
+
+    interface CssFunction {
+      (styles: SystemStyleObject): string
+      raw: (styles: SystemStyleObject) => SystemStyleObject
+    }
+
+    export declare const css: CssFunction;
     `,
     js: outdent`
     ${ctx.file.import('createCss, createMergeCss, hypenateProperty, withoutSpace', '../helpers')}
     ${ctx.file.import('sortConditions, finalizeConditions', './conditions')}
 
     const classNameMap = ${stringify(utility.entries())}
-    
+
     const shorthands = ${stringify(utility.shorthands)}
-    
+
     const breakpointKeys = ${JSON.stringify(conditions.breakpoints.keys)}
 
     const hasShorthand = ${utility.hasShorthand ? 'true' : 'false'}
@@ -54,6 +60,7 @@ export function generateCssFn(ctx: Context) {
     }
 
     export const css = createCss(context)
+    css.raw = (styles) => styles
 
     export const { mergeCss, assignCss } = createMergeCss(context)
     `,

--- a/packages/generator/src/artifacts/js/pattern.ts
+++ b/packages/generator/src/artifacts/js/pattern.ts
@@ -58,8 +58,13 @@ export function generatePattern(ctx: Context) {
 
           type ${upperName}Options = ${upperName}Properties & Omit<SystemStyleObject, keyof ${upperName}Properties ${blocklistType}>
 
+          interface ${upperName}PatternFn {
+            (options?: ${upperName}Options): string
+            raw: (options: ${upperName}Options) => ${upperName}Options
+          }
+
           ${description ? `/** ${description} */` : ''}
-          export declare function ${name}(options?: ${upperName}Options): string
+          export declare const ${name}: ${upperName}PatternFn;
           `
       }
 
@@ -73,6 +78,7 @@ export function generatePattern(ctx: Context) {
     export const ${styleFnName} = (styles = {}) => ${name}Config.transform(styles, { map: mapObject })
 
     export const ${name} = (styles) => css(${styleFnName}(styles))
+    ${name}.raw = (styles) => styles
     `,
     }
   })

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -113,6 +113,7 @@ export function generateRecipes(ctx: Context) {
         interface ${upperName}Recipe {
           __type: ${upperName}VariantProps
           (props?: ${upperName}VariantProps): string
+          raw: (props?: ${upperName}VariantProps) => ${upperName}VariantProps
           variantMap: ${upperName}VariantMap
           variantKeys: Array<keyof ${upperName}Variant>
           splitVariantProps<Props extends ${upperName}VariantProps>(props: Props): [${upperName}VariantProps, Pretty<Omit<Props, keyof ${upperName}VariantProps>>]

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2957,11 +2957,13 @@ describe('preset patterns', () => {
     `)
   })
 
-  test('css.raw', () => {
+  test('{fn}.raw', () => {
     const code = `
     import { css } from ".panda/css";
     import { button } from ".panda/recipes";
     import { stack } from ".panda/patterns";
+
+    const filePath = String.raw\`C:\\Development\\profile\\aboutme.html\`;
 
     export default function App() {
       return (

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2956,4 +2956,117 @@ describe('preset patterns', () => {
       }"
     `)
   })
+
+  test('css.raw', () => {
+    const code = `
+    import { css } from ".panda/css";
+    import { button } from ".panda/recipes";
+    import { stack } from ".panda/patterns";
+
+    export default function App() {
+      return (
+        <Button rootProps={css.raw({ bg: "red.400" })} />
+      );
+    }
+
+    // recipe in storybook
+    export const Funky: Story = {
+      args: button.raw({
+        visual: "funky",
+        shape: "circle",
+        size: "sm",
+      }),
+    };
+
+    // mixed with pattern
+    const stackProps = {
+      sm: stack.raw({ direction: "column" }),
+      md: stack.raw({ direction: "row" })
+    }
+
+    stack(stackProps[props.size]))
+
+     `
+    const result = run(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "bg": "red.400",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "Button",
+          "type": "jsx-recipe",
+        },
+        {
+          "data": [
+            {
+              "shape": "circle",
+              "size": "sm",
+              "visual": "funky",
+            },
+          ],
+          "name": "button",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "direction": "column",
+            },
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+        {
+          "data": [
+            {
+              "direction": "row",
+            },
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .bg_red\\\\.400 {
+          background: var(--colors-red-400)
+          }
+
+        .flex_row {
+          flex-direction: row
+          }
+
+        .d_flex {
+          display: flex
+          }
+
+        .flex_column {
+          flex-direction: column
+          }
+
+        .gap_10px {
+          gap: 10px
+          }
+      }"
+    `)
+  })
 })

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -28,6 +28,7 @@ const isNodeRecipe = (node: ParserNodeOptions): node is ParserRecipeNode => node
 
 const cvaProps = ['compoundVariants', 'defaultVariants', 'variants', 'base']
 const isCva = (map: BoxNodeMap['value']) => cvaProps.some((prop) => map.has(prop))
+const isRawFn = (name: string) => Boolean(name.endsWith('.raw'))
 
 export type ParserOptions = {
   importMap: Record<'css' | 'recipe' | 'pattern' | 'jsx', string[]>
@@ -220,7 +221,7 @@ export function createParser(options: ParserOptions) {
 
     const matchFn = memo((fnName: string) => {
       if (recipes.has(fnName) || patterns.has(fnName)) return true
-      if (fnName === cvaAlias || fnName === cssAlias || isFactory(fnName)) return true
+      if (fnName === cvaAlias || fnName === cssAlias || isRawFn(fnName) || isFactory(fnName)) return true
       return functions.has(fnName)
     })
 
@@ -251,7 +252,9 @@ export function createParser(options: ParserOptions) {
     measure()
 
     extractResultByName.forEach((result, alias) => {
-      const name = imports.getName(alias)
+      let name = imports.getName(alias)
+      if (isRawFn(name)) name = name.replace('.raw', '')
+
       logger.debug(`ast:${name}`, name !== alias ? { kind: result.kind, alias } : { kind: result.kind })
 
       if (result.kind === 'function') {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -28,7 +28,6 @@ const isNodeRecipe = (node: ParserNodeOptions): node is ParserRecipeNode => node
 
 const cvaProps = ['compoundVariants', 'defaultVariants', 'variants', 'base']
 const isCva = (map: BoxNodeMap['value']) => cvaProps.some((prop) => map.has(prop))
-const isRawFn = (name: string) => Boolean(name.endsWith('.raw'))
 
 export type ParserOptions = {
   importMap: Record<'css' | 'recipe' | 'pattern' | 'jsx', string[]>
@@ -134,6 +133,10 @@ export function createParser(options: ParserOptions) {
     const isValidRecipe = imports.createMatch(importMap.recipe)
     const isValidStyleFn = (name: string) => name === jsx?.factory
     const isFactory = (name: string) => Boolean(jsx && name.startsWith(jsxFactoryAlias))
+    const isRawFn = (fullName: string) => {
+      const name = fullName.split('.raw')[0] ?? ''
+      return name === 'css' || isValidPattern(name) || isValidRecipe(name)
+    }
 
     const jsxPatternNodes = new RegExp(
       `^(${jsx?.nodes

--- a/packages/studio/styled-system/css/css.d.ts
+++ b/packages/studio/styled-system/css/css.d.ts
@@ -1,3 +1,9 @@
 /* eslint-disable */
 import type { SystemStyleObject } from '../types'
-export declare function css(styles: SystemStyleObject): string
+
+interface CssFunction {
+  (styles: SystemStyleObject): string
+  raw: (styles: SystemStyleObject) => SystemStyleObject
+}
+
+export declare const css: CssFunction;

--- a/packages/studio/styled-system/css/css.mjs
+++ b/packages/studio/styled-system/css/css.mjs
@@ -393,5 +393,6 @@ const context = {
 }
 
 export const css = createCss(context)
+css.raw = (styles) => styles
 
 export const { mergeCss, assignCss } = createMergeCss(context)

--- a/packages/studio/styled-system/patterns/aspect-ratio.d.ts
+++ b/packages/studio/styled-system/patterns/aspect-ratio.d.ts
@@ -11,5 +11,10 @@ export type AspectRatioProperties = {
 
 type AspectRatioOptions = AspectRatioProperties & Omit<SystemStyleObject, keyof AspectRatioProperties | 'aspectRatio'>
 
+interface AspectRatioPatternFn {
+  (options?: AspectRatioOptions): string
+  raw: (options: AspectRatioOptions) => AspectRatioOptions
+}
 
-export declare function aspectRatio(options?: AspectRatioOptions): string
+
+export declare const aspectRatio: AspectRatioPatternFn;

--- a/packages/studio/styled-system/patterns/aspect-ratio.mjs
+++ b/packages/studio/styled-system/patterns/aspect-ratio.mjs
@@ -33,3 +33,4 @@ const aspectRatioConfig = {
 export const getAspectRatioStyle = (styles = {}) => aspectRatioConfig.transform(styles, { map: mapObject })
 
 export const aspectRatio = (styles) => css(getAspectRatioStyle(styles))
+aspectRatio.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/box.d.ts
+++ b/packages/studio/styled-system/patterns/box.d.ts
@@ -11,5 +11,10 @@ export type BoxProperties = {
 
 type BoxOptions = BoxProperties & Omit<SystemStyleObject, keyof BoxProperties >
 
+interface BoxPatternFn {
+  (options?: BoxOptions): string
+  raw: (options: BoxOptions) => BoxOptions
+}
 
-export declare function box(options?: BoxOptions): string
+
+export declare const box: BoxPatternFn;

--- a/packages/studio/styled-system/patterns/box.mjs
+++ b/packages/studio/styled-system/patterns/box.mjs
@@ -10,3 +10,4 @@ const boxConfig = {
 export const getBoxStyle = (styles = {}) => boxConfig.transform(styles, { map: mapObject })
 
 export const box = (styles) => css(getBoxStyle(styles))
+box.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/center.d.ts
+++ b/packages/studio/styled-system/patterns/center.d.ts
@@ -11,5 +11,10 @@ export type CenterProperties = {
 
 type CenterOptions = CenterProperties & Omit<SystemStyleObject, keyof CenterProperties >
 
+interface CenterPatternFn {
+  (options?: CenterOptions): string
+  raw: (options: CenterOptions) => CenterOptions
+}
 
-export declare function center(options?: CenterOptions): string
+
+export declare const center: CenterPatternFn;

--- a/packages/studio/styled-system/patterns/center.mjs
+++ b/packages/studio/styled-system/patterns/center.mjs
@@ -16,3 +16,4 @@ const centerConfig = {
 export const getCenterStyle = (styles = {}) => centerConfig.transform(styles, { map: mapObject })
 
 export const center = (styles) => css(getCenterStyle(styles))
+center.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/circle.d.ts
+++ b/packages/studio/styled-system/patterns/circle.d.ts
@@ -11,5 +11,10 @@ export type CircleProperties = {
 
 type CircleOptions = CircleProperties & Omit<SystemStyleObject, keyof CircleProperties >
 
+interface CirclePatternFn {
+  (options?: CircleOptions): string
+  raw: (options: CircleOptions) => CircleOptions
+}
 
-export declare function circle(options?: CircleOptions): string
+
+export declare const circle: CirclePatternFn;

--- a/packages/studio/styled-system/patterns/circle.mjs
+++ b/packages/studio/styled-system/patterns/circle.mjs
@@ -20,3 +20,4 @@ const circleConfig = {
 export const getCircleStyle = (styles = {}) => circleConfig.transform(styles, { map: mapObject })
 
 export const circle = (styles) => css(getCircleStyle(styles))
+circle.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/container.d.ts
+++ b/packages/studio/styled-system/patterns/container.d.ts
@@ -11,5 +11,10 @@ export type ContainerProperties = {
 
 type ContainerOptions = ContainerProperties & Omit<SystemStyleObject, keyof ContainerProperties >
 
+interface ContainerPatternFn {
+  (options?: ContainerOptions): string
+  raw: (options: ContainerOptions) => ContainerOptions
+}
 
-export declare function container(options?: ContainerOptions): string
+
+export declare const container: ContainerPatternFn;

--- a/packages/studio/styled-system/patterns/container.mjs
+++ b/packages/studio/styled-system/patterns/container.mjs
@@ -16,3 +16,4 @@ const containerConfig = {
 export const getContainerStyle = (styles = {}) => containerConfig.transform(styles, { map: mapObject })
 
 export const container = (styles) => css(getContainerStyle(styles))
+container.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/divider.d.ts
+++ b/packages/studio/styled-system/patterns/divider.d.ts
@@ -13,5 +13,10 @@ export type DividerProperties = {
 
 type DividerOptions = DividerProperties & Omit<SystemStyleObject, keyof DividerProperties >
 
+interface DividerPatternFn {
+  (options?: DividerOptions): string
+  raw: (options: DividerOptions) => DividerOptions
+}
 
-export declare function divider(options?: DividerOptions): string
+
+export declare const divider: DividerPatternFn;

--- a/packages/studio/styled-system/patterns/divider.mjs
+++ b/packages/studio/styled-system/patterns/divider.mjs
@@ -19,3 +19,4 @@ const dividerConfig = {
 export const getDividerStyle = (styles = {}) => dividerConfig.transform(styles, { map: mapObject })
 
 export const divider = (styles) => css(getDividerStyle(styles))
+divider.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/flex.d.ts
+++ b/packages/studio/styled-system/patterns/flex.d.ts
@@ -17,5 +17,10 @@ export type FlexProperties = {
 
 type FlexOptions = FlexProperties & Omit<SystemStyleObject, keyof FlexProperties >
 
+interface FlexPatternFn {
+  (options?: FlexOptions): string
+  raw: (options: FlexOptions) => FlexOptions
+}
 
-export declare function flex(options?: FlexOptions): string
+
+export declare const flex: FlexPatternFn;

--- a/packages/studio/styled-system/patterns/flex.mjs
+++ b/packages/studio/styled-system/patterns/flex.mjs
@@ -21,3 +21,4 @@ const flexConfig = {
 export const getFlexStyle = (styles = {}) => flexConfig.transform(styles, { map: mapObject })
 
 export const flex = (styles) => css(getFlexStyle(styles))
+flex.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/float.d.ts
+++ b/packages/studio/styled-system/patterns/float.d.ts
@@ -14,5 +14,10 @@ export type FloatProperties = {
 
 type FloatOptions = FloatProperties & Omit<SystemStyleObject, keyof FloatProperties >
 
+interface FloatPatternFn {
+  (options?: FloatOptions): string
+  raw: (options: FloatOptions) => FloatOptions
+}
 
-export declare function float(options?: FloatOptions): string
+
+export declare const float: FloatPatternFn;

--- a/packages/studio/styled-system/patterns/float.mjs
+++ b/packages/studio/styled-system/patterns/float.mjs
@@ -43,3 +43,4 @@ const floatConfig = {
 export const getFloatStyle = (styles = {}) => floatConfig.transform(styles, { map: mapObject })
 
 export const float = (styles) => css(getFloatStyle(styles))
+float.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/grid-item.d.ts
+++ b/packages/studio/styled-system/patterns/grid-item.d.ts
@@ -16,5 +16,10 @@ export type GridItemProperties = {
 
 type GridItemOptions = GridItemProperties & Omit<SystemStyleObject, keyof GridItemProperties >
 
+interface GridItemPatternFn {
+  (options?: GridItemOptions): string
+  raw: (options: GridItemOptions) => GridItemOptions
+}
 
-export declare function gridItem(options?: GridItemOptions): string
+
+export declare const gridItem: GridItemPatternFn;

--- a/packages/studio/styled-system/patterns/grid-item.mjs
+++ b/packages/studio/styled-system/patterns/grid-item.mjs
@@ -20,3 +20,4 @@ const gridItemConfig = {
 export const getGridItemStyle = (styles = {}) => gridItemConfig.transform(styles, { map: mapObject })
 
 export const gridItem = (styles) => css(getGridItemStyle(styles))
+gridItem.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/grid.d.ts
+++ b/packages/studio/styled-system/patterns/grid.d.ts
@@ -15,5 +15,10 @@ export type GridProperties = {
 
 type GridOptions = GridProperties & Omit<SystemStyleObject, keyof GridProperties >
 
+interface GridPatternFn {
+  (options?: GridOptions): string
+  raw: (options: GridOptions) => GridOptions
+}
 
-export declare function grid(options?: GridOptions): string
+
+export declare const grid: GridPatternFn;

--- a/packages/studio/styled-system/patterns/grid.mjs
+++ b/packages/studio/styled-system/patterns/grid.mjs
@@ -23,3 +23,4 @@ const gridConfig = {
 export const getGridStyle = (styles = {}) => gridConfig.transform(styles, { map: mapObject })
 
 export const grid = (styles) => css(getGridStyle(styles))
+grid.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/hstack.d.ts
+++ b/packages/studio/styled-system/patterns/hstack.d.ts
@@ -12,5 +12,10 @@ export type HstackProperties = {
 
 type HstackOptions = HstackProperties & Omit<SystemStyleObject, keyof HstackProperties >
 
+interface HstackPatternFn {
+  (options?: HstackOptions): string
+  raw: (options: HstackOptions) => HstackOptions
+}
 
-export declare function hstack(options?: HstackOptions): string
+
+export declare const hstack: HstackPatternFn;

--- a/packages/studio/styled-system/patterns/hstack.mjs
+++ b/packages/studio/styled-system/patterns/hstack.mjs
@@ -18,3 +18,4 @@ const hstackConfig = {
 export const getHstackStyle = (styles = {}) => hstackConfig.transform(styles, { map: mapObject })
 
 export const hstack = (styles) => css(getHstackStyle(styles))
+hstack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/link-box.d.ts
+++ b/packages/studio/styled-system/patterns/link-box.d.ts
@@ -11,5 +11,10 @@ export type LinkBoxProperties = {
 
 type LinkBoxOptions = LinkBoxProperties & Omit<SystemStyleObject, keyof LinkBoxProperties >
 
+interface LinkBoxPatternFn {
+  (options?: LinkBoxOptions): string
+  raw: (options: LinkBoxOptions) => LinkBoxOptions
+}
 
-export declare function linkBox(options?: LinkBoxOptions): string
+
+export declare const linkBox: LinkBoxPatternFn;

--- a/packages/studio/styled-system/patterns/link-box.mjs
+++ b/packages/studio/styled-system/patterns/link-box.mjs
@@ -17,3 +17,4 @@ const linkBoxConfig = {
 export const getLinkBoxStyle = (styles = {}) => linkBoxConfig.transform(styles, { map: mapObject })
 
 export const linkBox = (styles) => css(getLinkBoxStyle(styles))
+linkBox.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/link-overlay.d.ts
+++ b/packages/studio/styled-system/patterns/link-overlay.d.ts
@@ -11,5 +11,10 @@ export type LinkOverlayProperties = {
 
 type LinkOverlayOptions = LinkOverlayProperties & Omit<SystemStyleObject, keyof LinkOverlayProperties >
 
+interface LinkOverlayPatternFn {
+  (options?: LinkOverlayOptions): string
+  raw: (options: LinkOverlayOptions) => LinkOverlayOptions
+}
 
-export declare function linkOverlay(options?: LinkOverlayOptions): string
+
+export declare const linkOverlay: LinkOverlayPatternFn;

--- a/packages/studio/styled-system/patterns/link-overlay.mjs
+++ b/packages/studio/styled-system/patterns/link-overlay.mjs
@@ -22,3 +22,4 @@ const linkOverlayConfig = {
 export const getLinkOverlayStyle = (styles = {}) => linkOverlayConfig.transform(styles, { map: mapObject })
 
 export const linkOverlay = (styles) => css(getLinkOverlayStyle(styles))
+linkOverlay.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/spacer.d.ts
+++ b/packages/studio/styled-system/patterns/spacer.d.ts
@@ -11,5 +11,10 @@ export type SpacerProperties = {
 
 type SpacerOptions = SpacerProperties & Omit<SystemStyleObject, keyof SpacerProperties >
 
+interface SpacerPatternFn {
+  (options?: SpacerOptions): string
+  raw: (options: SpacerOptions) => SpacerOptions
+}
 
-export declare function spacer(options?: SpacerOptions): string
+
+export declare const spacer: SpacerPatternFn;

--- a/packages/studio/styled-system/patterns/spacer.mjs
+++ b/packages/studio/styled-system/patterns/spacer.mjs
@@ -16,3 +16,4 @@ const spacerConfig = {
 export const getSpacerStyle = (styles = {}) => spacerConfig.transform(styles, { map: mapObject })
 
 export const spacer = (styles) => css(getSpacerStyle(styles))
+spacer.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/square.d.ts
+++ b/packages/studio/styled-system/patterns/square.d.ts
@@ -11,5 +11,10 @@ export type SquareProperties = {
 
 type SquareOptions = SquareProperties & Omit<SystemStyleObject, keyof SquareProperties >
 
+interface SquarePatternFn {
+  (options?: SquareOptions): string
+  raw: (options: SquareOptions) => SquareOptions
+}
 
-export declare function square(options?: SquareOptions): string
+
+export declare const square: SquarePatternFn;

--- a/packages/studio/styled-system/patterns/square.mjs
+++ b/packages/studio/styled-system/patterns/square.mjs
@@ -19,3 +19,4 @@ const squareConfig = {
 export const getSquareStyle = (styles = {}) => squareConfig.transform(styles, { map: mapObject })
 
 export const square = (styles) => css(getSquareStyle(styles))
+square.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/stack.d.ts
+++ b/packages/studio/styled-system/patterns/stack.d.ts
@@ -14,5 +14,10 @@ export type StackProperties = {
 
 type StackOptions = StackProperties & Omit<SystemStyleObject, keyof StackProperties >
 
+interface StackPatternFn {
+  (options?: StackOptions): string
+  raw: (options: StackOptions) => StackOptions
+}
 
-export declare function stack(options?: StackOptions): string
+
+export declare const stack: StackPatternFn;

--- a/packages/studio/styled-system/patterns/stack.mjs
+++ b/packages/studio/styled-system/patterns/stack.mjs
@@ -18,3 +18,4 @@ const stackConfig = {
 export const getStackStyle = (styles = {}) => stackConfig.transform(styles, { map: mapObject })
 
 export const stack = (styles) => css(getStackStyle(styles))
+stack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/styled-link.d.ts
+++ b/packages/studio/styled-system/patterns/styled-link.d.ts
@@ -11,5 +11,10 @@ export type StyledLinkProperties = {
 
 type StyledLinkOptions = StyledLinkProperties & Omit<SystemStyleObject, keyof StyledLinkProperties >
 
+interface StyledLinkPatternFn {
+  (options?: StyledLinkOptions): string
+  raw: (options: StyledLinkOptions) => StyledLinkOptions
+}
 
-export declare function styledLink(options?: StyledLinkOptions): string
+
+export declare const styledLink: StyledLinkPatternFn;

--- a/packages/studio/styled-system/patterns/styled-link.mjs
+++ b/packages/studio/styled-system/patterns/styled-link.mjs
@@ -16,3 +16,4 @@ const styledLinkConfig = {
 export const getStyledLinkStyle = (styles = {}) => styledLinkConfig.transform(styles, { map: mapObject })
 
 export const styledLink = (styles) => css(getStyledLinkStyle(styles))
+styledLink.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/vstack.d.ts
+++ b/packages/studio/styled-system/patterns/vstack.d.ts
@@ -12,5 +12,10 @@ export type VstackProperties = {
 
 type VstackOptions = VstackProperties & Omit<SystemStyleObject, keyof VstackProperties >
 
+interface VstackPatternFn {
+  (options?: VstackOptions): string
+  raw: (options: VstackOptions) => VstackOptions
+}
 
-export declare function vstack(options?: VstackOptions): string
+
+export declare const vstack: VstackPatternFn;

--- a/packages/studio/styled-system/patterns/vstack.mjs
+++ b/packages/studio/styled-system/patterns/vstack.mjs
@@ -18,3 +18,4 @@ const vstackConfig = {
 export const getVstackStyle = (styles = {}) => vstackConfig.transform(styles, { map: mapObject })
 
 export const vstack = (styles) => css(getVstackStyle(styles))
+vstack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/wrap.d.ts
+++ b/packages/studio/styled-system/patterns/wrap.d.ts
@@ -15,5 +15,10 @@ export type WrapProperties = {
 
 type WrapOptions = WrapProperties & Omit<SystemStyleObject, keyof WrapProperties >
 
+interface WrapPatternFn {
+  (options?: WrapOptions): string
+  raw: (options: WrapOptions) => WrapOptions
+}
 
-export declare function wrap(options?: WrapOptions): string
+
+export declare const wrap: WrapPatternFn;

--- a/packages/studio/styled-system/patterns/wrap.mjs
+++ b/packages/studio/styled-system/patterns/wrap.mjs
@@ -20,3 +20,4 @@ const wrapConfig = {
 export const getWrapStyle = (styles = {}) => wrapConfig.transform(styles, { map: mapObject })
 
 export const wrap = (styles) => css(getWrapStyle(styles))
+wrap.raw = (styles) => styles


### PR DESCRIPTION
## 📝 Description

@segunadebayo had this awesome idea:

This will allow for a super flexible usage and extraction.

```tsx
<Button rootProps={css.raw({ bg: "red.400" })} />

// recipe in storybook
export const Funky: Story = {
	args: button.raw({
		visual: "funky",
		shape: "circle",
		size: "sm",
	}),
};

// mixed with pattern
const stackProps = {
  sm: stack.raw({ direction: "column" }),
  md: stack.raw({ direction: "row" })
}

stack(stackProps[props.size]))
```

The .raw will be an identity function. Only serves as a marker for extractor


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

related to https://github.com/chakra-ui/panda/issues/1057
