### PR TITLE
Update redwood install instructions to fix Vite resolving issue

### DIFF
--- a/website/pages/docs/installation/redwood.mdx
+++ b/website/pages/docs/installation/redwood.mdx
@@ -83,6 +83,23 @@ Update the tsconfig file to include the `styled-system` folder.
 }
 ```
 
+
+Update the Vite config to resolve the `styled-system` folder.
+
+```ts {3-10} filename="web/vite.config.ts
+const viteConfig: UserConfig = {
+  plugins: [redwood()],
+  resolve: {
+    alias: [
+      {
+        find: 'styled-system',
+        replacement: resolve(__dirname, 'styled-system'),
+      },
+    ],
+  },
+};
+```
+
 ### Update package.json scripts
 
 Open the `web/package.json` file and update the `scripts` section as follows:


### PR DESCRIPTION
There's a missing step in the installation instructions for Redwood. By default, the Redwood Vite plugin only resolves in `web/src` so we need to add a resolve alias to the config.

[Full writeup](https://freddydumont.com/blog/vite-add-folder) of the issue if you need more info or background. It's a quick read.

I created this PR on GitHub itself so not sure if the formatting is correct.