### PR TITLE
Add @pandacss/dev npm package niceties

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,5 @@
+# Panda CLI
+
+[Panda](https://panda-css.com/) is a CSS-in-JS tool with build time generated styles, RSC compatible, multi-variant support, and best-in-class developer experience.
+
+This package is the CLI - documentation can be found at https://panda-css.com/docs/installation/cli.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,12 @@
     "./package.json": "./package.json"
   },
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/cli"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes [no issue that I'm aware of - I thought it'd be quicker/more helpful to open a PR directly]

## 📝 Description

This adds some optional package.json content that makes the npm page for `@pandacss/dev` more welcoming.

## ⛳️ Current behavior (updates)

When a user like me who doesn't usually memorise GitHub URLs wants to look for the information for a certain package, or the version history of it, goes to `https://npmjs.com/package/@pandacss/dev` (which is easier to remember because the package name is in my local package.json) - I see no helpful links to the GitHub repo, or the docs site, or really anything:

<img width="1424" alt="image" src="https://github.com/chakra-ui/panda/assets/15040698/fe3f37d0-8424-4fd6-bffd-9f44d444e42a">

## 🚀 New behavior

The user will see:

- A couple of lines in the readme describing what the package is
- A link in the sidebar to the github repo which navigates to the cli package specifically
- A link in the sidebar to pandacss.com
- A count of open issues and pull requests

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I copied some of the basic language from the docs site - I don't feel at all tied to it, just needed something in there, so feel free to add/edit/delete/whatever. IMO it'd also be nice to have a panda logo there etc. but I'll leave that to maintainers to add as a followup if they feel like it.