### PR TITLE
fix(#1637) grid minChildWidth value

### DIFF
--- a/.changeset/lazy-rice-move.md
+++ b/.changeset/lazy-rice-move.md
@@ -1,0 +1,29 @@
+---
+'@pandacss/preset-base': patch
+'@pandacss/studio': patch
+---
+
+Fix an issue with the `grid` pattern from @pandacss/preset-base (included by default), setting a minChildWidth wasn't
+interpreted as a token value
+
+Before:
+
+```tsx
+<div className={grid({ minChildWidth: '80px', gap: 8 })} />
+// ✅ grid-template-columns: repeat(auto-fit, minmax(80px, 1fr))
+
+<div className={grid({ minChildWidth: '20', gap: 8 })} />
+// ❌ grid-template-columns: repeat(auto-fit, minmax(20, 1fr))
+//                                                  ^^^
+```
+
+After:
+
+```tsx
+<div className={grid({ minChildWidth: '80px', gap: 8 })} />
+// ✅ grid-template-columns: repeat(auto-fit, minmax(80px, 1fr))
+
+<div className={grid({ minChildWidth: '20', gap: 8 })} />
+// ✅ grid-template-columns: repeat(auto-fit, minmax(var(--sizes-20, 20), 1fr))
+//                                                  ^^^^^^^^^^^^^^^^^^^
+```

--- a/packages/generator/__tests__/generate-pattern.test.ts
+++ b/packages/generator/__tests__/generate-pattern.test.ts
@@ -587,8 +587,9 @@ test('should generate pattern', () => {
 
     const gridConfig = {
     transform(props, { map }) {
+      const regex = /\\\\d+(cm|in|pt|em|px|rem|vh|vmax|vmin|vw|ch|lh|%)$/;
       const { columnGap, rowGap, gap = columnGap || rowGap ? void 0 : \\"10px\\", columns, minChildWidth, ...rest } = props;
-      const getValue = (v) => v.includes(\\"px\\") || v.includes(\\"em\\") || v.includes(\\"%\\") ? v : \`token(sizes.\${v}, \${v})\`;
+      const getValue = (v) => regex.test(v) ? v : \`token(sizes.\${v}, \${v})\`;
       return {
         display: \\"grid\\",
         gridTemplateColumns: columns != null ? map(columns, (v) => \`repeat(\${getValue(v)}, minmax(0, 1fr))\`) : minChildWidth != null ? map(minChildWidth, (v) => \`repeat(auto-fit, minmax(\${getValue(v)}, 1fr))\`) : void 0,

--- a/packages/generator/__tests__/generate-pattern.test.ts
+++ b/packages/generator/__tests__/generate-pattern.test.ts
@@ -588,9 +588,10 @@ test('should generate pattern', () => {
     const gridConfig = {
     transform(props, { map }) {
       const { columnGap, rowGap, gap = columnGap || rowGap ? void 0 : \\"10px\\", columns, minChildWidth, ...rest } = props;
+      const getValue = (v) => v.includes(\\"px\\") || v.includes(\\"em\\") || v.includes(\\"%\\") ? v : \`token(sizes.\${v}, \${v})\`;
       return {
         display: \\"grid\\",
-        gridTemplateColumns: columns != null ? map(columns, (v) => \`repeat(\${v}, minmax(0, 1fr))\`) : minChildWidth != null ? map(minChildWidth, (v) => \`repeat(auto-fit, minmax(\${v}, 1fr))\`) : void 0,
+        gridTemplateColumns: columns != null ? map(columns, (v) => \`repeat(\${getValue(v)}, minmax(0, 1fr))\`) : minChildWidth != null ? map(minChildWidth, (v) => \`repeat(auto-fit, minmax(\${getValue(v)}, 1fr))\`) : void 0,
         gap,
         columnGap,
         rowGap,

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2579,6 +2579,66 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test.only('grid pattern minChildWidth not interpreted as token value', () => {
+    const code = `
+    import { grid } from '.panda/patterns';
+
+    export const App = () => {
+      return (
+        <>
+          <div className={grid({ minChildWidth: '80px', gap: 8 })} />
+          <div className={grid({ minChildWidth: '20', gap: 8 })} />
+        </>
+      );
+    };
+     `
+    const result = run(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "gap": 8,
+              "minChildWidth": "80px",
+            },
+          ],
+          "name": "grid",
+          "type": "pattern",
+        },
+        {
+          "data": [
+            {
+              "gap": 8,
+              "minChildWidth": "20",
+            },
+          ],
+          "name": "grid",
+          "type": "pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .grid-cols_repeat\\\\(auto-fit\\\\,_minmax\\\\(80px\\\\,_1fr\\\\)\\\\) {
+          grid-template-columns: repeat(auto-fit, minmax(80px, 1fr))
+          }
+
+        .d_grid {
+          display: grid
+          }
+
+        .grid-cols_repeat\\\\(auto-fit\\\\,_minmax\\\\(20\\\\,_1fr\\\\)\\\\) {
+          grid-template-columns: repeat(auto-fit, minmax(20, 1fr))
+          }
+
+        .gap_8 {
+          gap: var(--spacing-8)
+          }
+      }"
+    `)
+  })
 })
 
 describe('preset patterns', () => {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2580,7 +2580,7 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
-  test.only('grid pattern minChildWidth not interpreted as token value', () => {
+  test('grid pattern minChildWidth not interpreted as token value', () => {
     const code = `
     import { grid } from '.panda/patterns';
 
@@ -2629,8 +2629,8 @@ describe('extract to css output pipeline', () => {
           display: grid
           }
 
-        .grid-cols_repeat\\\\(auto-fit\\\\,_minmax\\\\(20\\\\,_1fr\\\\)\\\\) {
-          grid-template-columns: repeat(auto-fit, minmax(20, 1fr))
+        .grid-cols_repeat\\\\(auto-fit\\\\,_minmax\\\\(token\\\\(sizes\\\\.20\\\\,_20\\\\)\\\\,_1fr\\\\)\\\\) {
+          grid-template-columns: repeat(auto-fit, minmax(var(--sizes-20, \\\\320), 1fr))
           }
 
         .gap_8 {

--- a/packages/preset-base/src/patterns.ts
+++ b/packages/preset-base/src/patterns.ts
@@ -156,13 +156,16 @@ const grid = definePattern({
   },
   transform(props, { map }) {
     const { columnGap, rowGap, gap = columnGap || rowGap ? undefined : '10px', columns, minChildWidth, ...rest } = props
+    const getValue = (v: string) =>
+      v.includes('px') || v.includes('em') || v.includes('%') ? v : `token(sizes.${v}, ${v})`
+
     return {
       display: 'grid',
       gridTemplateColumns:
         columns != null
-          ? map(columns, (v) => `repeat(${v}, minmax(0, 1fr))`)
+          ? map(columns, (v) => `repeat(${getValue(v)}, minmax(0, 1fr))`)
           : minChildWidth != null
-          ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${v}, 1fr))`)
+          ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${getValue(v)}, 1fr))`)
           : undefined,
       gap,
       columnGap,

--- a/packages/preset-base/src/patterns.ts
+++ b/packages/preset-base/src/patterns.ts
@@ -155,9 +155,9 @@ const grid = definePattern({
     minChildWidth: { type: 'token', value: 'sizes', property: 'width' },
   },
   transform(props, { map }) {
+    const regex = /\d+(cm|in|pt|em|px|rem|vh|vmax|vmin|vw|ch|lh|%)$/
     const { columnGap, rowGap, gap = columnGap || rowGap ? undefined : '10px', columns, minChildWidth, ...rest } = props
-    const getValue = (v: string) =>
-      v.includes('px') || v.includes('em') || v.includes('%') ? v : `token(sizes.${v}, ${v})`
+    const getValue = (v: string) => (regex.test(v) ? v : `token(sizes.${v}, ${v})`)
 
     return {
       display: 'grid',

--- a/packages/studio/styled-system/patterns/grid.mjs
+++ b/packages/studio/styled-system/patterns/grid.mjs
@@ -3,8 +3,9 @@ import { css } from '../css/index.mjs';
 
 const gridConfig = {
 transform(props, { map }) {
+  const regex = /\d+(em|px|rem|vh|vmax|vmin|vw|%)$/;
   const { columnGap, rowGap, gap = columnGap || rowGap ? void 0 : "10px", columns, minChildWidth, ...rest } = props;
-  const getValue = (v) => v.includes("px") || v.includes("em") || v.includes("%") ? v : `token(sizes.${v}, ${v})`;
+  const getValue = (v) => regex.test(v) ? v : `token(sizes.${v}, ${v})`;
   return {
     display: "grid",
     gridTemplateColumns: columns != null ? map(columns, (v) => `repeat(${getValue(v)}, minmax(0, 1fr))`) : minChildWidth != null ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${getValue(v)}, 1fr))`) : void 0,

--- a/packages/studio/styled-system/patterns/grid.mjs
+++ b/packages/studio/styled-system/patterns/grid.mjs
@@ -4,9 +4,10 @@ import { css } from '../css/index.mjs';
 const gridConfig = {
 transform(props, { map }) {
   const { columnGap, rowGap, gap = columnGap || rowGap ? void 0 : "10px", columns, minChildWidth, ...rest } = props;
+  const getValue = (v) => v.includes("px") || v.includes("em") || v.includes("%") ? v : `token(sizes.${v}, ${v})`;
   return {
     display: "grid",
-    gridTemplateColumns: columns != null ? map(columns, (v) => `repeat(${v}, minmax(0, 1fr))`) : minChildWidth != null ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${v}, 1fr))`) : void 0,
+    gridTemplateColumns: columns != null ? map(columns, (v) => `repeat(${getValue(v)}, minmax(0, 1fr))`) : minChildWidth != null ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${getValue(v)}, 1fr))`) : void 0,
     gap,
     columnGap,
     rowGap,

--- a/sandbox/preact-ts/src/app.tsx
+++ b/sandbox/preact-ts/src/app.tsx
@@ -1,7 +1,9 @@
 import { css, sva } from '../styled-system/css'
 import { card } from '../styled-system/recipes'
-import { splitCssProps, styled } from '../styled-system/jsx'
+import { styled } from '../styled-system/jsx'
+import { splitCssProps } from '../styled-system/jsx/is-valid-prop'
 import { HTMLStyledProps } from '../styled-system/types'
+import { grid } from '../styled-system/patterns/grid'
 
 const button = sva({
   slots: ['label', 'icon'],
@@ -78,6 +80,8 @@ export function App() {
       <SplitComponent w="2" onClick={() => console.log('123')}>
         Click me
       </SplitComponent>
+      <div className={grid({ minChildWidth: '80px', gap: 8 })}>grid.minChildWidth 80px</div>
+      <div className={grid({ minChildWidth: '20', gap: 8 })}>grid.minChildWidth 20</div>
     </div>
   )
 }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1637

## 📝 Description

Fix an issue with the `grid` pattern from @pandacss/preset-base (included by default), setting a minChildWidth wasn't
interpreted as a token value

Before:

```tsx
<div className={grid({ minChildWidth: '80px', gap: 8 })} />
// ✅ grid-template-columns: repeat(auto-fit, minmax(80px, 1fr))

<div className={grid({ minChildWidth: '20', gap: 8 })} />
// ❌ grid-template-columns: repeat(auto-fit, minmax(20, 1fr))
//                                                  ^^^
```

After:

```tsx
<div className={grid({ minChildWidth: '80px', gap: 8 })} />
// ✅ grid-template-columns: repeat(auto-fit, minmax(80px, 1fr))

<div className={grid({ minChildWidth: '20', gap: 8 })} />
// ✅ grid-template-columns: repeat(auto-fit, minmax(var(--sizes-20, 20), 1fr))
//                                                  ^^^^^^^^^^^^^^^^^^^
```


## 📝 Additional Information
