### PR TITLE
feat(postcss): silent option

### DIFF
--- a/.changeset/empty-rats-swim.md
+++ b/.changeset/empty-rats-swim.md
@@ -1,0 +1,16 @@
+---
+'@pandacss/postcss': patch
+'@pandacss/node': patch
+---
+
+Adds a new `silent` boolean option to the PostCSS plugin to suppress all output.
+
+```js
+module.exports = {
+  plugins: {
+    '@pandacss/dev/postcss': {
+      silent: true,
+    },
+  },
+}
+```

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -10,6 +10,7 @@ import { findConfig, loadConfigAndCreateContext } from './config'
 import { type PandaContext } from './create-context'
 import { emitArtifacts, extractFile } from './extract'
 import { parseDependency } from './parse-dependency'
+import type { Config } from '@pandacss/types'
 
 type ContentData = {
   fileCssMap: Map<string, string>
@@ -39,6 +40,13 @@ export class Builder {
   context: PandaContext | undefined
 
   configDependencies: Set<string> = new Set()
+
+  configOverrides: Config | undefined
+
+  constructor(overrides: Config = {}) {
+    this.configOverrides = overrides
+    if (this.configOverrides?.logLevel) logger.level = this.configOverrides.logLevel
+  }
 
   writeFileCss = (file: string, css: string) => {
     const oldCss = this.fileCssMap?.get(file) ?? ''
@@ -133,7 +141,7 @@ export class Builder {
   setupContext = async (options: { configPath: string; depsModifiedMap: Map<string, number> }) => {
     const { configPath, depsModifiedMap } = options
 
-    this.context = await loadConfigAndCreateContext({ configPath })
+    this.context = await loadConfigAndCreateContext({ configPath, config: this.configOverrides })
 
     // don't emit artifacts on first setup
     if (setupCount > 0) {

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -10,9 +10,15 @@ const interopDefault = (obj: any) => (obj && obj.__esModule ? obj.default : obj)
 
 export const loadConfig = () => interopDefault(require('@pandacss/postcss'))
 
-export const pandacss: PluginCreator<{ configPath?: string; cwd?: string }> = (options = {}) => {
-  const { configPath, cwd } = options
-  const builder = new Builder()
+interface PluginOptions {
+  configPath?: string
+  cwd?: string
+  silent?: boolean
+}
+
+export const pandacss: PluginCreator<PluginOptions> = (options = {}) => {
+  const { configPath, cwd, silent } = options
+  const builder = new Builder({ logLevel: silent ? 'silent' : undefined })
 
   return {
     postcssPlugin: PLUGIN_NAME,


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1451

## 📝 Description

Adds a new `silent` boolean option to the PostCSS plugin to suppress all output.

```js
module.exports = {
  plugins: {
    '@pandacss/dev/postcss': {
      silent: true,
    },
  },
}
```


## 💣 Is this a breaking change (Yes/No):

no
