### PR TITLE
fix(postcss): pass cwd or fallback to process.cwd in builder

### DIFF
--- a/.changeset/spotty-bugs-tease.md
+++ b/.changeset/spotty-bugs-tease.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/postcss': patch
+'@pandacss/node': patch
+---
+
+Fix PostCSS edge-case where the config file is not in the app root

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -10,8 +10,8 @@ const interopDefault = (obj: any) => (obj && obj.__esModule ? obj.default : obj)
 
 export const loadConfig = () => interopDefault(require('@pandacss/postcss'))
 
-export const pandacss: PluginCreator<{ configPath?: string }> = (options = {}) => {
-  const { configPath } = options
+export const pandacss: PluginCreator<{ configPath?: string; cwd?: string }> = (options = {}) => {
+  const { configPath, cwd } = options
   const builder = new Builder()
 
   return {
@@ -23,7 +23,7 @@ export const pandacss: PluginCreator<{ configPath?: string }> = (options = {}) =
           return
         }
 
-        await builder.setup({ configPath })
+        await builder.setup({ configPath, cwd })
         await builder.extract()
 
         builder.registerDependency((dep) => {


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1120

## 📝 Description

Fix PostCSS edge-case where the config file is not in the app root

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

fix(postcss): pass cwd or fallback to process.cwd in builder
can't use dirname(configPath) because sometimes the config path is somewhere else than in the app root
also, don't throw on missing file
