### PR TITLE
Expand _required condition to include data and ARIA attributes

### DIFF
--- a/packages/preset-base/src/conditions.ts
+++ b/packages/preset-base/src/conditions.ts
@@ -56,7 +56,7 @@ export const conditions = {
   groupInvalid: '.group:invalid &',
 
   indeterminate: '&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate")',
-  required: '&:required',
+  required: '&:is(:required, [data-required], [aria-required=true])',
   valid: '&:is(:valid, [data-valid])',
   invalid: '&:is(:invalid, [data-invalid])',
   autofill: '&:autofill',


### PR DESCRIPTION
## 📝 Description

The way the docs for [Conditional Styles](https://panda-css.com/docs/concepts/conditional-styles#state) are written make me believe that I should be able to react to the presence of a `data-required` prop using the `_required` condition, however the selector for `_required` doesn't currently account for that usage.

## ⛳️ Current behavior (updates)

The `_required` condition only targets elements with a truthy `required` prop.

## 🚀 New behavior

`_required` targets elements with `required`, `data-required`, or `aria-required` props.

## 💣 Is this a breaking change (Yes/No):

No
