### PR TITLE
feat(cli): cssgen --minimal / cssgen of type

### DIFF
--- a/.changeset/many-apes-love.md
+++ b/.changeset/many-apes-love.md
@@ -1,0 +1,44 @@
+---
+'@pandacss/generator': patch
+'@pandacss/node': patch
+'@pandacss/dev': patch
+---
+
+## --minimal flag
+
+Adds a new `--minimal` flag for the CLI on the `panda cssgen` command to skip generating CSS for theme tokens,
+preflightkeyframes, static and global css
+
+Thich means that the generated CSS will only contain the CSS related to the styles found in the included files.
+
+> Note that you can use a `glob` to override the `config.include` option like this:
+> `panda cssgen "src/**/*.css" --minimal`
+
+This is useful when you want to split your CSS into multiple files, for example if you want to split by pages.
+
+Use it like this:
+
+```bash
+panda cssgen "src/**/pages/*.css" --minimal --outfile dist/pages.css
+```
+
+---
+
+## cssgen {type}
+
+In addition to the optional `glob` that you can already pass to override the config.include option, the `panda cssgen`
+command now accepts a new `{type}` argument to generate only a specific type of CSS:
+
+- preflight
+- tokens
+- static
+- global
+- keyframes
+
+> Note that this only works when passing an `--outfile`.
+
+You can use it like this:
+
+```bash
+panda cssgen "static" --outfile dist/static.css
+```

--- a/.changeset/many-apes-love.md
+++ b/.changeset/many-apes-love.md
@@ -1,7 +1,7 @@
 ---
