### PR TITLE
studio: display semantic colors correctly

### DIFF
--- a/.changeset/hot-mangos-sip.md
+++ b/.changeset/hot-mangos-sip.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/studio': patch
+---
+
+Display semantic colors correctly in studio.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ packages/config/__tests__/samples/ts-import-map/ts-import-map-outdir/**
 packages/config/__tests__/samples/ts-import-map-one-source/outdir/**
 website/pages/**/*.mdx
 .draft/**/*.mdx
+styled-system

--- a/packages/studio/src/components/semantic-color.tsx
+++ b/packages/studio/src/components/semantic-color.tsx
@@ -1,14 +1,26 @@
 import { Flex, panda } from '../../styled-system/jsx'
 import { ColorWrapper } from './color-wrapper'
+import context from '../lib/panda.context'
+
+const getSemanticColorValue = (variable: string): string => {
+  const name = variable.match(/var\(\s*--(.*?)\s*\)/)![1].replaceAll('-', '.')
+  const token = context.tokens.getByName(name)
+  if (token) return token.originalValue
+  const defaultToken = context.tokens.getByName(`${name}.default`)
+  return getSemanticColorValue(defaultToken?.value)
+}
 
 // remove initial underscore
 const cleanCondition = (condition: string) => condition.replace(/^_/, '')
 
 export function SemanticColorDisplay(props: { value: string; condition: string; token?: string }) {
   const { value, condition, token } = props
+
+  const tokenValue = getSemanticColorValue(value)
+
   return (
     <Flex direction="column" w="full">
-      <ColorWrapper height="12" style={{ background: value }}>
+      <ColorWrapper height="12" style={{ background: tokenValue }}>
         <panda.span
           fontWeight="medium"
           fontSize="sm"
@@ -26,7 +38,7 @@ export function SemanticColorDisplay(props: { value: string; condition: string; 
       </ColorWrapper>
       {token && <panda.div fontWeight="medium">{token}</panda.div>}
       <panda.div opacity="0.7" fontSize="sm" textTransform="uppercase">
-        {value}
+        {value} - {tokenValue}
       </panda.div>
     </Flex>
   )


### PR DESCRIPTION
Display semantic colors correctly in studio.

**Before**
![CleanShot 2023-10-28 at 01 29 05@2x](https://github.com/chakra-ui/panda/assets/30869823/827e76da-5e02-4a8a-a98c-6c49de4e1070)

**After**
![CleanShot 2023-10-28 at 01 28 37@2x](https://github.com/chakra-ui/panda/assets/30869823/4c08c9e7-6d8f-453c-9371-bde269ab9880)

