### PR TITLE
feat(parser): smarter parser

### DIFF
--- a/.changeset/lucky-dots-report.md
+++ b/.changeset/lucky-dots-report.md
@@ -1,0 +1,60 @@
+---
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+---
+
+feat(parser): extract {fn}.raw as an identity fn
+
+so this will now work:
+
+```ts
+import { css } from 'styled-system/css'
+
+const paragraphSpacingStyle = css.raw({
+  '&:not(:first-child)': { marginBlockEnd: '1em' },
+})
+
+export const proseCss = css.raw({
+  maxWidth: '800px',
+  '& p': {
+    '&:not(:first-child)': { marginBlockStart: '1em' },
+  },
+  '& h1': paragraphSpacingStyle,
+  '& h2': paragraphSpacingStyle,
+})
+```
+
+& use ECMA preset for ts-evaluator: This means that no other globals than those that are defined in the ECMAScript spec
+such as Math, Promise, Object, etc, are available but it allows for some basic evaluation of expressions like this:
+
+```ts
+import { cva } from '.panda/css'
+
+const variants = () => {
+  const spacingTokens = Object.entries({
+    s: 'token(spacing.1)',
+    m: 'token(spacing.2)',
+    l: 'token(spacing.3)',
+  })
+
+  const spacingProps = {
+    px: 'paddingX',
+    py: 'paddingY',
+  }
+
+  // Generate variants programmatically
+  return Object.entries(spacingProps)
+    .map(([name, styleProp]) => {
+      const variants = spacingTokens
+        .map(([variant, token]) => ({ [variant]: { [styleProp]: token } }))
+        .reduce((_agg, kv) => ({ ..._agg, ...kv }))
+
+      return { [name]: variants }
+    })
+    .reduce((_agg, kv) => ({ ..._agg, ...kv }))
+}
+
+const baseStyle = cva({
+  variants: variants(),
+})
+```

