### PR TITLE
fix: recipe cache mismatch with theme.recipes

### DIFF
--- a/.changeset/wicked-emus-mix.md
+++ b/.changeset/wicked-emus-mix.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/core': patch
+---
+
+Fix issue where recipe artifacts might not match the recipes defined in the theme due to the internal cache not being
+cleared as needed.

--- a/packages/core/src/recipes.ts
+++ b/packages/core/src/recipes.ts
@@ -38,6 +38,7 @@ export class Recipes {
   keys: string[] = []
 
   constructor(private recipes: RecipeRecord = {}, private context: StylesheetContext) {
+    this.prune()
     this.assignRules()
   }
 
@@ -51,6 +52,19 @@ export class Recipes {
 
   private getClassName = (className: string, variant: string, value: string) => {
     return `${className}--${variant}${this.separator}${value}`
+  }
+
+  // check this.recipes against sharedState.nodes
+  // and remove any recipes (in sharedState) that are no longer in use
+  prune = () => {
+    const recipeNames = Object.keys(this.recipes)
+    const cachedRecipeNames = Array.from(sharedState.nodes.keys())
+    const removedRecipes = cachedRecipeNames.filter((name) => !recipeNames.includes(name))
+    removedRecipes.forEach((name) => {
+      sharedState.nodes.delete(name)
+      sharedState.classNames.delete(name)
+      sharedState.styles.delete(name)
+    })
   }
 
   save = () => {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -573,20 +573,6 @@ describe('extract to css output pipeline', () => {
           "name": "bgRecipe",
           "type": "recipe",
         },
-        {
-          "data": [
-            {},
-          ],
-          "name": "ComponentWithMultipleRecipes",
-          "type": "jsx-recipe",
-        },
-        {
-          "data": [
-            {},
-          ],
-          "name": "ComponentWithMultipleRecipes",
-          "type": "jsx-recipe",
-        },
       ]
     `)
 


### PR DESCRIPTION
Closes #1625

## 📝 Description

Fix issue where recipe artifacts might not match the recipes defined in the theme due to the internal cache not being
cleared as needed.
