### PR TITLE
feat(config): missingCssWarning

### DIFF
--- a/.changeset/tricky-students-glow.md
+++ b/.changeset/tricky-students-glow.md
@@ -1,0 +1,37 @@
+---
+'@pandacss/generator': patch
+'@pandacss/shared': patch
+'@pandacss/types': patch
+---
+
+Add `config.missingCssWarning` option that logs a warning message when a CSS rule was used at runtime but couldn't be
+statically extracted
+
+In the example code below, the `color` property and the `weight` value are not statically extractable, so there will be
+2 warning messages:
+
+- No matching CSS rule found for font_italic
+- No matching CSS rule found for text_pink.200
+
+```ts
+import { useState } from 'react'
+import { css, cx } from '../styled-system/css'
+
+export const App = () => {
+  const [colorTint, setColorTint] = useState(200)
+  const [weight, setWeight] = useState('italic')
+
+  return (
+    <>
+      <div
+        className={cx(
+          css({ fontSize: '4xl', fontWeight: weight }),
+          css({ backgroundColor: 'yellow.200', color: `pink.${colorTint}` }),
+        )}
+      >
+        Hello world
+      </div>
+    </>
+  )
+}
+```

--- a/packages/generator/scripts/prebuild.ts
+++ b/packages/generator/scripts/prebuild.ts
@@ -24,7 +24,7 @@ const fileMap = [
     ],
   ],
   ['@pandacss/is-valid-prop', [['index.mjs', 'is-valid-prop.mjs']]],
-  ['@pandacss/shared', [['shared.mjs', 'helpers.mjs'], ['astish.mjs'], ['normalize-html.mjs']]],
+  ['@pandacss/shared', [['shared.mjs', 'helpers.mjs'], ['astish.mjs'], ['normalize-html.mjs'], ['esc.mjs']]],
 ] as const
 
 async function main() {

--- a/packages/generator/src/artifacts/generated/esc.mjs.json
+++ b/packages/generator/src/artifacts/generated/esc.mjs.json
@@ -1,0 +1,3 @@
+{
+  "content": "// src/esc.ts\nvar rcssescape = /([\\0-\\x1f\\x7f]|^-?\\d)|^-$|^-|[^\\x80-\\uFFFF\\w-]/g;\nvar fcssescape = function(ch, asCodePoint) {\n  if (!asCodePoint)\n    return \"\\\\\" + ch;\n  if (ch === \"\\0\")\n    return \"\\uFFFD\";\n  if (ch === \"-\" && ch.length === 1)\n    return \"\\\\-\";\n  return ch.slice(0, -1) + \"\\\\\" + ch.charCodeAt(ch.length - 1).toString(16);\n};\nvar esc = (sel) => {\n  return (sel + \"\").replace(rcssescape, fcssescape);\n};\nexport {\n  esc\n};\n"
+}

--- a/packages/generator/src/artifacts/js/helpers.ts
+++ b/packages/generator/src/artifacts/js/helpers.ts
@@ -1,5 +1,6 @@
 import { outdent } from 'outdent'
 import helpersMjs from '../generated/helpers.mjs.json' assert { type: 'json' }
+import escMjs from '../generated/esc.mjs.json' assert { type: 'json' }
 import astishMjs from '../generated/astish.mjs.json' assert { type: 'json' }
 import normalizeHtmlMjs from '../generated/normalize-html.mjs.json' assert { type: 'json' }
 import type { Context } from '../../engines'
@@ -7,7 +8,7 @@ import type { Context } from '../../engines'
 export function generateHelpers(ctx: Context) {
   return {
     js: outdent`
-  ${helpersMjs.content}
+  ${ctx.config.missingCssWarning ? prependHelpersWithMissingCssWarningFn(helpersMjs.content) : helpersMjs.content}
   ${ctx.isTemplateLiteralSyntax ? astishMjs.content : ''}
 
   ${ctx.jsx.framework ? `${normalizeHtmlMjs.content}` : ''}
@@ -21,4 +22,58 @@ export function generateHelpers(ctx: Context) {
   }
   `,
   }
+}
+
+const prependHelpersWithMissingCssWarningFn = (helpers: string) => {
+  return (
+    helpers.replace('classNames.add(className)', 'classNames.add(className);\nisInCss(className)') +
+    outdent`
+    ${escMjs.content}
+
+    const isCssStyleRule = (rule) => rule instanceof CSSStyleRule
+    const isGroupingRule = (rule) => 'cssRules' in rule
+
+    function traverseCSSRule(rule, className) {
+      const stack = []
+      stack.push(rule)
+
+      while (stack.length > 0) {
+        const currentRule = stack.pop()
+        if (!currentRule) continue
+
+        if (isCssStyleRule(currentRule)) {
+          const selectorText = currentRule.selectorText
+          if (selectorText && selectorText.includes(className)) {
+            return currentRule
+          }
+        }
+
+        if (isGroupingRule(currentRule) && currentRule.cssRules) {
+          stack.push(...Array.from(currentRule.cssRules))
+        }
+      }
+    }
+
+
+    const missingRules = new Set()
+    const isInCss = (className) => {
+      if (typeof window === 'undefined') return
+      const escaped = '.' + esc(className)
+      const styleSheets = document.styleSheets
+      for (const styleSheet of styleSheets) {
+        const rules = styleSheet.cssRules || styleSheet.rules
+        if (!rules) continue
+
+        for (const rule of rules) {
+          const match = traverseCSSRule(rule, escaped)
+          if (match) return match
+        }
+      }
+
+      if (missingRules.has(className)) return
+      missingRules.add(className)
+      console.log(\`No matching CSS rule found for <\${className}>\`)
+    }
+    `
+  )
 }

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/shared.ts', 'src/astish.ts', 'src/normalize-html.ts'],
+  entry: ['src/index.ts', 'src/shared.ts', 'src/astish.ts', 'src/normalize-html.ts', 'src/esc.ts'],
   splitting: false,
   format: ['esm', 'cjs'],
 })

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -226,6 +226,11 @@ type CodegenOptions = {
    * @default 'true'
    */
   shorthands?: boolean
+  /**
+   * Whetehr to log a warning when a css rule wasn't generated but was referenced in the runtime.
+   * @default 'false'
+   */
+  missingCssWarning?: boolean
 }
 
 type PresetOptions = {


### PR DESCRIPTION
## 📝 Description

A lot of people using Panda CSS are used to runtime styling solution, switching to a static solution with its limitations can be a bit tricky at first. This option can help easily finding which className doesn't have its corresponding CSS Rule.

Add `config.missingCssWarning` option that logs a warning message when a CSS rule was used at runtime but couldn't be statically extracted

In the example code below, the `color` property and the `weight` value are not statically extractable, so there will be
2 warning messages:

- No matching CSS rule found for font_italic
- No matching CSS rule found for text_pink.200

```ts
import { useState } from 'react'
import { css, cx } from '../styled-system/css'

export const App = () => {
  const [colorTint, setColorTint] = useState(200)
  const [weight, setWeight] = useState('italic')

  return (
    <>
      <div
        className={cx(
          css({ fontSize: '4xl', fontWeight: weight }),
          css({ backgroundColor: 'yellow.200', color: `pink.${colorTint}` }),
        )}
      >
        Hello world
      </div>
    </>
  )
}
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

this also works just fine with SSR (tried with next app/pages) thanks to this check `if (typeof window === 'undefined') return`