### PR TITLE
feat: better slot recipe jsx defaults

### DIFF
--- a/.changeset/slimy-ducks-beg.md
+++ b/.changeset/slimy-ducks-beg.md
@@ -1,0 +1,15 @@
+---
+'@pandacss/core': patch
+---
+
+Automatically add each recipe slots to the `jsx` property, with a dot notation
+
+```ts
+const button = defineSlotRecipe({
+  className: 'button',
+  slots: ['root', 'icon', 'label'],
+  // ...
+})
+```
+
+will have a default `jsx` property of: `[Button, Button.Root, Button.Icon, Button.Label]`

--- a/packages/core/__tests__/fixture.ts
+++ b/packages/core/__tests__/fixture.ts
@@ -64,7 +64,7 @@ export function processSlotRecipe(recipe: 'button', value: Record<string, any>) 
   const recipes = new Recipes(mocks.slotRecipes, createContext())
   recipes.save()
   recipes.process(recipe, { styles: value })
-  return recipes.toCss()
+  return recipes
 }
 
 export const compositions = {

--- a/packages/core/__tests__/slot-recipe.test.ts
+++ b/packages/core/__tests__/slot-recipe.test.ts
@@ -3,7 +3,7 @@ import { processSlotRecipe } from './fixture'
 
 describe('slot recipe ruleset', () => {
   test('should work', () => {
-    expect(processSlotRecipe('button', { size: 'sm' })).toMatchInlineSnapshot(`
+    expect(processSlotRecipe('button', { size: 'sm' }).toCss()).toMatchInlineSnapshot(`
       "@layer recipes.slots {
           @layer _base {
               .button__container {
@@ -25,6 +25,71 @@ describe('slot recipe ruleset', () => {
               font-size: 2rem
           }
       }"
+    `)
+  })
+
+  test('assigned recipe with default jsx from slots', () => {
+    expect(processSlotRecipe('button', { size: 'sm' }).getRecipe('button')).toMatchInlineSnapshot(`
+      {
+        "baseName": "button",
+        "config": {
+          "base": {
+            "container": {
+              "fontFamily": "mono",
+            },
+            "icon": {
+              "fontSize": "1.5rem",
+            },
+          },
+          "className": "button",
+          "slots": [
+            "container",
+            "icon",
+          ],
+          "variants": {
+            "size": {
+              "md": {
+                "container": {
+                  "fontSize": "3rem",
+                  "lineHeight": "1.2em",
+                },
+              },
+              "sm": {
+                "container": {
+                  "fontSize": "5rem",
+                  "lineHeight": "1em",
+                },
+                "icon": {
+                  "fontSize": "2rem",
+                },
+              },
+            },
+          },
+        },
+        "dashName": "button",
+        "jsx": [
+          "Button",
+          "Button.Container",
+          "Button.Icon",
+        ],
+        "jsxName": "Button",
+        "match": /\\^Button\\$\\|\\^Button\\.Container\\$\\|\\^Button\\.Icon\\$/,
+        "props": [
+          "size",
+        ],
+        "splitProps": [Function],
+        "type": "recipe",
+        "upperName": "Button",
+        "variantKeyMap": {
+          "size": [
+            "sm",
+            "md",
+          ],
+        },
+        "variantKeys": [
+          "size",
+        ],
+      }
     `)
   })
 })

--- a/packages/core/src/recipes.ts
+++ b/packages/core/src/recipes.ts
@@ -78,7 +78,12 @@ export class Recipes {
 
   private assignRecipe = (name: string, recipe: RecipeConfig | SlotRecipeConfig) => {
     const variantKeys = Object.keys(recipe.variants ?? {})
-    const jsx = recipe.jsx ?? [capitalize(name)]
+    const capitalized = capitalize(name)
+    const jsx = recipe.jsx ?? [capitalized]
+    if ('slots' in recipe) {
+      jsx.push(...recipe.slots.map((slot) => capitalized + '.' + capitalize(slot)))
+    }
+
     const match = createRegex(jsx)
 
     sharedState.nodes.set(name, {


### PR DESCRIPTION
## 📝 Description

Automatically add each recipe slots to the `jsx` property, with a dot notation

```ts
const button = defineSlotRecipe({
  className: 'button',
  slots: ['root', 'icon', 'label'],
  // ...
})
```

will have a default `jsx` property of: `[Button, Button.Root, Button.Icon, Button.Label]`

## 💣 Is this a breaking change (Yes/No):

no
