### PR TITLE
types: fix ExtendableUtilityConfig

### DIFF
--- a/.changeset/silent-spies-design.md
+++ b/.changeset/silent-spies-design.md
@@ -2,4 +2,7 @@
 '@pandacss/types': patch
 ---
 
-Fix ExtendableUtilityConfig typings after a regression in 0.15.2 (due to https://github.com/chakra-ui/panda/pull/1410)
+- Fix `ExtendableUtilityConfig` typings after a regression in 0.15.2 (due to
+  https://github.com/chakra-ui/panda/pull/1410)
+- Fix `ExtendableTheme` (specifically make the `RecipeConfig` Partial inside the `theme: { extend: { ... } }` object),
+  same for slotRecipes

--- a/.changeset/silent-spies-design.md
+++ b/.changeset/silent-spies-design.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/types': patch
+---
+
+Fix ExtendableUtilityConfig typings after a regression in 0.15.2 (due to https://github.com/chakra-ui/panda/pull/1410)

--- a/packages/types/src/theme.ts
+++ b/packages/types/src/theme.ts
@@ -39,6 +39,18 @@ export interface Theme {
   slotRecipes?: Record<string, SlotRecipeConfig>
 }
 
+interface PartialTheme extends Omit<Theme, 'recipes' | 'slotRecipes'> {
+  /**
+   * Multi-variant style definitions for your project.
+   * Useful for defining component styles.
+   */
+  recipes?: Record<string, Partial<RecipeConfig>>
+  /**
+   * Multi-variant style definitions for component slots.
+   */
+  slotRecipes?: Record<string, Partial<SlotRecipeConfig>>
+}
+
 export interface ExtendableTheme extends Theme {
-  extend?: Theme | undefined
+  extend?: PartialTheme | undefined
 }

--- a/packages/types/src/utility.ts
+++ b/packages/types/src/utility.ts
@@ -55,6 +55,10 @@ export type UtilityConfig = {
   [property in LiteralUnion<CssProperty>]?: PropertyConfig
 }
 
-export type ExtendableUtilityConfig = UtilityConfig & {
-  extend?: UtilityConfig
+type UtilityConfigWithExtend = {
+  [pattern in LiteralUnion<CssProperty>]?: PropertyConfig | UtilityConfig | undefined
+}
+
+export type ExtendableUtilityConfig = UtilityConfigWithExtend & {
+  extend?: UtilityConfig | undefined
 }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1430

## 📝 Description

- Fix `ExtendableUtilityConfig` typings after a regression in 0.15.2 (due to
  https://github.com/chakra-ui/panda/pull/1410)
- Fix `ExtendableTheme` (specifically make the `RecipeConfig` Partial inside the `theme: { extend: { ... } }` object),
  same for slotRecipes


## 💣 Is this a breaking change (Yes/No):

no
