### PR TITLE
docs: fix example of assets token definition

### DIFF
--- a/website/pages/docs/theming/tokens.md
+++ b/website/pages/docs/theming/tokens.md
@@ -501,10 +501,10 @@ const theme = {
   tokens: {
     assets: {
       logo: {
-        value: { type: 'url', url: '/static/logo.png' }
+        value: { type: 'url', value: '/static/logo.png' }
       },
       checkmark: {
-        value: { type: 'svg', svg: '<svg>...</svg>' }
+        value: { type: 'svg', value: '<svg>...</svg>' }
       }
     }
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

>  Documentation provides an example of assets declaration that has a typo
![image](https://github.com/chakra-ui/panda/assets/33724243/08d2949d-9e6d-4457-adb0-5a8d7877a007)


## ⛳️ Current behavior (updates)

>  Fix `assets` example in documentation

## 🚀 New behavior

> change property `url` to `value`, matching type `Asset`
<img width="215" alt="image" src="https://github.com/chakra-ui/panda/assets/33724243/b9bfd9a5-c192-48ee-9a4a-c0d7a47c92c9">


## 💣 Is this a breaking change (Yes/No):
No
 
