### PR TITLE
feat: reuse css variable in semantic token alias

### DIFF
--- a/.changeset/purple-impalas-sneeze.md
+++ b/.changeset/purple-impalas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/token-dictionary': patch
+---
+
+- reuse css variable in semantic token alias

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -620,11 +620,17 @@ describe('generator', () => {
                 red: {
                   value: '#ef4444',
                 },
+                semanticRed: {
+                  value: '{colors.danger}',
+                }
               },
               borders: {
                 red: {
                   value: '1px solid {colors.red}',
                 },
+                semanticRed: {
+                  value: '{borders.danger}',
+                }
               },
             },
             semanticTokens: {
@@ -654,9 +660,11 @@ describe('generator', () => {
       "@layer tokens {
           :where(:root, :host) {
         --colors-red: #ef4444;
+        --colors-semantic-red: var(--colors-danger);
         --borders-red: 1px solid var(--colors-red);
+        --borders-semantic-red: var(--borders-danger);
         --colors-danger: var(--colors-red);
-        --borders-danger: 1px solid var(--colors-red)
+        --borders-danger: var(--borders-red)
       }
         }
         "

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -607,7 +607,7 @@ describe('generator', () => {
     })
   })
 
-  test.only('should reuse css variable in semantic token alias', () => {
+  test('should reuse css variable in semantic token alias', () => {
     const css = generateTokenCss(
       createGenerator({
         dependencies: [],

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -432,18 +432,18 @@ describe('generator', () => {
         --breakpoints-lg: 1024px;
         --breakpoints-xl: 1280px;
         --breakpoints-2xl: 1536px;
-        --colors-primary: #ef4444;
-        --colors-secondary: #991b1b;
-        --colors-complex: #991b1b;
+        --colors-primary: var(--colors-red-500);
+        --colors-secondary: var(--colors-red-800);
+        --colors-complex: var(--colors-red-800);
         --colors-button-thick: #fff;
         --colors-button-card-body: #fff;
         --colors-button-card-heading: #fff;
-        --spacing-gutter: 1rem
+        --spacing-gutter: var(--spacing-4)
       }
 
       :where([data-theme=dark], .dark) {
-        --colors-primary: #f87171;
-        --colors-secondary: #b91c1c;
+        --colors-primary: var(--colors-red-400);
+        --colors-secondary: var(--colors-red-700);
         --colors-button-thick: #000;
         --colors-button-card-body: #000;
         --colors-button-card-heading: #000
@@ -451,7 +451,7 @@ describe('generator', () => {
 
       @media (forced-colors: active) {
         :where([data-theme=dark], .dark) {
-          --colors-complex: #b91c1c
+          --colors-complex: var(--colors-red-700)
                   }
               }
 
@@ -475,7 +475,7 @@ describe('generator', () => {
 
       @media screen and (min-width: 64em) {
         :where(html) {
-          --spacing-gutter: 1.25rem
+          --spacing-gutter: var(--spacing-5)
               }
           }
         }

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -622,7 +622,7 @@ describe('generator', () => {
                 },
                 semanticRed: {
                   value: '{colors.danger}',
-                }
+                },
               },
               borders: {
                 red: {
@@ -630,13 +630,13 @@ describe('generator', () => {
                 },
                 semanticRed: {
                   value: '{borders.danger}',
-                }
+                },
               },
             },
             semanticTokens: {
               colors: {
-                danger: { 
-                  value: '{colors.red}' 
+                danger: {
+                  value: '{colors.red}',
                 },
               },
               borders: {

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -606,4 +606,60 @@ describe('generator', () => {
       `)
     })
   })
+
+  test.only('should reuse css variable in semantic token alias', () => {
+    const css = generateTokenCss(
+      createGenerator({
+        dependencies: [],
+        config: {
+          cwd: '',
+          include: [],
+          theme: {
+            tokens: {
+              colors: {
+                red: {
+                  value: '#ef4444',
+                },
+              },
+              borders: {
+                red: {
+                  value: '1px solid {colors.red}',
+                },
+              },
+            },
+            semanticTokens: {
+              colors: {
+                danger: { 
+                  value: '{colors.red}' 
+                },
+              },
+              borders: {
+                danger: {
+                  value: '{borders.red}',
+                },
+              },
+            },
+          },
+          conditions: {
+            dark: '.dark &',
+          },
+          outdir: '',
+        },
+        path: '',
+        hooks: createHooks(),
+      }),
+    )
+
+    expect(css).toMatchInlineSnapshot(`
+      "@layer tokens {
+          :where(:root, :host) {
+        --colors-red: #ef4444;
+        --borders-red: 1px solid var(--colors-red);
+        --colors-danger: var(--colors-red);
+        --borders-danger: 1px solid var(--colors-red)
+      }
+        }
+        "
+    `)
+  })
 })

--- a/packages/token-dictionary/__tests__/docs.test.ts
+++ b/packages/token-dictionary/__tests__/docs.test.ts
@@ -230,7 +230,7 @@ test('should generate categorize token', () => {
                 "primary",
               ],
               "type": "color",
-              "value": "#ef4444",
+              "value": "var(--colors-red-500)",
             },
             Token {
               "description": undefined,
@@ -252,7 +252,7 @@ test('should generate categorize token', () => {
                 "primary",
               ],
               "type": "color",
-              "value": "#f87171",
+              "value": "var(--colors-red-400)",
             },
             Token {
               "description": undefined,
@@ -274,7 +274,7 @@ test('should generate categorize token', () => {
                 "secondary",
               ],
               "type": "color",
-              "value": "#991b1b",
+              "value": "var(--colors-red-800)",
             },
             Token {
               "description": undefined,
@@ -296,7 +296,7 @@ test('should generate categorize token', () => {
                 "secondary",
               ],
               "type": "color",
-              "value": "#b91c1c",
+              "value": "var(--colors-red-700)",
             },
             Token {
               "description": undefined,
@@ -320,7 +320,7 @@ test('should generate categorize token', () => {
                 "complex",
               ],
               "type": "color",
-              "value": "#991b1b",
+              "value": "var(--colors-red-800)",
             },
             Token {
               "description": undefined,
@@ -344,7 +344,7 @@ test('should generate categorize token', () => {
                 "complex",
               ],
               "type": "color",
-              "value": "#b91c1c",
+              "value": "var(--colors-red-700)",
             },
             Token {
               "description": undefined,

--- a/packages/token-dictionary/__tests__/format-vars.test.ts
+++ b/packages/token-dictionary/__tests__/format-vars.test.ts
@@ -36,10 +36,10 @@ test('format / json flat', () => {
         "--colors-green" => "#00ff00",
         "--colors-pink-50" => "#ff0000",
         "--colors-pink-100" => "#0000ff",
-        "--colors-brand" => "#ff0000",
+        "--colors-brand" => "var(--colors-red)",
       },
       "dark" => Map {
-        "--colors-brand" => "#0000ff",
+        "--colors-brand" => "var(--colors-blue)",
       },
     }
   `)

--- a/packages/token-dictionary/__tests__/tokens.test.ts
+++ b/packages/token-dictionary/__tests__/tokens.test.ts
@@ -667,7 +667,7 @@ test('should work with default fixture', () => {
             "base": "{spacing.4}",
             "lg": "{spacing.5}",
           },
-          "pixelValue": "16px",
+          "pixelValue": "var(--spacing-4)",
           "prop": "gutter",
           "var": "--spacing-gutter",
           "varRef": "var(--spacing-gutter)",
@@ -679,7 +679,7 @@ test('should work with default fixture', () => {
           "gutter",
         ],
         "type": "dimension",
-        "value": "1rem",
+        "value": "var(--spacing-4)",
       },
       Token {
         "description": undefined,
@@ -690,7 +690,7 @@ test('should work with default fixture', () => {
             "base": "{spacing.4}",
             "lg": "{spacing.5}",
           },
-          "pixelValue": "20px",
+          "pixelValue": "var(--spacing-5)",
           "prop": "gutter",
           "var": "--spacing-gutter",
           "varRef": "var(--spacing-gutter)",
@@ -702,7 +702,7 @@ test('should work with default fixture', () => {
           "gutter",
         ],
         "type": "dimension",
-        "value": "1.25rem",
+        "value": "var(--spacing-5)",
       },
       Token {
         "description": undefined,
@@ -1515,7 +1515,7 @@ test('should work with default fixture', () => {
           "-gutter",
         ],
         "type": "dimension",
-        "value": "1.25rem",
+        "value": "var(--spacing-5)",
       },
     ]
   `)

--- a/packages/token-dictionary/__tests__/transform-border.test.ts
+++ b/packages/token-dictionary/__tests__/transform-border.test.ts
@@ -65,7 +65,7 @@ test('transform / border', () => {
           "sm",
         ],
         "type": "border",
-        "value": "1px solid #ff0000",
+        "value": "1px solid var(--colors-red)",
       },
       Token {
         "description": undefined,
@@ -83,7 +83,7 @@ test('transform / border', () => {
           "md",
         ],
         "type": "border",
-        "value": "2px solid #ff0000",
+        "value": "2px solid var(--colors-red)",
       },
       Token {
         "description": undefined,
@@ -105,7 +105,7 @@ test('transform / border', () => {
           "controlBorder",
         ],
         "type": "border",
-        "value": "1px solid #ff0000",
+        "value": "var(--borders-sm)",
       },
       Token {
         "description": undefined,
@@ -127,7 +127,7 @@ test('transform / border', () => {
           "controlBorder",
         ],
         "type": "border",
-        "value": "2px solid #ff0000",
+        "value": "var(--borders-md)",
       },
       Token {
         "description": undefined,

--- a/packages/token-dictionary/src/token.ts
+++ b/packages/token-dictionary/src/token.ts
@@ -105,7 +105,7 @@ export class Token {
   }
 
   /**
-   * Returns the token variable reference with the references expanded.
+   * Returns the token value with the references expanded.
    * e.g. {color.gray.100} => var(--colors-gray-100)
    * 
    */

--- a/packages/token-dictionary/src/token.ts
+++ b/packages/token-dictionary/src/token.ts
@@ -105,12 +105,12 @@ export class Token {
   }
 
   /**
-   * Returns the token value with the references expanded.
-   * e.g. {color.gray.100} => #f7fafc
-   *
+   * Returns the token variable reference with the references expanded.
+   * e.g. {color.gray.100} => var(--colors-gray-100)
+   * 
    */
   expandReferences(): string {
-    if (!this.hasReference) return this.value
+    if (!this.hasReference) return this.extensions.varRef ?? this.value
 
     const references = this.extensions.references ?? {}
 

--- a/packages/token-dictionary/src/token.ts
+++ b/packages/token-dictionary/src/token.ts
@@ -107,7 +107,7 @@ export class Token {
   /**
    * Returns the token value with the references expanded.
    * e.g. {color.gray.100} => var(--colors-gray-100)
-   * 
+   *
    */
   expandReferences(): string {
     if (!this.hasReference) return this.extensions.varRef ?? this.value


### PR DESCRIPTION
Closes #1196

## 📝 Description

Tis PR implements the reuse of css variable in semantic token alias/references.

## ⛳️ Current behavior (updates)

For example:
```
const tokens = {
  colors: {
    red: {
      value: '#ef4444',
    },
  },
  semanticTokens: {
    colors: {
      danger: { value: '{colors.red}' },
    },
  },
}
```
will output:
```
--colors-red: #ef4444;
--colors-danger: #ef4444;
```

## 🚀 New behavior

will output:
```
--colors-red: #ef4444;
--colors-danger: var(--colors-red);
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
