### PR TITLE
fix(postcss): config change detection

### DIFF
--- a/.changeset/tame-jars-whisper.md
+++ b/.changeset/tame-jars-whisper.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/postcss': patch
+---
+
+Fix an issue with the Postcss builder config change detection, which triggered unnecessary a rebuild of the artifacts.

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -62,13 +62,13 @@ export class Builder {
       const time = stats.mtimeMs
       newModified.set(file, time)
 
-      if (!prevModified || !prevModified.has(file) || time > prevModified.get(file)!) {
+      if (prevModified && (!prevModified.has(file) || time > prevModified.get(file)!)) {
         modified = true
       }
     }
 
     if (!modified) {
-      return { isModified: false, modifiedMap: prevModified! }
+      return { isModified: false, modifiedMap: prevModified || new Map() }
     }
 
     for (const file of deps) {


### PR DESCRIPTION
## 📝 Description

Fix an issue with the Postcss builder config change detection, which triggered unnecessary a rebuild of the artifacts.

