### PR TITLE
fix(cli): add missing recipe type exports

### DIFF
--- a/.changeset/chilly-jobs-try.md
+++ b/.changeset/chilly-jobs-try.md
@@ -1,0 +1,6 @@
+---
+"@pandacss/dev": patch
+---
+
+Add missing types (PatternConfig, RecipeConfig, RecipeVariantRecord) to solve a TypeScript issue (The inferred type of
+xxx cannot be named without a reference...)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,6 +104,8 @@ export type {
   LayerStyles,
   Preset,
   PropertyConfig,
+  RecipeConfig,
+  RecipeVariantRecord,
   SemanticTokens,
   SlotRecipeConfig,
   SlotRecipeVariantRecord,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -106,6 +106,7 @@ export type {
   PropertyConfig,
   RecipeConfig,
   RecipeVariantRecord,
+  PatternConfig,
   SemanticTokens,
   SlotRecipeConfig,
   SlotRecipeVariantRecord,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1317  <!-- Github issue # here -->

## 📝 Description

Adds `RecipeConfig` and `RecipeVariantRecord` to the type exports.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Types targeting recipe configs are not exported in @pandacss/dev. Slot recipes do not face this issue as they are exported.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Adding recipe-related types fixes this issue in particular (and my own use case).

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
That being said, `PatternConfig` and `Parts` might want to be exported too (let me know if that's needed too and I'll make the changes)