### PR TITLE
fix: `token()` CSS syntax error when non-existing

### DIFF
--- a/.changeset/ten-zebras-trade.md
+++ b/.changeset/ten-zebras-trade.md
@@ -1,0 +1,22 @@
+---
+'@pandacss/core': patch
+---
+
+Fix issue with the `token()` function in CSS strings that produced CSS syntax error when non-existing token were left
+unchanged (due to the `.`)
+
+Before:
+
+```css
+* {
+  color: token(colors.magenta, pink);
+}
+```
+
+Now:
+
+```css
+* {
+  color: token('colors.magenta', pink);
+}
+```

--- a/packages/core/__tests__/expand-token-fn.test.ts
+++ b/packages/core/__tests__/expand-token-fn.test.ts
@@ -52,7 +52,7 @@ describe('expandTokenFn', () => {
     `)
   })
 
-  test('non-existing should remain unchanged', () => {
+  test('non-existing should be wrapped in quotes to avoid CSS Syntax error', () => {
     const result = run(css`
       * {
         color: token(colors.magenta, pink);
@@ -62,7 +62,7 @@ describe('expandTokenFn', () => {
     expect(result.css).toMatchInlineSnapshot(`
       "
             * {
-              color: var(colors.magenta, pink);
+              color: var('colors.magenta', pink);
             }
           "
     `)

--- a/packages/core/src/plugins/expand-token-fn.ts
+++ b/packages/core/src/plugins/expand-token-fn.ts
@@ -9,7 +9,9 @@ function expandTokenFn(fn?: (str: string) => string | undefined): TransformCallb
       if (decl.value.includes('token(')) {
         const value = decl.value.replace(tokenRegex, (_, token) => {
           const [tokenValue, tokenFallback] = token.split(',').map((s: string) => s.trim())
-          const result = [tokenValue, tokenFallback].filter(Boolean).map((s) => fn?.(s) ?? s)
+          const result = [tokenValue, tokenFallback]
+            .filter(Boolean)
+            .map((s) => fn?.(s) ?? (s.includes('.') ? `'${s}'` : s))
 
           if (result.length > 1) {
             const [a, b] = result

--- a/packages/studio/styled-system/chunks/..__core____tests____expand-token-fn.test.css
+++ b/packages/studio/styled-system/chunks/..__core____tests____expand-token-fn.test.css
@@ -1,0 +1,21 @@
+@layer utilities {
+  .\ \*\:text_token\(colors\.red\) {
+    color: 'colors.red'
+    }
+
+  .\ \*\:border_1px_solid_token\(colors\.blue\) {
+    border: 1px solid 'colors.blue'
+    }
+
+  .\ \*\:background-image_linear-gradient\(token\(colors\.red\)\,_token\(colors\.blue\)\) {
+    background-image: linear-gradient('colors.red', 'colors.blue')
+    }
+
+  .\ \*\:text_token\(colors\.red\,_colors\.blue\) {
+    color: var('colors.red', 'colors.blue')
+    }
+
+  .\ \*\:text_token\(colors\.magenta\,_pink\) {
+    color: var('colors.magenta', pink)
+    }
+}

--- a/packages/studio/styled-system/styles.css
+++ b/packages/studio/styled-system/styles.css
@@ -16,6 +16,26 @@
     color: green500;
     }
 
+  .\ \*\:text_token\(colors\.red\) {
+    color: 'colors.red'
+    }
+
+  .\ \*\:border_1px_solid_token\(colors\.blue\) {
+    border: 1px solid 'colors.blue'
+    }
+
+  .\ \*\:background-image_linear-gradient\(token\(colors\.red\)\,_token\(colors\.blue\)\) {
+    background-image: linear-gradient('colors.red', 'colors.blue')
+    }
+
+  .\ \*\:text_token\(colors\.red\,_colors\.blue\) {
+    color: var('colors.red', 'colors.blue')
+    }
+
+  .\ \*\:text_token\(colors\.magenta\,_pink\) {
+    color: var('colors.magenta', pink)
+    }
+
   .font_12px\/1\.5_Helvetica\,_Arial\,_sans-serif {
     font: 12px/1.5 Helvetica, Arial, sans-serif;
   }


### PR DESCRIPTION
## 📝 Description

Fix issue with the `token()` function in CSS strings that produced CSS syntax error when non-existing token were left
unchanged (due to the `.`)

## ⛳️ Current behavior (updates)

```css
* {
  color: token(colors.magenta, pink);
}
```


## 🚀 New behavior

```css
* {
  color: token('colors.magenta', pink);
}
```

## 💣 Is this a breaking change (Yes/No):

no
