### PR TITLE
fix(extractor): never override node/ts

### DIFF
--- a/.changeset/quiet-toys-tell.md
+++ b/.changeset/quiet-toys-tell.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/language-server': patch
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+'@pandacss/node': patch
+---
+
+Fix node evaluation in extractor process (can happen when using a BinaryExpression, simple CallExpression or conditions)

--- a/extension/language-server/package.json
+++ b/extension/language-server/package.json
@@ -38,7 +38,7 @@
     "postcss": "^8.4.25",
     "prettier": "^2.8.8",
     "satori": "^0.10.1",
-    "ts-morph": "18.0.0",
+    "ts-morph": "19.0.0",
     "ts-pattern": "5.0.1",
     "tsup": "7.1.0",
     "typescript": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "husky": "8.0.3",
     "lint-staged": "13.2.3",
     "prettier": "^2.8.8",
-    "ts-morph": "18.0.0",
+    "ts-morph": "19.0.0",
     "tsup": "7.1.0",
     "tsx": "3.12.7",
     "typescript": "5.1.6",

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "lil-fp": "1.4.5",
     "ts-evaluator": "^1.1.0",
-    "ts-morph": "18.0.0",
+    "ts-morph": "19.0.0",
     "ts-pattern": "5.0.1"
   }
 }

--- a/packages/extractor/src/evaluate-node.ts
+++ b/packages/extractor/src/evaluate-node.ts
@@ -20,8 +20,6 @@ export const evaluateNode = (node: Expression, stack: Node[], ctx: BoxContext) =
   }
 
   const result = evaluate({
-    node: node.compilerNode as any,
-    typescript: ts as any,
     policy: {
       deterministic: true,
       network: false,
@@ -32,6 +30,8 @@ export const evaluateNode = (node: Expression, stack: Node[], ctx: BoxContext) =
       process: { exit: false, spawnChild: false },
     },
     ...ctx.getEvaluateOptions?.(node, stack),
+    node: node.compilerNode as any,
+    typescript: ts as any,
   })
 
   const expr = result.success ? result.value : TsEvalError

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -47,7 +47,7 @@
     "pluralize": "8.0.0",
     "postcss": "8.4.25",
     "preferred-pm": "^3.0.3",
-    "ts-morph": "18.0.0",
+    "ts-morph": "19.0.0",
     "ts-pattern": "5.0.1",
     "tsconfck": "^2.1.1"
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -25,7 +25,7 @@
     "@vue/compiler-sfc": "^3.3.4",
     "lil-fp": "1.4.5",
     "magic-string": "^0.30.1",
