### PR TITLE
fix: postcss and emit failures in CI

### DIFF
--- a/.changeset/beige-geese-impress.md
+++ b/.changeset/beige-geese-impress.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/postcss': patch
+'@pandacss/node': patch
+---
+
+Fix persistent error that causes CI builds to fail due to PostCSS plugin emitting artifacts in the middle of a build
+process.

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -25,6 +25,8 @@ export const pandacss: PluginCreator<{ configPath?: string; cwd?: string }> = (o
           return
         }
 
+        builder.emit()
+
         await builder.extract()
 
         builder.registerDependency((dep) => {


### PR DESCRIPTION
## 📝 Description

This PR fixes a long-standing issue where CI builds fail randomly due to the PostCSS plugin emitting the codegen artifacts again in the middle of a build

## ⛳️ Current behavior (updates)

Inconsistent build results

![CleanShot 2023-10-25 at 15 07 19@2x](https://github.com/chakra-ui/panda/assets/6916170/ddc657a2-03f6-4984-8d3e-c7df5ed3a11e)


## 🚀 New behavior

Fixed permanently. We avoid re-running the codegen within the PostCSS process

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
