### PR TITLE
fix(BREAKING): presets merging order

### DIFF
--- a/.changeset/strange-moose-fix.md
+++ b/.changeset/strange-moose-fix.md
@@ -1,0 +1,82 @@
+---
+'@pandacss/config': patch
+---
+
+> Note: This is only relevant for users using more than 1 custom defined preset that overlap with each other.
+
+BREAKING CHANGE: Presets merging order felt wrong (left overriding right presets) and is now more intuitive (right
+overriding left presets)
+
+Example:
+
+```ts
+const firstConfig = definePreset({
+  theme: {
+    tokens: {
+      colors: {
+        'first-main': { value: 'override' },
+      },
+    },
+    extend: {
+      tokens: {
+        colors: {
+          orange: { value: 'orange' },
+          gray: { value: 'from-first-config' },
+        },
+      },
+    },
+  },
+})
+
+const secondConfig = definePreset({
+  theme: {
+    tokens: {
+      colors: {
+        pink: { value: 'pink' },
+      },
+    },
+    extend: {
+      tokens: {
+        colors: {
+          blue: { value: 'blue' },
+          gray: { value: 'gray' },
+        },
+      },
+    },
+  },
+})
+
+// Final config
+export default defineConfig({
+  presets: [firstConfig, secondConfig],
+})
+```
+
+Here's the difference between the old and new behavior:
+
+```diff
+{
+  "theme": {
+    "tokens": {
+      "colors": {
+        "blue": {
+          "value": "blue"
+        },
+-        "first-main": {
+-          "value": "override"
+-        },
+        "gray": {
+-          "value": "from-first-config"
++          "value": "gray"
+        },
+        "orange": {
+          "value": "orange"
+        },
++        "pink": {
++            "value": "pink",
++        },
+      }
+    }
+  }
+}
+```

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -203,14 +203,14 @@ describe('mergeConfigs / theme', () => {
               "blue": {
                 "value": "blue",
               },
-              "default-main": {
-                "value": "override",
-              },
               "gray": {
-                "value": "from-default-config",
+                "value": "gray",
               },
               "orange": {
                 "value": "orange",
+              },
+              "pink": {
+                "value": "pink",
               },
             },
           },

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { mergeConfigs } from '../src/merge-config'
+import { getResolvedConfig } from '../src/get-resolved-config'
 import type { Config } from '@pandacss/types'
 
 const defineConfig = <T extends Config>(config: T) => config
@@ -142,6 +143,74 @@ describe('mergeConfigs / theme', () => {
               },
               "pink": {
                 "value": "pink",
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
+
+  test('should getResolvedConfig, merge and override', async () => {
+    const defaultConfig = defineConfig({
+      theme: {
+        tokens: {
+          colors: {
+            'default-main': { value: 'override' },
+          },
+        },
+        extend: {
+          tokens: {
+            colors: {
+              orange: { value: 'orange' },
+              gray: { value: 'from-default-config' },
+            },
+          },
+        },
+      },
+    })
+
+    const userConfig = defineConfig({
+      theme: {
+        tokens: {
+          colors: {
+            pink: { value: 'pink' },
+          },
+        },
+        extend: {
+          tokens: {
+            colors: {
+              blue: { value: 'blue' },
+              gray: { value: 'gray' },
+            },
+          },
+        },
+      },
+    })
+
+    const result = await getResolvedConfig(
+      {
+        presets: [defaultConfig, userConfig],
+      },
+      '',
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "theme": {
+          "tokens": {
+            "colors": {
+              "blue": {
+                "value": "blue",
+              },
+              "default-main": {
+                "value": "override",
+              },
+              "gray": {
+                "value": "from-default-config",
+              },
+              "orange": {
+                "value": "orange",
               },
             },
           },

--- a/packages/config/src/get-resolved-config.ts
+++ b/packages/config/src/get-resolved-config.ts
@@ -16,10 +16,10 @@ export async function getResolvedConfig(config: ExtendableConfig, cwd: string) {
     const preset = await presets.shift()!
     if (typeof preset === 'string') {
       const presetModule = await bundle(preset, cwd)
-      configs.push(await presetModule.config)
+      configs.unshift(await presetModule.config)
       presets.unshift(...((await presetModule.config.presets) ?? []))
     } else {
-      configs.push(preset)
+      configs.unshift(preset)
       presets.unshift(...(preset.presets ?? []))
     }
   }

--- a/packages/studio/styled-system/tokens/index.css
+++ b/packages/studio/styled-system/tokens/index.css
@@ -420,18 +420,18 @@
   --breakpoints-xl: 1280px;
   --breakpoints-2xl: 1536px;
   --shadows-inset: inset 0 0 0 1px rgba(0,0,0,0.1);
-  --colors-text: #000;
-  --colors-bg: #fff;
-  --colors-card: #e5e5e5;
-  --colors-border: #d4d4d4
+  --colors-text: var(--colors-black);
+  --colors-bg: var(--colors-white);
+  --colors-card: var(--colors-neutral-200);
+  --colors-border: var(--colors-neutral-300)
 }
 
 .dark {
   --shadows-inset: inset 0 0 0 1px rgba(255,255,255,0.2);
-  --colors-text: #e5e5e5;
-  --colors-bg: #171717;
-  --colors-card: #262626;
-  --colors-border: #404040
+  --colors-text: var(--colors-neutral-200);
+  --colors-bg: var(--colors-neutral-900);
+  --colors-card: var(--colors-neutral-800);
+  --colors-border: var(--colors-neutral-700)
 }
   }
   

--- a/playground/src/lib/resolve-config.ts
+++ b/playground/src/lib/resolve-config.ts
@@ -22,11 +22,11 @@ export function getResolvedConfig(config: ExtendableConfig) {
 
     if (preset instanceof Promise) {
       preset.then((result) => {
-        configs.push(result)
+        configs.unshift(result)
         presets.unshift(...(result.presets ?? []))
       })
     } else {
-      configs.push(preset)
+      configs.unshift(preset)
       presets.unshift(...(preset.presets ?? []))
     }
   }


### PR DESCRIPTION
## 📝 Description

> Note: This is only relevant for users using more than 1 custom defined preset that overlap with each other.

BREAKING CHANGE: Presets merging order felt wrong (left overriding right presets) and is now more intuitive (right
overriding left presets)

Example:

```ts
const firstConfig = definePreset({
  theme: {
    tokens: {
      colors: {
        'first-main': { value: 'override' },
      },
    },
    extend: {
      tokens: {
        colors: {
          orange: { value: 'orange' },
          gray: { value: 'from-first-config' },
        },
      },
    },
  },
})

const secondConfig = definePreset({
  theme: {
    tokens: {
      colors: {
        pink: { value: 'pink' },
      },
    },
    extend: {
      tokens: {
        colors: {
          blue: { value: 'blue' },
          gray: { value: 'gray' },
        },
      },
    },
  },
})

// Final config
export default defineConfig({
  presets: [firstConfig, secondConfig],
})
```

Here's the difference between the old and new behavior:

```diff
{
  "theme": {
    "tokens": {
      "colors": {
        "blue": {
          "value": "blue"
        },
-        "first-main": {
-          "value": "override"
-        },
        "gray": {
-          "value": "from-first-config"
+          "value": "gray"
        },
        "orange": {
          "value": "orange"
        },
+        "pink": {
+            "value": "pink",
+        },
      }
    }
  }
}
```

## 💣 Is this a breaking change (Yes/No):

yes, only if using more than 1 custom defined preset that overlap with each other
