### PR TITLE
fix: mixed path separator during tsconfig path mapping

### DIFF
--- a/.changeset/famous-avocados-play.md
+++ b/.changeset/famous-avocados-play.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/config': patch
+---
+
+Normalize tsconfig path mapping result to posix path.
+
+It fix not generating pattern styles on windows eventually.

--- a/packages/config/src/resolve-ts-path-pattern.ts
+++ b/packages/config/src/resolve-ts-path-pattern.ts
@@ -1,3 +1,4 @@
+import { posix, sep } from 'path'
 import type { PathMapping } from './ts-config-paths'
 
 /**
@@ -20,7 +21,7 @@ export const resolveTsPathPattern = (pathMappings: PathMapping[], moduleSpecifie
         return match[matchIndex]
       })
 
-      return mappedId
+      return mappedId.split(sep).join(posix.sep)
     }
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1130 <!-- Github issue # here -->

## 📝 Description

Described in the issue.

## ⛳️ Current behavior (updates)

Pattern style was not generated in windows.

## 🚀 New behavior

Works as expected.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
