### PR TITLE
fix(unbox): array syntax with conditionals

### DIFF
--- a/.changeset/sixty-wombats-occur.md
+++ b/.changeset/sixty-wombats-occur.md
@@ -1,0 +1,79 @@
+---
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+---
+
+Fix static extraction of the [Array Syntax](https://panda-css.com/docs/concepts/responsive-design#the-array-syntax) when
+used with runtime conditions
+
+Given a component like this:
+
+```ts
+function App() {
+  return <Box py={[2, verticallyCondensed ? 2 : 3, 4]} />
+}
+```
+
+the `py` value was incorrectly extracted like this:
+
+```ts
+ {
+    "py": {
+        "1": 2,
+    },
+},
+{
+    "py": {
+        "1": 3,
+    },
+},
+```
+
+which would then generate invalid CSS like:
+
+```css
+.paddingBlock\\\\:1_2 {
+  1: 2px;
+}
+
+.paddingBlock\\\\:1_3 {
+  1: 3px;
+}
+```
+
+it's now correctly transformed back to an array:
+
+```diff
+{
+  "py": {
+-    "1": 2,
++   [
++       undefined,
++       2,
++   ]
+  },
+},
+{
+  "py": {
+-    "1": 3,
++   [
++       undefined,
++       3,
++   ]
+  },
+},
+```
+
+which will generate the correct CSS
+
+```css
+@media screen and (min-width: 40em) {
+  .sm\\\\:py_2 {
+    padding-block: var(--spacing-2);
+  }
+
+  .sm\\\\:py_3 {
+    padding-block: var(--spacing-3);
+  }
+}
+```

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2188,6 +2188,157 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('array syntax - simple', () => {
+    const code = `
+        import { Box } from ".panda/jsx"
+
+         function App() {
+           return (
+            <Box paddingLeft={[0]} />
+          )
+         }
+       `
+
+    const result = run(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "paddingLeft": [
+                0,
+              ],
+            },
+          ],
+          "name": "Box",
+          "type": "jsx-pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .pl_0 {
+          padding-left: var(--spacing-0)
+          }
+      }"
+    `)
+  })
+
+  test('array syntax - simple conditional', () => {
+    const code = `
+        import { Box } from ".panda/jsx"
+
+         function App() {
+           return (
+            <Box paddingLeft={hasIcon ? [0] : [4]} />
+          )
+         }
+       `
+
+    const result = run(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "paddingLeft": [
+                0,
+              ],
+            },
+            {
+              "paddingLeft": [
+                4,
+              ],
+            },
+            {},
+          ],
+          "name": "Box",
+          "type": "jsx-pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .pl_0 {
+          padding-left: var(--spacing-0)
+          }
+
+        .pl_4 {
+          padding-left: var(--spacing-4)
+          }
+      }"
+    `)
+  })
+
+  test('array syntax - conditional in middle', () => {
+    const code = `
+        import { Box } from ".panda/jsx"
+
+         function App() {
+           return (
+            <Box py={[2, verticallyCondensed ? 2 : 3, 4]} />
+          )
+         }
+       `
+
+    const result = run(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "py": [
+                undefined,
+                2,
+              ],
+            },
+            {
+              "py": [
+                undefined,
+                3,
+              ],
+            },
+            {
+              "py": [
+                2,
+                undefined,
+                4,
+              ],
+            },
+          ],
+          "name": "Box",
+          "type": "jsx-pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .py_2 {
+          padding-block: var(--spacing-2)
+          }
+
+        @media screen and (min-width: 40em) {
+          .sm\\\\:py_2 {
+            padding-block: var(--spacing-2)
+          }
+
+          .sm\\\\:py_3 {
+            padding-block: var(--spacing-3)
+          }
+              }
+
+        @media screen and (min-width: 48em) {
+          .md\\\\:py_4 {
+            padding-block: var(--spacing-4)
+          }
+              }
+      }"
+    `)
+  })
 })
 
 describe('preset patterns', () => {


### PR DESCRIPTION
## 📝 Description

Fix static extraction of the [Array Syntax](https://panda-css.com/docs/concepts/responsive-design#the-array-syntax) when
used with runtime conditions

Given a component like this:

```ts
function App() {
  return <Box py={[2, verticallyCondensed ? 2 : 3, 4]} />
}
```

the `py` value was incorrectly extracted like this:

```ts
 {
    "py": {
        "1": 2,
    },
},
{
    "py": {
        "1": 3,
    },
},
```

which would then generate invalid CSS like:

```css
.paddingBlock\\\\:1_2 {
  1: 2px;
}

.paddingBlock\\\\:1_3 {
  1: 3px;
}
```

it's now correctly transformed back to an array:

```diff
{
  "py": {
-    "1": 2,
+   [
+       undefined,
+       2,
+   ]
  },
},
{
  "py": {
-    "1": 3,
+   [
+       undefined,
+       3,
+   ]
  },
},
```

which will generate the correct CSS

```css
@media screen and (min-width: 40em) {
  .sm\\\\:py_2 {
    padding-block: var(--spacing-2);
  }

  .sm\\\\:py_3 {
    padding-block: var(--spacing-3);
  }
}
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

also fix a cache issue with unbox, which would only cache the `raw` value but not the conditions
