### PR TITLE
fix(extractor): handle satisfies keyword

### DIFF
--- a/.changeset/stupid-lions-know.md
+++ b/.changeset/stupid-lions-know.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/extractor': patch
+---
+
+Fix issue where the `satisfies` would prevent an object from being extracted

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5740,3 +5740,24 @@ it('extract all `css` style objects', () => {
     }
   `)
 })
+
+it('unwrapExpression with satisfies', () => {
+  expect(
+    extractFromCode(`
+      const someObject = { red: "red.600" } satisfies any;
+      <ColorBox color={someObject.red}></ColorBox>
+        `),
+  ).toMatchInlineSnapshot(`
+    {
+      "ColorBox": [
+        {
+          "conditions": [],
+          "raw": {
+            "color": "red.600",
+          },
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/extractor/src/utils.ts
+++ b/packages/extractor/src/utils.ts
@@ -41,6 +41,11 @@ export const unwrapExpression = (node: Node): Node => {
     return unwrapExpression(node.getExpression())
   }
 
+  // xxx satisfies yyy -> xxx
+  if (Node.isSatisfiesExpression(node)) {
+    return unwrapExpression(node.getExpression())
+  }
+
   return node
 }
 


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1360

## 📝 Description

Fix issue where the `satisfies` would prevent an object from being extracted

## 💣 Is this a breaking change (Yes/No):

no
