### PR TITLE
feat: strictTokens escape hatch for arbitrary values

### DIFF
--- a/.changeset/heavy-tips-train.md
+++ b/.changeset/heavy-tips-train.md
@@ -1,0 +1,23 @@
+---
+'@pandacss/generator': minor
+'@pandacss/shared': minor
+'@pandacss/core': minor
+---
+
+Add an escape-hatch for arbitrary values when using `config.strictTokens`, by prefixing the value with `[` and suffixing
+with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
+
+```ts
+import { css } from '../styled-system/css'
+
+css({
+  // @ts-expect-error TS will throw when using from strictTokens: true
+  color: '#fff',
+  // @ts-expect-error TS will throw when using from strictTokens: true
+  width: '100px',
+
+  // ✅ but this is now allowed:
+  bgColor: '[rgb(51 155 240)]',
+  fontSize: '[12px]',
+})
+```

--- a/packages/core/src/utility.ts
+++ b/packages/core/src/utility.ts
@@ -1,4 +1,12 @@
-import { compact, hypenateProperty, isFunction, isString, memo, withoutSpace } from '@pandacss/shared'
+import {
+  compact,
+  getArbitraryValue,
+  hypenateProperty,
+  isFunction,
+  isString,
+  memo,
+  withoutSpace,
+} from '@pandacss/shared'
 import type { TokenDictionary } from '@pandacss/token-dictionary'
 import type { AnyFunction, Dict, PropertyConfig, PropertyTransform, UtilityConfig } from '@pandacss/types'
 import type { TransformResult } from './types'
@@ -386,10 +394,11 @@ export class Utility {
       return { className: '', styles: {} }
     }
     const key = this.resolveShorthand(prop)
+
     return compact({
       layer: this.configs.get(key)?.layer,
       className: this.getOrCreateClassName(key, withoutSpace(value)),
-      styles: this.getOrCreateStyle(key, value),
+      styles: this.getOrCreateStyle(key, getArbitraryValue(value)),
     })
   }
 

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -316,7 +316,7 @@ describe('generate property types', () => {
       }
 
 
-      export type PropertyValue<T extends string> = T extends keyof PropertyTypes
+        export type PropertyValue<T extends string> = T extends keyof PropertyTypes
         ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
         : T extends keyof CssProperties
         ? ConditionalValue<CssProperties[T] | (string & {})>
@@ -636,12 +636,15 @@ describe('generate property types', () => {
       	y: Shorthand<\\"translateY\\">;
       }
 
-      type FilterString<T> = T extends \`\${infer _}\` ? T : never;
-      export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-        ? ConditionalValue<FilterString<PropertyTypes[T]>>
-        : T extends keyof CssProperties
-        ? ConditionalValue<FilterString<CssProperties[T]>>
-        : ConditionalValue<string | number>"
+
+        type FilterString<T> = T extends \`\${infer _}\` ? T : never;
+        type WithArbitraryValue<T> = T | \`[\${string}]\`
+
+        export type PropertyValue<T extends string> = WithArbitraryValue<(T extends keyof PropertyTypes
+          ? ConditionalValue<FilterString<PropertyTypes[T]>>
+          : T extends keyof CssProperties
+          ? ConditionalValue<FilterString<CssProperties[T]>>
+          : ConditionalValue<string | number>)>"
     `)
   })
 })

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -316,11 +316,21 @@ describe('generate property types', () => {
       }
 
 
+
+        type PropertyTypeValue<T extends string> = T extends keyof PropertyTypes
+          ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
+          : never;
+
+        type CssPropertyValue<T extends string> = T extends keyof CssProperties
+          ? ConditionalValue<CssProperties[T] | (string & {})>
+          : never;
+
         export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-        ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
-        : T extends keyof CssProperties
-        ? ConditionalValue<CssProperties[T] | (string & {})>
-        : ConditionalValue<string | number>"
+          ? PropertyTypeValue<T>
+          : T extends keyof CssProperties
+            ? CssPropertyValue<T>
+            : ConditionalValue<string | number>
+        "
     `)
   })
 
@@ -640,11 +650,20 @@ describe('generate property types', () => {
         type FilterString<T> = T extends \`\${infer _}\` ? T : never;
         type WithArbitraryValue<T> = T | \`[\${string}]\`
 
-        export type PropertyValue<T extends string> = WithArbitraryValue<(T extends keyof PropertyTypes
+        type PropertyTypeValue<T extends string> = T extends keyof PropertyTypes
           ? ConditionalValue<FilterString<PropertyTypes[T]>>
-          : T extends keyof CssProperties
+          : never;
+
+        type CssPropertyValue<T extends string> = T extends keyof CssProperties
           ? ConditionalValue<FilterString<CssProperties[T]>>
-          : ConditionalValue<string | number>)>"
+          : never;
+
+        export type PropertyValue<T extends string> = WithArbitraryValue<T extends keyof PropertyTypes
+          ? PropertyTypeValue<T>
+          : T extends keyof CssProperties
+            ? CssPropertyValue<T>
+            : ConditionalValue<string | number>
+          >"
     `)
   })
 })

