### PR TITLE
feat(recipes): nested @layer _slots inside @layer recipes

### DIFF
--- a/.changeset/rude-wasps-speak.md
+++ b/.changeset/rude-wasps-speak.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/core': patch
+---
+
+Add a new `_slots` @layer for slot recipes so that "normal" recipes will have a higher CSS specificity

--- a/packages/core/__tests__/recipe-nesting.test.ts
+++ b/packages/core/__tests__/recipe-nesting.test.ts
@@ -54,6 +54,7 @@ function run(value: Record<string, any> = {}) {
 test('[recipe] direct nesting / recipe ruleset', () => {
   expect(run({ variant: 'sm' })).toMatchInlineSnapshot(`
     "@layer recipes {
+        @layer _base, _slots;
         @layer _base {
             .text {
                 margin-top: auto;
@@ -84,6 +85,7 @@ test('[recipe] direct nesting / recipe ruleset', () => {
 
   expect(run({ variant: 'md' })).toMatchInlineSnapshot(`
     "@layer recipes {
+        @layer _base, _slots;
         @layer _base {
             .text {
                 margin-top: auto;

--- a/packages/core/__tests__/recipe.test.ts
+++ b/packages/core/__tests__/recipe.test.ts
@@ -5,6 +5,7 @@ describe('recipe ruleset', () => {
   test('should work with basic', () => {
     expect(processRecipe('textStyle', { variant: 'h1' })).toMatchInlineSnapshot(`
       "@layer recipes {
+          @layer _base, _slots;
           @layer _base {
               .textStyle {
                   font-family: var(--fonts-mono);
@@ -19,6 +20,7 @@ describe('recipe ruleset', () => {
 
     expect(processRecipe('textStyle', {})).toMatchInlineSnapshot(`
       "@layer recipes {
+          @layer _base, _slots;
           @layer _base {
               .textStyle {
                   font-family: var(--fonts-mono);
@@ -33,6 +35,7 @@ describe('recipe ruleset', () => {
 
     expect(processRecipe('textStyle', { variant: { base: 'h1', md: 'h2' } })).toMatchInlineSnapshot(`
       "@layer recipes {
+          @layer _base, _slots;
           @layer _base {
               .textStyle {
                   font-family: var(--fonts-mono);
@@ -49,6 +52,7 @@ describe('recipe ruleset', () => {
   test('should work with complex selectors', () => {
     expect(processRecipe('tooltipStyle', {})).toMatchInlineSnapshot(`
       "@layer recipes {
+          @layer _base, _slots;
           @layer _base {
               .tooltipStyle {
                   &[data-tooltip].dark, .dark &[data-tooltip], & [data-tooltip].dark, .dark & [data-tooltip] {
@@ -128,6 +132,7 @@ describe('recipe ruleset', () => {
 
     expect(processRecipe('buttonStyle', { variant: 'solid' })).toMatchInlineSnapshot(`
       "@layer recipes {
+          @layer _base, _slots;
           @layer _base {
               .buttonStyle {
                   display: inline-flex;
@@ -156,6 +161,7 @@ describe('recipe ruleset', () => {
 
     expect(processRecipe('buttonStyle', { variant: { base: 'solid', lg: 'outline' } })).toMatchInlineSnapshot(`
       "@layer recipes {
+          @layer _base, _slots;
           @layer _base {
               .buttonStyle {
                   display: inline-flex;

--- a/packages/core/__tests__/slot-recipe.test.ts
+++ b/packages/core/__tests__/slot-recipe.test.ts
@@ -5,7 +5,8 @@ describe('slot recipe ruleset', () => {
   test('should work', () => {
     expect(processSlotRecipe('button', { size: 'sm' })).toMatchInlineSnapshot(`
       "@layer recipes {
-          @layer _base {
+          @layer _base, _slots;
+          @layer _slots {
               .button__container {
                   font-family: var(--fonts-mono)
               }
@@ -16,7 +17,7 @@ describe('slot recipe ruleset', () => {
           }
       }
       @layer recipes {
-          @layer _base {
+          @layer _slots {
               .button__icon {
                   font-size: 1.5rem
               }

--- a/packages/parser/__tests__/css-2.test.ts
+++ b/packages/parser/__tests__/css-2.test.ts
@@ -540,15 +540,15 @@ export function Card({ className }) {
     )
 
     expect(result.css).toMatchInlineSnapshot(`
-    "@layer utilities {
-      .text_red\\\\.400 {
-        color: var(--colors-red-400)
-        }
+      "@layer utilities {
+        .text_red\\\\.400 {
+          color: var(--colors-red-400)
+          }
 
-      .max-w_1000px {
-        max-width: 1000px
-        }
-    }"
+        .max-w_1000px {
+          max-width: 1000px
+          }
+      }"
     `)
   })
 })

--- a/website/pages/docs/concepts/slot-recipes.md
+++ b/website/pages/docs/concepts/slot-recipes.md
@@ -261,7 +261,7 @@ const Checkbox = { Root, Control, Label }
 
 ## Config Slot Recipe
 
-Config slot recipes are very similar atomic recipes except that they use well-defined classNames and store the styles in the `recipes` cascade layer.
+Config slot recipes are very similar atomic recipes except that they use well-defined classNames and store the styles in the `_slots` layer, itself in the `recipes` [cascade layer](/docs/concepts/cascade-layers.mdx).
 
 The config slot recipe takes the following additional properties:
 
@@ -351,7 +351,7 @@ const Checkbox = () => {
 }
 ```
 
-The generated css is registered under the `recipe` [cascade layer](/docs/concepts/cascade-layers.mdx) with the class name that matches the recipe-slot-variant name pattern `<recipe-className>__<slot-name>--<variant-name>`.
+The generated css is registered in the `_slots` layer, itself under the `recipe` [cascade layer](/docs/concepts/cascade-layers.mdx), with the class name that matches the recipe-slot-variant name pattern `<recipe-className>__<slot-name>--<variant-name>`.
 
 ```css
 @layer recipes {


### PR DESCRIPTION
## 📝 Description

Add a new `_slots` @layer for slot recipes so that "normal" recipes will have a higher CSS specificity

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

original issue 
https://discord.com/channels/1118988919804010566/1120305029056831548/1145979787156926504
https://play.panda-css.com/XJynA6uzUU
