### PR TITLE
fix(playground): fix typo intialState to initialState

### DIFF
--- a/playground/src/app/[id]/page.tsx
+++ b/playground/src/app/[id]/page.tsx
@@ -11,7 +11,7 @@ const Page = async (props: any) => {
     select: { code: true, config: true },
   })
 
-  return <Playground intialState={initialState} />
+  return <Playground initialState={initialState} />
 }
 
 export default Page

--- a/playground/src/hooks/usePlayground.ts
+++ b/playground/src/hooks/usePlayground.ts
@@ -8,11 +8,11 @@ export type State = {
 }
 
 export type UsePlayGroundProps = {
-  intialState?: State | null
+  initialState?: State | null
 }
 
 export const usePlayground = (props: UsePlayGroundProps) => {
-  const { intialState } = props
+  const { initialState } = props
   const [layout, setLayout] = useState<Extract<Layout, 'horizontal' | 'vertical'>>('horizontal')
   const [isPristine, setIsPristine] = useState(true)
   const [isSharing, setIsSharing] = useState(false)
@@ -58,8 +58,8 @@ export const usePlayground = (props: UsePlayGroundProps) => {
   }
 
   const [state, setState] = useState(
-    intialState
-      ? intialState
+    initialState
+      ? initialState
       : {
           code: `import { css } from 'styled-system/css'
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

I was reading `playground` workspace code, and found some typo.(initialState)

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

minor typo

```ts
export type UsePlayGroundProps = {
  intialState?: State | null // typo initialState
}
```

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Will fix the typo

```ts
export type UsePlayGroundProps = {
  initialState?: State | null // fix
}
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No

## 📝 Additional Information
