### PR TITLE
feat(config): importMap as string

### DIFF
--- a/.changeset/honest-frogs-wave.md
+++ b/.changeset/honest-frogs-wave.md
@@ -1,0 +1,27 @@
+---
+'@pandacss/generator': patch
+'@pandacss/types': patch
+---
+
+Add a shortcut for the `config.importMap` option
+
+You can now also use a string to customize the base import path and keep the default entrypoints:
+
+```json
+{
+  "importMap": "@scope/styled-system"
+}
+```
+
+is the equivalent of:
+
+```json
+{
+  "importMap": {
+    "css": "@scope/styled-system/css",
+    "recipes": "@scope/styled-system/recipes",
+    "patterns": "@scope/styled-system/patterns",
+    "jsx": "@scope/styled-system/jsx"
+  }
+}
+```

--- a/packages/generator/src/parser-options.ts
+++ b/packages/generator/src/parser-options.ts
@@ -3,8 +3,18 @@ import type { Context } from './engines'
 import type { PatternDetail } from './engines/pattern'
 import type { RecipeNode } from '@pandacss/core'
 
-const getImportMap = (outdir: string, configImportMap?: OutdirImportMap): ParserImportMap => {
+const getImportMap = (outdir: string, configImportMap?: string | OutdirImportMap): ParserImportMap => {
+  if (typeof configImportMap === 'string') {
+    return {
+      css: [configImportMap, 'css'],
+      recipe: [configImportMap, 'recipes'],
+      pattern: [configImportMap, 'patterns'],
+      jsx: [configImportMap, 'jsx'],
+    }
+  }
+
   const { css, recipes, patterns, jsx } = configImportMap ?? {}
+
   return {
     css: css ? [css] : [outdir, 'css'],
     recipe: recipes ? [recipes] : [outdir, 'recipes'],

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2182,6 +2182,125 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
+  test('import map as string', () => {
+    const code = `
+    import { css } from "string-import-map/css";
+    import { buttonStyle } from "string-import-map/recipes";
+    import { stack } from "string-import-map/patterns";
+    import { Box } from "string-import-map/jsx";
+
+    css({ mx: '3' })
+    stack({ direction: "column" })
+    buttonStyle({ visual: "funky" })
+
+    const App = () => {
+      return (
+        <>
+          <Box color="red" />
+        </>
+      );
+    }
+     `
+    const result = run(code, {
+      outdir: 'anywhere',
+      importMap: 'string-import-map',
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "mx": "3",
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {
+              "visual": "funky",
+            },
+          ],
+          "name": "buttonStyle",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "direction": "column",
+            },
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+        {
+          "data": [
+            {
+              "color": "red",
+            },
+          ],
+          "name": "Box",
+          "type": "jsx-pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .mx_3 {
+          margin-inline: var(--spacing-3)
+          }
+
+        .d_flex {
+          display: flex
+          }
+
+        .flex_column {
+          flex-direction: column
+          }
+
+        .gap_10px {
+          gap: 10px
+          }
+
+        .text_red {
+          color: red
+          }
+      }
+
+      @layer recipes {
+        .buttonStyle--size_md {
+          height: 3rem;
+          min-width: 3rem;
+          padding: 0 0.75rem
+          }
+
+        .buttonStyle--variant_solid {
+          background-color: blue;
+          color: var(--colors-white);
+          }
+
+        .buttonStyle--variant_solid[data-disabled] {
+          background-color: gray;
+          color: var(--colors-black)
+              }
+
+        .buttonStyle--variant_solid:is(:hover, [data-hover]) {
+          background-color: darkblue
+              }
+
+        @layer _base {
+          .buttonStyle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center
+              }
+          }
+      }"
+    `)
+  })
+
   test('array syntax - simple', () => {
     const code = `
         import { Box } from ".panda/jsx"

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -137,7 +137,7 @@ interface FileSystemOptions {
    * }
    * ```
    */
-  importMap?: OutdirImportMap
+  importMap?: string | OutdirImportMap
   /**
    * List of files glob to watch for changes.
    * @default []

--- a/website/pages/docs/references/config.md
+++ b/website/pages/docs/references/config.md
@@ -361,7 +361,7 @@ The output directory for the generated css.
 
 ### importMap
 
-**Type**: `Partial<OutdirImportMap>`
+**Type**: `string | Partial<OutdirImportMap>`
 
 **Default**: `{ "css": "styled-system/css", "recipes": "styled-system/recipes", "patterns": "styled-system/patterns", "jsx": "styled-system/jsx" }`
 
@@ -374,6 +374,27 @@ Allows you to customize the import paths for the generated outdir.
     "recipes": "@acme/styled-system",
     "patterns": "@acme/styled-system",
     "jsx": "@acme/styled-system"
+  }
+}
+```
+
+You can also use a string to customize the base import path and keep the default entrypoints:
+
+```json
+{
+  "importMap": "@scope/styled-system"
+}
+```
+
+is the equivalent of:
+
+```json
+{
+  "importMap": {
+    "css": "@scope/styled-system/css",
+    "recipes": "@scope/styled-system/recipes",
+    "patterns": "@scope/styled-system/patterns",
+    "jsx": "@scope/styled-system/jsx"
   }
 }
 ```


### PR DESCRIPTION
## 📝 Description

Add a shortcut for the `config.importMap` option

You can now also use a string to customize the base import path and keep the default entrypoints:

```json
{
  "importMap": "@scope/styled-system"
}
```

is the equivalent of:

```json
{
  "importMap": {
    "css": "@scope/styled-system/css",
    "recipes": "@scope/styled-system/recipes",
    "patterns": "@scope/styled-system/patterns",
    "jsx": "@scope/styled-system/jsx"
  }
}
```


## 💣 Is this a breaking change (Yes/No):

no
