### PR TITLE
chore(extension): disable extension in svelte/vue files

### DIFF
--- a/.changeset/silent-insects-shake.md
+++ b/.changeset/silent-insects-shake.md
@@ -1,0 +1,5 @@
+---
+'panda-css-vscode': patch
+---
+
+Temporarily disable extension in svelte/vue files

--- a/extension/vscode/src/index.ts
+++ b/extension/vscode/src/index.ts
@@ -19,8 +19,9 @@ const docSelector: vscode.DocumentSelector = [
   'javascript',
   'javascriptreact',
   'astro',
-  'svelte',
-  'vue',
+  // TODO re-enable whenever we figured out how to map transformed file AST nodes to their original positions
+  // 'svelte',
+  // 'vue',
 ]
 
 let client: LanguageClient


### PR DESCRIPTION
## 📝 Description

Temporarily disable extension in svelte/vue files

## 💣 Is this a breaking change (Yes/No):

no
