### PR TITLE
Adding missing comma for generated panda config

### DIFF
--- a/.changeset/eighty-hats-speak.md
+++ b/.changeset/eighty-hats-speak.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/node": patch
+---
+
+Adding missing comma for generated panda config

--- a/packages/node/src/setup-config.ts
+++ b/packages/node/src/setup-config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
 
     // The output directory for your css system
     outdir: "styled-system",
-    ${jsxFramework ? `\n // The JSX framework to use\njsxFramework: '${jsxFramework}'` : ''}
+    ${jsxFramework ? `\n // The JSX framework to use\njsxFramework: '${jsxFramework}',` : ''}
     ${syntax ? `\n // The CSS Syntax to use to use\nsyntax: '${syntax}'` : ''}
 })
     `


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Add missing command when generating panda config


## ⛳️ Current behavior (updates)

When init the panda config with the following command:

```
pnpm exec panda init -p --syntax template-literal --jsx-framework react
```

The generated config was:

```ts
import { defineConfig } from "@pandacss/dev"

export default defineConfig({
    // Whether to use css reset
    preflight: true,
    
    // Where to look for your css declarations
    include: ["./src/**/*.{js,jsx,ts,tsx}", "./pages/**/*.{js,jsx,ts,tsx}"],

    // Files to exclude
    exclude: [],

    // Useful for theme customization
    theme: {
      extend: {}
    },

    // The output directory for your css system
    outdir: "styled-system",
    
 // The JSX framework to use
jsxFramework: 'react'
    
 // The CSS Syntax to use to use
syntax: 'template-literal'
})
```

which was missing the `,` seperator between the `jsxFramework` and `syntax`

## 🚀 New behavior

The missing comma is added

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
