### PR TITLE
fix: reset css button color style

### DIFF
--- a/.changeset/hip-gorillas-sleep.md
+++ b/.changeset/hip-gorillas-sleep.md
@@ -1,0 +1,6 @@
+---
+"@pandacss/generator": patch
+"@pandacss/studio": patch
+---
+
+Fix issue in reset styles where button does not inherit color style

--- a/packages/generator/__tests__/generate-reset.test.ts
+++ b/packages/generator/__tests__/generate-reset.test.ts
@@ -100,6 +100,14 @@ describe('generate reset', () => {
             background-color: transparent;
             background-image: none;
           }
+          
+          .pd-reset button,
+          .pd-reset input,
+          .pd-reset optgroup,
+          .pd-reset select,
+          .pd-reset textarea {
+            color: inherit;
+          }
 
           .pd-reset button,
           .pd-reset select {

--- a/packages/generator/src/artifacts/css/reset-css.ts
+++ b/packages/generator/src/artifacts/css/reset-css.ts
@@ -99,6 +99,14 @@ export function generateResetCss(ctx: Context, scope = '') {
   }
 
   ${selector}button,
+  ${selector}input,
+  ${selector}optgroup,
+  ${selector}select,
+  ${selector}textarea {
+    color: inherit;
+  }
+
+  ${selector}button,
   ${selector}select {
     text-transform: none;
   }

--- a/packages/studio/styled-system/reset.css
+++ b/packages/studio/styled-system/reset.css
@@ -90,6 +90,14 @@
     background-color: transparent;
     background-image: none;
   }
+  
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    color: inherit;
+  }
 
   button,
   select {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In Safari there's default blue text color for some tags including button. It might cause pitfall in some cases.

For comparison Tailwind preflight resets button color.

```css
button,
input,
optgroup,
select,
textarea {
  font-family: inherit;
  font-feature-settings: inherit;
  font-variation-settings: inherit;
  font-size: 100%;
  font-weight: inherit;
  line-height: inherit;
  color: inherit;
  margin: 0;
  padding: 0;
}
```

## ⛳️ Current behavior (updates)

Some tag's text color is set to blue by Safari's user agent stylesheet.

## 🚀 New behavior

```css
button,
input,
optgroup,
select,
textarea {
  color: inherit;
}
```

## 💣 Is this a breaking change (Yes/No):

Maybe, but in a good way?

