### PR TITLE
fix(patterns): custom JSX pattern matching

### DIFF
--- a/.changeset/tough-dots-burn.md
+++ b/.changeset/tough-dots-burn.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix an issue with custom JSX components not finding their matching patterns

--- a/packages/generator/src/artifacts/css/parser-css.ts
+++ b/packages/generator/src/artifacts/css/parser-css.ts
@@ -66,7 +66,7 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
               // treat pattern jsx like regular pattern
               .with({ type: 'jsx-pattern', name: P.string }, ({ name: jsxName }) => {
                 pattern.data.forEach((data) => {
-                  const fnName = patterns.getFnName(jsxName)
+                  const fnName = patterns.find(jsxName)
                   const styleProps = patterns.transform(fnName, data)
                   sheet.processStyleProps(styleProps)
                 })

--- a/packages/generator/src/engines/pattern.ts
+++ b/packages/generator/src/engines/pattern.ts
@@ -1,4 +1,4 @@
-import { capitalize, dashCase, mapObject, memo, uncapitalize, createRegex } from '@pandacss/shared'
+import { capitalize, dashCase, mapObject, memo, createRegex, uncapitalize } from '@pandacss/shared'
 import type { Dict, UserConfig } from '@pandacss/types'
 
 const helpers = { map: mapObject }
@@ -37,8 +37,8 @@ export const getPatternEngine = (config: UserConfig) => {
     },
     getNames,
     details,
-    getFnName: memo((jsxName: string) => {
-      return details.find((node) => node.jsxName === jsxName)?.baseName ?? uncapitalize(jsxName)
+    find: memo((jsxName: string) => {
+      return details.find((node) => node.match.test(jsxName))?.baseName ?? uncapitalize(jsxName)
     }),
     filter: memo((jsxName: string) => {
       return details.filter((node) => node.match.test(jsxName))

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -1165,6 +1165,10 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
+        .items_center {
+          align-items: center
+          }
+
         .d_flex {
           display: flex
           }
@@ -1173,8 +1177,8 @@ describe('extract to css output pipeline', () => {
           flex-direction: column
           }
 
-        .items_center {
-          align-items: center
+        .items_flex-end {
+          align-items: flex-end
           }
 
         .gap_10px {


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1260

## 📝 Description

Fix an issue with custom JSX components not finding their matching patterns

Given this config:
```
patterns: {
    extend: {
      circle: {
        jsx: ["Circle", "CustomCircle"],
      },
    },
  },
```

and usage like:

```
import CustomCircle from './CustomCircle'

function App() {
  return <CustomCircle size={16} backgroundColor="blue" />
}
```

the `CustomCircle` was trying to find a pattern named `customCircle` instead of being matched to the `circle` pattern

## 💣 Is this a breaking change (Yes/No):

no