### PR TITLE
codegen: export needed types to bundle outdir

### DIFF
--- a/.changeset/gold-zebras-battle.md
+++ b/.changeset/gold-zebras-battle.md
@@ -1,0 +1,28 @@
+---
+'@pandacss/generator': patch
+---
+
+When bundling the `outdir` in a library, you usually want to generate type declaration files (`d.ts`). Sometimes TS will
+complain about types not being exported.
+
+- Export all types from `{outdir}/types/index.d.ts`, this fixes errors looking like this:
+
+```
+src/components/Checkbox/index.tsx(8,7): error TS2742: The inferred type of 'Root' cannot be named without a reference to '../../../node_modules/@acmeorg/styled-system/types/system-types'. This is likely not portable. A type annotation is necessary.
+src/components/Checkbox/index.tsx(8,7): error TS2742: The inferred type of 'Root' cannot be named without a reference to '../../../node_modules/@acmeorg/styled-system/types/csstype'. This is likely not portable. A type annotation is necessary.
+src/components/Checkbox/index.tsx(8,7): error TS2742: The inferred type of 'Root' cannot be named without a reference to '../../../node_modules/@acmeorg/styled-system/types/conditions'. This is likely not portable. A type annotation is necessary.
+```
+
+- Export generated recipe interfaces from `{outdir}/recipes/{recipeFn}.d.ts`, this fixes errors looking like this:
+
+```
+src/ui/avatar.tsx (16:318) "AvatarRecipe" is not exported by "styled-system/recipes/index.d.ts", imported by "src/ui/avatar.tsx".
+src/ui/card.tsx (2:164) "CardRecipe" is not exported by "styled-system/recipes/index.d.ts", imported by "src/ui/card.tsx".
+src/ui/checkbox.tsx (19:310) "CheckboxRecipe" is not exported by "styled-system/recipes/index.d.ts", imported by "src/ui/checkbox.tsx".
+```
+
+- Export type `ComponentProps` from `{outdir}/types/jsx.d.ts`, this fixes errors looking like this:
+
+```
+ "ComponentProps" is not exported by "styled-system/types/jsx.d.ts", imported by "src/ui/form-control.tsx".
+```

