### PR TITLE
Feat: support functions generating the recipe styles

### DIFF
--- a/packages/parser/__tests__/cva.test.ts
+++ b/packages/parser/__tests__/cva.test.ts
@@ -312,4 +312,115 @@ describe('ast parser / cva', () => {
       }
     `)
   })
+
+  test('should evaluate variants supplied as a function', () => {
+    const code = `
+    import {cva} from ".panda/css"
+
+    const variants = () => {
+      const spacingTokens = Object.entries({
+          s: 'token(spacing.1)',
+          m: 'token(spacing.2)',
+          l: 'token(spacing.3)',
+      });
+      
+      const spacingProps = {
+          'px': 'paddingX',
+          'py': 'paddingY',
+      };
+      
+      // Generate variants programmatically
+      return Object.entries(spacingProps)
+          .map(([name, styleProp]) => {
+              const variants = spacingTokens
+                  .map(([variant, token]) => ({ [variant]: { [styleProp]: token } }))
+                  .reduce((_agg, kv) => ({ ..._agg, ...kv }));
+      
+              return { [name]: variants };
+          })
+          .reduce((_agg, kv) => ({ ..._agg, ...kv }));
+    }
+
+    const baseStyle = cva({
+        variants: variants(),
+    })
+     `
+
+    expect(cvaParser(code)).toMatchInlineSnapshot(`
+      {
+        "cva": Set {
+          {
+            "box": {
+              "column": 23,
+              "line": 28,
+              "node": "CallExpression",
+              "type": "map",
+              "value": Map {
+                "variants" => {
+                  "column": 19,
+                  "line": 29,
+                  "node": "CallExpression",
+                  "type": "object",
+                  "value": {
+                    "px": {
+                      "l": {
+                        "paddingX": "token(spacing.3)",
+                      },
+                      "m": {
+                        "paddingX": "token(spacing.2)",
+                      },
+                      "s": {
+                        "paddingX": "token(spacing.1)",
+                      },
+                    },
+                    "py": {
+                      "l": {
+                        "paddingY": "token(spacing.3)",
+                      },
+                      "m": {
+                        "paddingY": "token(spacing.2)",
+                      },
+                      "s": {
+                        "paddingY": "token(spacing.1)",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "data": [
+              {
+                "variants": {
+                  "px": {
+                    "l": {
+                      "paddingX": "token(spacing.3)",
+                    },
+                    "m": {
+                      "paddingX": "token(spacing.2)",
+                    },
+                    "s": {
+                      "paddingX": "token(spacing.1)",
+                    },
+                  },
+                  "py": {
+                    "l": {
+                      "paddingY": "token(spacing.3)",
+                    },
+                    "m": {
+                      "paddingY": "token(spacing.2)",
+                    },
+                    "s": {
+                      "paddingY": "token(spacing.1)",
+                    },
+                  },
+                },
+              },
+            ],
+            "name": "cva",
+            "type": "object",
+          },
+        },
+      }
+    `)
+  })
 })

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -60,7 +60,7 @@ type GetEvaluateOptions = NonNullable<Parameters<typeof extract>['0']['getEvalua
 
 type EvalOptions = ReturnType<GetEvaluateOptions>
 
-const defaultEnv: EvalOptions['environment'] = { preset: 'NONE' }
+const defaultEnv: EvalOptions['environment'] = { preset: 'ECMA' }
 
 export function createParser(options: ParserOptions) {
   const { jsx, getRecipesByJsxName, getPatternsByJsxName, tsOptions, join } = options

--- a/packages/types/src/recipe.ts
+++ b/packages/types/src/recipe.ts
@@ -45,23 +45,24 @@ export type RecipeCompoundVariant<T extends RecipeVariantRecord> = RecipeCompoun
   css: SystemStyleObject
 }
 
+type LiteralOrGenerated<T> = T | (() => T)
 export type RecipeDefinition<T extends RecipeVariantRecord> = {
   /**
    * The base styles of the recipe.
    */
-  base?: SystemStyleObject
+  base?: LiteralOrGenerated<SystemStyleObject>
   /**
    * The multi-variant styles of the recipe.
    */
-  variants?: T | RecipeVariantRecord
+  variants?: LiteralOrGenerated<T | RecipeVariantRecord>
   /**
    * The default variants of the recipe.
    */
-  defaultVariants?: RecipeSelection<T>
+  defaultVariants?: LiteralOrGenerated<RecipeSelection<T>>
   /**
    * The styles to apply when a combination of variants is selected.
    */
-  compoundVariants?: Array<RecipeCompoundVariant<T>>
+  compoundVariants?: LiteralOrGenerated<Array<RecipeCompoundVariant<T>>>
 }
 
 export type RecipeCreatorFn = <T extends RecipeVariantRecord>(config: RecipeDefinition<T>) => RecipeRuntimeFn<T>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1332 

## 📝 Description

Updated ts-evaluator preset to `ECMA` so that parsing
CallExpressions could leverage the evaluator functionality.

This allows generating styles programmatically, as opposed to specifying literals only, e.g.:
```
cva({
  variants: generateVariants()
})
```

## ⛳️ Current behavior (updates)

At the moment, only the literal styles are parsed, even though `CallExpression`s are matched when attempting to create `BoxNode`s:
https://github.com/chakra-ui/panda/blob/4bc515ea31d9dade49ccdf5d9947cc5220ab38e0/packages/extractor/src/maybe-box-node.ts#L195-L200

This happens because during the evaluation in `ts-evaluator`, `Function` handling is not defined due to limited preset:
https://github.com/chakra-ui/panda/blob/bc3b077d4050a996500fa106b2171f7e128c2662/packages/parser/src/parser.ts#L63

## 🚀 New behavior

Changing the preset to `ECMA` allows evaluating a reasonable set of functions leveraging existing integration with `ts-evaluator`. In turn, this allows generating styles via functions, that are still resolved at build time.

## 💣 Is this a breaking change (Yes/No):

No