-'@pandacss/generator': patch
-'@pandacss/node': patch
-'@pandacss/dev': patch
+'@pandacss/generator': minor
+'@pandacss/node': minor
+'@pandacss/dev': minor
 ---
 
 ## --minimal flag

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,6 +13,7 @@ export interface CssGenCommandFlags {
   silent?: boolean
   clean?: boolean
   outfile?: string
+  minimal?: boolean
   watch?: boolean
   poll?: boolean
   cwd?: string

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -4,6 +4,11 @@ import { generateFlattenedCss } from './artifacts/css/flat-css'
 import { generateParserCss } from './artifacts/css/parser-css'
 import { getEngine } from './engines'
 import { getMessages } from './messages'
+import { generateStaticCss } from './artifacts/css/static-css'
+import { generateResetCss } from './artifacts/css/reset-css'
+import { generateTokenCss } from './artifacts/css/token-css'
+import { generateKeyframeCss } from './artifacts/css/keyframe-css'
+import { generateGlobalCss } from './artifacts/css/global-css'
 
 const defaults = (conf: ConfigResultWithHooks): ConfigResultWithHooks => ({
   ...conf,
@@ -46,8 +51,16 @@ export const createGenerator = (conf: ConfigResultWithHooks) => {
   return {
     ...ctx,
     getArtifacts: generateArtifacts(ctx),
+    //
+    getStaticCss: generateStaticCss,
+    getResetCss: generateResetCss,
+    getTokenCss: generateTokenCss,
+    getKeyframeCss: generateKeyframeCss,
+    getGlobalCss: generateGlobalCss,
+    //
     getCss: generateFlattenedCss(ctx),
     getParserCss: generateParserCss(ctx),
+    //
     messages: getMessages(ctx),
     parserOptions: {
       importMap: getImportMap(config.outdir.replace(relativeBaseUrl, ''), config.importMap),

--- a/packages/node/src/extract.ts
+++ b/packages/node/src/extract.ts
@@ -148,15 +148,19 @@ export type CssArtifactType = 'preflight' | 'tokens' | 'static' | 'global' | 'ke
  * Generates the CSS for a given artifact type
  */
 export async function generateCssArtifactOfType(ctx: PandaContext, cssType: CssArtifactType, outfile: string) {
+  let notFound = false
   const css = match(cssType)
     .with('preflight', () => ctx.getResetCss(ctx))
     .with('tokens', () => ctx.getTokenCss(ctx))
     .with('static', () => ctx.getStaticCss(ctx))
     .with('global', () => ctx.getGlobalCss(ctx))
     .with('keyframes', () => ctx.getKeyframeCss(ctx))
-    .exhaustive()
+    .otherwise(() => {
+      notFound = true
+    })
 
-  if (!css) return { msg: `No css artifact of type <${cssType}> was found` }
+  if (notFound) return { msg: `No css artifact of type <${cssType}> was found` }
+  if (!css) return { msg: `No css to generate for type <${cssType}>` }
 
   await writeFile(outfile, css)
   return { msg: `Successfully generated ${cssType} css artifact ✨` }

--- a/packages/node/src/extract.ts
+++ b/packages/node/src/extract.ts
@@ -3,8 +3,14 @@ import { Obj, pipe, tap, tryCatch } from 'lil-fp'
 import { createBox } from './cli-box'
 import type { PandaContext } from './create-context'
 import { writeFile } from 'fs/promises'
+import { createParserResult } from '@pandacss/parser'
+import { match } from 'ts-pattern'
 
-export async function bundleChunks(ctx: PandaContext) {
+/**
+ * Bundles all the included files CSS into outdir/styles.css
+ * And import the root CSS artifacts files (global, static, reset, tokens, keyframes) in there
+ */
+export async function bundleStyleChunksWithImports(ctx: PandaContext) {
   const files = ctx.chunks.getFiles()
   await ctx.output.write({
     dir: ctx.paths.root,
@@ -13,6 +19,9 @@ export async function bundleChunks(ctx: PandaContext) {
   return { files, msg: ctx.messages.buildComplete(files.length) }
 }
 
+/**
+ * Writes in outdir/chunks/{file}.css
+ */
 export async function writeFileChunk(ctx: PandaContext, file: string) {
   const { path } = ctx.runtime
   logger.debug('chunk:write', `File: ${path.relative(ctx.config.cwd, file)}`)
@@ -24,6 +33,9 @@ export async function writeFileChunk(ctx: PandaContext, file: string) {
   return ctx.output.write(artifact)
 }
 
+/**
+ * Parse a file and return the corresponding css
+ */
 export function extractFile(ctx: PandaContext, file: string) {
   const {
     runtime: { path },
@@ -47,7 +59,10 @@ export function extractFile(ctx: PandaContext, file: string) {
   )
 }
 
-function extractFiles(ctx: PandaContext) {
+/**
+ * Writes all the css chunks in outdir/chunks/{file}.css
+ */
+function writeChunks(ctx: PandaContext) {
   return Promise.allSettled(ctx.getFiles().map((file) => writeFileChunk(ctx, file)))
 }
 
@@ -70,22 +85,79 @@ export async function emitArtifacts(ctx: PandaContext) {
   }
 }
 
-export async function emitAndExtract(ctx: PandaContext) {
+export async function emitArtfifactsAndCssChunks(ctx: PandaContext) {
   await emitArtifacts(ctx)
   if (ctx.config.emitTokensOnly) {
     return { files: [], msg: 'Successfully rebuilt the css variables and js function to query your tokens ✨' }
   }
-  return extractCss(ctx)
+  return writeAndBundleCssChunks(ctx)
 }
 
-export async function extractCss(ctx: PandaContext) {
-  await extractFiles(ctx)
-  return bundleChunks(ctx)
+/**
+ * Writes all the css chunks in outdir/chunks/{file}.css
+ * and bundles them in outdir/styles.css
+ */
+export async function writeAndBundleCssChunks(ctx: PandaContext) {
+  await writeChunks(ctx)
+  return bundleStyleChunksWithImports(ctx)
 }
 
+/**
+ * Bundles all the included files CSS into the given outfile
+ * Including the root CSS artifact files content (global, static, reset, tokens, keyframes)
+ * Without any imports
+ */
 export async function bundleCss(ctx: PandaContext, outfile: string) {
-  const extracted = await extractFiles(ctx)
+  const extracted = await writeChunks(ctx)
   const files = ctx.chunks.getFiles()
   await writeFile(outfile, ctx.getCss({ files, resolve: true }))
   return { files, msg: ctx.messages.buildComplete(extracted.length) }
+}
+
+/**
+ * Bundles all the files CSS into outdir/chunks/{file}.css
+ * Without writing any chunks or needing any imports
+ */
+export async function bundleMinimalFilesCss(ctx: PandaContext, outfile: string) {
+  const files = ctx.getFiles()
+  const filesWithCss = []
+
+  const collector = createParserResult()
+
+  files.forEach((file) => {
+    const measure = logger.time.debug(`Parsed ${file}`)
+    const result = ctx.project.parseSourceFile(file)
+
+    measure()
+    if (!result) return
+
+    collector.merge(result)
+    filesWithCss.push(file)
+  })
+
+  const css = ctx.getParserCss(collector)
+  if (!css) return { files, msg: ctx.messages.buildComplete(files.length) }
+
+  await writeFile(outfile, css)
+  return { files, msg: ctx.messages.buildComplete(files.length) }
+}
+
+export type CssArtifactType = 'preflight' | 'tokens' | 'static' | 'global' | 'keyframes'
+
+/**
+ * Generates the CSS for a given artifact type
+ */
+export async function generateCssArtifactOfType(ctx: PandaContext, cssType: CssArtifactType, outfile: string) {
+  const css = match(cssType)
+    .with('preflight', () => ctx.getResetCss(ctx))
+    .with('tokens', () => ctx.getTokenCss(ctx))
+    .with('static', () => ctx.getStaticCss(ctx))
+    .with('global', () => ctx.getGlobalCss(ctx))
+    .with('keyframes', () => ctx.getKeyframeCss(ctx))
+    .exhaustive()
+
+  if (!css) return { msg: `No css artifact of type <${cssType}> was found` }
+
+  await writeFile(outfile, css)
+  return { msg: `Successfully generated ${cssType} css artifact ✨` }
 }

--- a/packages/node/src/generate.ts
+++ b/packages/node/src/generate.ts
@@ -2,11 +2,11 @@ import { logger } from '@pandacss/logger'
 import type { Config } from '@pandacss/types'
 import { match } from 'ts-pattern'
 import type { PandaContext } from './create-context'
-import { bundleChunks, emitAndExtract, writeFileChunk } from './extract'
+import { bundleStyleChunksWithImports, emitArtfifactsAndCssChunks, writeFileChunk } from './extract'
 import { loadContext } from './load-context'
 
 async function build(ctx: PandaContext) {
-  const { msg } = await emitAndExtract(ctx)
+  const { msg } = await emitArtfifactsAndCssChunks(ctx)
   logger.info('css:emit', msg)
 }
 
@@ -42,11 +42,11 @@ export async function generate(config: Config, configPath?: string) {
         .with('change', async () => {
           ctx.project.reloadSourceFile(file)
           await writeFileChunk(ctxRef.current, file)
-          return bundleChunks(ctxRef.current)
+          return bundleStyleChunksWithImports(ctxRef.current)
         })
         .with('add', async () => {
           ctx.project.createSourceFile(file)
-          return bundleChunks(ctxRef.current)
+          return bundleStyleChunksWithImports(ctxRef.current)
         })
         .otherwise(() => {
           // noop

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -5,7 +5,16 @@ export { findConfig, loadConfigAndCreateContext } from './config'
 export { createContext, type PandaContext } from './create-context'
 export { debugFiles } from './debug-files'
 export { execCommand } from './exec-command'
-export { bundleCss, emitAndExtract, emitArtifacts, extractCss, extractFile } from './extract'
+export {
+  bundleCss,
+  bundleMinimalFilesCss,
+  emitArtfifactsAndCssChunks,
+  emitArtifacts,
+  writeAndBundleCssChunks,
+  extractFile,
+  generateCssArtifactOfType,
+  type CssArtifactType,
+} from './extract'
 export { generate } from './generate'
 export { setupGitIgnore } from './git-ignore'
 export { parseDependency } from './parse-dependency'

--- a/website/pages/docs/references/cli.md
+++ b/website/pages/docs/references/cli.md
@@ -143,6 +143,26 @@ Related: [`config.logLevel`](/docs/references/config#log-level)
 
 Generate the CSS from files.
 
+You can use a `glob` to override the `config.include` option like this:
+
+`panda cssgen "src/**/*.css" --outfile dist.css`
+
+or you can use it with a `{type}` argument to generate only a specific type of CSS:
+
+- preflight
+- tokens
+- static
+- global
+- keyframes
+
+> Note that this only works when passing an `--outfile`.
+
+You can use it like this:
+
+```bash
+panda cssgen "static" --outfile dist/static.css
+```
+
 ### Flags
 
 #### `--clean`
@@ -168,6 +188,23 @@ Related: [`config.cwd`](/docs/references/config#cwd)
 Whether to suppress all output
 
 Related: [`config.logLevel`](/docs/references/config#log-level)
+
+## `--minimal`
+
+Skip generating CSS for theme tokens, preflight, keyframes, static and global css.
+
+Thich means that the generated CSS will only contain the CSS related to the styles found in the included files.
+
+> Note that you can use a `glob` to override the `config.include` option like this:
+> `panda cssgen "src/**/*.css" --minimal`
+
+This is useful when you want to split your CSS into multiple files, for example if you want to split by pages.
+
+Use it like this:
+
+```bash
+panda cssgen "src/**/pages/*.css" --minimal --outfile dist/pages.css
+```
 
 ## `panda studio`
 


### PR DESCRIPTION
## 📝 Description

## --minimal flag

Adds a new `--minimal` flag for the CLI on the `panda cssgen` command to skip generating CSS for theme tokens,
preflightkeyframes, static and global css

Thich means that the generated CSS will only contain the CSS related to the styles found in the included files.

> Note that you can use a `glob` to override the `config.include` option like this:
> `panda cssgen "src/**/*.css" --minimal`

This is useful when you want to split your CSS into multiple files, for example if you want to split by pages.

Use it like this:

```bash
panda cssgen "src/**/pages/*.css" --minimal --outfile dist/pages.css
```

---

## cssgen {type}

In addition to the optional `glob` that you can already pass to override the config.include option, the `panda cssgen`
command now accepts a new `{type}` argument to generate only a specific type of CSS:

- preflight
- tokens
- static
- global
- keyframes

> Note that this only works when passing an `--outfile`.

You can use it like this:

```bash
panda cssgen "static" --outfile dist/static.css
```


## 💣 Is this a breaking change (Yes/No):

no