### PR TITLE
Fix `AnimationName` type

### DIFF
--- a/.changeset/good-readers-attend.md
+++ b/.changeset/good-readers-attend.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix issue where `AnimationName` type was generated wrongly if keyframes were not resolved

--- a/packages/generator/src/artifacts/types/token-types.ts
+++ b/packages/generator/src/artifacts/types/token-types.ts
@@ -52,9 +52,9 @@ export function generateTokenTypes(ctx: Context) {
       result.add(`\t\t${key}: ${typeName}Token`)
     }
 
-    const keyframes = Object.keys(theme?.keyframes ?? {})
+    const keyframes = unionType(Object.keys(theme?.keyframes ?? {}))
 
-    set.add(`export type AnimationName = ${unionType(keyframes)}`)
+    if (keyframes) set.add(`export type AnimationName = ${keyframes}`)
     result.add(`\t\tanimationName: AnimationName`)
   }
 


### PR DESCRIPTION
Fix issue where `AnimationName` type was generated wrongly if keyframes were not resolved