### PR TITLE
fix(cli): cssgen/ship/analyze ensure dir exists before writing file

### DIFF
--- a/.changeset/brave-planets-cheat.md
+++ b/.changeset/brave-planets-cheat.md
@@ -2,4 +2,5 @@
 '@pandacss/node': patch
 ---
 
-Ensure dir exists before writing file for the `panda ship` and `panda analyze` commands
+Ensure dir exists before writing file for the `panda cssgen` / `panda ship` / `panda analyze` commands when specifying
+an outfile.

--- a/.changeset/brave-planets-cheat.md
+++ b/.changeset/brave-planets-cheat.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Ensure dir exists before writing file for the `panda ship` and `panda analyze` commands

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -180,6 +180,8 @@ export async function main() {
       const cssgen = async (ctx: PandaContext) => {
         if (outfile) {
           const outPath = resolve(cwd, outfile)
+          const dirname = ctx.runtime.path.dirname(outPath)
+          ctx.runtime.fs.ensureDirSync(dirname)
 
           if (cssArtifact) {
             const { msg } = await generateCssArtifactOfType(ctx, cssArtifact, outfile)

--- a/packages/node/src/analyze-tokens.ts
+++ b/packages/node/src/analyze-tokens.ts
@@ -84,14 +84,17 @@ const analyzeResultSerializer = (_key: string, value: any) => {
   return value
 }
 
-export const writeAnalyzeJSON = (fileName: string, result: ReturnType<typeof analyzeTokens>, ctx: PandaContext) => {
+export const writeAnalyzeJSON = (filePath: string, result: ReturnType<typeof analyzeTokens>, ctx: PandaContext) => {
   // prevent writing twice the same BoxNode in the output (already serialized in the `byId` map)
   result.details.byInstanceId.forEach((item) => {
     item.box = item.box.toJSON() as any
   })
 
+  const dirname = ctx.runtime.path.dirname(filePath)
+  ctx.runtime.fs.ensureDirSync(dirname)
+
   return writeFile(
-    fileName,
+    filePath,
     JSON.stringify(
       Object.assign(result, {
         cwd: ctx.config.cwd,

--- a/packages/node/src/ship-files.ts
+++ b/packages/node/src/ship-files.ts
@@ -27,6 +27,8 @@ export async function shipFiles(ctx: PandaContext, outfile: string) {
   logger.info('cli', `Writing ${minify ? '[min] ' : ' '}${colors.bold(outfile)}`)
 
   const output = JSON.stringify(extractResult.toJSON(), null, minify ? 0 : 2)
+  const dirname = ctx.runtime.path.dirname(outfile)
+  ctx.runtime.fs.ensureDirSync(dirname)
   await writeFile(outfile, output)
   logger.info('cli', 'Done!')
 }


### PR DESCRIPTION
Closes # https://github.com/chakra-ui/panda/discussions/1616

## 📝 Description

Ensure dir exists before writing file for the `panda ship` and `panda analyze` commands

## 💣 Is this a breaking change (Yes/No):

no
