### PR TITLE
fix: allow `string` as opacity and zIndex tokens

### DIFF
--- a/.changeset/eight-lies-sing.md
+++ b/.changeset/eight-lies-sing.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/types': patch
+---
+
+Allow `string`s as `zIndex` and `opacity` tokens in order to support css custom properties

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -65,8 +65,8 @@ type Gradient = {
 type Asset = { type: 'url' | 'svg'; value: string }
 
 export type TokenDataTypes = {
-  zIndex: number
-  opacity: number
+  zIndex: string | number
+  opacity: string | number
   colors: string
   fonts: string | string[]
   fontSizes: string


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1330 <!-- Github issue # here -->

## 📝 Description

both `zIndex` and `opacity` tokens can of course be css custom properties. Forcing them to a number precludes this notion.

## ⛳️ Current behavior (updates)

Currently, when passing a custom property as the `value` of a `zIndex` or `opacity` token, you get this ts error:

```ts
zIndex: {
  1: { value: 'var(--layer-1)' },
}
```

> Type 'string' is not assignable to type 'number | Token<number> | Recursive<Token<number>>'.ts(2322)

This theoretically makes sense, but it doesn't account for css custom properties.

## 🚀 New behavior

This pr brings `opacity` and `zIndex` inline with the other token values and makes it possible to set them as a `string`.

## 💣 Is this a breaking change (Yes/No):

No, it adds options rather than removing them.

## 📝 Additional Information

This came up as I was implementing an [open props](https://open-props.style/) theme in panda.