### PR TITLE
types: export implicitly used types needed for TS d.ts generation

### DIFF
--- a/.changeset/nasty-bulldogs-hide.md
+++ b/.changeset/nasty-bulldogs-hide.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/generator': patch
+---
+
+Add missing types (`StyledComponents`, `RecipeConfig`, `PatternConfig` etc) to solve a TypeScript issue (The inferred
+type of xxx cannot be named without a reference...) when generating declaration files in addition to using
+`emitPackage: true`

--- a/packages/generator/src/artifacts/index.ts
+++ b/packages/generator/src/artifacts/index.ts
@@ -196,12 +196,12 @@ function setupJsx(ctx: Context): Artifact {
   `,
     dts: outdent`
   ${ctx.file.exportTypeStar('./factory')}
-  
+
   ${isValidProp?.dts ? ctx.file.exportTypeStar('./is-valid-prop') : ''}
-  
+
   ${outdent.string(patterns.map((file) => ctx.file.exportTypeStar(`./${file.name}`)).join('\n'))}
-  
-  ${ctx.file.exportType(ctx.jsx.typeName, '../types/jsx')}
+
+  ${ctx.file.exportType([ctx.jsx.typeName, ctx.jsx.componentName].join(', '), '../types/jsx')}
     `,
   }
 

--- a/packages/generator/src/artifacts/types/main.ts
+++ b/packages/generator/src/artifacts/types/main.ts
@@ -22,9 +22,12 @@ export const generateTypesEntry = (ctx: Context) => ({
       export function defineParts<T extends Parts>(parts: T): (config: Partial<Record<keyof T, SystemStyleObject>>) => Partial<Record<keyof T, SystemStyleObject>>
     }
     `,
+  // We need to export types used in the global.d.ts here to avoid TS errors such as `The inferred type of 'xxx' cannot be named without a reference to 'yyy'`
   index: outdent`
     import '${ctx.file.extDts('./global')}'
     ${ctx.file.exportType('ConditionalValue', './conditions')}
+    ${ctx.file.exportType('PatternConfig, PatternProperties', './pattern')}
+    ${ctx.file.exportType('RecipeVariantRecord, RecipeConfig, SlotRecipeVariantRecord, SlotRecipeConfig', './recipe')}
     ${ctx.file.exportType('GlobalStyleObject, JsxStyleProps, SystemStyleObject', './system-types')}
 
     `,

--- a/packages/studio/styled-system/jsx/index.d.ts
+++ b/packages/studio/styled-system/jsx/index.d.ts
@@ -25,4 +25,4 @@ export * from './bleed';
 export * from './visually-hidden';
 export * from './styled-link';
 
-export type { HTMLPandaProps } from '../types/jsx';
+export type { HTMLPandaProps, PandaComponent } from '../types/jsx';

--- a/packages/studio/styled-system/patterns/aspect-ratio.d.ts
+++ b/packages/studio/styled-system/patterns/aspect-ratio.d.ts
@@ -14,7 +14,7 @@ type AspectRatioStyles = AspectRatioProperties & DistributiveOmit<SystemStyleObj
 
 interface AspectRatioPatternFn {
   (styles?: AspectRatioStyles): string
-  raw: (styles: AspectRatioStyles) => SystemStyleObject
+  raw: (styles?: AspectRatioStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/bleed.d.ts
+++ b/packages/studio/styled-system/patterns/bleed.d.ts
@@ -15,7 +15,7 @@ type BleedStyles = BleedProperties & DistributiveOmit<SystemStyleObject, keyof B
 
 interface BleedPatternFn {
   (styles?: BleedStyles): string
-  raw: (styles: BleedStyles) => SystemStyleObject
+  raw: (styles?: BleedStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/box.d.ts
+++ b/packages/studio/styled-system/patterns/box.d.ts
@@ -14,7 +14,7 @@ type BoxStyles = BoxProperties & DistributiveOmit<SystemStyleObject, keyof BoxPr
 
 interface BoxPatternFn {
   (styles?: BoxStyles): string
-  raw: (styles: BoxStyles) => SystemStyleObject
+  raw: (styles?: BoxStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/center.d.ts
+++ b/packages/studio/styled-system/patterns/center.d.ts
@@ -14,7 +14,7 @@ type CenterStyles = CenterProperties & DistributiveOmit<SystemStyleObject, keyof
 
 interface CenterPatternFn {
   (styles?: CenterStyles): string
-  raw: (styles: CenterStyles) => SystemStyleObject
+  raw: (styles?: CenterStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/circle.d.ts
+++ b/packages/studio/styled-system/patterns/circle.d.ts
@@ -14,7 +14,7 @@ type CircleStyles = CircleProperties & DistributiveOmit<SystemStyleObject, keyof
 
 interface CirclePatternFn {
   (styles?: CircleStyles): string
-  raw: (styles: CircleStyles) => SystemStyleObject
+  raw: (styles?: CircleStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/container.d.ts
+++ b/packages/studio/styled-system/patterns/container.d.ts
@@ -14,7 +14,7 @@ type ContainerStyles = ContainerProperties & DistributiveOmit<SystemStyleObject,
 
 interface ContainerPatternFn {
   (styles?: ContainerStyles): string
-  raw: (styles: ContainerStyles) => SystemStyleObject
+  raw: (styles?: ContainerStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/divider.d.ts
+++ b/packages/studio/styled-system/patterns/divider.d.ts
@@ -16,7 +16,7 @@ type DividerStyles = DividerProperties & DistributiveOmit<SystemStyleObject, key
 
 interface DividerPatternFn {
   (styles?: DividerStyles): string
-  raw: (styles: DividerStyles) => SystemStyleObject
+  raw: (styles?: DividerStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/flex.d.ts
+++ b/packages/studio/styled-system/patterns/flex.d.ts
@@ -20,7 +20,7 @@ type FlexStyles = FlexProperties & DistributiveOmit<SystemStyleObject, keyof Fle
 
 interface FlexPatternFn {
   (styles?: FlexStyles): string
-  raw: (styles: FlexStyles) => SystemStyleObject
+  raw: (styles?: FlexStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/float.d.ts
+++ b/packages/studio/styled-system/patterns/float.d.ts
@@ -17,7 +17,7 @@ type FloatStyles = FloatProperties & DistributiveOmit<SystemStyleObject, keyof F
 
 interface FloatPatternFn {
   (styles?: FloatStyles): string
-  raw: (styles: FloatStyles) => SystemStyleObject
+  raw: (styles?: FloatStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/grid-item.d.ts
+++ b/packages/studio/styled-system/patterns/grid-item.d.ts
@@ -19,7 +19,7 @@ type GridItemStyles = GridItemProperties & DistributiveOmit<SystemStyleObject, k
 
 interface GridItemPatternFn {
   (styles?: GridItemStyles): string
-  raw: (styles: GridItemStyles) => SystemStyleObject
+  raw: (styles?: GridItemStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/grid.d.ts
+++ b/packages/studio/styled-system/patterns/grid.d.ts
@@ -18,7 +18,7 @@ type GridStyles = GridProperties & DistributiveOmit<SystemStyleObject, keyof Gri
 
 interface GridPatternFn {
   (styles?: GridStyles): string
-  raw: (styles: GridStyles) => SystemStyleObject
+  raw: (styles?: GridStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/hstack.d.ts
+++ b/packages/studio/styled-system/patterns/hstack.d.ts
@@ -15,7 +15,7 @@ type HstackStyles = HstackProperties & DistributiveOmit<SystemStyleObject, keyof
 
 interface HstackPatternFn {
   (styles?: HstackStyles): string
-  raw: (styles: HstackStyles) => SystemStyleObject
+  raw: (styles?: HstackStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/link-box.d.ts
+++ b/packages/studio/styled-system/patterns/link-box.d.ts
@@ -14,7 +14,7 @@ type LinkBoxStyles = LinkBoxProperties & DistributiveOmit<SystemStyleObject, key
 
 interface LinkBoxPatternFn {
   (styles?: LinkBoxStyles): string
-  raw: (styles: LinkBoxStyles) => SystemStyleObject
+  raw: (styles?: LinkBoxStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/link-overlay.d.ts
+++ b/packages/studio/styled-system/patterns/link-overlay.d.ts
@@ -14,7 +14,7 @@ type LinkOverlayStyles = LinkOverlayProperties & DistributiveOmit<SystemStyleObj
 
 interface LinkOverlayPatternFn {
   (styles?: LinkOverlayStyles): string
-  raw: (styles: LinkOverlayStyles) => SystemStyleObject
+  raw: (styles?: LinkOverlayStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/spacer.d.ts
+++ b/packages/studio/styled-system/patterns/spacer.d.ts
@@ -14,7 +14,7 @@ type SpacerStyles = SpacerProperties & DistributiveOmit<SystemStyleObject, keyof
 
 interface SpacerPatternFn {
   (styles?: SpacerStyles): string
-  raw: (styles: SpacerStyles) => SystemStyleObject
+  raw: (styles?: SpacerStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/square.d.ts
+++ b/packages/studio/styled-system/patterns/square.d.ts
@@ -14,7 +14,7 @@ type SquareStyles = SquareProperties & DistributiveOmit<SystemStyleObject, keyof
 
 interface SquarePatternFn {
   (styles?: SquareStyles): string
-  raw: (styles: SquareStyles) => SystemStyleObject
+  raw: (styles?: SquareStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/stack.d.ts
+++ b/packages/studio/styled-system/patterns/stack.d.ts
@@ -17,7 +17,7 @@ type StackStyles = StackProperties & DistributiveOmit<SystemStyleObject, keyof S
 
 interface StackPatternFn {
   (styles?: StackStyles): string
-  raw: (styles: StackStyles) => SystemStyleObject
+  raw: (styles?: StackStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/styled-link.d.ts
+++ b/packages/studio/styled-system/patterns/styled-link.d.ts
@@ -14,7 +14,7 @@ type StyledLinkStyles = StyledLinkProperties & DistributiveOmit<SystemStyleObjec
 
 interface StyledLinkPatternFn {
   (styles?: StyledLinkStyles): string
-  raw: (styles: StyledLinkStyles) => SystemStyleObject
+  raw: (styles?: StyledLinkStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/visually-hidden.d.ts
+++ b/packages/studio/styled-system/patterns/visually-hidden.d.ts
@@ -14,7 +14,7 @@ type VisuallyHiddenStyles = VisuallyHiddenProperties & DistributiveOmit<SystemSt
 
 interface VisuallyHiddenPatternFn {
   (styles?: VisuallyHiddenStyles): string
-  raw: (styles: VisuallyHiddenStyles) => SystemStyleObject
+  raw: (styles?: VisuallyHiddenStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/vstack.d.ts
+++ b/packages/studio/styled-system/patterns/vstack.d.ts
@@ -15,7 +15,7 @@ type VstackStyles = VstackProperties & DistributiveOmit<SystemStyleObject, keyof
 
 interface VstackPatternFn {
   (styles?: VstackStyles): string
-  raw: (styles: VstackStyles) => SystemStyleObject
+  raw: (styles?: VstackStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/patterns/wrap.d.ts
+++ b/packages/studio/styled-system/patterns/wrap.d.ts
@@ -18,7 +18,7 @@ type WrapStyles = WrapProperties & DistributiveOmit<SystemStyleObject, keyof Wra
 
 interface WrapPatternFn {
   (styles?: WrapStyles): string
-  raw: (styles: WrapStyles) => SystemStyleObject
+  raw: (styles?: WrapStyles) => SystemStyleObject
 }
 
 

--- a/packages/studio/styled-system/types/index.d.ts
+++ b/packages/studio/styled-system/types/index.d.ts
@@ -1,4 +1,6 @@
 /* eslint-disable */
 import './global.d.ts'
 export type { ConditionalValue } from './conditions';
+export type { PatternConfig, PatternProperties } from './pattern';
+export type { RecipeVariantRecord, RecipeConfig, SlotRecipeVariantRecord, SlotRecipeConfig } from './recipe';
 export type { GlobalStyleObject, JsxStyleProps, SystemStyleObject } from './system-types';

--- a/packages/studio/styled-system/types/recipe.d.ts
+++ b/packages/studio/styled-system/types/recipe.d.ts
@@ -100,6 +100,7 @@ export type SlotRecipeVariantFn<S extends string, T extends RecipeVariantRecord>
 ) => SlotRecord<S, string>
 
 export type SlotRecipeRuntimeFn<S extends string, T extends SlotRecipeVariantRecord<S>> = SlotRecipeVariantFn<S, T> & {
+  raw: (props?: RecipeSelection<T>) => Record<S, SystemStyleObject>
   variantKeys: (keyof T)[]
   variantMap: RecipeVariantMap<T>
   splitVariantProps<Props extends RecipeSelection<T>>(props: Props): [RecipeSelection<T>, Pretty<Omit<Props, keyof T>>]


### PR DESCRIPTION
## 📝 Description

Add missing types (`StyledComponents`, `RecipeConfig`, `PatternConfig` etc) to solve a TypeScript issue (The inferred
type of xxx cannot be named without a reference...) when generating declaration files in addition to using
`emitPackage: true`

## 💣 Is this a breaking change (Yes/No):

no

## Additional informations

this is a similar but different issue than https://github.com/chakra-ui/panda/pull/1318 
(same TS error but different source cause)

#1318 is about missing exported types from `@pandacss/dev`
this (#1322) is about missing exported types from the generated `outdir`