### PR TITLE
types: make css(...args) allow falsy values

### DIFF
--- a/.changeset/smart-mails-train.md
+++ b/.changeset/smart-mails-train.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/generator': patch
+---
+
+Change the typings for the `css(...args)` function so that you can pass possibly undefined values to it.
+
+This is mostly intended for component props that have optional values like `cssProps?: SystemStyleObject` and would use
+it like `css({ ... }, cssProps)`

--- a/packages/generator/src/artifacts/js/css-fn.ts
+++ b/packages/generator/src/artifacts/js/css-fn.ts
@@ -15,7 +15,7 @@ export function generateCssFn(ctx: Context) {
     ${ctx.file.importType('SystemStyleObject', '../types/index')}
 
     interface CssFunction {
-      (...styles: SystemStyleObject[]): string
+      (...styles: Array<SystemStyleObject | undefined | null | false>): string
       raw: (styles: SystemStyleObject) => SystemStyleObject
     }
 

--- a/packages/studio/styled-system/css/css.d.ts
+++ b/packages/studio/styled-system/css/css.d.ts
@@ -2,7 +2,7 @@
 import type { SystemStyleObject } from '../types/index';
 
 interface CssFunction {
-  (...styles: SystemStyleObject[]): string
+  (...styles: Array<SystemStyleObject | undefined | null | false>): string
   raw: (styles: SystemStyleObject) => SystemStyleObject
 }
 


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/pull/1264#issuecomment-1698394167

## 📝 Description

`css(...args)` are already filtered to only take objects, this PR makes the typings lenient with falsy values, mostly intended for component props that have optional values like `cssProps?: SystemStyleObject` and then later `css({ ... }, cssProps)`

## 💣 Is this a breaking change (Yes/No):

no
