### PR TITLE
fix(recipes): add .raw fn & fix test case

### DIFF
--- a/.changeset/angry-years-mate.md
+++ b/.changeset/angry-years-mate.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Adds the `{recipe}.raw()` in generated runtime

--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -81,6 +81,7 @@ describe('generate recipes', () => {
 
       export const textStyle = Object.assign(textStyleFn, {
         __recipe__: true,
+        raw: (props) => props,
         variantKeys: [
         \\"size\\"
       ],
@@ -132,6 +133,7 @@ describe('generate recipes', () => {
 
       export const tooltipStyle = Object.assign(tooltipStyleFn, {
         __recipe__: true,
+        raw: (props) => props,
         variantKeys: [],
         variantMap: {},
         splitVariantProps(props) {
@@ -178,6 +180,7 @@ describe('generate recipes', () => {
 
       export const buttonStyle = Object.assign(buttonStyleFn, {
         __recipe__: true,
+        raw: (props) => props,
         variantKeys: [
         \\"size\\",
         \\"variant\\"

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -78,6 +78,7 @@ export function generateRecipes(ctx: Context) {
 
         export const ${name} = Object.assign(${name}Fn, {
           __recipe__: true,
+          raw: (props) => props,
           variantKeys: ${stringify(Object.keys(variantKeyMap))},
           variantMap: ${stringify(variantKeyMap)},
           splitVariantProps(props) {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -203,7 +203,7 @@ describe('extract to css output pipeline', () => {
     export default function Page() {
       return (
         <>
-          <ComponentWithMultipleRecipes variant="sm" />
+          <ComponentWithMultipleRecipes variant="small" />
         </>
       )
     }
@@ -257,7 +257,7 @@ describe('extract to css output pipeline', () => {
         {
           "data": [
             {
-              "variant": "sm",
+              "variant": "small",
             },
           ],
           "name": "ComponentWithMultipleRecipes",
@@ -273,7 +273,7 @@ describe('extract to css output pipeline', () => {
         {
           "data": [
             {
-              "variant": "sm",
+              "variant": "small",
             },
           ],
           "name": "ComponentWithMultipleRecipes",
@@ -289,7 +289,7 @@ describe('extract to css output pipeline', () => {
         {
           "data": [
             {
-              "variant": "sm",
+              "variant": "small",
             },
           ],
           "name": "ComponentWithMultipleRecipes",
@@ -300,6 +300,10 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer recipes {
+        .pinkRecipe--variant_small,.greenRecipe--variant_small,.blueRecipe--variant_small {
+          font-size: sm
+          }
+
         @layer _base {
           .pinkRecipe {
             color: pink.100

--- a/packages/studio/styled-system/tokens/index.css
+++ b/packages/studio/styled-system/tokens/index.css
@@ -425,17 +425,6 @@
     --colors-bg: #fff;
     --colors-card: #e5e5e5;
     --colors-border: #d4d4d4;
-    --colors-color-palette-50: var(--colors-color-palette-50);
-    --colors-color-palette-100: var(--colors-color-palette-100);
-    --colors-color-palette-200: var(--colors-color-palette-200);
-    --colors-color-palette-300: var(--colors-color-palette-300);
-    --colors-color-palette-400: var(--colors-color-palette-400);
-    --colors-color-palette-500: var(--colors-color-palette-500);
-    --colors-color-palette-600: var(--colors-color-palette-600);
-    --colors-color-palette-700: var(--colors-color-palette-700);
-    --colors-color-palette-800: var(--colors-color-palette-800);
-    --colors-color-palette-900: var(--colors-color-palette-900);
-    --colors-color-palette-950: var(--colors-color-palette-950);
   }
 
   .dark {


### PR DESCRIPTION
related to: https://github.com/chakra-ui/panda/issues/1093

## 📝 Description

Adds the `{recipe}.raw()` in generated runtime (my bad I had only added the typings)
Fix test case (was using `sm` instead of `small`)

## 💣 Is this a breaking change (Yes/No):

no

