### PR TITLE
Minor typo fix in the getting-started.mdx page

### DIFF
--- a/website/pages/docs/overview/getting-started.mdx
+++ b/website/pages/docs/overview/getting-started.mdx
@@ -24,7 +24,7 @@ Panda combines the developer experience of CSS-in-JS and the performance of atom
 
 ### Framework Guides
 
-Starting using Panda CSS in your JavaScript framework using our framework-specific guides that cover our recommended approach.
+Start using Panda CSS in your JavaScript framework using our framework-specific guides that cover our recommended approach.
 
 <FrameworkCards />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> I was going through the getting started docs on how to use Panda CSS and the sentence under the Framework Guides header began with "Starting" instead of "Start" and I thought to fix that 😄

## ⛳️ Current behavior (updates)

> A minor typo that may be off-putting

## 🚀 New behavior

> Will fix the typo and may improve readability

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