--- a/packages/generator/src/artifacts/types/prop-types.ts
+++ b/packages/generator/src/artifacts/types/prop-types.ts
@@ -43,13 +43,23 @@ export function generatePropTypes(ctx: Context) {
   return outdent`
   ${result.join('\n')}
 
-  ${strictTokens ? `type FilterString<T> = T extends \`\${infer _}\` ? T : never;` : ''}
-  export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-    ? ConditionalValue<${
-      strictTokens ? 'FilterString<PropertyTypes[T]>' : 'PropertyTypes[T] | CssValue<T> | (string & {})'
-    }>
+  ${
+    strictTokens
+      ? `
+  type FilterString<T> = T extends \`\${infer _}\` ? T : never;
+  type WithArbitraryValue<T> = T | \`[\${string}]\`
+
+  export type PropertyValue<T extends string> = WithArbitraryValue<(T extends keyof PropertyTypes
+    ? ConditionalValue<FilterString<PropertyTypes[T]>>
     : T extends keyof CssProperties
-    ? ConditionalValue<${strictTokens ? 'FilterString<CssProperties[T]>' : 'CssProperties[T] | (string & {})'}>
-    : ConditionalValue<string | number>
+    ? ConditionalValue<FilterString<CssProperties[T]>>
+    : ConditionalValue<string | number>)>`
+      : `
+  export type PropertyValue<T extends string> = T extends keyof PropertyTypes
+  ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
+  : T extends keyof CssProperties
+  ? ConditionalValue<CssProperties[T] | (string & {})>
+  : ConditionalValue<string | number>`
+  }
   `
 }

--- a/packages/generator/src/artifacts/types/prop-types.ts
+++ b/packages/generator/src/artifacts/types/prop-types.ts
@@ -49,17 +49,36 @@ export function generatePropTypes(ctx: Context) {
   type FilterString<T> = T extends \`\${infer _}\` ? T : never;
   type WithArbitraryValue<T> = T | \`[\${string}]\`
 
-  export type PropertyValue<T extends string> = WithArbitraryValue<(T extends keyof PropertyTypes
+  type PropertyTypeValue<T extends string> = T extends keyof PropertyTypes
     ? ConditionalValue<FilterString<PropertyTypes[T]>>
-    : T extends keyof CssProperties
+    : never;
+
+  type CssPropertyValue<T extends string> = T extends keyof CssProperties
     ? ConditionalValue<FilterString<CssProperties[T]>>
-    : ConditionalValue<string | number>)>`
+    : never;
+
+  export type PropertyValue<T extends string> = WithArbitraryValue<T extends keyof PropertyTypes
+    ? PropertyTypeValue<T>
+    : T extends keyof CssProperties
+      ? CssPropertyValue<T>
+      : ConditionalValue<string | number>
+    >`
       : `
+
+  type PropertyTypeValue<T extends string> = T extends keyof PropertyTypes
+    ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
+    : never;
+
+  type CssPropertyValue<T extends string> = T extends keyof CssProperties
+    ? ConditionalValue<CssProperties[T] | (string & {})>
+    : never;
+
   export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-  ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
