### PR TITLE
[generator] narrow down the `!important` modifier type implementation

### DIFF
--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -307,9 +307,9 @@ describe('generate property types', () => {
       }
 
       export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-        ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
+        ? ConditionalValue<PropertyTypes[T] | CssValue<T> | \`\${string}!\`>
         : T extends keyof CssProperties
-        ? ConditionalValue<CssProperties[T] | (string & {})>
+        ? ConditionalValue<CssProperties[T] | \`\${string}!\`>
         : ConditionalValue<string | number>"
     `)
   })

--- a/packages/generator/src/artifacts/types/prop-types.ts
+++ b/packages/generator/src/artifacts/types/prop-types.ts
@@ -9,6 +9,8 @@ export function generatePropTypes(ctx: Context) {
 
   const strictText = `${strictTokens ? '' : ' | CssValue<T>'}`
 
+  const allowImportantModifier = '`${string}!`'
+
   const result: string[] = [
     outdent`
     import type { ConditionalValue } from './conditions';
@@ -44,9 +46,9 @@ export function generatePropTypes(ctx: Context) {
   ${result.join('\n')}
 
   export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-    ? ConditionalValue<PropertyTypes[T]${strictText} | (string & {})>
+    ? ConditionalValue<PropertyTypes[T]${strictText} | ${allowImportantModifier}>
     : T extends keyof CssProperties
-    ? ConditionalValue<CssProperties[T] | (string & {})>
+    ? ConditionalValue<CssProperties[T] | ${allowImportantModifier}>
     : ConditionalValue<string | number>
   `
 }

--- a/packages/generator/src/artifacts/types/style-props.ts
+++ b/packages/generator/src/artifacts/types/style-props.ts
@@ -10,7 +10,7 @@ export function generateStyleProps(ctx: Context) {
     import type { Token } from '../tokens'
 
     export type CssVarProperties = {
-      [key in \`--\${string}\`]?: ConditionalValue<Token | (string & {}) | (number & {})>
+      [key in \`--\${string}\`]?: ConditionalValue<Token | \`\${string}!\` | (number & {})>
     }
 
     export type SystemProperties = {


### PR DESCRIPTION
## 📝 Description

I think we should only allow strings with the trailing `!`.

Here is the TS playground demonstration https://www.typescriptlang.org/play?#code/C4TwDgpgBAwg9gGzgJwAoEMEWMaBeKAImTgGcJCoAfIsASwDsBrSmgClOGUYHMoAyKAG8AvgEoA3ACgA9DKgKAegH4pU0JFiIUGLDggB1OsAAWASQC2YFMHQNgUAsTIVqtRizcADACRDO3Aw8IgCEXrLySqpSAMZwDJxQAK4J6ABmEAD6EAAe6FZYAIwAXFpIaJjYuI5QAOQk5LXScQkOKaTpWbn5YFgATKXw5bpV+HUNECFNsfGJ7Z3ZeQUQAMyD2hV61QT1Lj5NUHJQmKRwxwhIAO4QACYzrcmpGYs9WAAs68OV+jW1KUwMOCXBgHI4nM6YK63NQtRIdZ7dZYlMo6b64IymSzWZC2ey-Ca1e5whaI3oQAYozajDHmKw2OwOHYTKZEhzwrpLMlrSkjfQ0rH0vFMva1Q7yQEOSFA6GwtkkznvT6oraGYy07G4xl1f6A4FTMVQUx0UiPNI2FLoXAIEBQS4oJikAA0UAARkkHHQ0rboDczkaTb4hENlaNQl5DSYIAxju64ABaUhJHg8CCcOjxW10C5QFq2RiuuCmKBeCbhuw3YvM8JAA

## ⛳️ Current behavior (updates)

Current implementation allows any arbitrary string to be passed as a styled prop.

## 🚀 New behavior

It will throw an TS error if string contain anything else except trailing `!`, for example `colorPalette: "rose$"`

## 💣 Is this a breaking change (Yes/No):

No
