### PR TITLE
playground: set `jsxFramework` by default

### DIFF
--- a/playground/src/hooks/usePlayground.ts
+++ b/playground/src/hooks/usePlayground.ts
@@ -89,6 +89,7 @@ export const config = defineConfig({
       bg: { base: 'white', _dark: '#2C2C2C' },
     },
   },
+  jsxFramework: 'react',
 });    
           
 `,


### PR DESCRIPTION
Set `jsxFramework` by default in playground