-  : T extends keyof CssProperties
-  ? ConditionalValue<CssProperties[T] | (string & {})>
-  : ConditionalValue<string | number>`
+    ? PropertyTypeValue<T>
+    : T extends keyof CssProperties
+      ? CssPropertyValue<T>
+      : ConditionalValue<string | number>
+  `
   }
   `
 }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2711,6 +2711,50 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot('""')
   })
+
+  test('strictTokens arbitrary value escape hatch', () => {
+    const code = `
+    import { css } from '.panda/css';
+
+    css({
+      color: '[#fff]',
+      bg: 'red.300',
+      bgColor: '[rgb(51 155 240)]',
+    })
+     `
+    const result = run(code, { strictTokens: true })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "bg": "red.300",
+              "bgColor": "[rgb(51 155 240)]",
+              "color": "[#fff]",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_\\\\[\\\\#fff\\\\] {
+          color: #fff
+          }
+
+        .bg_red\\\\.300 {
+          background: var(--colors-red-300)
+          }
+
+        .bg_\\\\[rgb\\\\(51_155_240\\\\)\\\\] {
+          background-color: rgb(51 155 240)
+          }
+      }"
+    `)
+  })
 })
 
 describe('preset patterns', () => {

--- a/packages/shared/src/arbitrary-value.ts
+++ b/packages/shared/src/arbitrary-value.ts
@@ -1,0 +1,9 @@
+export const getArbitraryValue = (value: string) => {
+  if (!value) return value
+
+  if (value[0] === '[' && value[value.length - 1] === ']') {
+    return value.slice(1, -1)
+  }
+
+  return value
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from './arbitrary-value'
 export * from './assert'
 export * from './astish'
 export * from './calc'

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -310,7 +310,7 @@ interface PropertyValueTypes {
 }
 
 
-export type PropertyValue<T extends string> = T extends keyof PropertyTypes
+  export type PropertyValue<T extends string> = T extends keyof PropertyTypes
   ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
   : T extends keyof CssProperties
   ? ConditionalValue<CssProperties[T] | (string & {})>

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -310,8 +310,18 @@ interface PropertyValueTypes {
 }
 
 
+
+  type PropertyTypeValue<T extends string> = T extends keyof PropertyTypes
+    ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
+    : never;
+
+  type CssPropertyValue<T extends string> = T extends keyof CssProperties
+    ? ConditionalValue<CssProperties[T] | (string & {})>
+    : never;
+
   export type PropertyValue<T extends string> = T extends keyof PropertyTypes
-  ? ConditionalValue<PropertyTypes[T] | CssValue<T> | (string & {})>
-  : T extends keyof CssProperties
-  ? ConditionalValue<CssProperties[T] | (string & {})>
-  : ConditionalValue<string | number>
+    ? PropertyTypeValue<T>
+    : T extends keyof CssProperties
+      ? CssPropertyValue<T>
+      : ConditionalValue<string | number>
+  

--- a/sandbox/codegen/__tests__/scenarios/strict.test.ts
+++ b/sandbox/codegen/__tests__/scenarios/strict.test.ts
@@ -61,6 +61,15 @@ describe('css', () => {
     )
   })
 
+  test('arbitrary value escape hatch', () => {
+    assertType(
+      css({
+        color: '[#fff]',
+        fontSize: '[123px]',
+      }),
+    )
+  })
+
   test('arbitrary selector', () => {
     assertType(css({ ['&:data-panda']: { display: 'flex' } }))
   })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/1001

## 📝 Description

Add an escape-hatch for arbitrary values when using `config.strictTokens`, by prefixing the value with `[` and suffixing
with `]`, e.g. writing `[123px]` as a value will bypass the token validation.

```ts
import { css } from '../styled-system/css'

css({
  // @ts-expect-error TS will throw when using from strictTokens: true
  color: '#fff',
  // @ts-expect-error TS will throw when using from strictTokens: true
  width: '100px',

  // ✅ but this is now allowed:
  bgColor: '[rgb(51 155 240)]',
  fontSize: '[12px]',
})
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

We've listened and more enhancements will come for the `config.strictTokens` DX, thank you for providing great feedback !