### PR TITLE
feat(cli): debug --only-config

### DIFF
--- a/.changeset/lucky-beds-sin.md
+++ b/.changeset/lucky-beds-sin.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Add a `--only-config` flag for the `panda debug` command, to skip writing app files and just output the resolved config.

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -355,6 +355,7 @@ export async function main() {
     .option('--silent', "Don't print any logs")
     .option('--dry', 'Output debug files in stdout without writing to disk')
     .option('--outdir [dir]', "Output directory for debug files, default to './styled-system/debug'")
+    .option('--only-config', "Should only output the config file, default to 'false'")
     .option('-c, --config <path>', 'Path to panda config file')
     .option('--cwd <cwd>', 'Current working directory', { default: cwd })
     .action(async (maybeGlob?: string, flags: DebugCommandFlags = {}) => {
@@ -374,7 +375,7 @@ export async function main() {
 
       const outdir = outdirFlag ?? join(...ctx.paths.root, 'debug')
 
-      await debugFiles(ctx, { outdir, dry })
+      await debugFiles(ctx, { outdir, dry, onlyConfig: flags.onlyConfig })
     })
 
   cli

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -43,6 +43,7 @@ export interface DebugCommandFlags {
   outdir?: string
   cwd?: string
   config?: string
+  onlyConfig?: boolean
 }
 
 export interface ShipCommandFlags {

--- a/packages/node/src/debug-files.ts
+++ b/packages/node/src/debug-files.ts
@@ -2,7 +2,7 @@ import { colors, logger } from '@pandacss/logger'
 import type { PandaContext } from './create-context'
 import * as nodePath from 'path'
 
-export async function debugFiles(ctx: PandaContext, options: { outdir: string; dry: boolean }) {
+export async function debugFiles(ctx: PandaContext, options: { outdir: string; dry: boolean; onlyConfig?: boolean }) {
   const files = ctx.getFiles()
   const measureTotal = logger.time.debug(`Done parsing ${files.length} files`)
 
@@ -17,6 +17,11 @@ export async function debugFiles(ctx: PandaContext, options: { outdir: string; d
     fs.ensureDirSync(outdir)
     logger.info('cli', `Writing ${colors.bold(`${outdir}/config.json`)}`)
     await fs.writeFile(`${outdir}/config.json`, JSON.stringify(ctx.config, null, 2))
+  }
+
+  if (options.onlyConfig) {
+    measureTotal()
+    return
   }
 
   const filesWithCss = []


### PR DESCRIPTION
## 📝 Description

Add a `--only-config` flag for the `panda debug` command, to skip writing app files and just output the resolved config.
