### PR TITLE
feat: add css prop to recipes/patterns functions

### DIFF
--- a/.changeset/soft-moons-approve.md
+++ b/.changeset/soft-moons-approve.md
@@ -1,0 +1,17 @@
+---
+'@pandacss/generator': patch
+---
+
+Add `css` prop to recipes and patterns so you don't have to import and use `cx` for that one little edge case.
+
+Before:
+
+```tsx
+<button className={cx(button({ variant: 'primary', state: 'focused' }), css({ color: 'yellow' }))}>Click me</button>
+```
+
+Now:
+
+```tsx
+<button className={button({ variant: 'primary', state: 'focused', css: { color: 'yellow' } })}>Click me</button>
+```

--- a/packages/generator/__tests__/generate-pattern.test.ts
+++ b/packages/generator/__tests__/generate-pattern.test.ts
@@ -19,7 +19,7 @@ test('should generate pattern', () => {
     type BoxOptions = BoxProperties & Omit<SystemStyleObject, keyof BoxProperties >
 
     interface BoxPatternFn {
-      (options?: BoxOptions): string
+      (options?: BoxOptions & { css?: SystemStyleObject }): string
       raw: (options: BoxOptions) => BoxOptions
     }
 
@@ -27,7 +27,7 @@ test('should generate pattern', () => {
     export declare const box: BoxPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const boxConfig = {
     transform(props) {
@@ -36,7 +36,7 @@ test('should generate pattern', () => {
 
     export const getBoxStyle = (styles = {}) => boxConfig.transform(styles, { map: mapObject })
 
-    export const box = (styles) => css(getBoxStyle(styles))
+    export const box = ({ css: cssStyles, ...styles }) => cx(css(getBoxStyle(styles)), css(cssStyles))
     box.raw = (styles) => styles",
         "name": "box",
       },
@@ -60,7 +60,7 @@ test('should generate pattern', () => {
     type FlexOptions = FlexProperties & Omit<SystemStyleObject, keyof FlexProperties >
 
     interface FlexPatternFn {
-      (options?: FlexOptions): string
+      (options?: FlexOptions & { css?: SystemStyleObject }): string
       raw: (options: FlexOptions) => FlexOptions
     }
 
@@ -68,7 +68,7 @@ test('should generate pattern', () => {
     export declare const flex: FlexPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const flexConfig = {
     transform(props) {
@@ -88,7 +88,7 @@ test('should generate pattern', () => {
 
     export const getFlexStyle = (styles = {}) => flexConfig.transform(styles, { map: mapObject })
 
-    export const flex = (styles) => css(getFlexStyle(styles))
+    export const flex = ({ css: cssStyles, ...styles }) => cx(css(getFlexStyle(styles)), css(cssStyles))
     flex.raw = (styles) => styles",
         "name": "flex",
       },
@@ -109,7 +109,7 @@ test('should generate pattern', () => {
     type StackOptions = StackProperties & Omit<SystemStyleObject, keyof StackProperties >
 
     interface StackPatternFn {
-      (options?: StackOptions): string
+      (options?: StackOptions & { css?: SystemStyleObject }): string
       raw: (options: StackOptions) => StackOptions
     }
 
@@ -117,7 +117,7 @@ test('should generate pattern', () => {
     export declare const stack: StackPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const stackConfig = {
     transform(props) {
@@ -134,7 +134,7 @@ test('should generate pattern', () => {
 
     export const getStackStyle = (styles = {}) => stackConfig.transform(styles, { map: mapObject })
 
-    export const stack = (styles) => css(getStackStyle(styles))
+    export const stack = ({ css: cssStyles, ...styles }) => cx(css(getStackStyle(styles)), css(cssStyles))
     stack.raw = (styles) => styles",
         "name": "stack",
       },
@@ -153,7 +153,7 @@ test('should generate pattern', () => {
     type VstackOptions = VstackProperties & Omit<SystemStyleObject, keyof VstackProperties >
 
     interface VstackPatternFn {
-      (options?: VstackOptions): string
+      (options?: VstackOptions & { css?: SystemStyleObject }): string
       raw: (options: VstackOptions) => VstackOptions
     }
 
@@ -161,7 +161,7 @@ test('should generate pattern', () => {
     export declare const vstack: VstackPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const vstackConfig = {
     transform(props) {
@@ -178,7 +178,7 @@ test('should generate pattern', () => {
 
     export const getVstackStyle = (styles = {}) => vstackConfig.transform(styles, { map: mapObject })
 
-    export const vstack = (styles) => css(getVstackStyle(styles))
+    export const vstack = ({ css: cssStyles, ...styles }) => cx(css(getVstackStyle(styles)), css(cssStyles))
     vstack.raw = (styles) => styles",
         "name": "vstack",
       },
@@ -197,7 +197,7 @@ test('should generate pattern', () => {
     type HstackOptions = HstackProperties & Omit<SystemStyleObject, keyof HstackProperties >
 
     interface HstackPatternFn {
-      (options?: HstackOptions): string
+      (options?: HstackOptions & { css?: SystemStyleObject }): string
       raw: (options: HstackOptions) => HstackOptions
     }
 
@@ -205,7 +205,7 @@ test('should generate pattern', () => {
     export declare const hstack: HstackPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const hstackConfig = {
     transform(props) {
@@ -222,7 +222,7 @@ test('should generate pattern', () => {
 
     export const getHstackStyle = (styles = {}) => hstackConfig.transform(styles, { map: mapObject })
 
-    export const hstack = (styles) => css(getHstackStyle(styles))
+    export const hstack = ({ css: cssStyles, ...styles }) => cx(css(getHstackStyle(styles)), css(cssStyles))
     hstack.raw = (styles) => styles",
         "name": "hstack",
       },
@@ -240,7 +240,7 @@ test('should generate pattern', () => {
     type SpacerOptions = SpacerProperties & Omit<SystemStyleObject, keyof SpacerProperties >
 
     interface SpacerPatternFn {
-      (options?: SpacerOptions): string
+      (options?: SpacerOptions & { css?: SystemStyleObject }): string
       raw: (options: SpacerOptions) => SpacerOptions
     }
 
@@ -248,7 +248,7 @@ test('should generate pattern', () => {
     export declare const spacer: SpacerPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const spacerConfig = {
     transform(props, { map }) {
@@ -263,7 +263,7 @@ test('should generate pattern', () => {
 
     export const getSpacerStyle = (styles = {}) => spacerConfig.transform(styles, { map: mapObject })
 
-    export const spacer = (styles) => css(getSpacerStyle(styles))
+    export const spacer = ({ css: cssStyles, ...styles }) => cx(css(getSpacerStyle(styles)), css(cssStyles))
     spacer.raw = (styles) => styles",
         "name": "spacer",
       },
@@ -281,7 +281,7 @@ test('should generate pattern', () => {
     type SquareOptions = SquareProperties & Omit<SystemStyleObject, keyof SquareProperties >
 
     interface SquarePatternFn {
-      (options?: SquareOptions): string
+      (options?: SquareOptions & { css?: SystemStyleObject }): string
       raw: (options: SquareOptions) => SquareOptions
     }
 
@@ -289,7 +289,7 @@ test('should generate pattern', () => {
     export declare const square: SquarePatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const squareConfig = {
     transform(props) {
@@ -307,7 +307,7 @@ test('should generate pattern', () => {
 
     export const getSquareStyle = (styles = {}) => squareConfig.transform(styles, { map: mapObject })
 
-    export const square = (styles) => css(getSquareStyle(styles))
+    export const square = ({ css: cssStyles, ...styles }) => cx(css(getSquareStyle(styles)), css(cssStyles))
     square.raw = (styles) => styles",
         "name": "square",
       },
@@ -325,7 +325,7 @@ test('should generate pattern', () => {
     type CircleOptions = CircleProperties & Omit<SystemStyleObject, keyof CircleProperties >
 
     interface CirclePatternFn {
-      (options?: CircleOptions): string
+      (options?: CircleOptions & { css?: SystemStyleObject }): string
       raw: (options: CircleOptions) => CircleOptions
     }
 
@@ -333,7 +333,7 @@ test('should generate pattern', () => {
     export declare const circle: CirclePatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const circleConfig = {
     transform(props) {
@@ -352,7 +352,7 @@ test('should generate pattern', () => {
 
     export const getCircleStyle = (styles = {}) => circleConfig.transform(styles, { map: mapObject })
 
-    export const circle = (styles) => css(getCircleStyle(styles))
+    export const circle = ({ css: cssStyles, ...styles }) => cx(css(getCircleStyle(styles)), css(cssStyles))
     circle.raw = (styles) => styles",
         "name": "circle",
       },
@@ -370,7 +370,7 @@ test('should generate pattern', () => {
     type CenterOptions = CenterProperties & Omit<SystemStyleObject, keyof CenterProperties >
 
     interface CenterPatternFn {
-      (options?: CenterOptions): string
+      (options?: CenterOptions & { css?: SystemStyleObject }): string
       raw: (options: CenterOptions) => CenterOptions
     }
 
@@ -378,7 +378,7 @@ test('should generate pattern', () => {
     export declare const center: CenterPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const centerConfig = {
     transform(props) {
@@ -393,7 +393,7 @@ test('should generate pattern', () => {
 
     export const getCenterStyle = (styles = {}) => centerConfig.transform(styles, { map: mapObject })
 
-    export const center = (styles) => css(getCenterStyle(styles))
+    export const center = ({ css: cssStyles, ...styles }) => cx(css(getCenterStyle(styles)), css(cssStyles))
     center.raw = (styles) => styles",
         "name": "center",
       },
@@ -411,7 +411,7 @@ test('should generate pattern', () => {
     type LinkBoxOptions = LinkBoxProperties & Omit<SystemStyleObject, keyof LinkBoxProperties >
 
     interface LinkBoxPatternFn {
-      (options?: LinkBoxOptions): string
+      (options?: LinkBoxOptions & { css?: SystemStyleObject }): string
       raw: (options: LinkBoxOptions) => LinkBoxOptions
     }
 
@@ -419,7 +419,7 @@ test('should generate pattern', () => {
     export declare const linkBox: LinkBoxPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const linkBoxConfig = {
     transform(props) {
@@ -435,7 +435,7 @@ test('should generate pattern', () => {
 
     export const getLinkBoxStyle = (styles = {}) => linkBoxConfig.transform(styles, { map: mapObject })
 
-    export const linkBox = (styles) => css(getLinkBoxStyle(styles))
+    export const linkBox = ({ css: cssStyles, ...styles }) => cx(css(getLinkBoxStyle(styles)), css(cssStyles))
     linkBox.raw = (styles) => styles",
         "name": "link-box",
       },
@@ -453,7 +453,7 @@ test('should generate pattern', () => {
     type LinkOverlayOptions = LinkOverlayProperties & Omit<SystemStyleObject, keyof LinkOverlayProperties >
 
     interface LinkOverlayPatternFn {
-      (options?: LinkOverlayOptions): string
+      (options?: LinkOverlayOptions & { css?: SystemStyleObject }): string
       raw: (options: LinkOverlayOptions) => LinkOverlayOptions
     }
 
@@ -461,7 +461,7 @@ test('should generate pattern', () => {
     export declare const linkOverlay: LinkOverlayPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const linkOverlayConfig = {
     transform(props) {
@@ -482,7 +482,7 @@ test('should generate pattern', () => {
 
     export const getLinkOverlayStyle = (styles = {}) => linkOverlayConfig.transform(styles, { map: mapObject })
 
-    export const linkOverlay = (styles) => css(getLinkOverlayStyle(styles))
+    export const linkOverlay = ({ css: cssStyles, ...styles }) => cx(css(getLinkOverlayStyle(styles)), css(cssStyles))
     linkOverlay.raw = (styles) => styles",
         "name": "link-overlay",
       },
@@ -500,7 +500,7 @@ test('should generate pattern', () => {
     type AspectRatioOptions = AspectRatioProperties & Omit<SystemStyleObject, keyof AspectRatioProperties | 'aspectRatio'>
 
     interface AspectRatioPatternFn {
-      (options?: AspectRatioOptions): string
+      (options?: AspectRatioOptions & { css?: SystemStyleObject }): string
       raw: (options: AspectRatioOptions) => AspectRatioOptions
     }
 
@@ -508,7 +508,7 @@ test('should generate pattern', () => {
     export declare const aspectRatio: AspectRatioPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const aspectRatioConfig = {
     transform(props, { map }) {
@@ -540,7 +540,7 @@ test('should generate pattern', () => {
 
     export const getAspectRatioStyle = (styles = {}) => aspectRatioConfig.transform(styles, { map: mapObject })
 
-    export const aspectRatio = (styles) => css(getAspectRatioStyle(styles))
+    export const aspectRatio = ({ css: cssStyles, ...styles }) => cx(css(getAspectRatioStyle(styles)), css(cssStyles))
     aspectRatio.raw = (styles) => styles",
         "name": "aspect-ratio",
       },
@@ -562,7 +562,7 @@ test('should generate pattern', () => {
     type GridOptions = GridProperties & Omit<SystemStyleObject, keyof GridProperties >
 
     interface GridPatternFn {
-      (options?: GridOptions): string
+      (options?: GridOptions & { css?: SystemStyleObject }): string
       raw: (options: GridOptions) => GridOptions
     }
 
@@ -570,7 +570,7 @@ test('should generate pattern', () => {
     export declare const grid: GridPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const gridConfig = {
     transform(props, { map }) {
@@ -587,7 +587,7 @@ test('should generate pattern', () => {
 
     export const getGridStyle = (styles = {}) => gridConfig.transform(styles, { map: mapObject })
 
-    export const grid = (styles) => css(getGridStyle(styles))
+    export const grid = ({ css: cssStyles, ...styles }) => cx(css(getGridStyle(styles)), css(cssStyles))
     grid.raw = (styles) => styles",
         "name": "grid",
       },
@@ -610,7 +610,7 @@ test('should generate pattern', () => {
     type GridItemOptions = GridItemProperties & Omit<SystemStyleObject, keyof GridItemProperties >
 
     interface GridItemPatternFn {
-      (options?: GridItemOptions): string
+      (options?: GridItemOptions & { css?: SystemStyleObject }): string
       raw: (options: GridItemOptions) => GridItemOptions
     }
 
@@ -618,7 +618,7 @@ test('should generate pattern', () => {
     export declare const gridItem: GridItemPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const gridItemConfig = {
     transform(props, { map }) {
@@ -637,7 +637,7 @@ test('should generate pattern', () => {
 
     export const getGridItemStyle = (styles = {}) => gridItemConfig.transform(styles, { map: mapObject })
 
-    export const gridItem = (styles) => css(getGridItemStyle(styles))
+    export const gridItem = ({ css: cssStyles, ...styles }) => cx(css(getGridItemStyle(styles)), css(cssStyles))
     gridItem.raw = (styles) => styles",
         "name": "grid-item",
       },
@@ -659,7 +659,7 @@ test('should generate pattern', () => {
     type WrapOptions = WrapProperties & Omit<SystemStyleObject, keyof WrapProperties >
 
     interface WrapPatternFn {
-      (options?: WrapOptions): string
+      (options?: WrapOptions & { css?: SystemStyleObject }): string
       raw: (options: WrapOptions) => WrapOptions
     }
 
@@ -667,7 +667,7 @@ test('should generate pattern', () => {
     export declare const wrap: WrapPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const wrapConfig = {
     transform(props) {
@@ -686,7 +686,7 @@ test('should generate pattern', () => {
 
     export const getWrapStyle = (styles = {}) => wrapConfig.transform(styles, { map: mapObject })
 
-    export const wrap = (styles) => css(getWrapStyle(styles))
+    export const wrap = ({ css: cssStyles, ...styles }) => cx(css(getWrapStyle(styles)), css(cssStyles))
     wrap.raw = (styles) => styles",
         "name": "wrap",
       },
@@ -704,7 +704,7 @@ test('should generate pattern', () => {
     type ContainerOptions = ContainerProperties & Omit<SystemStyleObject, keyof ContainerProperties >
 
     interface ContainerPatternFn {
-      (options?: ContainerOptions): string
+      (options?: ContainerOptions & { css?: SystemStyleObject }): string
       raw: (options: ContainerOptions) => ContainerOptions
     }
 
@@ -712,7 +712,7 @@ test('should generate pattern', () => {
     export declare const container: ContainerPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const containerConfig = {
     transform(props) {
@@ -727,7 +727,7 @@ test('should generate pattern', () => {
 
     export const getContainerStyle = (styles = {}) => containerConfig.transform(styles, { map: mapObject })
 
-    export const container = (styles) => css(getContainerStyle(styles))
+    export const container = ({ css: cssStyles, ...styles }) => cx(css(getContainerStyle(styles)), css(cssStyles))
     container.raw = (styles) => styles",
         "name": "container",
       },
@@ -747,7 +747,7 @@ test('should generate pattern', () => {
     type DividerOptions = DividerProperties & Omit<SystemStyleObject, keyof DividerProperties >
 
     interface DividerPatternFn {
-      (options?: DividerOptions): string
+      (options?: DividerOptions & { css?: SystemStyleObject }): string
       raw: (options: DividerOptions) => DividerOptions
     }
 
@@ -755,7 +755,7 @@ test('should generate pattern', () => {
     export declare const divider: DividerPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const dividerConfig = {
     transform(props, { map }) {
@@ -773,7 +773,7 @@ test('should generate pattern', () => {
 
     export const getDividerStyle = (styles = {}) => dividerConfig.transform(styles, { map: mapObject })
 
-    export const divider = (styles) => css(getDividerStyle(styles))
+    export const divider = ({ css: cssStyles, ...styles }) => cx(css(getDividerStyle(styles)), css(cssStyles))
     divider.raw = (styles) => styles",
         "name": "divider",
       },
@@ -794,7 +794,7 @@ test('should generate pattern', () => {
     type FloatOptions = FloatProperties & Omit<SystemStyleObject, keyof FloatProperties >
 
     interface FloatPatternFn {
-      (options?: FloatOptions): string
+      (options?: FloatOptions & { css?: SystemStyleObject }): string
       raw: (options: FloatOptions) => FloatOptions
     }
 
@@ -802,7 +802,7 @@ test('should generate pattern', () => {
     export declare const float: FloatPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const floatConfig = {
     transform(props, { map }) {
@@ -844,7 +844,7 @@ test('should generate pattern', () => {
 
     export const getFloatStyle = (styles = {}) => floatConfig.transform(styles, { map: mapObject })
 
-    export const float = (styles) => css(getFloatStyle(styles))
+    export const float = ({ css: cssStyles, ...styles }) => cx(css(getFloatStyle(styles)), css(cssStyles))
     float.raw = (styles) => styles",
         "name": "float",
       },
@@ -863,7 +863,7 @@ test('should generate pattern', () => {
     type BleedOptions = BleedProperties & Omit<SystemStyleObject, keyof BleedProperties >
 
     interface BleedPatternFn {
-      (options?: BleedOptions): string
+      (options?: BleedOptions & { css?: SystemStyleObject }): string
       raw: (options: BleedOptions) => BleedOptions
     }
 
@@ -871,7 +871,7 @@ test('should generate pattern', () => {
     export declare const bleed: BleedPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const bleedConfig = {
     transform(props) {
@@ -887,7 +887,7 @@ test('should generate pattern', () => {
 
     export const getBleedStyle = (styles = {}) => bleedConfig.transform(styles, { map: mapObject })
 
-    export const bleed = (styles) => css(getBleedStyle(styles))
+    export const bleed = ({ css: cssStyles, ...styles }) => cx(css(getBleedStyle(styles)), css(cssStyles))
     bleed.raw = (styles) => styles",
         "name": "bleed",
       },
@@ -905,7 +905,7 @@ test('should generate pattern', () => {
     type VisuallyHiddenOptions = VisuallyHiddenProperties & Omit<SystemStyleObject, keyof VisuallyHiddenProperties >
 
     interface VisuallyHiddenPatternFn {
-      (options?: VisuallyHiddenOptions): string
+      (options?: VisuallyHiddenOptions & { css?: SystemStyleObject }): string
       raw: (options: VisuallyHiddenOptions) => VisuallyHiddenOptions
     }
 
@@ -913,7 +913,7 @@ test('should generate pattern', () => {
     export declare const visuallyHidden: VisuallyHiddenPatternFn;
     ",
         "js": "import { mapObject } from '../helpers.mjs';
-    import { css } from '../css/index.mjs';
+    import { css, cx } from '../css/index.mjs';
 
     const visuallyHiddenConfig = {
     transform(props) {
@@ -925,7 +925,7 @@ test('should generate pattern', () => {
 
     export const getVisuallyHiddenStyle = (styles = {}) => visuallyHiddenConfig.transform(styles, { map: mapObject })
 
-    export const visuallyHidden = (styles) => css(getVisuallyHiddenStyle(styles))
+    export const visuallyHidden = ({ css: cssStyles, ...styles }) => cx(css(getVisuallyHiddenStyle(styles)), css(cssStyles))
     visuallyHidden.raw = (styles) => styles",
         "name": "visually-hidden",
       },

--- a/packages/generator/__tests__/generate-pattern.test.ts
+++ b/packages/generator/__tests__/generate-pattern.test.ts
@@ -36,7 +36,7 @@ test('should generate pattern', () => {
 
     export const getBoxStyle = (styles = {}) => boxConfig.transform(styles, { map: mapObject })
 
-    export const box = ({ css: cssStyles, ...styles }) => cx(css(getBoxStyle(styles)), css(cssStyles))
+    export const box = ({ css: cssStyles, ...styles } = {}) => cx(css(getBoxStyle(styles)), css(cssStyles))
     box.raw = (styles) => styles",
         "name": "box",
       },
@@ -88,7 +88,7 @@ test('should generate pattern', () => {
 
     export const getFlexStyle = (styles = {}) => flexConfig.transform(styles, { map: mapObject })
 
-    export const flex = ({ css: cssStyles, ...styles }) => cx(css(getFlexStyle(styles)), css(cssStyles))
+    export const flex = ({ css: cssStyles, ...styles } = {}) => cx(css(getFlexStyle(styles)), css(cssStyles))
     flex.raw = (styles) => styles",
         "name": "flex",
       },
@@ -134,7 +134,7 @@ test('should generate pattern', () => {
 
     export const getStackStyle = (styles = {}) => stackConfig.transform(styles, { map: mapObject })
 
-    export const stack = ({ css: cssStyles, ...styles }) => cx(css(getStackStyle(styles)), css(cssStyles))
+    export const stack = ({ css: cssStyles, ...styles } = {}) => cx(css(getStackStyle(styles)), css(cssStyles))
     stack.raw = (styles) => styles",
         "name": "stack",
       },
@@ -178,7 +178,7 @@ test('should generate pattern', () => {
 
     export const getVstackStyle = (styles = {}) => vstackConfig.transform(styles, { map: mapObject })
 
-    export const vstack = ({ css: cssStyles, ...styles }) => cx(css(getVstackStyle(styles)), css(cssStyles))
+    export const vstack = ({ css: cssStyles, ...styles } = {}) => cx(css(getVstackStyle(styles)), css(cssStyles))
     vstack.raw = (styles) => styles",
         "name": "vstack",
       },
@@ -222,7 +222,7 @@ test('should generate pattern', () => {
 
     export const getHstackStyle = (styles = {}) => hstackConfig.transform(styles, { map: mapObject })
 
-    export const hstack = ({ css: cssStyles, ...styles }) => cx(css(getHstackStyle(styles)), css(cssStyles))
+    export const hstack = ({ css: cssStyles, ...styles } = {}) => cx(css(getHstackStyle(styles)), css(cssStyles))
     hstack.raw = (styles) => styles",
         "name": "hstack",
       },
@@ -263,7 +263,7 @@ test('should generate pattern', () => {
 
     export const getSpacerStyle = (styles = {}) => spacerConfig.transform(styles, { map: mapObject })
 
-    export const spacer = ({ css: cssStyles, ...styles }) => cx(css(getSpacerStyle(styles)), css(cssStyles))
+    export const spacer = ({ css: cssStyles, ...styles } = {}) => cx(css(getSpacerStyle(styles)), css(cssStyles))
     spacer.raw = (styles) => styles",
         "name": "spacer",
       },
@@ -307,7 +307,7 @@ test('should generate pattern', () => {
 
     export const getSquareStyle = (styles = {}) => squareConfig.transform(styles, { map: mapObject })
 
-    export const square = ({ css: cssStyles, ...styles }) => cx(css(getSquareStyle(styles)), css(cssStyles))
+    export const square = ({ css: cssStyles, ...styles } = {}) => cx(css(getSquareStyle(styles)), css(cssStyles))
     square.raw = (styles) => styles",
         "name": "square",
       },
@@ -352,7 +352,7 @@ test('should generate pattern', () => {
 
     export const getCircleStyle = (styles = {}) => circleConfig.transform(styles, { map: mapObject })
 
-    export const circle = ({ css: cssStyles, ...styles }) => cx(css(getCircleStyle(styles)), css(cssStyles))
+    export const circle = ({ css: cssStyles, ...styles } = {}) => cx(css(getCircleStyle(styles)), css(cssStyles))
     circle.raw = (styles) => styles",
         "name": "circle",
       },
@@ -393,7 +393,7 @@ test('should generate pattern', () => {
 
     export const getCenterStyle = (styles = {}) => centerConfig.transform(styles, { map: mapObject })
 
-    export const center = ({ css: cssStyles, ...styles }) => cx(css(getCenterStyle(styles)), css(cssStyles))
+    export const center = ({ css: cssStyles, ...styles } = {}) => cx(css(getCenterStyle(styles)), css(cssStyles))
     center.raw = (styles) => styles",
         "name": "center",
       },
@@ -435,7 +435,7 @@ test('should generate pattern', () => {
 
     export const getLinkBoxStyle = (styles = {}) => linkBoxConfig.transform(styles, { map: mapObject })
 
-    export const linkBox = ({ css: cssStyles, ...styles }) => cx(css(getLinkBoxStyle(styles)), css(cssStyles))
+    export const linkBox = ({ css: cssStyles, ...styles } = {}) => cx(css(getLinkBoxStyle(styles)), css(cssStyles))
     linkBox.raw = (styles) => styles",
         "name": "link-box",
       },
@@ -482,7 +482,7 @@ test('should generate pattern', () => {
 
     export const getLinkOverlayStyle = (styles = {}) => linkOverlayConfig.transform(styles, { map: mapObject })
 
-    export const linkOverlay = ({ css: cssStyles, ...styles }) => cx(css(getLinkOverlayStyle(styles)), css(cssStyles))
+    export const linkOverlay = ({ css: cssStyles, ...styles } = {}) => cx(css(getLinkOverlayStyle(styles)), css(cssStyles))
     linkOverlay.raw = (styles) => styles",
         "name": "link-overlay",
       },
@@ -540,7 +540,7 @@ test('should generate pattern', () => {
 
     export const getAspectRatioStyle = (styles = {}) => aspectRatioConfig.transform(styles, { map: mapObject })
 
-    export const aspectRatio = ({ css: cssStyles, ...styles }) => cx(css(getAspectRatioStyle(styles)), css(cssStyles))
+    export const aspectRatio = ({ css: cssStyles, ...styles } = {}) => cx(css(getAspectRatioStyle(styles)), css(cssStyles))
     aspectRatio.raw = (styles) => styles",
         "name": "aspect-ratio",
       },
@@ -587,7 +587,7 @@ test('should generate pattern', () => {
 
     export const getGridStyle = (styles = {}) => gridConfig.transform(styles, { map: mapObject })
 
-    export const grid = ({ css: cssStyles, ...styles }) => cx(css(getGridStyle(styles)), css(cssStyles))
+    export const grid = ({ css: cssStyles, ...styles } = {}) => cx(css(getGridStyle(styles)), css(cssStyles))
     grid.raw = (styles) => styles",
         "name": "grid",
       },
@@ -637,7 +637,7 @@ test('should generate pattern', () => {
 
     export const getGridItemStyle = (styles = {}) => gridItemConfig.transform(styles, { map: mapObject })
 
-    export const gridItem = ({ css: cssStyles, ...styles }) => cx(css(getGridItemStyle(styles)), css(cssStyles))
+    export const gridItem = ({ css: cssStyles, ...styles } = {}) => cx(css(getGridItemStyle(styles)), css(cssStyles))
     gridItem.raw = (styles) => styles",
         "name": "grid-item",
       },
@@ -686,7 +686,7 @@ test('should generate pattern', () => {
 
     export const getWrapStyle = (styles = {}) => wrapConfig.transform(styles, { map: mapObject })
 
-    export const wrap = ({ css: cssStyles, ...styles }) => cx(css(getWrapStyle(styles)), css(cssStyles))
+    export const wrap = ({ css: cssStyles, ...styles } = {}) => cx(css(getWrapStyle(styles)), css(cssStyles))
     wrap.raw = (styles) => styles",
         "name": "wrap",
       },
@@ -727,7 +727,7 @@ test('should generate pattern', () => {
 
     export const getContainerStyle = (styles = {}) => containerConfig.transform(styles, { map: mapObject })
 
-    export const container = ({ css: cssStyles, ...styles }) => cx(css(getContainerStyle(styles)), css(cssStyles))
+    export const container = ({ css: cssStyles, ...styles } = {}) => cx(css(getContainerStyle(styles)), css(cssStyles))
     container.raw = (styles) => styles",
         "name": "container",
       },
@@ -773,7 +773,7 @@ test('should generate pattern', () => {
 
     export const getDividerStyle = (styles = {}) => dividerConfig.transform(styles, { map: mapObject })
 
-    export const divider = ({ css: cssStyles, ...styles }) => cx(css(getDividerStyle(styles)), css(cssStyles))
+    export const divider = ({ css: cssStyles, ...styles } = {}) => cx(css(getDividerStyle(styles)), css(cssStyles))
     divider.raw = (styles) => styles",
         "name": "divider",
       },
@@ -844,7 +844,7 @@ test('should generate pattern', () => {
 
     export const getFloatStyle = (styles = {}) => floatConfig.transform(styles, { map: mapObject })
 
-    export const float = ({ css: cssStyles, ...styles }) => cx(css(getFloatStyle(styles)), css(cssStyles))
+    export const float = ({ css: cssStyles, ...styles } = {}) => cx(css(getFloatStyle(styles)), css(cssStyles))
     float.raw = (styles) => styles",
         "name": "float",
       },
@@ -887,7 +887,7 @@ test('should generate pattern', () => {
 
     export const getBleedStyle = (styles = {}) => bleedConfig.transform(styles, { map: mapObject })
 
-    export const bleed = ({ css: cssStyles, ...styles }) => cx(css(getBleedStyle(styles)), css(cssStyles))
+    export const bleed = ({ css: cssStyles, ...styles } = {}) => cx(css(getBleedStyle(styles)), css(cssStyles))
     bleed.raw = (styles) => styles",
         "name": "bleed",
       },
@@ -925,7 +925,7 @@ test('should generate pattern', () => {
 
     export const getVisuallyHiddenStyle = (styles = {}) => visuallyHiddenConfig.transform(styles, { map: mapObject })
 
-    export const visuallyHidden = ({ css: cssStyles, ...styles }) => cx(css(getVisuallyHiddenStyle(styles)), css(cssStyles))
+    export const visuallyHidden = ({ css: cssStyles, ...styles } = {}) => cx(css(getVisuallyHiddenStyle(styles)), css(cssStyles))
     visuallyHidden.raw = (styles) => styles",
         "name": "visually-hidden",
       },

--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -14,7 +14,7 @@ describe('generate recipes', () => {
       import { compact, createCss, withoutSpace } from '../helpers.mjs';
 
       export const createRecipe = (name, defaultVariants, compoundVariants) => {
-        return ({ css: cssStyles, ...variants }) => {
+        return ({ css: cssStyles, ...variants } = {}) => {
          const transform = (prop, value) => {
            assertCompoundVariant(name, compoundVariants, variants, prop)
 

--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -14,7 +14,7 @@ describe('generate recipes', () => {
       import { compact, createCss, withoutSpace } from '../helpers.mjs';
 
       export const createRecipe = (name, defaultVariants, compoundVariants) => {
-        return (variants) => {
+        return ({ css: cssStyles, ...variants }) => {
          const transform = (prop, value) => {
            assertCompoundVariant(name, compoundVariants, variants, prop)
 
@@ -42,13 +42,13 @@ describe('generate recipes', () => {
 
          const compoundVariantStyles = getCompoundVariantCss(compoundVariants, recipeStyles)
 
-         return cx(recipeCss(recipeStyles), css(compoundVariantStyles))
+         return cx(recipeCss(recipeStyles), css(compoundVariantStyles), css(cssStyles))
         }
       }",
           "name": "create-recipe",
         },
         {
-          "dts": "import type { ConditionalValue } from '../types'
+          "dts": "import type { ConditionalValue, SystemStyleObject } from '../types'
       import type { Pretty } from '../types/helpers'
 
       type TextStyleVariant = {
@@ -65,7 +65,7 @@ describe('generate recipes', () => {
 
       interface TextStyleRecipe {
         __type: TextStyleVariantProps
-        (props?: TextStyleVariantProps): string
+        (props?: TextStyleVariantProps & { css?: SystemStyleObject }): string
         raw: (props?: TextStyleVariantProps) => TextStyleVariantProps
         variantMap: TextStyleVariantMap
         variantKeys: Array<keyof TextStyleVariant>
@@ -98,7 +98,7 @@ describe('generate recipes', () => {
           "name": "text-style",
         },
         {
-          "dts": "import type { ConditionalValue } from '../types'
+          "dts": "import type { ConditionalValue, SystemStyleObject } from '../types'
       import type { Pretty } from '../types/helpers'
 
       type TooltipStyleVariant = {
@@ -115,7 +115,7 @@ describe('generate recipes', () => {
 
       interface TooltipStyleRecipe {
         __type: TooltipStyleVariantProps
-        (props?: TooltipStyleVariantProps): string
+        (props?: TooltipStyleVariantProps & { css?: SystemStyleObject }): string
         raw: (props?: TooltipStyleVariantProps) => TooltipStyleVariantProps
         variantMap: TooltipStyleVariantMap
         variantKeys: Array<keyof TooltipStyleVariant>
@@ -143,7 +143,7 @@ describe('generate recipes', () => {
           "name": "tooltip-style",
         },
         {
-          "dts": "import type { ConditionalValue } from '../types'
+          "dts": "import type { ConditionalValue, SystemStyleObject } from '../types'
       import type { Pretty } from '../types/helpers'
 
       type ButtonStyleVariant = {
@@ -161,7 +161,7 @@ describe('generate recipes', () => {
 
       interface ButtonStyleRecipe {
         __type: ButtonStyleVariantProps
-        (props?: ButtonStyleVariantProps): string
+        (props?: ButtonStyleVariantProps & { css?: SystemStyleObject }): string
         raw: (props?: ButtonStyleVariantProps) => ButtonStyleVariantProps
         variantMap: ButtonStyleVariantMap
         variantKeys: Array<keyof ButtonStyleVariant>

--- a/packages/generator/src/artifacts/css/parser-css.ts
+++ b/packages/generator/src/artifacts/css/parser-css.ts
@@ -54,7 +54,7 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
                   sheet.processRecipe(recipeName, recipeConfig, recipeProps)
 
                   if (css) {
-                    sheet.processStyleProps({ css })
+                    sheet.processAtomic(css)
                   }
                 })
               })
@@ -79,11 +79,11 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
               .otherwise(() => {
                 pattern.data.forEach((data) => {
                   const { css, ...patternProps } = data ?? {}
-                  const styleProps = patterns.transform(name, data)
+                  const styleProps = patterns.transform(name, patternProps)
                   sheet.processAtomic(styleProps)
 
                   if (css) {
-                    sheet.processStyleProps(patternProps)
+                    sheet.processAtomic(css)
                   }
                 })
               })

--- a/packages/generator/src/artifacts/css/parser-css.ts
+++ b/packages/generator/src/artifacts/css/parser-css.ts
@@ -50,7 +50,7 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
               })
               .otherwise(() => {
                 recipe.data.forEach((data) => {
-                  const { css, ...recipeProps } = data
+                  const { css, ...recipeProps } = data ?? {}
                   sheet.processRecipe(recipeName, recipeConfig, recipeProps)
 
                   if (css) {
@@ -78,7 +78,7 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
               })
               .otherwise(() => {
                 pattern.data.forEach((data) => {
-                  const { css, ...patternProps } = data
+                  const { css, ...patternProps } = data ?? {}
                   const styleProps = patterns.transform(name, data)
                   sheet.processAtomic(styleProps)
 

--- a/packages/generator/src/artifacts/css/parser-css.ts
+++ b/packages/generator/src/artifacts/css/parser-css.ts
@@ -50,7 +50,12 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
               })
               .otherwise(() => {
                 recipe.data.forEach((data) => {
-                  sheet.processRecipe(recipeName, recipeConfig, data)
+                  const { css, ...recipeProps } = data
+                  sheet.processRecipe(recipeName, recipeConfig, recipeProps)
+
+                  if (css) {
+                    sheet.processStyleProps({ css })
+                  }
                 })
               })
           }
@@ -73,8 +78,13 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
               })
               .otherwise(() => {
                 pattern.data.forEach((data) => {
+                  const { css, ...patternProps } = data
                   const styleProps = patterns.transform(name, data)
                   sheet.processAtomic(styleProps)
+
+                  if (css) {
+                    sheet.processStyleProps(patternProps)
+                  }
                 })
               })
           }

--- a/packages/generator/src/artifacts/js/pattern.ts
+++ b/packages/generator/src/artifacts/js/pattern.ts
@@ -77,7 +77,7 @@ export function generatePattern(ctx: Context) {
 
     export const ${styleFnName} = (styles = {}) => ${baseName}Config.transform(styles, { map: mapObject })
 
-    export const ${baseName} = ({ css: cssStyles, ...styles }) => cx(css(${styleFnName}(styles)), css(cssStyles))
+    export const ${baseName} = ({ css: cssStyles, ...styles } = {}) => cx(css(${styleFnName}(styles)), css(cssStyles))
     ${baseName}.raw = (styles) => styles
     `,
     }

--- a/packages/generator/src/artifacts/js/pattern.ts
+++ b/packages/generator/src/artifacts/js/pattern.ts
@@ -59,7 +59,7 @@ export function generatePattern(ctx: Context) {
           type ${upperName}Options = ${upperName}Properties & Omit<SystemStyleObject, keyof ${upperName}Properties ${blocklistType}>
 
           interface ${upperName}PatternFn {
-            (options?: ${upperName}Options): string
+            (options?: ${upperName}Options & { css?: SystemStyleObject }): string
             raw: (options: ${upperName}Options) => ${upperName}Options
           }
 
@@ -71,13 +71,13 @@ export function generatePattern(ctx: Context) {
      `,
       js: outdent`
     ${ctx.file.import(helperImports.join(', '), '../helpers')}
-    ${ctx.file.import('css', '../css/index')}
+    ${ctx.file.import('css, cx', '../css/index')}
 
     const ${baseName}Config = ${transformFn.replace(`{transform`, `{\ntransform`)}
 
     export const ${styleFnName} = (styles = {}) => ${baseName}Config.transform(styles, { map: mapObject })
 
-    export const ${baseName} = (styles) => css(${styleFnName}(styles))
+    export const ${baseName} = ({ css: cssStyles, ...styles }) => cx(css(${styleFnName}(styles)), css(cssStyles))
     ${baseName}.raw = (styles) => styles
     `,
     }

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -27,7 +27,7 @@ export function generateRecipes(ctx: Context) {
    ${ctx.file.import('compact, createCss, withoutSpace', '../helpers')}
 
    export const createRecipe = (name, defaultVariants, compoundVariants) => {
-     return (variants) => {
+     return ({ css: cssStyles, ...variants }) => {
       const transform = (prop, value) => {
         assertCompoundVariant(name, compoundVariants, variants, prop)
 
@@ -55,7 +55,7 @@ export function generateRecipes(ctx: Context) {
 
       const compoundVariantStyles = getCompoundVariantCss(compoundVariants, recipeStyles)
 
-      return cx(recipeCss(recipeStyles), css(compoundVariantStyles))
+      return cx(recipeCss(recipeStyles), css(compoundVariantStyles), css(cssStyles))
      }
    }
   `,
@@ -126,7 +126,7 @@ export function generateRecipes(ctx: Context) {
         js: jsCode,
 
         dts: outdent`
-        import type { ConditionalValue } from '../types'
+        import type { ConditionalValue, SystemStyleObject } from '../types'
         import type { Pretty } from '../types/helpers'
 
         type ${upperName}Variant = {
@@ -151,7 +151,7 @@ export function generateRecipes(ctx: Context) {
 
         interface ${upperName}Recipe {
           __type: ${upperName}VariantProps
-          (props?: ${upperName}VariantProps): ${
+          (props?: ${upperName}VariantProps & { css?: SystemStyleObject }): ${
           isSlotRecipe(config) ? `Pretty<Record<${unionType(config.slots)}, string>>` : 'string'
         }
           raw: (props?: ${upperName}VariantProps) => ${upperName}VariantProps

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -27,7 +27,7 @@ export function generateRecipes(ctx: Context) {
    ${ctx.file.import('compact, createCss, withoutSpace', '../helpers')}
 
    export const createRecipe = (name, defaultVariants, compoundVariants) => {
-     return ({ css: cssStyles, ...variants }) => {
+     return ({ css: cssStyles, ...variants } = {}) => {
       const transform = (prop, value) => {
         assertCompoundVariant(name, compoundVariants, variants, prop)
 

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -1570,6 +1570,102 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('css prop with recipes and patterns', () => {
+    const code = `
+      import { stack } from ".panda/patterns"
+      import { button } from ".panda/recipes";
+
+      stack({ align: "center", css: { backgroundColor: "red.100" } })
+      button({ shape: "circle", css: { backgroundColor: "yellow.100" } })
+
+     `
+    const result = run(code, {
+      theme: {
+        extend: {
+          recipes: {
+            button: {
+              className: 'btn',
+              base: { color: 'pink.100' },
+              variants: {
+                shape: {
+                  circle: { borderRadius: '50%' },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "css": {
+                "backgroundColor": "yellow.100",
+              },
+              "shape": "circle",
+            },
+          ],
+          "name": "button",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "align": "center",
+              "css": {
+                "backgroundColor": "red.100",
+              },
+            },
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes {
+        .btn--shape_circle {
+          border-radius: 50%
+          }
+
+        @layer _base {
+          .btn {
+            color: var(--colors-pink-100)
+              }
+          }
+      }
+
+      @layer utilities {
+        .bg_yellow\\\\.100 {
+          background-color: var(--colors-yellow-100)
+          }
+
+        .d_flex {
+          display: flex
+          }
+
+        .flex_column {
+          flex-direction: column
+          }
+
+        .items_center {
+          align-items: center
+          }
+
+        .gap_10px {
+          gap: 10px
+          }
+
+        .bg_red\\\\.100 {
+          background-color: var(--colors-red-100)
+          }
+      }"
+    `)
+  })
 })
 
 describe('preset patterns', () => {

--- a/packages/studio/styled-system/patterns/aspect-ratio.d.ts
+++ b/packages/studio/styled-system/patterns/aspect-ratio.d.ts
@@ -12,7 +12,7 @@ export type AspectRatioProperties = {
 type AspectRatioOptions = AspectRatioProperties & Omit<SystemStyleObject, keyof AspectRatioProperties | 'aspectRatio'>
 
 interface AspectRatioPatternFn {
-  (options?: AspectRatioOptions): string
+  (options?: AspectRatioOptions & { css?: SystemStyleObject }): string
   raw: (options: AspectRatioOptions) => AspectRatioOptions
 }
 

--- a/packages/studio/styled-system/patterns/aspect-ratio.mjs
+++ b/packages/studio/styled-system/patterns/aspect-ratio.mjs
@@ -32,5 +32,5 @@ const aspectRatioConfig = {
 
 export const getAspectRatioStyle = (styles = {}) => aspectRatioConfig.transform(styles, { map: mapObject })
 
-export const aspectRatio = ({ css: cssStyles, ...styles }) => cx(css(getAspectRatioStyle(styles)), css(cssStyles))
+export const aspectRatio = ({ css: cssStyles, ...styles } = {}) => cx(css(getAspectRatioStyle(styles)), css(cssStyles))
 aspectRatio.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/aspect-ratio.mjs
+++ b/packages/studio/styled-system/patterns/aspect-ratio.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const aspectRatioConfig = {
   transform(props, { map }) {
@@ -32,5 +32,5 @@ const aspectRatioConfig = {
 
 export const getAspectRatioStyle = (styles = {}) => aspectRatioConfig.transform(styles, { map: mapObject })
 
-export const aspectRatio = (styles) => css(getAspectRatioStyle(styles))
+export const aspectRatio = ({ css: cssStyles, ...styles }) => cx(css(getAspectRatioStyle(styles)), css(cssStyles))
 aspectRatio.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/bleed.d.ts
+++ b/packages/studio/styled-system/patterns/bleed.d.ts
@@ -13,7 +13,7 @@ export type BleedProperties = {
 type BleedOptions = BleedProperties & Omit<SystemStyleObject, keyof BleedProperties >
 
 interface BleedPatternFn {
-  (options?: BleedOptions): string
+  (options?: BleedOptions & { css?: SystemStyleObject }): string
   raw: (options: BleedOptions) => BleedOptions
 }
 

--- a/packages/studio/styled-system/patterns/bleed.mjs
+++ b/packages/studio/styled-system/patterns/bleed.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const bleedConfig = {
   transform(props) {
@@ -16,5 +16,5 @@ const bleedConfig = {
 
 export const getBleedStyle = (styles = {}) => bleedConfig.transform(styles, { map: mapObject })
 
-export const bleed = (styles) => css(getBleedStyle(styles))
+export const bleed = ({ css: cssStyles, ...styles }) => cx(css(getBleedStyle(styles)), css(cssStyles))
 bleed.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/bleed.mjs
+++ b/packages/studio/styled-system/patterns/bleed.mjs
@@ -16,5 +16,5 @@ const bleedConfig = {
 
 export const getBleedStyle = (styles = {}) => bleedConfig.transform(styles, { map: mapObject })
 
-export const bleed = ({ css: cssStyles, ...styles }) => cx(css(getBleedStyle(styles)), css(cssStyles))
+export const bleed = ({ css: cssStyles, ...styles } = {}) => cx(css(getBleedStyle(styles)), css(cssStyles))
 bleed.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/box.d.ts
+++ b/packages/studio/styled-system/patterns/box.d.ts
@@ -12,7 +12,7 @@ export type BoxProperties = {
 type BoxOptions = BoxProperties & Omit<SystemStyleObject, keyof BoxProperties >
 
 interface BoxPatternFn {
-  (options?: BoxOptions): string
+  (options?: BoxOptions & { css?: SystemStyleObject }): string
   raw: (options: BoxOptions) => BoxOptions
 }
 

--- a/packages/studio/styled-system/patterns/box.mjs
+++ b/packages/studio/styled-system/patterns/box.mjs
@@ -9,5 +9,5 @@ const boxConfig = {
 
 export const getBoxStyle = (styles = {}) => boxConfig.transform(styles, { map: mapObject })
 
-export const box = ({ css: cssStyles, ...styles }) => cx(css(getBoxStyle(styles)), css(cssStyles))
+export const box = ({ css: cssStyles, ...styles } = {}) => cx(css(getBoxStyle(styles)), css(cssStyles))
 box.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/box.mjs
+++ b/packages/studio/styled-system/patterns/box.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const boxConfig = {
   transform(props) {
@@ -9,5 +9,5 @@ const boxConfig = {
 
 export const getBoxStyle = (styles = {}) => boxConfig.transform(styles, { map: mapObject })
 
-export const box = (styles) => css(getBoxStyle(styles))
+export const box = ({ css: cssStyles, ...styles }) => cx(css(getBoxStyle(styles)), css(cssStyles))
 box.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/center.d.ts
+++ b/packages/studio/styled-system/patterns/center.d.ts
@@ -12,7 +12,7 @@ export type CenterProperties = {
 type CenterOptions = CenterProperties & Omit<SystemStyleObject, keyof CenterProperties >
 
 interface CenterPatternFn {
-  (options?: CenterOptions): string
+  (options?: CenterOptions & { css?: SystemStyleObject }): string
   raw: (options: CenterOptions) => CenterOptions
 }
 

--- a/packages/studio/styled-system/patterns/center.mjs
+++ b/packages/studio/styled-system/patterns/center.mjs
@@ -15,5 +15,5 @@ const centerConfig = {
 
 export const getCenterStyle = (styles = {}) => centerConfig.transform(styles, { map: mapObject })
 
-export const center = ({ css: cssStyles, ...styles }) => cx(css(getCenterStyle(styles)), css(cssStyles))
+export const center = ({ css: cssStyles, ...styles } = {}) => cx(css(getCenterStyle(styles)), css(cssStyles))
 center.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/center.mjs
+++ b/packages/studio/styled-system/patterns/center.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const centerConfig = {
   transform(props) {
@@ -15,5 +15,5 @@ const centerConfig = {
 
 export const getCenterStyle = (styles = {}) => centerConfig.transform(styles, { map: mapObject })
 
-export const center = (styles) => css(getCenterStyle(styles))
+export const center = ({ css: cssStyles, ...styles }) => cx(css(getCenterStyle(styles)), css(cssStyles))
 center.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/circle.d.ts
+++ b/packages/studio/styled-system/patterns/circle.d.ts
@@ -12,7 +12,7 @@ export type CircleProperties = {
 type CircleOptions = CircleProperties & Omit<SystemStyleObject, keyof CircleProperties >
 
 interface CirclePatternFn {
-  (options?: CircleOptions): string
+  (options?: CircleOptions & { css?: SystemStyleObject }): string
   raw: (options: CircleOptions) => CircleOptions
 }
 

--- a/packages/studio/styled-system/patterns/circle.mjs
+++ b/packages/studio/styled-system/patterns/circle.mjs
@@ -19,5 +19,5 @@ const circleConfig = {
 
 export const getCircleStyle = (styles = {}) => circleConfig.transform(styles, { map: mapObject })
 
-export const circle = ({ css: cssStyles, ...styles }) => cx(css(getCircleStyle(styles)), css(cssStyles))
+export const circle = ({ css: cssStyles, ...styles } = {}) => cx(css(getCircleStyle(styles)), css(cssStyles))
 circle.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/circle.mjs
+++ b/packages/studio/styled-system/patterns/circle.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const circleConfig = {
   transform(props) {
@@ -19,5 +19,5 @@ const circleConfig = {
 
 export const getCircleStyle = (styles = {}) => circleConfig.transform(styles, { map: mapObject })
 
-export const circle = (styles) => css(getCircleStyle(styles))
+export const circle = ({ css: cssStyles, ...styles }) => cx(css(getCircleStyle(styles)), css(cssStyles))
 circle.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/container.d.ts
+++ b/packages/studio/styled-system/patterns/container.d.ts
@@ -12,7 +12,7 @@ export type ContainerProperties = {
 type ContainerOptions = ContainerProperties & Omit<SystemStyleObject, keyof ContainerProperties >
 
 interface ContainerPatternFn {
-  (options?: ContainerOptions): string
+  (options?: ContainerOptions & { css?: SystemStyleObject }): string
   raw: (options: ContainerOptions) => ContainerOptions
 }
 

--- a/packages/studio/styled-system/patterns/container.mjs
+++ b/packages/studio/styled-system/patterns/container.mjs
@@ -15,5 +15,5 @@ const containerConfig = {
 
 export const getContainerStyle = (styles = {}) => containerConfig.transform(styles, { map: mapObject })
 
-export const container = ({ css: cssStyles, ...styles }) => cx(css(getContainerStyle(styles)), css(cssStyles))
+export const container = ({ css: cssStyles, ...styles } = {}) => cx(css(getContainerStyle(styles)), css(cssStyles))
 container.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/container.mjs
+++ b/packages/studio/styled-system/patterns/container.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const containerConfig = {
   transform(props) {
@@ -15,5 +15,5 @@ const containerConfig = {
 
 export const getContainerStyle = (styles = {}) => containerConfig.transform(styles, { map: mapObject })
 
-export const container = (styles) => css(getContainerStyle(styles))
+export const container = ({ css: cssStyles, ...styles }) => cx(css(getContainerStyle(styles)), css(cssStyles))
 container.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/divider.d.ts
+++ b/packages/studio/styled-system/patterns/divider.d.ts
@@ -14,7 +14,7 @@ export type DividerProperties = {
 type DividerOptions = DividerProperties & Omit<SystemStyleObject, keyof DividerProperties >
 
 interface DividerPatternFn {
-  (options?: DividerOptions): string
+  (options?: DividerOptions & { css?: SystemStyleObject }): string
   raw: (options: DividerOptions) => DividerOptions
 }
 

--- a/packages/studio/styled-system/patterns/divider.mjs
+++ b/packages/studio/styled-system/patterns/divider.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const dividerConfig = {
   transform(props, { map }) {
@@ -18,5 +18,5 @@ const dividerConfig = {
 
 export const getDividerStyle = (styles = {}) => dividerConfig.transform(styles, { map: mapObject })
 
-export const divider = (styles) => css(getDividerStyle(styles))
+export const divider = ({ css: cssStyles, ...styles }) => cx(css(getDividerStyle(styles)), css(cssStyles))
 divider.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/divider.mjs
+++ b/packages/studio/styled-system/patterns/divider.mjs
@@ -18,5 +18,5 @@ const dividerConfig = {
 
 export const getDividerStyle = (styles = {}) => dividerConfig.transform(styles, { map: mapObject })
 
-export const divider = ({ css: cssStyles, ...styles }) => cx(css(getDividerStyle(styles)), css(cssStyles))
+export const divider = ({ css: cssStyles, ...styles } = {}) => cx(css(getDividerStyle(styles)), css(cssStyles))
 divider.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/flex.d.ts
+++ b/packages/studio/styled-system/patterns/flex.d.ts
@@ -18,7 +18,7 @@ export type FlexProperties = {
 type FlexOptions = FlexProperties & Omit<SystemStyleObject, keyof FlexProperties >
 
 interface FlexPatternFn {
-  (options?: FlexOptions): string
+  (options?: FlexOptions & { css?: SystemStyleObject }): string
   raw: (options: FlexOptions) => FlexOptions
 }
 

--- a/packages/studio/styled-system/patterns/flex.mjs
+++ b/packages/studio/styled-system/patterns/flex.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const flexConfig = {
   transform(props) {
@@ -20,5 +20,5 @@ const flexConfig = {
 
 export const getFlexStyle = (styles = {}) => flexConfig.transform(styles, { map: mapObject })
 
-export const flex = (styles) => css(getFlexStyle(styles))
+export const flex = ({ css: cssStyles, ...styles }) => cx(css(getFlexStyle(styles)), css(cssStyles))
 flex.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/flex.mjs
+++ b/packages/studio/styled-system/patterns/flex.mjs
@@ -20,5 +20,5 @@ const flexConfig = {
 
 export const getFlexStyle = (styles = {}) => flexConfig.transform(styles, { map: mapObject })
 
-export const flex = ({ css: cssStyles, ...styles }) => cx(css(getFlexStyle(styles)), css(cssStyles))
+export const flex = ({ css: cssStyles, ...styles } = {}) => cx(css(getFlexStyle(styles)), css(cssStyles))
 flex.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/float.d.ts
+++ b/packages/studio/styled-system/patterns/float.d.ts
@@ -15,7 +15,7 @@ export type FloatProperties = {
 type FloatOptions = FloatProperties & Omit<SystemStyleObject, keyof FloatProperties >
 
 interface FloatPatternFn {
-  (options?: FloatOptions): string
+  (options?: FloatOptions & { css?: SystemStyleObject }): string
   raw: (options: FloatOptions) => FloatOptions
 }
 

--- a/packages/studio/styled-system/patterns/float.mjs
+++ b/packages/studio/styled-system/patterns/float.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const floatConfig = {
   transform(props, { map }) {
@@ -42,5 +42,5 @@ const floatConfig = {
 
 export const getFloatStyle = (styles = {}) => floatConfig.transform(styles, { map: mapObject })
 
-export const float = (styles) => css(getFloatStyle(styles))
+export const float = ({ css: cssStyles, ...styles }) => cx(css(getFloatStyle(styles)), css(cssStyles))
 float.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/float.mjs
+++ b/packages/studio/styled-system/patterns/float.mjs
@@ -42,5 +42,5 @@ const floatConfig = {
 
 export const getFloatStyle = (styles = {}) => floatConfig.transform(styles, { map: mapObject })
 
-export const float = ({ css: cssStyles, ...styles }) => cx(css(getFloatStyle(styles)), css(cssStyles))
+export const float = ({ css: cssStyles, ...styles } = {}) => cx(css(getFloatStyle(styles)), css(cssStyles))
 float.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/grid-item.d.ts
+++ b/packages/studio/styled-system/patterns/grid-item.d.ts
@@ -17,7 +17,7 @@ export type GridItemProperties = {
 type GridItemOptions = GridItemProperties & Omit<SystemStyleObject, keyof GridItemProperties >
 
 interface GridItemPatternFn {
-  (options?: GridItemOptions): string
+  (options?: GridItemOptions & { css?: SystemStyleObject }): string
   raw: (options: GridItemOptions) => GridItemOptions
 }
 

--- a/packages/studio/styled-system/patterns/grid-item.mjs
+++ b/packages/studio/styled-system/patterns/grid-item.mjs
@@ -19,5 +19,5 @@ const gridItemConfig = {
 
 export const getGridItemStyle = (styles = {}) => gridItemConfig.transform(styles, { map: mapObject })
 
-export const gridItem = ({ css: cssStyles, ...styles }) => cx(css(getGridItemStyle(styles)), css(cssStyles))
+export const gridItem = ({ css: cssStyles, ...styles } = {}) => cx(css(getGridItemStyle(styles)), css(cssStyles))
 gridItem.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/grid-item.mjs
+++ b/packages/studio/styled-system/patterns/grid-item.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const gridItemConfig = {
   transform(props, { map }) {
@@ -19,5 +19,5 @@ const gridItemConfig = {
 
 export const getGridItemStyle = (styles = {}) => gridItemConfig.transform(styles, { map: mapObject })
 
-export const gridItem = (styles) => css(getGridItemStyle(styles))
+export const gridItem = ({ css: cssStyles, ...styles }) => cx(css(getGridItemStyle(styles)), css(cssStyles))
 gridItem.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/grid.d.ts
+++ b/packages/studio/styled-system/patterns/grid.d.ts
@@ -16,7 +16,7 @@ export type GridProperties = {
 type GridOptions = GridProperties & Omit<SystemStyleObject, keyof GridProperties >
 
 interface GridPatternFn {
-  (options?: GridOptions): string
+  (options?: GridOptions & { css?: SystemStyleObject }): string
   raw: (options: GridOptions) => GridOptions
 }
 

--- a/packages/studio/styled-system/patterns/grid.mjs
+++ b/packages/studio/styled-system/patterns/grid.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const gridConfig = {
   transform(props, { map }) {
@@ -22,5 +22,5 @@ const gridConfig = {
 
 export const getGridStyle = (styles = {}) => gridConfig.transform(styles, { map: mapObject })
 
-export const grid = (styles) => css(getGridStyle(styles))
+export const grid = ({ css: cssStyles, ...styles }) => cx(css(getGridStyle(styles)), css(cssStyles))
 grid.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/grid.mjs
+++ b/packages/studio/styled-system/patterns/grid.mjs
@@ -22,5 +22,5 @@ const gridConfig = {
 
 export const getGridStyle = (styles = {}) => gridConfig.transform(styles, { map: mapObject })
 
-export const grid = ({ css: cssStyles, ...styles }) => cx(css(getGridStyle(styles)), css(cssStyles))
+export const grid = ({ css: cssStyles, ...styles } = {}) => cx(css(getGridStyle(styles)), css(cssStyles))
 grid.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/hstack.d.ts
+++ b/packages/studio/styled-system/patterns/hstack.d.ts
@@ -13,7 +13,7 @@ export type HstackProperties = {
 type HstackOptions = HstackProperties & Omit<SystemStyleObject, keyof HstackProperties >
 
 interface HstackPatternFn {
-  (options?: HstackOptions): string
+  (options?: HstackOptions & { css?: SystemStyleObject }): string
   raw: (options: HstackOptions) => HstackOptions
 }
 

--- a/packages/studio/styled-system/patterns/hstack.mjs
+++ b/packages/studio/styled-system/patterns/hstack.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const hstackConfig = {
   transform(props) {
@@ -17,5 +17,5 @@ const hstackConfig = {
 
 export const getHstackStyle = (styles = {}) => hstackConfig.transform(styles, { map: mapObject })
 
-export const hstack = (styles) => css(getHstackStyle(styles))
+export const hstack = ({ css: cssStyles, ...styles }) => cx(css(getHstackStyle(styles)), css(cssStyles))
 hstack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/hstack.mjs
+++ b/packages/studio/styled-system/patterns/hstack.mjs
@@ -17,5 +17,5 @@ const hstackConfig = {
 
 export const getHstackStyle = (styles = {}) => hstackConfig.transform(styles, { map: mapObject })
 
-export const hstack = ({ css: cssStyles, ...styles }) => cx(css(getHstackStyle(styles)), css(cssStyles))
+export const hstack = ({ css: cssStyles, ...styles } = {}) => cx(css(getHstackStyle(styles)), css(cssStyles))
 hstack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/link-box.d.ts
+++ b/packages/studio/styled-system/patterns/link-box.d.ts
@@ -12,7 +12,7 @@ export type LinkBoxProperties = {
 type LinkBoxOptions = LinkBoxProperties & Omit<SystemStyleObject, keyof LinkBoxProperties >
 
 interface LinkBoxPatternFn {
-  (options?: LinkBoxOptions): string
+  (options?: LinkBoxOptions & { css?: SystemStyleObject }): string
   raw: (options: LinkBoxOptions) => LinkBoxOptions
 }
 

--- a/packages/studio/styled-system/patterns/link-box.mjs
+++ b/packages/studio/styled-system/patterns/link-box.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const linkBoxConfig = {
   transform(props) {
@@ -16,5 +16,5 @@ const linkBoxConfig = {
 
 export const getLinkBoxStyle = (styles = {}) => linkBoxConfig.transform(styles, { map: mapObject })
 
-export const linkBox = (styles) => css(getLinkBoxStyle(styles))
+export const linkBox = ({ css: cssStyles, ...styles }) => cx(css(getLinkBoxStyle(styles)), css(cssStyles))
 linkBox.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/link-box.mjs
+++ b/packages/studio/styled-system/patterns/link-box.mjs
@@ -16,5 +16,5 @@ const linkBoxConfig = {
 
 export const getLinkBoxStyle = (styles = {}) => linkBoxConfig.transform(styles, { map: mapObject })
 
-export const linkBox = ({ css: cssStyles, ...styles }) => cx(css(getLinkBoxStyle(styles)), css(cssStyles))
+export const linkBox = ({ css: cssStyles, ...styles } = {}) => cx(css(getLinkBoxStyle(styles)), css(cssStyles))
 linkBox.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/link-overlay.d.ts
+++ b/packages/studio/styled-system/patterns/link-overlay.d.ts
@@ -12,7 +12,7 @@ export type LinkOverlayProperties = {
 type LinkOverlayOptions = LinkOverlayProperties & Omit<SystemStyleObject, keyof LinkOverlayProperties >
 
 interface LinkOverlayPatternFn {
-  (options?: LinkOverlayOptions): string
+  (options?: LinkOverlayOptions & { css?: SystemStyleObject }): string
   raw: (options: LinkOverlayOptions) => LinkOverlayOptions
 }
 

--- a/packages/studio/styled-system/patterns/link-overlay.mjs
+++ b/packages/studio/styled-system/patterns/link-overlay.mjs
@@ -21,5 +21,5 @@ const linkOverlayConfig = {
 
 export const getLinkOverlayStyle = (styles = {}) => linkOverlayConfig.transform(styles, { map: mapObject })
 
-export const linkOverlay = ({ css: cssStyles, ...styles }) => cx(css(getLinkOverlayStyle(styles)), css(cssStyles))
+export const linkOverlay = ({ css: cssStyles, ...styles } = {}) => cx(css(getLinkOverlayStyle(styles)), css(cssStyles))
 linkOverlay.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/link-overlay.mjs
+++ b/packages/studio/styled-system/patterns/link-overlay.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const linkOverlayConfig = {
   transform(props) {
@@ -21,5 +21,5 @@ const linkOverlayConfig = {
 
 export const getLinkOverlayStyle = (styles = {}) => linkOverlayConfig.transform(styles, { map: mapObject })
 
-export const linkOverlay = (styles) => css(getLinkOverlayStyle(styles))
+export const linkOverlay = ({ css: cssStyles, ...styles }) => cx(css(getLinkOverlayStyle(styles)), css(cssStyles))
 linkOverlay.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/spacer.d.ts
+++ b/packages/studio/styled-system/patterns/spacer.d.ts
@@ -12,7 +12,7 @@ export type SpacerProperties = {
 type SpacerOptions = SpacerProperties & Omit<SystemStyleObject, keyof SpacerProperties >
 
 interface SpacerPatternFn {
-  (options?: SpacerOptions): string
+  (options?: SpacerOptions & { css?: SystemStyleObject }): string
   raw: (options: SpacerOptions) => SpacerOptions
 }
 

--- a/packages/studio/styled-system/patterns/spacer.mjs
+++ b/packages/studio/styled-system/patterns/spacer.mjs
@@ -15,5 +15,5 @@ const spacerConfig = {
 
 export const getSpacerStyle = (styles = {}) => spacerConfig.transform(styles, { map: mapObject })
 
-export const spacer = ({ css: cssStyles, ...styles }) => cx(css(getSpacerStyle(styles)), css(cssStyles))
+export const spacer = ({ css: cssStyles, ...styles } = {}) => cx(css(getSpacerStyle(styles)), css(cssStyles))
 spacer.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/spacer.mjs
+++ b/packages/studio/styled-system/patterns/spacer.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const spacerConfig = {
   transform(props, { map }) {
@@ -15,5 +15,5 @@ const spacerConfig = {
 
 export const getSpacerStyle = (styles = {}) => spacerConfig.transform(styles, { map: mapObject })
 
-export const spacer = (styles) => css(getSpacerStyle(styles))
+export const spacer = ({ css: cssStyles, ...styles }) => cx(css(getSpacerStyle(styles)), css(cssStyles))
 spacer.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/square.d.ts
+++ b/packages/studio/styled-system/patterns/square.d.ts
@@ -12,7 +12,7 @@ export type SquareProperties = {
 type SquareOptions = SquareProperties & Omit<SystemStyleObject, keyof SquareProperties >
 
 interface SquarePatternFn {
-  (options?: SquareOptions): string
+  (options?: SquareOptions & { css?: SystemStyleObject }): string
   raw: (options: SquareOptions) => SquareOptions
 }
 

--- a/packages/studio/styled-system/patterns/square.mjs
+++ b/packages/studio/styled-system/patterns/square.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const squareConfig = {
   transform(props) {
@@ -18,5 +18,5 @@ const squareConfig = {
 
 export const getSquareStyle = (styles = {}) => squareConfig.transform(styles, { map: mapObject })
 
-export const square = (styles) => css(getSquareStyle(styles))
+export const square = ({ css: cssStyles, ...styles }) => cx(css(getSquareStyle(styles)), css(cssStyles))
 square.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/square.mjs
+++ b/packages/studio/styled-system/patterns/square.mjs
@@ -18,5 +18,5 @@ const squareConfig = {
 
 export const getSquareStyle = (styles = {}) => squareConfig.transform(styles, { map: mapObject })
 
-export const square = ({ css: cssStyles, ...styles }) => cx(css(getSquareStyle(styles)), css(cssStyles))
+export const square = ({ css: cssStyles, ...styles } = {}) => cx(css(getSquareStyle(styles)), css(cssStyles))
 square.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/stack.d.ts
+++ b/packages/studio/styled-system/patterns/stack.d.ts
@@ -15,7 +15,7 @@ export type StackProperties = {
 type StackOptions = StackProperties & Omit<SystemStyleObject, keyof StackProperties >
 
 interface StackPatternFn {
-  (options?: StackOptions): string
+  (options?: StackOptions & { css?: SystemStyleObject }): string
   raw: (options: StackOptions) => StackOptions
 }
 

--- a/packages/studio/styled-system/patterns/stack.mjs
+++ b/packages/studio/styled-system/patterns/stack.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const stackConfig = {
   transform(props) {
@@ -17,5 +17,5 @@ const stackConfig = {
 
 export const getStackStyle = (styles = {}) => stackConfig.transform(styles, { map: mapObject })
 
-export const stack = (styles) => css(getStackStyle(styles))
+export const stack = ({ css: cssStyles, ...styles }) => cx(css(getStackStyle(styles)), css(cssStyles))
 stack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/stack.mjs
+++ b/packages/studio/styled-system/patterns/stack.mjs
@@ -17,5 +17,5 @@ const stackConfig = {
 
 export const getStackStyle = (styles = {}) => stackConfig.transform(styles, { map: mapObject })
 
-export const stack = ({ css: cssStyles, ...styles }) => cx(css(getStackStyle(styles)), css(cssStyles))
+export const stack = ({ css: cssStyles, ...styles } = {}) => cx(css(getStackStyle(styles)), css(cssStyles))
 stack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/styled-link.d.ts
+++ b/packages/studio/styled-system/patterns/styled-link.d.ts
@@ -12,7 +12,7 @@ export type StyledLinkProperties = {
 type StyledLinkOptions = StyledLinkProperties & Omit<SystemStyleObject, keyof StyledLinkProperties >
 
 interface StyledLinkPatternFn {
-  (options?: StyledLinkOptions): string
+  (options?: StyledLinkOptions & { css?: SystemStyleObject }): string
   raw: (options: StyledLinkOptions) => StyledLinkOptions
 }
 

--- a/packages/studio/styled-system/patterns/styled-link.mjs
+++ b/packages/studio/styled-system/patterns/styled-link.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const styledLinkConfig = {
   transform: (props) => ({
@@ -15,5 +15,5 @@ const styledLinkConfig = {
 
 export const getStyledLinkStyle = (styles = {}) => styledLinkConfig.transform(styles, { map: mapObject })
 
-export const styledLink = (styles) => css(getStyledLinkStyle(styles))
+export const styledLink = ({ css: cssStyles, ...styles }) => cx(css(getStyledLinkStyle(styles)), css(cssStyles))
 styledLink.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/styled-link.mjs
+++ b/packages/studio/styled-system/patterns/styled-link.mjs
@@ -15,5 +15,5 @@ const styledLinkConfig = {
 
 export const getStyledLinkStyle = (styles = {}) => styledLinkConfig.transform(styles, { map: mapObject })
 
-export const styledLink = ({ css: cssStyles, ...styles }) => cx(css(getStyledLinkStyle(styles)), css(cssStyles))
+export const styledLink = ({ css: cssStyles, ...styles } = {}) => cx(css(getStyledLinkStyle(styles)), css(cssStyles))
 styledLink.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/visually-hidden.d.ts
+++ b/packages/studio/styled-system/patterns/visually-hidden.d.ts
@@ -12,7 +12,7 @@ export type VisuallyHiddenProperties = {
 type VisuallyHiddenOptions = VisuallyHiddenProperties & Omit<SystemStyleObject, keyof VisuallyHiddenProperties >
 
 interface VisuallyHiddenPatternFn {
-  (options?: VisuallyHiddenOptions): string
+  (options?: VisuallyHiddenOptions & { css?: SystemStyleObject }): string
   raw: (options: VisuallyHiddenOptions) => VisuallyHiddenOptions
 }
 

--- a/packages/studio/styled-system/patterns/visually-hidden.mjs
+++ b/packages/studio/styled-system/patterns/visually-hidden.mjs
@@ -12,5 +12,6 @@ const visuallyHiddenConfig = {
 
 export const getVisuallyHiddenStyle = (styles = {}) => visuallyHiddenConfig.transform(styles, { map: mapObject })
 
-export const visuallyHidden = ({ css: cssStyles, ...styles }) => cx(css(getVisuallyHiddenStyle(styles)), css(cssStyles))
+export const visuallyHidden = ({ css: cssStyles, ...styles } = {}) =>
+  cx(css(getVisuallyHiddenStyle(styles)), css(cssStyles))
 visuallyHidden.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/visually-hidden.mjs
+++ b/packages/studio/styled-system/patterns/visually-hidden.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const visuallyHiddenConfig = {
   transform(props) {
@@ -12,5 +12,5 @@ const visuallyHiddenConfig = {
 
 export const getVisuallyHiddenStyle = (styles = {}) => visuallyHiddenConfig.transform(styles, { map: mapObject })
 
-export const visuallyHidden = (styles) => css(getVisuallyHiddenStyle(styles))
+export const visuallyHidden = ({ css: cssStyles, ...styles }) => cx(css(getVisuallyHiddenStyle(styles)), css(cssStyles))
 visuallyHidden.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/vstack.d.ts
+++ b/packages/studio/styled-system/patterns/vstack.d.ts
@@ -13,7 +13,7 @@ export type VstackProperties = {
 type VstackOptions = VstackProperties & Omit<SystemStyleObject, keyof VstackProperties >
 
 interface VstackPatternFn {
-  (options?: VstackOptions): string
+  (options?: VstackOptions & { css?: SystemStyleObject }): string
   raw: (options: VstackOptions) => VstackOptions
 }
 

--- a/packages/studio/styled-system/patterns/vstack.mjs
+++ b/packages/studio/styled-system/patterns/vstack.mjs
@@ -17,5 +17,5 @@ const vstackConfig = {
 
 export const getVstackStyle = (styles = {}) => vstackConfig.transform(styles, { map: mapObject })
 
-export const vstack = ({ css: cssStyles, ...styles }) => cx(css(getVstackStyle(styles)), css(cssStyles))
+export const vstack = ({ css: cssStyles, ...styles } = {}) => cx(css(getVstackStyle(styles)), css(cssStyles))
 vstack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/vstack.mjs
+++ b/packages/studio/styled-system/patterns/vstack.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const vstackConfig = {
   transform(props) {
@@ -17,5 +17,5 @@ const vstackConfig = {
 
 export const getVstackStyle = (styles = {}) => vstackConfig.transform(styles, { map: mapObject })
 
-export const vstack = (styles) => css(getVstackStyle(styles))
+export const vstack = ({ css: cssStyles, ...styles }) => cx(css(getVstackStyle(styles)), css(cssStyles))
 vstack.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/wrap.d.ts
+++ b/packages/studio/styled-system/patterns/wrap.d.ts
@@ -16,7 +16,7 @@ export type WrapProperties = {
 type WrapOptions = WrapProperties & Omit<SystemStyleObject, keyof WrapProperties >
 
 interface WrapPatternFn {
-  (options?: WrapOptions): string
+  (options?: WrapOptions & { css?: SystemStyleObject }): string
   raw: (options: WrapOptions) => WrapOptions
 }
 

--- a/packages/studio/styled-system/patterns/wrap.mjs
+++ b/packages/studio/styled-system/patterns/wrap.mjs
@@ -19,5 +19,5 @@ const wrapConfig = {
 
 export const getWrapStyle = (styles = {}) => wrapConfig.transform(styles, { map: mapObject })
 
-export const wrap = ({ css: cssStyles, ...styles }) => cx(css(getWrapStyle(styles)), css(cssStyles))
+export const wrap = ({ css: cssStyles, ...styles } = {}) => cx(css(getWrapStyle(styles)), css(cssStyles))
 wrap.raw = (styles) => styles

--- a/packages/studio/styled-system/patterns/wrap.mjs
+++ b/packages/studio/styled-system/patterns/wrap.mjs
@@ -1,5 +1,5 @@
 import { mapObject } from '../helpers.mjs'
-import { css } from '../css/index.mjs'
+import { css, cx } from '../css/index.mjs'
 
 const wrapConfig = {
   transform(props) {
@@ -19,5 +19,5 @@ const wrapConfig = {
 
 export const getWrapStyle = (styles = {}) => wrapConfig.transform(styles, { map: mapObject })
 
-export const wrap = (styles) => css(getWrapStyle(styles))
+export const wrap = ({ css: cssStyles, ...styles }) => cx(css(getWrapStyle(styles)), css(cssStyles))
 wrap.raw = (styles) => styles

--- a/website/pages/docs/concepts/recipes.md
+++ b/website/pages/docs/concepts/recipes.md
@@ -491,6 +491,29 @@ const PageButton = (props: ButtonProps) => {
 }
 ```
 
+## Css Property
+
+You can add extra styles when using a recipe by passing a `css` object to the recipe function. This can also be used to override a variant style.
+
+```tsx
+import { button } from '../styled-system/recipes'
+
+function App() {
+  return (
+    <div>
+      <button
+        class={button({
+          size: 'sm', // means { padding: '4', fontSize: '12px' }
+          css: { fontWeight: 'bold', fontSize: '20px' } // will override the fontSize
+        })}
+      >
+        Click me
+      </button>
+    </div>
+  )
+}
+```
+
 ## Best Practices
 
 - Leverage css variables in the base styles as much as possible. Makes it easier to theme the component with JS


### PR DESCRIPTION
## 📝 Description

Add `css` prop to recipes and patterns so you don't have to import and use `cx` for that one little edge case.

Before:

```tsx
<button className={cx(button({ variant: 'primary', state: 'focused' }), css({ color: 'yellow' }))}>Click me</button>
```

Now:

```tsx
<button className={button({ variant: 'primary', state: 'focused', css: { color: 'yellow' } })}>Click me</button>
```


## 💣 Is this a breaking change (Yes/No):

no