### PR TITLE
feat(extractor): EnumDeclaration

### DIFF
--- a/.changeset/soft-seahorses-provide.md
+++ b/.changeset/soft-seahorses-provide.md
@@ -1,0 +1,16 @@
+---
+'@pandacss/extractor': patch
+---
+
+Extract identifier values coming from an `EnumDeclaration` member
+
+Example:
+
+```ts
+enum Color {
+  Red = 'red.400',
+  Blue = 'blue.400',
+}
+
+const className = css({ color: Color.Red, backgroundColor: Color['Blue'] })
+```

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5794,3 +5794,77 @@ it('extracts arrays without removing nullish values', () => {
     }
   `)
 })
+
+it('handles TS enum', () => {
+  const code = `import { sva } from 'styled-system/css';
+
+  enum Size {
+    S = 's',
+    L = 'l',
+  };
+
+  enum Color {
+    Red = 'red.400',
+    Blue = 'blue.400',
+  }
+
+  const className = css({ color: Color.Red, backgroundColor: Color["Blue"] })
+
+  const useStyles = sva({
+    slots: ['root'],
+    base: {
+      root: {}
+    },
+    variants: {
+      size: {
+        [Size.S]: {
+          root: {
+            bgColor: 'red'
+          }
+        }
+      }
+    }
+  });`
+
+  expect(extractFromCode(code, { functionNameList: ['css', 'sva'] })).toMatchInlineSnapshot(`
+    {
+      "css": [
+        {
+          "conditions": [],
+          "raw": [
+            {
+              "backgroundColor": "blue.400",
+              "color": "red.400",
+            },
+          ],
+          "spreadConditions": [],
+        },
+      ],
+      "sva": [
+        {
+          "conditions": [],
+          "raw": [
+            {
+              "base": {
+                "root": {},
+              },
+              "slots": [
+                "root",
+              ],
+              "variants": {
+                "size": {
+                  "s": {
+                    "root": {
+                      "bgColor": "red",
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/extractor/src/find-identifier-value-declaration.ts
+++ b/packages/extractor/src/find-identifier-value-declaration.ts
@@ -25,6 +25,7 @@ export function getDeclarationFor(node: Identifier, stack: Node[], ctx: BoxConte
     (Node.isVariableDeclaration(parent) ||
       Node.isParameterDeclaration(parent) ||
       Node.isFunctionDeclaration(parent) ||
+      Node.isEnumDeclaration(parent) ||
       Node.isBindingElement(parent)) &&
     parent.getNameNode() == node
   ) {

--- a/packages/extractor/src/maybe-box-node.ts
+++ b/packages/extractor/src/maybe-box-node.ts
@@ -556,6 +556,18 @@ function maybePropDefinitionValue(def: Node, accessList: string[], _stack: Node[
     const value = maybeBindingElementValue(def, _stack, propName, ctx)
     if (value) return value
   }
+
+  if (Node.isEnumDeclaration(def)) {
+    const member = def.getMember(propName)
+    if (!member) return
+
+    const initializer = member.getInitializer()
+    if (!initializer) return
+
+    const innerStack = [..._stack, initializer]
+    const maybeValue = maybeBoxNode(initializer, innerStack, ctx)
+    if (maybeValue) return maybeValue
+  }
 }
 
 const maybePropIdentifierValue = (


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1572

## 📝 Description

Extract identifier values coming from an `EnumDeclaration` member

Example:

```ts
enum Color {
  Red = 'red.400',
  Blue = 'blue.400',
}

const className = css({ color: Color.Red, backgroundColor: Color['Blue'] })
```

## 💣 Is this a breaking change (Yes/No):

no