### PR TITLE
fix(#1506): cssVarRoot issue with multiple selectors

### DIFF
--- a/.changeset/bright-worms-live.md
+++ b/.changeset/bright-worms-live.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix an issue with the `@layer tokens` CSS declarations when using `cssVarRoot` with multiple selectors, like
+`root, :host, ::backdrop`

--- a/packages/generator/__tests__/cleanup-selector.test.ts
+++ b/packages/generator/__tests__/cleanup-selector.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest'
+import { cleanupSelectors } from '../src/artifacts/css/token-css'
+
+const css = `
+  @layer tokens {
+
+      .class1, :AAAA .class2, :host .class3, :AAAA, :BBBB, ::CCCC .class2 {
+          font-size: 1rem;
+      }
+
+      :host .class2, :AAAA, :BBBB, ::CCCC {
+          font-size: 2rem;
+      }
+    }
+`
+
+test('cleanupSelectors - single', () => {
+  const varSelector = ':AAAA'
+
+  expect(cleanupSelectors(css, varSelector)).toMatchInlineSnapshot(`
+    "
+      @layer tokens {
+
+          ::CCCC .class2 {
+              font-size: 1rem;
+          }
+
+          ::CCCC {
+              font-size: 2rem;
+          }
+        }
+    "
+  `)
+})
+
+test('cleanupSelectors - multiple', () => {
+  const varSelector = ':AAAA, :BBBB, ::CCCC'
+
+  expect(cleanupSelectors(css, varSelector)).toMatchInlineSnapshot(`
+    "
+      @layer tokens {
+
+          ::CCCC .class2 {
+              font-size: 1rem;
+          }
+
+          ::CCCC {
+              font-size: 2rem;
+          }
+        }
+    "
+  `)
+})

--- a/packages/generator/__tests__/cleanup-selector.test.ts
+++ b/packages/generator/__tests__/cleanup-selector.test.ts
@@ -21,11 +21,11 @@ test('cleanupSelectors - single', () => {
     "
       @layer tokens {
 
-          ::CCCC .class2 {
+          .class1,  .class2, :host .class3, :BBBB, ::CCCC .class2 {
               font-size: 1rem;
           }
 
-          ::CCCC {
+          :host .class2, :BBBB, ::CCCC {
               font-size: 2rem;
           }
         }
@@ -40,11 +40,11 @@ test('cleanupSelectors - multiple', () => {
     "
       @layer tokens {
 
-          ::CCCC .class2 {
+          .class1, :AAAA .class2, :host .class3, :AAAA, :BBBB, ::CCCC .class2 {
               font-size: 1rem;
           }
 
-          ::CCCC {
+          :host .class2, :AAAA, :BBBB, ::CCCC {
               font-size: 2rem;
           }
         }

--- a/packages/generator/src/artifacts/css/token-css.ts
+++ b/packages/generator/src/artifacts/css/token-css.ts
@@ -82,7 +82,7 @@ function getDeepestNode(node: AtRule | Rule): Rule | AtRule | undefined {
   return node
 }
 
-function cleanupSelectors(css: string, varSelector: string) {
+export function cleanupSelectors(css: string, varSelector: string) {
   const root = postcss.parse(css)
 
   root.walkRules((rule) => {

--- a/packages/generator/src/artifacts/css/token-css.ts
+++ b/packages/generator/src/artifacts/css/token-css.ts
@@ -86,11 +86,32 @@ export function cleanupSelectors(css: string, varSelector: string) {
   const root = postcss.parse(css)
 
   root.walkRules((rule) => {
+    // [':root', ' :host,', '  ::backdrop ']
+    const selectors = [] as string[]
     rule.selectors.forEach((selector) => {
-      const res = selector.split(varSelector).filter(Boolean)
-      if (res.length === 0) return
-      rule.selector = res.join(varSelector)
+      selectors.push(selector.trim())
     })
+
+    // ':root, :host, ::backdrop'
+    const ruleSelector = selectors.join(', ')
+    if (ruleSelector === varSelector) {
+      return
+    }
+
+    // ':root,:host,::backdrop'
+    const trimmedSelector = selectors.join(',')
+    if (trimmedSelector === varSelector) {
+      return
+    }
+
+    const selectorsWithoutVarRoot = selectors
+      .map((selector) => {
+        const res = selector.split(varSelector).filter(Boolean)
+        return res.join('')
+      })
+      .filter(Boolean)
+    if (selectorsWithoutVarRoot.length === 0) return
+    rule.selector = selectorsWithoutVarRoot.join(', ')
   })
 
   return root.toString()


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1506#issuecomment-1753829797

## 📝 Description

Fix an issue with the `@layer tokens` CSS declarations when using `cssVarRoot` with multiple selectors, like
`root, :host, ::backdrop`

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
