### PR TITLE
Improve semantic colors in studio

### DIFF
--- a/.changeset/curly-adults-accept.md
+++ b/.changeset/curly-adults-accept.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/studio': patch
+---
+
+Improve semantic colors in studio

--- a/packages/studio/src/components/semantic-color.tsx
+++ b/packages/studio/src/components/semantic-color.tsx
@@ -5,11 +5,17 @@ import context from '../lib/panda.context'
 const getSemanticColorValue = (variable: string): string => {
   const _name = variable.match(/var\(\s*--(.*?)\s*\)/)
   if (!_name) return variable
+
   const name = _name[1].replaceAll('-', '.')
   const token = context.tokens.getByName(name)
-  if (token) return token.originalValue
-  const defaultToken = context.tokens.getByName(`${name}.default`)
-  return getSemanticColorValue(defaultToken?.value)
+
+  if (!token) {
+    const defaultToken = context.tokens.getByName(`${name}.default`)
+    return getSemanticColorValue(defaultToken?.value)
+  }
+
+  if (token.value.startsWith('var(--')) return getSemanticColorValue(token.value)
+  return token.value
 }
 
 // remove initial underscore


### PR DESCRIPTION
Improve semantic colors in studio 
**Before**
![CleanShot 2023-10-31 at 23 18 12@2x](https://github.com/chakra-ui/panda/assets/30869823/150ebc1f-5408-4829-afe1-a69cd7208e0f)


**After**

![CleanShot 2023-10-31 at 23 17 42@2x](https://github.com/chakra-ui/panda/assets/30869823/c393ca87-a69b-41cd-b68c-8b8179b54011)
