### PR TITLE
fix(cva): add optional chaining on assertCompoundVariant

### DIFF
--- a/.changeset/quick-oranges-mix.md
+++ b/.changeset/quick-oranges-mix.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix issue with cva when using compoundVariants and not passing any variants in the usage (ex: `button()` with
+`const button = cva({ ... })`)

--- a/packages/generator/src/artifacts/js/cva.ts
+++ b/packages/generator/src/artifacts/js/cva.ts
@@ -63,7 +63,7 @@ export function generateCvaFn(ctx: Context) {
     }
 
     export function assertCompoundVariant(name, compoundVariants, variants, prop) {
-      if (compoundVariants.length > 0 && typeof variants[prop] === 'object') {
+      if (compoundVariants.length > 0 && typeof variants?.[prop] === 'object') {
         throw new Error(\`[recipe:\${name}:\${prop}] Conditions are not supported when using compound variants.\`)
       }
     }

--- a/packages/studio/styled-system/css/cva.mjs
+++ b/packages/studio/styled-system/css/cva.mjs
@@ -57,7 +57,7 @@ export function getCompoundVariantCss(compoundVariants, variantMap) {
 }
 
 export function assertCompoundVariant(name, compoundVariants, variants, prop) {
-  if (compoundVariants.length > 0 && typeof variants[prop] === 'object') {
+  if (compoundVariants.length > 0 && typeof variants?.[prop] === 'object') {
     throw new Error(`[recipe:${name}:${prop}] Conditions are not supported when using compound variants.`)
   }
 }


### PR DESCRIPTION
## 📝 Description

Fix issue with cva when using compoundVariants and not passing any variants in the usage (ex: `button()` with
`const button = cva({ ... })`)

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

Note: since `cva` runtime implementation is also used for config recipe, it fixes both
