### PR TITLE
refactor: use `promise.allSettled`

### DIFF
--- a/.changeset/pretty-lamps-tease.md
+++ b/.changeset/pretty-lamps-tease.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+'@pandacss/node': patch
+---
+
+- Fix issue with `Promise.all` where it aborts premature ine weird events. Switched to `Promise.allSettled`

--- a/packages/generator/src/artifacts/css/flat-css.ts
+++ b/packages/generator/src/artifacts/css/flat-css.ts
@@ -37,7 +37,8 @@ export const generateFlattenedCss = (ctx: Context) => (options: { files: string[
   sheet.append(...files)
 
   const output = sheet.toCss({ optimize: true, minify })
-  ctx.hooks.callHook('generator:css', 'styles.css', output)
+
+  void ctx.hooks.callHook('generator:css', 'styles.css', output)
 
   return output
 }

--- a/packages/generator/src/artifacts/css/global-css.ts
+++ b/packages/generator/src/artifacts/css/global-css.ts
@@ -44,6 +44,8 @@ export const generateGlobalCss = (ctx: Context) => {
   sheet.processGlobalCss(globalCss)
 
   const output = sheet.toCss({ optimize })
-  ctx.hooks.callHook('generator:css', 'global.css', output)
+
+  void ctx.hooks.callHook('generator:css', 'global.css', output)
+
   return output
 }

--- a/packages/generator/src/artifacts/css/keyframe-css.ts
+++ b/packages/generator/src/artifacts/css/keyframe-css.ts
@@ -23,6 +23,8 @@ export function generateKeyframeCss(ctx: Context) {
   })
 
   const output = rule.toString()
-  ctx.hooks.callHook('generator:css', 'keyframes.css', output)
+
+  void ctx.hooks.callHook('generator:css', 'keyframes.css', output)
+
   return output
 }

--- a/packages/generator/src/artifacts/css/parser-css.ts
+++ b/packages/generator/src/artifacts/css/parser-css.ts
@@ -88,7 +88,7 @@ export const generateParserCss = (ctx: Context) => (result: ParserResultType) =>
     tryCatch(
       ({ sheet, result, config: { minify, optimize } }) => {
         const css = !result.isEmpty() ? sheet.toCss({ minify, optimize }) : undefined
-        ctx.hooks.callHook('parser:css', result.filePath ?? '', css)
+        void ctx.hooks.callHook('parser:css', result.filePath ?? '', css)
         return css
       },
       (err) => {

--- a/packages/generator/src/artifacts/css/reset-css.ts
+++ b/packages/generator/src/artifacts/css/reset-css.ts
@@ -212,6 +212,7 @@ export function generateResetCss(ctx: Context, scope = '') {
   }
 }`
 
-  ctx.hooks.callHook('generator:css', 'reset.css', output)
+  void ctx.hooks.callHook('generator:css', 'reset.css', output)
+
   return output
 }

--- a/packages/generator/src/artifacts/css/static-css.ts
+++ b/packages/generator/src/artifacts/css/static-css.ts
@@ -38,6 +38,8 @@ export const generateStaticCss = (ctx: Context) => {
   })
 
   const output = sheet.toCss({ optimize })
-  ctx.hooks.callHook('generator:css', 'static.css', output)
+
+  void ctx.hooks.callHook('generator:css', 'static.css', output)
+
   return output
 }

--- a/packages/generator/src/artifacts/css/token-css.ts
+++ b/packages/generator/src/artifacts/css/token-css.ts
@@ -51,7 +51,7 @@ export function generateTokenCss(ctx: Context) {
   }
   `
 
-  ctx.hooks.callHook('generator:css', 'tokens.css', output)
+  void ctx.hooks.callHook('generator:css', 'tokens.css', output)
   return output
 }
 

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -189,7 +189,7 @@ export class Builder {
 
     const done = logger.time.info('Extracted in')
 
-    await Promise.all(ctx.getFiles().map((file) => this.extractFile(ctx, file)))
+    await Promise.allSettled(ctx.getFiles().map((file) => this.extractFile(ctx, file)))
 
     done()
   }

--- a/packages/node/src/debug-files.ts
+++ b/packages/node/src/debug-files.ts
@@ -20,7 +20,7 @@ export async function debugFiles(ctx: PandaContext, options: { outdir: string; d
   }
 
   const filesWithCss = []
-  await Promise.all(
+  await Promise.allSettled(
     files.map(async (file) => {
       const measure = logger.time.debug(`Parsed ${file}`)
       const result = ctx.project.parseSourceFile(file)
@@ -47,7 +47,7 @@ export async function debugFiles(ctx: PandaContext, options: { outdir: string; d
         logger.info('cli', `Writing ${colors.bold(`${outdir}/${astJsonPath}`)}`)
         logger.info('cli', `Writing ${colors.bold(`${outdir}/${cssPath}`)}`)
 
-        return Promise.all([
+        return Promise.allSettled([
           fs.writeFile(`${outdir}/${astJsonPath}`, JSON.stringify(result.toJSON(), null, 2)),
           fs.writeFile(`${outdir}/${cssPath}`, css),
         ])

--- a/packages/node/src/extract.ts
+++ b/packages/node/src/extract.ts
@@ -48,7 +48,7 @@ export function extractFile(ctx: PandaContext, file: string) {
 }
 
 function extractFiles(ctx: PandaContext) {
-  return Promise.all(ctx.getFiles().map((file) => writeFileChunk(ctx, file)))
+  return Promise.allSettled(ctx.getFiles().map((file) => writeFileChunk(ctx, file)))
 }
 
 const randomWords = ['Sweet', 'Divine', 'Pandalicious', 'Super']
@@ -56,8 +56,11 @@ const pickRandom = (arr: string[]) => arr[Math.floor(Math.random() * arr.length)
 
 export async function emitArtifacts(ctx: PandaContext) {
   if (ctx.config.clean) ctx.output.empty()
-  await Promise.all(ctx.getArtifacts().map(ctx.output.write))
-  ctx.hooks.callHook('generator:done')
+
+  await Promise.allSettled(ctx.getArtifacts().map(ctx.output.write))
+
+  void ctx.hooks.callHook('generator:done')
+
   return {
     box: createBox({
       content: ctx.messages.codegenComplete(),

--- a/packages/node/src/output-engine.ts
+++ b/packages/node/src/output-engine.ts
@@ -15,7 +15,7 @@ export const getOutputEngine = ({
     const { dir = paths.root, files } = output
     fs.ensureDirSync(path.join(...dir))
 
-    return Promise.all(
+    return Promise.allSettled(
       files.map(async ({ file, code }) => {
         const absPath = path.join(...dir, file)
         if (code) {


### PR DESCRIPTION
Closes #1435

## 📝 Description

This PR refactors all promises to use `Promise.allSettled` to avoid early aborting of the promise chain.

## ⛳️ Current behavior (updates)

Fails intermittently

## 🚀 New behavior

Should work as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