-    "ts-morph": "18.0.0",
+    "ts-morph": "19.0.0",
     "ts-pattern": "5.0.1"
   },
   "devDependencies": {

--- a/packages/studio/styled-system/tokens/index.css
+++ b/packages/studio/styled-system/tokens/index.css
@@ -425,17 +425,6 @@
     --colors-bg: #fff;
     --colors-card: #e5e5e5;
     --colors-border: #d4d4d4;
-    --colors-color-palette-50: var(--colors-color-palette-50);
-    --colors-color-palette-100: var(--colors-color-palette-100);
-    --colors-color-palette-200: var(--colors-color-palette-200);
-    --colors-color-palette-300: var(--colors-color-palette-300);
-    --colors-color-palette-400: var(--colors-color-palette-400);
-    --colors-color-palette-500: var(--colors-color-palette-500);
-    --colors-color-palette-600: var(--colors-color-palette-600);
-    --colors-color-palette-700: var(--colors-color-palette-700);
-    --colors-color-palette-800: var(--colors-color-palette-800);
-    --colors-color-palette-900: var(--colors-color-palette-900);
-    --colors-color-palette-950: var(--colors-color-palette-950);
   }
 
   .dark {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^2.8.8
         version: 2.8.8
       ts-morph:
-        specifier: 18.0.0
-        version: 18.0.0
+        specifier: 19.0.0
+        version: 19.0.0
       tsup:
         specifier: 7.1.0
         version: 7.1.0(postcss@8.4.25)(typescript@5.1.6)
@@ -122,8 +122,8 @@ importers:
         specifier: ^0.10.1
         version: 0.10.1
       ts-morph:
-        specifier: 18.0.0
-        version: 18.0.0
+        specifier: 19.0.0
+        version: 19.0.0
       ts-pattern:
         specifier: 5.0.1
         version: 5.0.1
@@ -578,11 +578,11 @@ importers:
         specifier: 1.4.5
         version: 1.4.5
       ts-evaluator:
-        specifier: ^1.1.0
-        version: 1.1.0(typescript@5.1.6)
+        specifier: /Users/astahmer/dev/open-source/ts-evaluator
+        version: link:../../../ts-evaluator
       ts-morph:
-        specifier: 18.0.0
-        version: 18.0.0
+        specifier: 19.0.0
+        version: 19.0.0
       ts-pattern:
         specifier: 5.0.1
         version: 5.0.1
@@ -754,8 +754,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       ts-morph:
-        specifier: 18.0.0
-        version: 18.0.0
+        specifier: 19.0.0
+        version: 19.0.0
       ts-pattern:
         specifier: 5.0.1
         version: 5.0.1
@@ -815,8 +815,8 @@ importers:
         specifier: ^0.30.1
         version: 0.30.1
       ts-morph:
-        specifier: 18.0.0
-        version: 18.0.0
+        specifier: 19.0.0
+        version: 19.0.0
       ts-pattern:
         specifier: 5.0.1
         version: 5.0.1
@@ -11352,8 +11352,8 @@ packages:
       path-browserify: 1.0.1
     dev: false
 
-  /@ts-morph/common@0.19.0:
-    resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
+  /@ts-morph/common@0.20.0:
+    resolution: {integrity: sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==}
     dependencies:
       fast-glob: 3.3.0
       minimatch: 7.4.6
@@ -11787,10 +11787,6 @@ packages:
   /@types/node@16.18.34:
     resolution: {integrity: sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==}
     dev: true
-
-  /@types/node@17.0.45:
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-    dev: false
 
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
@@ -15754,13 +15750,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  /crosspath@2.0.0:
-    resolution: {integrity: sha512-ju88BYCQ2uvjO2bR+SsgLSTwTSctU+6Vp2ePbKPgSCZyy4MWZxYsT738DlKVRE5utUjobjPRm1MkTYKJxCmpTA==}
-    engines: {node: '>=14.9.0'}
-    dependencies:
-      '@types/node': 17.0.45
-    dev: false
 
   /crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -24201,11 +24190,6 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  /object-path@0.11.8:
-    resolution: {integrity: sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==}
-    engines: {node: '>= 10.12.0'}
-    dev: false
-
   /object.assign@4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
     engines: {node: '>= 0.4'}
@@ -28840,22 +28824,6 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  /ts-evaluator@1.1.0(typescript@5.1.6):
-    resolution: {integrity: sha512-B7j9Gw7NisfV+vTjZgYBjPAyNj48CgjFhHLmxpvN24mwln6v4sumL4LaQJn5ZMwFAQx2gGrzRE4V1Xt/0B5tvA==}
-    engines: {node: '>=14.19.0'}
-    peerDependencies:
-      jsdom: '>=14.x'
-      typescript: '>=3.2.x || >= 4.x'
-    peerDependenciesMeta:
-      jsdom:
-        optional: true
-    dependencies:
-      ansi-colors: 4.1.3
-      crosspath: 2.0.0
-      object-path: 0.11.8
-      typescript: 5.1.6
-    dev: false
-
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -28866,10 +28834,10 @@ packages:
       code-block-writer: 10.1.1
     dev: false
 
-  /ts-morph@18.0.0:
-    resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
+  /ts-morph@19.0.0:
+    resolution: {integrity: sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==}
     dependencies:
-      '@ts-morph/common': 0.19.0
+      '@ts-morph/common': 0.20.0
       code-block-writer: 12.0.0
 
   /ts-node@10.9.1(@types/node@14.18.33)(typescript@4.9.5):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,8 +578,8 @@ importers:
         specifier: 1.4.5
         version: 1.4.5
       ts-evaluator:
-        specifier: /Users/astahmer/dev/open-source/ts-evaluator
-        version: link:../../../ts-evaluator
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.1.6)
       ts-morph:
         specifier: 19.0.0
         version: 19.0.0
@@ -11788,6 +11788,10 @@ packages:
     resolution: {integrity: sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==}
     dev: true
 
+  /@types/node@17.0.45:
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
+
   /@types/node@20.4.1:
     resolution: {integrity: sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==}
 
@@ -15750,6 +15754,13 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  /crosspath@2.0.0:
+    resolution: {integrity: sha512-ju88BYCQ2uvjO2bR+SsgLSTwTSctU+6Vp2ePbKPgSCZyy4MWZxYsT738DlKVRE5utUjobjPRm1MkTYKJxCmpTA==}
+    engines: {node: '>=14.9.0'}
+    dependencies:
+      '@types/node': 17.0.45
+    dev: false
 
   /crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -24190,6 +24201,11 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
+  /object-path@0.11.8:
+    resolution: {integrity: sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==}
+    engines: {node: '>= 10.12.0'}
+    dev: false
+
   /object.assign@4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
     engines: {node: '>= 0.4'}
@@ -28823,6 +28839,22 @@ packages:
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  /ts-evaluator@1.1.0(typescript@5.1.6):
+    resolution: {integrity: sha512-B7j9Gw7NisfV+vTjZgYBjPAyNj48CgjFhHLmxpvN24mwln6v4sumL4LaQJn5ZMwFAQx2gGrzRE4V1Xt/0B5tvA==}
+    engines: {node: '>=14.19.0'}
+    peerDependencies:
+      jsdom: '>=14.x'
+      typescript: '>=3.2.x || >= 4.x'
+    peerDependenciesMeta:
+      jsdom:
+        optional: true
+    dependencies:
+      ansi-colors: 4.1.3
+      crosspath: 2.0.0
+      object-path: 0.11.8
+      typescript: 5.1.6
+    dev: false
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1008#issuecomment-1646967843

## 📝 Description

Fix node evaluation in extractor process (can happen when using a BinaryExpression, simple CallExpression or conditions)
Also updated `ts-morph` version to match the one from `typescript` so there is no mismatch in the `SyntaxKind` enum which can cause subtle issues such as the ones linked above

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

we should probably never update `typescript` without updating `ts-morph` as well