### PR TITLE
feat(utility): allow retrieving the token object

### DIFF
--- a/.changeset/polite-shoes-attack.md
+++ b/.changeset/polite-shoes-attack.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/types': patch
+'@pandacss/core': patch
+---
+
+The utility transform fn now allow retrieving the token object with the raw value/conditions as currently there's no way
+to get it from there.

--- a/packages/core/__tests__/utility.test.ts
+++ b/packages/core/__tests__/utility.test.ts
@@ -2317,4 +2317,38 @@ describe('Utility', () => {
       }
     `)
   })
+
+  test('allow retrieving the token object with the raw value', () => {
+    const utility = new Utility({
+      tokens: new TokenDictionary({
+        tokens: { colors: { someColor: { value: '#aabbcc' } } },
+      }),
+      config: {
+        backgroundColor: {
+          shorthand: 'bgColor',
+          className: 'bg',
+          values: 'colors',
+          transform(_, args) {
+            const token = args.token.raw('colors.' + args.raw)
+            return {
+              backgroundColor: token?.value.replace('aa', 'ee'),
+            }
+          },
+        },
+      },
+    })
+
+    expect(utility.classNames).toMatchInlineSnapshot(`
+      Map {
+        "(backgroundColor = someColor)" => "bg_someColor",
+      }
+    `)
+    expect(utility.styles).toMatchInlineSnapshot(`
+      Map {
+        "(backgroundColor = someColor)" => {
+          "backgroundColor": "#eebbcc",
+        },
+      }
+    `)
+  })
 })

--- a/packages/core/src/utility.ts
+++ b/packages/core/src/utility.ts
@@ -309,7 +309,10 @@ export class Utility {
     const defaultTransform = (value: string) => this.defaultTransform(value, property)
     const getStyles = this.transforms.get(property) ?? defaultTransform
 
-    const styles = getStyles(raw, { token: this.getToken.bind(this), raw: alias })
+    const tokenFn = Object.assign(this.getToken.bind(this), {
+      raw: (path: string) => this.tokens.getByName(path),
+    })
+    const styles = getStyles(raw, { token: tokenFn, raw: alias })
 
     this.styles.set(propKey, styles ?? {})
 

--- a/packages/types/src/utility.ts
+++ b/packages/types/src/utility.ts
@@ -1,10 +1,13 @@
 import type { LiteralUnion } from './shared'
 import type { CssProperty, NestedCssProperties } from './system-types'
-import type { TokenCategory } from './tokens'
+import type { Token, TokenCategory } from './tokens'
 
-type Getter = (path: string) => any
+interface TokenFn {
+  (path: string): string | undefined
+  raw: (path: string) => Token | undefined
+}
 
-type ThemeFn = (token: Getter) => Record<string, string>
+type ThemeFn = (token: (path: string) => any) => Record<string, string>
 
 export type PropertyValues =
   | LiteralUnion<TokenCategory>
@@ -14,7 +17,7 @@ export type PropertyValues =
   | ThemeFn
 
 type TransformArgs = {
-  token: Getter
+  token: TokenFn
   raw: any
 }
 


### PR DESCRIPTION
## 📝 Description

The utility transform fn now allow retrieving the token object with the raw value/conditions as currently there's no way
to get it from there.

Example:


Given I have this config.tokens:
`colors: { redish: { value: '#9c1d1d' } }`

And this utility transform:

```ts
{
    utilities: {
        backgroundColor: {
            shorthand: "bgColor",
            className: "bg",
            values: "colors",
            transform(value, args) {
                console.log({ value, args, raw: args.token(args.raw), fromPath: args.token('colors.' + args.raw) })
                return {
                    backgroundColor: `rgba(${convertToRgba(value)}, var(--panda-text-opacity))`,
                };
            },
        },
    },
}
```

the output log would be

```ts
{
  value: 'var(--colors-redish)',
  args: { token: [Function: bound getToken], raw: 'redish' },
  raw: undefined,
  fromPath: 'var(--colors-redish)'
}
```

now it can be retrieved like this:

```
transform(_, args) {
    const token = args.token.raw('colors.' + args.raw)
    return { 
        // ...
    }
}
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
