### PR TITLE
fix(generator): add font smoothing for firefox macos

### DIFF
--- a/.changeset/three-birds-know.md
+++ b/.changeset/three-birds-know.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Add the property `-moz-osx-font-smoothing: grayscale;` to the `reset.css` under the `html` selector.

--- a/packages/generator/src/artifacts/css/reset-css.ts
+++ b/packages/generator/src/artifacts/css/reset-css.ts
@@ -29,6 +29,7 @@ export function generateResetCss(ctx: Context, scope = '') {
     -webkit-text-size-adjust: 100%;
     -webkit-text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     -moz-tab-size: 4;
     tab-size: 4;
     font-family: var(--global-font-body, var(--font-fallback));


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1378

## 📝 Description

Add the property `-moz-osx-font-smoothing: grayscale;` to the `reset.css` under the `html` selector.

## 💣 Is this a breaking change (Yes/No):

No