--- a/packages/extractor/src/types.ts
+++ b/packages/extractor/src/types.ts
@@ -101,7 +101,7 @@ export type MatchTaggedTemplateArgs = {
 export type MatchTaggedTemplate = (tag: MatchTaggedTemplateArgs) => boolean
 
 export type BoxContext = {
-  getEvaluateOptions?: (node: Expression, stack: Node[]) => EvaluateOptions
+  getEvaluateOptions?: (node: Expression, stack: Node[]) => Omit<EvaluateOptions, 'node' | 'policy'> | void
   canEval?: (node: Expression, stack: Node[]) => boolean
   flags?: {
     skipEvaluate?: boolean

--- a/packages/parser/__tests__/ts-eval.bench.ts
+++ b/packages/parser/__tests__/ts-eval.bench.ts
@@ -1,0 +1,66 @@
+import { bench, describe } from 'vitest'
+import { getFixtureProject } from './fixture'
+import type { Config, TSConfig } from '@pandacss/types'
+
+const run = (code: string, userConfig?: Config, tsconfig?: TSConfig) => {
+  const { parse, generator } = getFixtureProject(code, userConfig, tsconfig)
+  const result = parse()!
+  return {
+    json: result?.toArray().map(({ box, ...item }) => item),
+    css: generator.getParserCss(result)!,
+  }
+}
+
+describe('ts-eval', () => {
+  bench(
+    'with ts-eval',
+    () => {
+      const code = `
+    const variants = () => {
+        const spacingTokens = Object.entries({
+            s: 'token(spacing.1)',
+            m: 'token(spacing.2)',
+            l: 'token(spacing.3)',
+        });
+
+        const spacingProps = {
+            'px': 'paddingX',
+            'py': 'paddingY',
+        };
+
+        // Generate variants programmatically
+        return Object.entries(spacingProps)
+            .map(([name, styleProp]) => {
+                const variants = spacingTokens
+                    .map(([variant, token]) => ({ [variant]: { [styleProp]: token } }))
+                    .reduce((_agg, kv) => ({ ..._agg, ...kv }));
+
+                return { [name]: variants };
+            })
+            .reduce((_agg, kv) => ({ ..._agg, ...kv }));
+      }
+      const baseStyle = cva({
+          variants: variants(),
+      })
+      `
+
+      run(code)
+    },
+    { iterations: 50 },
+  )
+
+  bench(
+    'without ts-eval',
+    () => {
+      const code = `const variants = () => {
+            return {"px":{"s":{"paddingX":"token(spacing.1)"},"m":{"paddingX":"token(spacing.2)"},"l":{"paddingX":"token(spacing.3)"}},"py":{"s":{"paddingY":"token(spacing.1)"},"m":{"paddingY":"token(spacing.2)"},"l":{"paddingY":"token(spacing.3)"}}}
+          }
+          const baseStyle = cva({
+              variants: variants(),
+          })`
+
+      run(code)
+    },
+    { iterations: 50 },
+  )
+})

--- a/website/pages/docs/guides/dynamic-styling.md
+++ b/website/pages/docs/guides/dynamic-styling.md
@@ -219,6 +219,91 @@ export const Funky: Story = {
 }
 ```
 
+## Static expressions
+
+Panda supports static expressions in your styles, as long as they are statically analyzable.
+
+### Static Composition
+
+You can compose different style objects together using the `css.raw()` function.
+
+```tsx filename="App.tsx"
+import { css } from 'styled-system/css'
+
+const paragraphSpacingStyle = css.raw({
+  '& p': { marginBlockEnd: '1em' }
+})
+
+export const proseCss = css.raw({
+  '& h1': paragraphSpacingStyle
+})
+```
+
+This will result in the following CSS:
+
+```css
+/* ... */
+@layer utilities {
+  .\[\&_p\]\:mb_1em p,
+  .\[\&_h1\]\:\[\&_p\]\:mb_1em h1 p {
+    margin-block-end: 1em;
+  }
+}
+```
+
+### Static Expressions
+
+Panda supports the use of functions to generate the style objects as long they are statically analyzable.
+
+You can only use functions that are defined in the ECMAScript spec such as `Math`, `Object`, `Array`, etc, to support the evaluation of basic expressions like this:
+
+```ts
+import { cva } from '.panda/css'
+
+const getVariants = () => {
+  const spacingTokens = Object.entries({
+    sm: 'token(spacing.1)',
+    md: 'token(spacing.2)'
+  })
+
+  // Generate variants programmatically
+  const variants = spacingTokens.map(([variant, token]) => [
+    variant,
+    { paddingX: token }
+  ])
+  return Object.fromEntries(variants)
+}
+
+const baseStyle = cva({
+  variants: {
+    variant: getVariants()
+  }
+})
+```
+
+This will generate the following variants object:
+
+```json
+{
+  "sm": { "paddingX": "token(spacing.1)" },
+  "md": { "paddingX": "token(spacing.2)" }
+}
+```
+
+And the following CSS
+
+```css
+@layer utilities {
+  .px_token\(spacing\.1\) {
+    padding-inline: var(--spacing-1);
+  }
+
+  .px_token\(spacing\.2\) {
+    padding-inline: var(--spacing-2);
+  }
+}
+```
+
 ## Runtime conditions
 
 Even though we recommend that you first look for better alternatives (such as using


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1370#issuecomment-1719289977 https://github.com/chakra-ui/panda/pull/1333 https://github.com/chakra-ui/panda/discussions/1332

## 📝 Description

feat(parser): extract {fn}.raw as an identity fn

so this will now work:

```ts
import { css } from 'styled-system/css'

const paragraphSpacingStyle = css.raw({
  '&:not(:first-child)': { marginBlockEnd: '1em' },
})

export const proseCss = css.raw({
  maxWidth: '800px',
  '& p': {
    '&:not(:first-child)': { marginBlockStart: '1em' },
  },
  '& h1': paragraphSpacingStyle,
  '& h2': paragraphSpacingStyle,
})
```

& use ECMA preset for ts-evaluator: This means that no other globals than those that are defined in the ECMAScript spec
such as Math, Promise, Object, etc, are available but it allows for some basic evaluation of expressions like this:

```ts
import { cva } from '.panda/css'

const variants = () => {
  const spacingTokens = Object.entries({
    s: 'token(spacing.1)',
    m: 'token(spacing.2)',
    l: 'token(spacing.3)',
  })

  const spacingProps = {
    px: 'paddingX',
    py: 'paddingY',
  }

  // Generate variants programmatically
  return Object.entries(spacingProps)
    .map(([name, styleProp]) => {
      const variants = spacingTokens
        .map(([variant, token]) => ({ [variant]: { [styleProp]: token } }))
        .reduce((_agg, kv) => ({ ..._agg, ...kv }))

      return { [name]: variants }
    })
    .reduce((_agg, kv) => ({ ..._agg, ...kv }))
}

const baseStyle = cva({
  variants: variants(),
})
```

## 💣 Is this a breaking change (Yes/No):

no