### PR TITLE
docs: update text-styles

### DIFF
--- a/website/pages/docs/theming/text-styles.md
+++ b/website/pages/docs/theming/text-styles.md
@@ -30,7 +30,7 @@ export const textStyles = defineTextStyles({
     value: {
       fontFamily: 'Inter',
       fontWeight: '500',
-      fontSize: '16',
+      fontSize: '16px',
       lineHeight: '24',
       letterSpacing: '0',
       textDecoration: 'None',


### PR DESCRIPTION
## 📝 Description
The example for text-styles shows fontSize without a unit which has no effect on the styles. 

As someone new to panda this could be confusing. In some frameworks that have a set of default font sizings, a unitless fontSize might be valid.