--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -64,7 +64,7 @@ describe('generate recipes', () => {
         [key in keyof TextStyleVariant]?: ConditionalValue<TextStyleVariant[key]>
       }
 
-      interface TextStyleRecipe {
+      export interface TextStyleRecipe {
         __type: TextStyleVariantProps
         (props?: TextStyleVariantProps): string
         raw: (props?: TextStyleVariantProps) => TextStyleVariantProps
@@ -115,7 +115,7 @@ describe('generate recipes', () => {
         [key in keyof TooltipStyleVariant]?: ConditionalValue<TooltipStyleVariant[key]>
       }
 
-      interface TooltipStyleRecipe {
+      export interface TooltipStyleRecipe {
         __type: TooltipStyleVariantProps
         (props?: TooltipStyleVariantProps): string
         raw: (props?: TooltipStyleVariantProps) => TooltipStyleVariantProps
@@ -162,7 +162,7 @@ describe('generate recipes', () => {
         [key in keyof ButtonStyleVariant]?: ConditionalValue<ButtonStyleVariant[key]>
       }
 
-      interface ButtonStyleRecipe {
+      export interface ButtonStyleRecipe {
         __type: ButtonStyleVariantProps
         (props?: ButtonStyleVariantProps): string
         raw: (props?: ButtonStyleVariantProps) => ButtonStyleVariantProps

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -150,7 +150,7 @@ export function generateRecipes(ctx: Context) {
         }
         }
 
-        interface ${upperName}Recipe {
+        export interface ${upperName}Recipe {
           __type: ${upperName}VariantProps
           (props?: ${upperName}VariantProps): ${
           isSlotRecipe(config) ? `Pretty<Record<${unionType(config.slots)}, string>>` : 'string'

--- a/packages/generator/src/artifacts/qwik-jsx/types.string-literal.ts
+++ b/packages/generator/src/artifacts/qwik-jsx/types.string-literal.ts
@@ -14,7 +14,7 @@ import type { Component, QwikIntrinsicElements } from '@builder.io/qwik'
 
 type ElementType = keyof QwikIntrinsicElements | Component<any>
 
-type ComponentProps<T extends ElementType> = T extends keyof QwikIntrinsicElements
+export type ComponentProps<T extends ElementType> = T extends keyof QwikIntrinsicElements
   ? QwikIntrinsicElements[T]
   : T extends Component<infer P>
   ? P

--- a/packages/generator/src/artifacts/qwik-jsx/types.ts
+++ b/packages/generator/src/artifacts/qwik-jsx/types.ts
@@ -16,7 +16,7 @@ import type { RecipeDefinition, RecipeSelection, RecipeVariantRecord } from './r
 
 type ElementType = keyof QwikIntrinsicElements | Component<any>
 
-type ComponentProps<T extends ElementType> = T extends keyof QwikIntrinsicElements
+export type ComponentProps<T extends ElementType> = T extends keyof QwikIntrinsicElements
   ? QwikIntrinsicElements[T]
   : T extends Component<infer P>
   ? P

--- a/packages/generator/src/artifacts/react-jsx/types.string-literal.ts
+++ b/packages/generator/src/artifacts/react-jsx/types.string-literal.ts
@@ -15,7 +15,7 @@ ${ctx.file.importType('DistributiveOmit', '../types/system-types')}
 
 type Dict = Record<string, unknown>
 
-type ComponentProps<T extends ElementType> = DistributiveOmit<ComponentPropsWithoutRef<T>, 'ref'> & {
+export type ComponentProps<T extends ElementType> = DistributiveOmit<ComponentPropsWithoutRef<T>, 'ref'> & {
   ref?: Ref<ElementRef<T>>
 }
 

--- a/packages/generator/src/artifacts/react-jsx/types.ts
+++ b/packages/generator/src/artifacts/react-jsx/types.ts
@@ -16,7 +16,7 @@ ${ctx.file.importType('RecipeDefinition, RecipeSelection, RecipeVariantRecord', 
 
 type Dict = Record<string, unknown>
 
-type ComponentProps<T extends ElementType> = DistributiveOmit<ComponentPropsWithoutRef<T>, 'ref'> & {
+export type ComponentProps<T extends ElementType> = DistributiveOmit<ComponentPropsWithoutRef<T>, 'ref'> & {
   ref?: Ref<ElementRef<T>>
 }
 

--- a/packages/generator/src/artifacts/types/main.ts
+++ b/packages/generator/src/artifacts/types/main.ts
@@ -25,10 +25,12 @@ export const generateTypesEntry = (ctx: Context) => ({
   // We need to export types used in the global.d.ts here to avoid TS errors such as `The inferred type of 'xxx' cannot be named without a reference to 'yyy'`
   index: outdent`
     import '${ctx.file.extDts('./global')}'
-    ${ctx.file.exportType('ConditionalValue', './conditions')}
-    ${ctx.file.exportType('PatternConfig, PatternProperties', './pattern')}
-    ${ctx.file.exportType('RecipeVariantRecord, RecipeConfig, SlotRecipeVariantRecord, SlotRecipeConfig', './recipe')}
-    ${ctx.file.exportType('GlobalStyleObject, JsxStyleProps, SystemStyleObject', './system-types')}
+    ${ctx.file.exportTypeStar('./conditions')}
+    ${ctx.file.exportTypeStar('./pattern')}
+    ${ctx.file.exportTypeStar('./recipe')}
+    ${ctx.file.exportTypeStar('./system-types')}
+    ${ctx.file.exportTypeStar('./jsx')}
+    ${ctx.file.exportTypeStar('./style-props')}
 
     `,
   helpers: outdent`

--- a/packages/generator/src/artifacts/vue-jsx/types.string-literal.ts
+++ b/packages/generator/src/artifacts/vue-jsx/types.string-literal.ts
@@ -16,7 +16,7 @@ import type { Component, FunctionalComponent, NativeElements } from 'vue'
 type IntrinsicElement = keyof NativeElements
 type ElementType = IntrinsicElement | Component
 
-type ComponentProps<T extends ElementType> = T extends IntrinsicElement
+export type ComponentProps<T extends ElementType> = T extends IntrinsicElement
   ? NativeElements[T]
   : T extends Component<infer Props>
   ? Props

--- a/packages/generator/src/artifacts/vue-jsx/types.ts
+++ b/packages/generator/src/artifacts/vue-jsx/types.ts
@@ -19,7 +19,7 @@ ${ctx.file.importType('Assign, JsxStyleProps, JsxHTMLProps', './system-types')}
 type IntrinsicElement = keyof NativeElements
 type ElementType = IntrinsicElement | Component
 
-type ComponentProps<T extends ElementType> = T extends IntrinsicElement
+export type ComponentProps<T extends ElementType> = T extends IntrinsicElement
   ? NativeElements[T]
   : T extends Component<infer Props>
   ? Props

--- a/packages/studio/styled-system/types/index.d.ts
+++ b/packages/studio/styled-system/types/index.d.ts
@@ -1,6 +1,8 @@
 /* eslint-disable */
 import './global.d.ts'
-export type { ConditionalValue } from './conditions';
-export type { PatternConfig, PatternProperties } from './pattern';
-export type { RecipeVariantRecord, RecipeConfig, SlotRecipeVariantRecord, SlotRecipeConfig } from './recipe';
-export type { GlobalStyleObject, JsxStyleProps, SystemStyleObject } from './system-types';
+export * from './conditions';
+export * from './pattern';
+export * from './recipe';
+export * from './system-types';
+export * from './jsx';
+export * from './style-props';

--- a/packages/studio/styled-system/types/jsx.d.ts
+++ b/packages/studio/styled-system/types/jsx.d.ts
@@ -5,7 +5,7 @@ import type { RecipeDefinition, RecipeSelection, RecipeVariantRecord } from './r
 
 type Dict = Record<string, unknown>
 
-type ComponentProps<T extends ElementType> = DistributiveOmit<ComponentPropsWithoutRef<T>, 'ref'> & {
+export type ComponentProps<T extends ElementType> = DistributiveOmit<ComponentPropsWithoutRef<T>, 'ref'> & {
   ref?: Ref<ElementRef<T>>
 }
 


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1327

## 📝 Description

When bundling the `outdir` in a library, you usually want to generate type declaration files (`d.ts`). Sometimes TS will
complain about types not being exported.

- Export all types from `{outdir}/types/index.d.ts`, this fixes errors looking like this:

```
src/components/Checkbox/index.tsx(8,7): error TS2742: The inferred type of 'Root' cannot be named without a reference to '../../../node_modules/@acmeorg/styled-system/types/system-types'. This is likely not portable. A type annotation is necessary.
src/components/Checkbox/index.tsx(8,7): error TS2742: The inferred type of 'Root' cannot be named without a reference to '../../../node_modules/@acmeorg/styled-system/types/csstype'. This is likely not portable. A type annotation is necessary.
src/components/Checkbox/index.tsx(8,7): error TS2742: The inferred type of 'Root' cannot be named without a reference to '../../../node_modules/@acmeorg/styled-system/types/conditions'. This is likely not portable. A type annotation is necessary.
```

- Export generated recipe interfaces from `{outdir}/recipes/{recipeFn}.d.ts`, this fixes errors looking like this:

```
src/ui/avatar.tsx (16:318) "AvatarRecipe" is not exported by "styled-system/recipes/index.d.ts", imported by "src/ui/avatar.tsx".
src/ui/card.tsx (2:164) "CardRecipe" is not exported by "styled-system/recipes/index.d.ts", imported by "src/ui/card.tsx".
src/ui/checkbox.tsx (19:310) "CheckboxRecipe" is not exported by "styled-system/recipes/index.d.ts", imported by "src/ui/checkbox.tsx".
```

- Export type `ComponentProps` from `{outdir}/types/jsx.d.ts`, this fixes errors looking like this:

```
 "ComponentProps" is not exported by "styled-system/types/jsx.d.ts", imported by "src/ui/form-control.tsx".
```


## 💣 Is this a breaking change (Yes/No):

no
