### PR TITLE
chore: support types package prepare script on windows

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "scripts": {
-    "prepare": "cp node_modules/csstype/index.d.ts src/csstype.d.ts",
+    "prepare": "ncp node_modules/csstype/index.d.ts src/csstype.d.ts",
     "build": "tsx scripts/build.ts",
     "build-fast": "tsx scripts/build.ts",
     "dev": "chokidar -c 'pnpm build' src --initial"
@@ -23,6 +23,7 @@
     "chokidar-cli": "^3.0.0",
     "csstype": "3.1.2",
     "hookable": "5.5.3",
+    "ncp": "^2.0.0",
     "pkg-types": "1.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,9 @@ importers:
       hookable:
         specifier: 5.5.3
         version: 5.5.3
+      ncp:
+        specifier: ^2.0.0
+        version: 2.0.0
       pkg-types:
         specifier: 1.0.3
         version: 1.0.3
@@ -24031,6 +24034,11 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  /ncp@2.0.0:
+    resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
+    hasBin: true
+    dev: true
+
   /ndjson@2.0.0:
     resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
     engines: {node: '>=10'}
@@ -24306,6 +24314,7 @@ packages:
 
   /node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -24388,6 +24397,7 @@ packages:
   /node-gyp-build-optional-packages@5.0.7:
     resolution: {integrity: sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==}
     hasBin: true
+    requiresBuild: true
     dev: false
     optional: true
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Currently (p)npm uses cmd on windows, and cmd doesn't have cp command.

In other words, the `cp` command is not cross-platform, and neither is the types package prepare script.

## ⛳️ Current behavior (updates)

I got this with `pnpm i --frozen-lockfile` on windows.
```
packages/types prepare$ cp node_modules/csstype/index.d.ts src/csstype.d.ts
│ 'cp' is not recognized as an internal or external command,
│ operable program or batch file.
└─ Failed in 11ms at D:\Repos\jeiea\2023\07\panda\packages\types
 ELIFECYCLE  Command failed with exit code 1.
```

## 🚀 New behavior

`pnpm i --frozen-lockfile` on windows should succeed.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
