### PR TITLE
docs: remove "Radius" suffix from keys

### DIFF
--- a/website/pages/docs/theming/tokens.md
+++ b/website/pages/docs/theming/tokens.md
@@ -416,8 +416,8 @@ const theme = {
         value: {
           offsetX: 0,
           offsetY: 4,
-          blurRadius: 4,
-          spreadRadius: 0,
+          blur: 4,
+          spread: 0,
           color: 'rgba(0, 0, 0, 0.1)'
         }
       },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

<!-- Closes # <!-- Github issue # here -->

## 📝 Description

<!--
> Add a brief description
-->
This PR addresses an issue where the documentation incorrectly indicated `blurRadius` and `spreadRadius` as valid keys for `CompositeShadow`, while the correct keys are simply `blur` and `spread`. I have updated the documentation to reflect the accurate usage of `CompositeShadow` properties.

<!--
## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
-->
<!--
## 🚀 New behavior

> Please describe the behavior or changes this PR adds
-->

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing Panda users. -->
<!--
## 📝 Additional Information
-->