### PR TITLE
(docs) Display changelog on docs site

### DIFF
--- a/website/pages/docs/overview/_meta.json
+++ b/website/pages/docs/overview/_meta.json
@@ -3,8 +3,5 @@
   "why-panda": "Why Panda?",
   "faq": "FAQs",
   "browser-support": "Browser Support",
-  "changelog": {
-    "title": "Changelog",
-    "href": "https://github.com/chakra-ui/panda/blob/main/CHANGELOG.md"
-  }
+  "changelog": "Changelog"
 }

--- a/website/pages/docs/overview/changelog.mdx
+++ b/website/pages/docs/overview/changelog.mdx
@@ -1,0 +1,16 @@
+import { buildDynamicMDX } from 'nextra/remote'
+import { RemoteContent } from 'nextra/data'
+
+export const getStaticProps = async () => {
+  const response = await fetch('https://raw.githubusercontent.com/chakra-ui/panda/main/CHANGELOG.md')
+  const markdown = await response.text()
+  const mdx = await buildDynamicMDX(markdown)
+  return {
+    props: {
+      ...mdx,
+    },
+    revalidate: 60 // Revalidate at most once every 60 seconds
+  }
+}
+
+<RemoteContent />

--- a/website/pages/docs/overview/changelog.mdx
+++ b/website/pages/docs/overview/changelog.mdx
@@ -1,15 +1,16 @@
 import { buildDynamicMDX } from 'nextra/remote'
 import { RemoteContent } from 'nextra/data'
+import { transformChangelog } from '@/mdx/transform-changelog'
 
 export const getStaticProps = async () => {
   const response = await fetch('https://raw.githubusercontent.com/chakra-ui/panda/main/CHANGELOG.md')
-  const markdown = await response.text()
+  const markdown = transformChangelog(await response.text())
   const mdx = await buildDynamicMDX(markdown)
   return {
     props: {
       ...mdx,
     },
-    revalidate: 60 // Revalidate at most once every 60 seconds
+    revalidate: 60
   }
 }
 

--- a/website/src/mdx/transform-changelog.ts
+++ b/website/src/mdx/transform-changelog.ts
@@ -1,0 +1,19 @@
+export const transformChangelog = (changelog: string) => {
+  const cleanChangelog = changelog
+    .replace('# CHANGELOG', '# Changelog')
+    .replace(/^.*\.\/\.changeset.*$/gm, '')
+    .replace('## [Unreleased]', '')
+
+  const versionAndDateRegex = /\[([\d.]+)\] - (\d{4}-\d{2}-\d{2})/g
+
+  const transformedChangelog = cleanChangelog.replace(
+    versionAndDateRegex,
+    (_, version, date) => {
+      const formattedVersion = `Version ${version}`
+      const formattedDate = `${date}`
+      return `${formattedVersion} \n${formattedDate}`
+    }
+  )
+
+  return transformedChangelog
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds the changelog to docs, instead of redirecting to github

## ⛳️ Current behavior (updates)

Currently, when "Changelog" is clicked in the, the browser redirects to the github file

## 🚀 New behavior

This PR adds support for fetching and displaying the changelog inline in the docs - with code highlighting, and same style and components as the rest of the docs 

## 💣 Is this a breaking change (Yes/No):

No