### PR TITLE
fix: token fn in at rules

### DIFF
--- a/.changeset/tall-forks-worry.md
+++ b/.changeset/tall-forks-worry.md
@@ -1,0 +1,16 @@
+---
+'@pandacss/core': patch
+---
+
+Fix issue with the `token(xxx.yyy)` fn used in AtRule, things like:
+
+```ts
+css({
+  '@container (min-width: token(sizes.xl))': {
+    color: 'green.300',
+  },
+  '@media (min-width: token(sizes.2xl))': {
+    color: 'red.300',
+  },
+})
+```

--- a/packages/core/__tests__/expand-token-fn.test.ts
+++ b/packages/core/__tests__/expand-token-fn.test.ts
@@ -74,6 +74,11 @@ describe('expandTokenFn', () => {
             color: green;
           }
         }
+        @container (min-width: token(sizes.12345)) {
+          .\[\@container_\(min-width\:_token\(sizes\.12345\)\)\]\:text_green {
+            color: green;
+          }
+        }
       }
     `)
 
@@ -81,7 +86,12 @@ describe('expandTokenFn', () => {
       "
             @layer utilities {
               @container (min-width: 56rem) {
-                .[@container_(min-width:_token(sizes.4xl))]:text_green {
+                .[@container_(min-width:_56rem)]:text_green {
+                  color: green;
+                }
+              }
+              @container (min-width: sizes\\\\.12345) {
+                .[@container_(min-width:_sizes\\\\.12345)]:text_green {
                   color: green;
                 }
               }

--- a/packages/core/src/plugins/expand-token-fn.ts
+++ b/packages/core/src/plugins/expand-token-fn.ts
@@ -42,6 +42,9 @@ function expandTokenFn(
       if (node.type === 'atrule' && node.params.includes('token(')) {
         node.params = expandToken(node.params, atRuleReplace, (path: string) => rawTokenFn?.(path)?.value)
       }
+      if (node.type === 'rule' && node.selector.includes('token(')) {
+        node.selector = expandToken(node.selector, atRuleReplace, (path: string) => rawTokenFn?.(path)?.value)
+      }
     })
   }
 }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2626,7 +2626,7 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
-  test.only('token fn in at-rules', () => {
+  test('token fn in at-rules', () => {
     const code = `
     import { css } from '.panda/css';
 
@@ -2667,19 +2667,19 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
-        @container (min-width: token(sizes.xl)) {
+        @container (min-width: 36rem) {
           .\\\\[\\\\@container_\\\\(min-width\\\\:_token\\\\(sizes\\\\.xl\\\\)\\\\)\\\\]\\\\:text_green\\\\.300 {
             color: var(--colors-green-300)
           }
               }
 
-        @container (min-width: token(sizes.4xl, 1280px)) {
+        @container (min-width: 56rem) {
           .\\\\[\\\\@container_\\\\(min-width\\\\:_token\\\\(sizes\\\\.4xl\\\\,_1280px\\\\)\\\\)\\\\]\\\\:d_flex {
             display: flex
           }
               }
 
-        @media (min-width: token(sizes.2xl)) {
+        @media (min-width: 42rem) {
           .\\\\[\\\\@media_\\\\(min-width\\\\:_token\\\\(sizes\\\\.2xl\\\\)\\\\)\\\\]\\\\:text_red\\\\.300 {
             color: var(--colors-red-300)
           }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2625,6 +2625,68 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test.only('token fn in at-rules', () => {
+    const code = `
+    import { css } from '.panda/css';
+
+    css({
+      '@container (min-width: token(sizes.xl))': {
+        color: 'green.300',
+      },
+      '@media (min-width: token(sizes.2xl))': {
+        color: 'red.300',
+      },
+      "@container (min-width: token(sizes.4xl, 1280px))": {
+        display: "flex"
+      }
+    })
+     `
+    const result = run(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "@container (min-width: token(sizes.4xl, 1280px))": {
+                "display": "flex",
+              },
+              "@container (min-width: token(sizes.xl))": {
+                "color": "green.300",
+              },
+              "@media (min-width: token(sizes.2xl))": {
+                "color": "red.300",
+              },
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        @container (min-width: token(sizes.xl)) {
+          .\\\\[\\\\@container_\\\\(min-width\\\\:_token\\\\(sizes\\\\.xl\\\\)\\\\)\\\\]\\\\:text_green\\\\.300 {
+            color: var(--colors-green-300)
+          }
+              }
+
+        @container (min-width: token(sizes.4xl, 1280px)) {
+          .\\\\[\\\\@container_\\\\(min-width\\\\:_token\\\\(sizes\\\\.4xl\\\\,_1280px\\\\)\\\\)\\\\]\\\\:d_flex {
+            display: flex
+          }
+              }
+
+        @media (min-width: token(sizes.2xl)) {
+          .\\\\[\\\\@media_\\\\(min-width\\\\:_token\\\\(sizes\\\\.2xl\\\\)\\\\)\\\\]\\\\:text_red\\\\.300 {
+            color: var(--colors-red-300)
+          }
+              }
+      }"
+    `)
+  })
 })
 
 describe('preset patterns', () => {


### PR DESCRIPTION
## 📝 Description

```ts
Fix issue with the `token(xxx.yyy)` fn used in AtRule, things like:

```ts
css({
  '@container (min-width: token(sizes.xl))': {
    color: 'green.300',
  },
  '@media (min-width: token(sizes.2xl))': {
    color: 'red.300',
  },
})
```

```

## 💣 Is this a breaking change (Yes/No):

no
