### PR TITLE
fix: recipe variant props conditional was removed

### DIFF
--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -60,7 +60,9 @@ describe('generate recipes', () => {
         [key in keyof TextStyleVariant]: Array<TextStyleVariant[key]>
       }
 
-      export interface TextStyleVariantProps extends Partial<TextStyleVariant> {}
+      export type TextStyleVariantProps = {
+        [key in keyof TextStyleVariant]?: ConditionalValue<TextStyleVariant[key]>
+      }
 
       interface TextStyleRecipe {
         __type: TextStyleVariantProps
@@ -109,7 +111,9 @@ describe('generate recipes', () => {
         [key in keyof TooltipStyleVariant]: Array<TooltipStyleVariant[key]>
       }
 
-      export interface TooltipStyleVariantProps extends Partial<TooltipStyleVariant> {}
+      export type TooltipStyleVariantProps = {
+        [key in keyof TooltipStyleVariant]?: ConditionalValue<TooltipStyleVariant[key]>
+      }
 
       interface TooltipStyleRecipe {
         __type: TooltipStyleVariantProps
@@ -154,7 +158,9 @@ describe('generate recipes', () => {
         [key in keyof ButtonStyleVariant]: Array<ButtonStyleVariant[key]>
       }
 
-      export interface ButtonStyleVariantProps extends Partial<ButtonStyleVariant> {}
+      export type ButtonStyleVariantProps = {
+        [key in keyof ButtonStyleVariant]?: ConditionalValue<ButtonStyleVariant[key]>
+      }
 
       interface ButtonStyleRecipe {
         __type: ButtonStyleVariantProps

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -144,7 +144,11 @@ export function generateRecipes(ctx: Context) {
           [key in keyof ${upperName}Variant]: Array<${upperName}Variant[key]>
         }
 
-        export interface ${upperName}VariantProps extends Partial<${upperName}Variant> {}
+        export type ${upperName}VariantProps = {
+          [key in keyof ${upperName}Variant]?: ${
+          compoundVariants?.length ? `${upperName}Variant[key]` : `ConditionalValue<${upperName}Variant[key]>`
+        }
+        }
 
         interface ${upperName}Recipe {
           __type: ${upperName}VariantProps


### PR DESCRIPTION
I made a mistake in the [switch to interface PR](https://github.com/chakra-ui/panda/commit/26a788c0a9e85dfff40fabcf3d678016944954ff), this one fixes it
