### PR TITLE
perf(types): faster DeepPartial

### DIFF
--- a/.changeset/shy-poets-warn.md
+++ b/.changeset/shy-poets-warn.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/generator': patch
+'@pandacss/parser': patch
+'@pandacss/studio': patch
+'@pandacss/types': patch
+'@pandacss/node': patch
+---
+
+Make the types suggestion faster (updated `DeepPartial`)

--- a/packages/node/src/classify.ts
+++ b/packages/node/src/classify.ts
@@ -73,11 +73,11 @@ export const classifyTokens = (ctx: PandaContext, parserResultByFilepath: Map<st
         return true
       }
 
-      if (patternProp.type === 'property') {
+      if (patternProp.type === 'property' && patternProp.value) {
         return Boolean(ctx.config.utilities?.[patternProp.value])
       }
 
-      if (patternProp.type === 'enum') {
+      if (patternProp.type === 'enum' && patternProp.value) {
         return Boolean(patternProp.value.includes(String(value)))
       }
 

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -1610,7 +1610,6 @@ describe('extract to css output pipeline', () => {
                   secondary: { color: 'pink.300', backgroundColor: 'green.500' },
                 },
               },
-              // @ts-expect-error
               compoundVariants: [{ variant: 'danger', size: 'md', css: { zIndex: 100 } }],
             },
             anotherButton: {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -139,7 +139,7 @@ export function createParser(options: ParserOptions) {
         pattern.jsx?.forEach((jsx) => {
           if (typeof jsx === 'string') {
             acc.string.add(jsx)
-          } else {
+          } else if (jsx) {
             acc.regex.push(jsx)
           }
         })

--- a/packages/studio/styled-system/types/recipe.d.ts
+++ b/packages/studio/styled-system/types/recipe.d.ts
@@ -39,7 +39,7 @@ export type RecipeRuntimeFn<T extends RecipeVariantRecord> = RecipeVariantFn<T> 
 }
 
 export type RecipeCompoundSelection<T extends RecipeVariantRecord> = {
-  [K in keyof T]?: StringToBoolean<keyof T[K]> | Array<StringToBoolean<keyof T[K]>>
+  [K in keyof T]?: StringToBoolean<keyof T[K]>
 }
 
 export type RecipeCompoundVariant<T extends RecipeVariantRecord> = RecipeCompoundSelection<T> & {

--- a/packages/types/src/shared.ts
+++ b/packages/types/src/shared.ts
@@ -10,9 +10,10 @@ export type RequiredBy<T, K extends keyof T> = Partial<Omit<T, K>> & Required<Pi
 
 export type AnyFunction<T = any> = (...args: T[]) => any
 
-type DeepPartial<T> = {
-  [P in keyof T]+?: DeepPartial<T[P]>
+type DeepPartialObject<T extends object> = {
+  [K in keyof T]?: DeepPartial<T[K]>
 }
+export type DeepPartial<T> = T extends object ? DeepPartialObject<T> : T
 
 export type Extendable<T extends Record<any, any>> = T | { extend?: DeepPartial<T> }
 


### PR DESCRIPTION
## 📝 Description

slightly tweak the `DeepPartial` type to skip a few steps`compoundVariants`

## summary

that's a 10s down in both cases for the ts checker speed, mostly from the DeepPartial change. this is pretty important for the DX when editing the panda.config.ts
when using compoundVariants, that's also few hundreds ms cut (600 in my local repo)

### using the website folder

before DeepPartial change:
<img width="1553" alt="Screenshot 2023-09-11 at 12 34 33" src="https://github.com/chakra-ui/panda/assets/47224540/0b5b7dd9-4efc-4018-8929-f0542652c423">
![Screenshot 2023-09-11 at 12 34 44](https://github.com/chakra-ui/panda/assets/47224540/3d694e4c-4e73-4df0-b045-9fc45e350065)

after DeepPartial change:
<img width="1554" alt="Screenshot 2023-09-11 at 12 36 54" src="https://github.com/chakra-ui/panda/assets/47224540/9eb572f4-3bd2-48d8-930d-ab7c6ca7649e">
![Screenshot 2023-09-11 at 12 37 06](https://github.com/chakra-ui/panda/assets/47224540/706a7200-683a-4d63-8f71-e85e565d6130)

### on a local repo

before DeepPartial change:
<img width="1542" alt="Screenshot 2023-09-11 at 12 10 11" src="https://github.com/chakra-ui/panda/assets/47224540/c94f87e1-83c2-4a5a-8be6-4085fb011dde">
![Screenshot 2023-09-11 at 12 11 09](https://github.com/chakra-ui/panda/assets/47224540/3d5231cf-05a8-4436-a07d-d5f23fb996f8)

after DeepPartial change:
![Screenshot 2023-09-11 at 12 13 28](https://github.com/chakra-ui/panda/assets/47224540/1cb547b7-98d0-425c-8a81-d7b2b4758e31)

```sh
pnpm tsc -p tsconfig.debug.json --outDir perf-issue  --generateTrace trace-dir 
npx @typescript/analyze-trace trace-dir --forceMillis=100 --skipMillis=50
```

tsconfig.debug.json
```ts
{
  "compilerOptions": {
    "skipLibCheck": true
  },
  "include": ["panda.config.ts"]
}
```

## 💣 Is this a breaking change (Yes/No):

no

## Additional informations

- it looks like `SystemProperties` / `CssVarProperties` are the main culprit. I quickly tried to improve those but didnt find a working solution, it might be worth it to investigate further

- when using presets, another workaround if things get too slow is too import presets as strings
