### PR TITLE
feat(preset-base): add opacity utility

### DIFF
--- a/.changeset/red-ads-mate.md
+++ b/.changeset/red-ads-mate.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/preset-base': patch
+---
+
+Add opacity utility to base preset

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -144,6 +144,7 @@ describe('generate property types', () => {
       	borderBlockEndColor: Tokens[\\"colors\\"];
       	borderBlockStart: Tokens[\\"borders\\"];
       	borderBlockStartColor: Tokens[\\"colors\\"];
+      	opacity: Tokens[\\"opacity\\"];
       	boxShadow: Tokens[\\"shadows\\"];
       	boxShadowColor: Tokens[\\"colors\\"];
       	filter: \\"auto\\";

--- a/packages/preset-base/src/utilities/effects.ts
+++ b/packages/preset-base/src/utilities/effects.ts
@@ -1,6 +1,9 @@
 import type { UtilityConfig } from '@pandacss/types'
 
 export const effects: UtilityConfig = {
+  opacity: {
+    values: 'opacity',
+  },
   boxShadow: {
     shorthand: 'shadow',
     className: 'shadow',

--- a/packages/studio/styled-system/jsx/is-valid-prop.mjs
+++ b/packages/studio/styled-system/jsx/is-valid-prop.mjs
@@ -262,6 +262,7 @@ var userGenerated = [
   'borderBlockEndColor',
   'borderBlockStart',
   'borderBlockStartColor',
+  'opacity',
   'boxShadow',
   'boxShadowColor',
   'mixBlendMode',

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -138,6 +138,7 @@ type PropertyValueTypes  = {
 	borderBlockEndColor: Tokens["colors"];
 	borderBlockStart: Tokens["borders"];
 	borderBlockStartColor: Tokens["colors"];
+	opacity: Tokens["opacity"];
 	boxShadow: Tokens["shadows"];
 	boxShadowColor: Tokens["colors"];
 	filter: "auto";


### PR DESCRIPTION
Add the `opacity` utility to the base preset.