### PR TITLE
fix failed styled component for solid-js when using recipe

### DIFF
--- a/.changeset/tough-gifts-bathe.md
+++ b/.changeset/tough-gifts-bathe.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/generator": patch
+---
+
+fix failed styled component for solid-js when using recipe

--- a/packages/generator/src/artifacts/solid-jsx/jsx.ts
+++ b/packages/generator/src/artifacts/solid-jsx/jsx.ts
@@ -13,7 +13,7 @@ export function generateSolidJsxFactory(ctx: Context) {
     ${ctx.file.import('allCssProperties', './is-valid-prop')}
 
     function styledFn(element, configOrCva = {}) {
-      const cvaFn = configOrCva.__cva__ ? configOrCva : cva(configOrCva)
+      const cvaFn = configOrCva.__cva__ || configOrCva.__recipe__ ? configOrCva : cva(configOrCva)
 
       return function ${componentName}(props) {
         const mergedProps = mergeProps({ as: element }, props)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> when using the styled function with a recipe for solid-js, no style are produced
example:
```
import { styled } from 'styled-system/jsx'
import { button } from 'styled-system/recipes'

export const Button = styled('button', button)
```

## ⛳️ Current behavior (updates)

> add the  missing test ```|| configOrCva.__recipe__``` to check if a recipe is passed to the styled function.
[The test is the same as in react framework for example](https://github.com/chakra-ui/panda/blob/cc4d2fc02d0bb9000790624111aa8c1ae7818d97/packages/generator/src/artifacts/react-jsx/jsx.ts#L16) and [it is missing in the current version (0.11.1)](https://github.com/chakra-ui/panda/blob/cc4d2fc02d0bb9000790624111aa8c1ae7818d97/packages/generator/src/artifacts/solid-jsx/jsx.ts#L16)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
