### PR TITLE
fix(#1451): apply config.logLevel in context

### DIFF
--- a/.changeset/mean-dogs-type.md
+++ b/.changeset/mean-dogs-type.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/node': patch
+---
+
+Apply `config.logLevel` from the Panda config to the logger in every context.
+
+Fixes https://github.com/chakra-ui/panda/issues/1451

--- a/packages/node/src/create-context.ts
+++ b/packages/node/src/create-context.ts
@@ -5,6 +5,7 @@ import type { Runtime } from '@pandacss/types'
 import { getChunkEngine } from './chunk-engine'
 import { nodeRuntime } from './node-runtime'
 import { getOutputEngine } from './output-engine'
+import { logger } from '@pandacss/logger'
 
 export const createContext = (conf: ConfigResultWithHooks) => {
   const generator = createGenerator(conf)
@@ -12,6 +13,10 @@ export const createContext = (conf: ConfigResultWithHooks) => {
   const runtime = nodeRuntime
 
   config.cwd ||= runtime.cwd()
+
+  if (config.logLevel) {
+    logger.level = config.logLevel
+  }
 
   const { include, exclude, cwd } = config
   const getFiles = () => runtime.fs.glob({ include, exclude, cwd })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1451

## 📝 Description

Apply `config.logLevel` from the Panda config to the logger in every context.

## 💣 Is this a breaking change (Yes/No):

no
