### PR TITLE
fix(generator): fix qwik component typings

### DIFF
--- a/.changeset/curvy-keys-sparkle.md
+++ b/.changeset/curvy-keys-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+correct typings for Qwik components

--- a/packages/generator/src/artifacts/qwik-jsx/types.ts
+++ b/packages/generator/src/artifacts/qwik-jsx/types.ts
@@ -24,7 +24,7 @@ export type ComponentProps<T extends ElementType> = T extends keyof QwikIntrinsi
 
 type Dict = Record<string, unknown>
 
-export interface ${componentName}<T extends ElementType, P extends Dict = {}> extends Component<Assign<ComponentProps<T>, PatchedHTMLProps, Assign<JsxStyleProps, P>>> {}
+export interface ${componentName}<T extends ElementType, P extends Dict = {}> extends Component<Assign<ComponentProps<T>, Assign<PatchedHTMLProps, Assign<JsxStyleProps, P>>>> {}
 
 interface RecipeFn { __type: any }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #1507 

## 📝 Description

There was a missing `Assign` inside the component typings.

## ⛳️ Current behavior (updates)

Qwik typings were broken.

## 🚀 New behavior

Qwik typings are now working

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The issue describes this in greater detail. 
