### PR TITLE
fix(#1365): keep extracted nullish values

### DIFF
--- a/.changeset/brave-geese-doubt.md
+++ b/.changeset/brave-geese-doubt.md
@@ -1,0 +1,12 @@
+---
+'@pandacss/extractor': patch
+---
+
+Fix issue (https://github.com/chakra-ui/panda/issues/1365) with the `unbox` fn that removed nullish values, which could
+be useful for the [Array Syntax](https://panda-css.com/docs/concepts/responsive-design#the-array-syntax)
+
+```ts
+const className = css({
+  color: ['black', undefined, 'orange', 'red'],
+})
+```

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5408,6 +5408,7 @@ it('extract CallExpression nested ObjectLiteralExpression', () => {
           "conditions": [],
           "raw": [
             "span",
+            undefined,
           ],
           "spreadConditions": [],
         },
@@ -5755,6 +5756,38 @@ it('unwrapExpression with satisfies', () => {
           "raw": {
             "color": "red.600",
           },
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})
+
+it('extracts arrays without removing nullish values', () => {
+  expect(
+    extractFromCode(
+      `
+    const className = css({
+      display: "flex", color: ['black', undefined, "orange", 'red'],
+    })`,
+      { functionNameList: ['css'] },
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "css": [
+        {
+          "conditions": [],
+          "raw": [
+            {
+              "color": [
+                "black",
+                undefined,
+                "orange",
+                "red",
+              ],
+              "display": "flex",
+            },
+          ],
           "spreadConditions": [],
         },
       ],

--- a/packages/extractor/src/unbox.ts
+++ b/packages/extractor/src/unbox.ts
@@ -76,7 +76,6 @@ const getLiteralValue = (node: BoxNode | undefined, ctx: UnboxContext): LiteralV
             Object.assign({}, ctx, { path: ctx.path.concat(String(index++)), parent: node }),
           ),
         ),
-        Arr.filter(isNotNullish),
         (v) => v.flat(),
       )
     })


### PR DESCRIPTION
Closes # https://github.com/chakra-ui/panda/issues/1365

## 📝 Description

Fix issue with the `unbox` fn that removed nullish values, which could
be useful for the [Array Syntax](https://panda-css.com/docs/concepts/responsive-design#the-array-syntax)

```ts
const className = css({
  color: ['black', undefined, 'orange', 'red'],
})
```

## 💣 Is this a breaking change (Yes/No):

no
