### PR TITLE
feat: adds support for generating staticCss for Panda patterns

### DIFF
--- a/packages/core/__tests__/static-css.test.ts
+++ b/packages/core/__tests__/static-css.test.ts
@@ -28,6 +28,14 @@ const ctx = {
     }
     return values[property] ?? []
   },
+  getPatternKeys: (property: string) => {
+    const values: Record<string, any> = {
+      margin: ['20px', '40px'],
+      padding: ['20px', '40px', '60px'],
+      color: ['red.200', 'blue.200', 'green.200'],
+    }
+    return values[property] ?? []
+  },
 }
 
 const getStyles = getStaticCss({
@@ -46,6 +54,16 @@ const getStyles = getStaticCss({
       },
     },
   ],
+  patterns: {
+    hstack: ['*'],
+    vstack: {
+      conditions: ['sm', 'md'],
+      properties: {
+        margin: ['20px', '40px'],
+        padding: ['20px', '40px', '60px'],
+      },
+    },
+  },
   recipes: {
     buttonStyle: [
       {
@@ -120,6 +138,53 @@ describe('static-css', () => {
             },
           },
         ],
+        "patterns": [
+          {
+            "vstack": {
+              "margin": {
+                "base": "20px",
+                "md": "20px",
+                "sm": "20px",
+              },
+            },
+          },
+          {
+            "vstack": {
+              "margin": {
+                "base": "40px",
+                "md": "40px",
+                "sm": "40px",
+              },
+            },
+          },
+          {
+            "vstack": {
+              "padding": {
+                "base": "20px",
+                "md": "20px",
+                "sm": "20px",
+              },
+            },
+          },
+          {
+            "vstack": {
+              "padding": {
+                "base": "40px",
+                "md": "40px",
+                "sm": "40px",
+              },
+            },
+          },
+          {
+            "vstack": {
+              "padding": {
+                "base": "60px",
+                "md": "60px",
+                "sm": "60px",
+              },
+            },
+          },
+        ],
         "recipes": [
           {
             "buttonStyle": {
@@ -183,6 +248,7 @@ describe('static-css', () => {
     expect(
       getStaticCss({
         css: [],
+        patterns: {},
         recipes: {
           buttonStyle: ['*'],
         },
@@ -190,6 +256,7 @@ describe('static-css', () => {
     ).toMatchInlineSnapshot(`
       {
         "css": [],
+        "patterns": [],
         "recipes": [
           {
             "buttonStyle": {
@@ -247,9 +314,44 @@ describe('static-css', () => {
             "margin": "40px",
           },
         ],
+        "patterns": [],
         "recipes": [],
       }
     `)
+  })
+
+  describe('patterns', () => {
+    test('using * in pattern CssRule', () => {
+      expect(
+        getStaticCss({
+          patterns: {
+            hstack: ['*'],
+            vstack: {
+              properties: {
+                margin: ['*'],
+              },
+            },
+          },
+        })(ctx),
+      ).toMatchInlineSnapshot(`
+        {
+          "css": [],
+          "patterns": [
+            {
+              "vstack": {
+                "margin": "20px",
+              },
+            },
+            {
+              "vstack": {
+                "margin": "40px",
+              },
+            },
+          ],
+          "recipes": [],
+        }
+      `)
+    })
   })
 
   test('using * in CssRule with responsive: true', () => {
@@ -282,6 +384,7 @@ describe('static-css', () => {
             },
           },
         ],
+        "patterns": [],
         "recipes": [],
       }
     `)
@@ -323,6 +426,7 @@ describe('static-css', () => {
             },
           },
         ],
+        "patterns": [],
         "recipes": [],
       }
     `)

--- a/packages/core/src/stylesheet.ts
+++ b/packages/core/src/stylesheet.ts
@@ -86,6 +86,11 @@ export class Stylesheet {
     })
   }
 
+  processPattern = (name: string, config: RecipeConfig | SlotRecipeConfig, styles: SystemStyleObject) => {
+    this.recipes.process(name, { styles })
+    this.processCompoundVariants(config)
+  }
+
   processRecipe = (name: string, config: RecipeConfig | SlotRecipeConfig, styles: SystemStyleObject) => {
     this.recipes.process(name, { styles })
     this.processCompoundVariants(config)

--- a/packages/generator/src/artifacts/css/static-css.ts
+++ b/packages/generator/src/artifacts/css/static-css.ts
@@ -2,7 +2,7 @@ import { getStaticCss } from '@pandacss/core'
 import type { Context } from '../../engines'
 
 export const generateStaticCss = (ctx: Context) => {
-  const { config, createSheet, utility, recipes } = ctx
+  const { config, createSheet, utility, recipes, patterns } = ctx
   const { staticCss = {}, theme = {}, optimize = true } = config
 
   const sheet = createSheet()
@@ -19,6 +19,11 @@ export const generateStaticCss = (ctx: Context) => {
 
       return Object.keys(values)
     },
+    getPatternKeys: (pattern) => {
+      const patternDetail = patterns.details.find((detail) => detail.baseName === pattern)
+      console.log('patternDetail', patternDetail)
+      // return Object.assign({ __base: recipeConfig?.config.base }, recipeConfig?.variantKeyMap ?? {})
+    },
     getRecipeKeys: (recipe) => {
       const recipeConfig = recipes.details.find((detail) => detail.baseName === recipe)
       return Object.assign({ __base: recipeConfig?.config.base }, recipeConfig?.variantKeyMap ?? {})
@@ -27,6 +32,10 @@ export const generateStaticCss = (ctx: Context) => {
 
   results.css.forEach((css) => {
     sheet.processAtomic(css)
+  })
+
+  results.patterns.forEach((pattern) => {
+    sheet.processPattern(pattern)
   })
 
   results.recipes.forEach((result) => {

--- a/packages/types/src/static-css.ts
+++ b/packages/types/src/static-css.ts
@@ -30,6 +30,14 @@ export type StaticCssOptions = {
    */
   css?: CssRule[]
   /**
+   * The css patterns to generate.
+   */
+  patterns?:
+    | ['*']
+    | {
+        [pattern: string]: ['*'] | CssRule
+      }
+  /**
    * The css recipes to generate.
    */
   recipes?: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR adds the new capability to generate static CSS for all the out of the box Panda patterns (`hstack`, `vstack`, etc.)

## ⛳️ Current behavior (updates)

Current behavior does not support this feature.

## 🚀 New behavior

Static CSS can now be generated for the default patterns via the new `patterns` key under the `staticCss` config field.

## 💣 Is this a breaking change (Yes/No):

No breaking changes

## 📝 Additional Information

This PR would allow component library authors that are pursuing the static CSS path to export out the default Panda patterns alongside their custom components which then would allow said component-library users to leverage the JSX patterns like `HStack` and `VStack` in their applications without the need to use Panda in their apps.
