### PR TITLE
fix(extractor): visit both condition branches when using default valu…

### DIFF
--- a/.changeset/short-dodos-cheer.md
+++ b/.changeset/short-dodos-cheer.md
@@ -1,0 +1,17 @@
+---
+'@pandacss/extractor': patch
+---
+
+Fix extractor issue where we didn't explore both branches when using a default value as the condition expression
+
+In the example below, only the `yellow` color would be generated although the `blue` color should also be generated in case the `disabled` prop is `true`.
+
+```tsx
+const CompB = ({ disabled = false }: { disabled: boolean }) => {
+    return (
+        <div className={css({ color: disabled ? 'blue' : 'yellow' })}>
+        Component B is disabled
+        </div>
+    );
+};
+```

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5668,3 +5668,44 @@ it('resolves identifier pointing to default value on parameters JsxExpression > 
     }
   `)
 })
+
+it('still explore both branches when using a default value as the condition expression', () => {
+  expect(
+    extractFromCode(
+      `import { css } from "../panda/css";
+
+      const CompB = ({ disabled = false }: { disabled: boolean }) => {
+        return (
+          <div className={css({ color: disabled ? 'blue' : 'yellow' })}>
+            Component B is {disabled ? 'disabled' : 'not disabled'}
+          </div>
+        );
+      };
+      `,
+      { functionNameList: ['css'] },
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "css": [
+        {
+          "conditions": [
+            {
+              "0": {
+                "color": "blue",
+              },
+            },
+            {
+              "0": {
+                "color": "yellow",
+              },
+            },
+          ],
+          "raw": [
+            {},
+          ],
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/extractor/src/maybe-box-node.ts
+++ b/packages/extractor/src/maybe-box-node.ts
@@ -170,7 +170,8 @@ export function maybeBoxNode(
         const condValue = isBoxNode(condBoxNode) ? condBoxNode : box.from(condBoxNode, node, stack)
         if (box.isEmptyInitializer(condValue)) return
 
-        if (box.isUnresolvable(condValue) || box.isConditional(condValue)) {
+        const isFromDefaultBinding = condValue.getStack().some((node) => Node.isBindingElement(node))
+        if (box.isUnresolvable(condValue) || box.isConditional(condValue) || isFromDefaultBinding) {
           const whenTrueExpr = unwrapExpression(node.getWhenTrue())
           const whenFalseExpr = unwrapExpression(node.getWhenFalse())
           return cache(maybeResolveConditionalExpression({ whenTrueExpr, whenFalseExpr, node, stack }, ctx))
@@ -231,7 +232,7 @@ export function maybeBoxNode(
   )
 }
 
-export const onlyStringLiteral = (boxNode: MaybeBoxNodeReturn) => {
+const onlyStringLiteral = (boxNode: MaybeBoxNodeReturn) => {
   if (!boxNode) return
 
   if (isBoxNode(boxNode) && box.isLiteral(boxNode) && typeof boxNode.value === 'string') {


### PR DESCRIPTION
…e as condition expression

Closes https://github.com/chakra-ui/panda/issues/1123

## 📝 Description

Fix extractor issue where we didn't explore both branches when using a default value as the condition expression

In the example below, only the `yellow` color would be generated although the `blue` color should also be generated in case the `disabled` prop is `true`.

```tsx
const CompB = ({ disabled = false }: { disabled: boolean }) => {
    return (
        <div className={css({ color: disabled ? 'blue' : 'yellow' })}>
        Component B is disabled
        </div>
    );
};
```


## 💣 Is this a breaking change (Yes/No):

no
