### PR TITLE
fix(extractor): JSX nodes as JSX attributes

### DIFF
--- a/.changeset/brave-cars-smell.md
+++ b/.changeset/brave-cars-smell.md
@@ -1,0 +1,25 @@
+---
+'@pandacss/extractor': patch
+---
+
+Fix static extraction issue when using JSX attributes (props) that are other JSX nodes
+
+While parsing over the AST Nodes, due to an optimization where we skipped retrieving the current JSX element and instead
+kept track of the latest one, the logic was flawed and did not extract other properties after encountering a JSX
+attribute that was another JSX node.
+
+```tsx
+const Component = () => {
+  return (
+    <>
+      {/* ❌ this wasn't extracting ml="2" */}
+      <Flex icon={<svg className="icon" />} ml="2" />
+
+      {/* ✅ this was fine */}
+      <Stack ml="4" icon={<div className="icon" />} />
+    </>
+  )
+}
+```
+
+Now both will be fine again.

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -22,7 +22,7 @@ const config: Record<string, string[]> = {
 
 const componentsMatcher: ComponentMatchers = {
   matchTag: ({ tagName }) => Boolean(config[tagName]),
-  matchProp: ({ tagName, propName }) => config[tagName].includes(propName),
+  matchProp: ({ tagName, propName }) => config[tagName]?.includes(propName),
 }
 
 type TestExtractOptions = Omit<ExtractOptions, 'ast'> & { tagNameList?: string[]; functionNameList?: string[] }
@@ -5788,6 +5788,80 @@ it('extracts arrays without removing nullish values', () => {
               "display": "flex",
             },
           ],
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})
+
+it('extracts props after a JSX attribute containing a JSX element', () => {
+  expect(
+    extractFromCode(
+      `
+      export const App = () => {
+        return (
+          <>
+            <Flex icon={<svg />} ml="2" />
+            <Stack ml="4" icon={<div />} />
+          </>
+        );
+      };
+          `,
+      { tagNameList: ['Flex', 'Stack'] },
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "Flex": [
+        {
+          "conditions": [],
+          "raw": {},
+          "spreadConditions": [],
+        },
+      ],
+      "Stack": [
+        {
+          "conditions": [],
+          "raw": {
+            "ml": "4",
+          },
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})
+
+it('extracts props after a JSX spread containing a JSX element', () => {
+  expect(
+    extractFromCode(
+      `
+      export const App = () => {
+        return (
+          <>
+            <Flex {...{ icon: <svg /> }} ml="2" />
+            <Stack ml="4" {...{ icon: <div /> }} />
+          </>
+        );
+      };
+          `,
+      { tagNameList: ['Flex', 'Stack'] },
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "Flex": [
+        {
+          "conditions": [],
+          "raw": {},
+          "spreadConditions": [],
+        },
+      ],
+      "Stack": [
+        {
+          "conditions": [],
+          "raw": {
+            "ml": "4",
+          },
           "spreadConditions": [],
         },
       ],

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -5815,7 +5815,9 @@ it('extracts props after a JSX attribute containing a JSX element', () => {
       "Flex": [
         {
           "conditions": [],
-          "raw": {},
+          "raw": {
+            "ml": "2",
+          },
           "spreadConditions": [],
         },
       ],
@@ -5852,7 +5854,9 @@ it('extracts props after a JSX spread containing a JSX element', () => {
       "Flex": [
         {
           "conditions": [],
-          "raw": {},
+          "raw": {
+            "ml": "2",
+          },
           "spreadConditions": [],
         },
       ],

--- a/packages/studio/styled-system/jsx/aspect-ratio.mjs
+++ b/packages/studio/styled-system/jsx/aspect-ratio.mjs
@@ -5,5 +5,8 @@ import { getAspectRatioStyle } from '../patterns/aspect-ratio.mjs';
 export const AspectRatio = /* @__PURE__ */ forwardRef(function AspectRatio(props, ref) {
   const { ratio, ...restProps } = props
 const styleProps = getAspectRatioStyle({ratio})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/bleed.mjs
+++ b/packages/studio/styled-system/jsx/bleed.mjs
@@ -5,5 +5,8 @@ import { getBleedStyle } from '../patterns/bleed.mjs';
 export const Bleed = /* @__PURE__ */ forwardRef(function Bleed(props, ref) {
   const { inline, block, ...restProps } = props
 const styleProps = getBleedStyle({inline, block})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/box.mjs
+++ b/packages/studio/styled-system/jsx/box.mjs
@@ -3,6 +3,10 @@ import { panda } from './factory.mjs';
 import { getBoxStyle } from '../patterns/box.mjs';
 
 export const Box = /* @__PURE__ */ forwardRef(function Box(props, ref) {
-  const styleProps = getBoxStyle()
-return createElement(panda.div, { ref, ...styleProps, ...props })
-})
+  const restProps = props
+const styleProps = getBoxStyle()
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/center.mjs
+++ b/packages/studio/styled-system/jsx/center.mjs
@@ -5,5 +5,8 @@ import { getCenterStyle } from '../patterns/center.mjs';
 export const Center = /* @__PURE__ */ forwardRef(function Center(props, ref) {
   const { inline, ...restProps } = props
 const styleProps = getCenterStyle({inline})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/circle.mjs
+++ b/packages/studio/styled-system/jsx/circle.mjs
@@ -5,5 +5,8 @@ import { getCircleStyle } from '../patterns/circle.mjs';
 export const Circle = /* @__PURE__ */ forwardRef(function Circle(props, ref) {
   const { size, ...restProps } = props
 const styleProps = getCircleStyle({size})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/container.mjs
+++ b/packages/studio/styled-system/jsx/container.mjs
@@ -3,6 +3,10 @@ import { panda } from './factory.mjs';
 import { getContainerStyle } from '../patterns/container.mjs';
 
 export const Container = /* @__PURE__ */ forwardRef(function Container(props, ref) {
-  const styleProps = getContainerStyle()
-return createElement(panda.div, { ref, ...styleProps, ...props })
-})
+  const restProps = props
+const styleProps = getContainerStyle()
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/divider.mjs
+++ b/packages/studio/styled-system/jsx/divider.mjs
@@ -5,5 +5,8 @@ import { getDividerStyle } from '../patterns/divider.mjs';
 export const Divider = /* @__PURE__ */ forwardRef(function Divider(props, ref) {
   const { orientation, thickness, color, ...restProps } = props
 const styleProps = getDividerStyle({orientation, thickness, color})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/flex.mjs
+++ b/packages/studio/styled-system/jsx/flex.mjs
@@ -5,5 +5,8 @@ import { getFlexStyle } from '../patterns/flex.mjs';
 export const Flex = /* @__PURE__ */ forwardRef(function Flex(props, ref) {
   const { align, justify, direction, wrap, basis, grow, shrink, ...restProps } = props
 const styleProps = getFlexStyle({align, justify, direction, wrap, basis, grow, shrink})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/float.mjs
+++ b/packages/studio/styled-system/jsx/float.mjs
@@ -5,5 +5,8 @@ import { getFloatStyle } from '../patterns/float.mjs';
 export const Float = /* @__PURE__ */ forwardRef(function Float(props, ref) {
   const { offsetX, offsetY, offset, placement, ...restProps } = props
 const styleProps = getFloatStyle({offsetX, offsetY, offset, placement})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/grid-item.mjs
+++ b/packages/studio/styled-system/jsx/grid-item.mjs
@@ -5,5 +5,8 @@ import { getGridItemStyle } from '../patterns/grid-item.mjs';
 export const GridItem = /* @__PURE__ */ forwardRef(function GridItem(props, ref) {
   const { colSpan, rowSpan, colStart, rowStart, colEnd, rowEnd, ...restProps } = props
 const styleProps = getGridItemStyle({colSpan, rowSpan, colStart, rowStart, colEnd, rowEnd})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/grid.mjs
+++ b/packages/studio/styled-system/jsx/grid.mjs
@@ -5,5 +5,8 @@ import { getGridStyle } from '../patterns/grid.mjs';
 export const Grid = /* @__PURE__ */ forwardRef(function Grid(props, ref) {
   const { gap, columnGap, rowGap, columns, minChildWidth, ...restProps } = props
 const styleProps = getGridStyle({gap, columnGap, rowGap, columns, minChildWidth})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/hstack.mjs
+++ b/packages/studio/styled-system/jsx/hstack.mjs
@@ -5,5 +5,8 @@ import { getHstackStyle } from '../patterns/hstack.mjs';
 export const HStack = /* @__PURE__ */ forwardRef(function HStack(props, ref) {
   const { justify, gap, ...restProps } = props
 const styleProps = getHstackStyle({justify, gap})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/link-box.mjs
+++ b/packages/studio/styled-system/jsx/link-box.mjs
@@ -3,6 +3,10 @@ import { panda } from './factory.mjs';
 import { getLinkBoxStyle } from '../patterns/link-box.mjs';
 
 export const LinkBox = /* @__PURE__ */ forwardRef(function LinkBox(props, ref) {
-  const styleProps = getLinkBoxStyle()
-return createElement(panda.div, { ref, ...styleProps, ...props })
-})
+  const restProps = props
+const styleProps = getLinkBoxStyle()
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/link-overlay.mjs
+++ b/packages/studio/styled-system/jsx/link-overlay.mjs
@@ -3,6 +3,10 @@ import { panda } from './factory.mjs';
 import { getLinkOverlayStyle } from '../patterns/link-overlay.mjs';
 
 export const LinkOverlay = /* @__PURE__ */ forwardRef(function LinkOverlay(props, ref) {
-  const styleProps = getLinkOverlayStyle()
-return createElement(panda.a, { ref, ...styleProps, ...props })
-})
+  const restProps = props
+const styleProps = getLinkOverlayStyle()
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.a, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/spacer.mjs
+++ b/packages/studio/styled-system/jsx/spacer.mjs
@@ -5,5 +5,8 @@ import { getSpacerStyle } from '../patterns/spacer.mjs';
 export const Spacer = /* @__PURE__ */ forwardRef(function Spacer(props, ref) {
   const { size, ...restProps } = props
 const styleProps = getSpacerStyle({size})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/square.mjs
+++ b/packages/studio/styled-system/jsx/square.mjs
@@ -5,5 +5,8 @@ import { getSquareStyle } from '../patterns/square.mjs';
 export const Square = /* @__PURE__ */ forwardRef(function Square(props, ref) {
   const { size, ...restProps } = props
 const styleProps = getSquareStyle({size})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/stack.mjs
+++ b/packages/studio/styled-system/jsx/stack.mjs
@@ -5,5 +5,8 @@ import { getStackStyle } from '../patterns/stack.mjs';
 export const Stack = /* @__PURE__ */ forwardRef(function Stack(props, ref) {
   const { align, justify, direction, gap, ...restProps } = props
 const styleProps = getStackStyle({align, justify, direction, gap})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/styled-link.mjs
+++ b/packages/studio/styled-system/jsx/styled-link.mjs
@@ -3,6 +3,10 @@ import { panda } from './factory.mjs';
 import { getStyledLinkStyle } from '../patterns/styled-link.mjs';
 
 export const StyledLink = /* @__PURE__ */ forwardRef(function StyledLink(props, ref) {
-  const styleProps = getStyledLinkStyle()
-return createElement(panda.div, { ref, ...styleProps, ...props })
-})
+  const restProps = props
+const styleProps = getStyledLinkStyle()
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/visually-hidden.mjs
+++ b/packages/studio/styled-system/jsx/visually-hidden.mjs
@@ -3,6 +3,10 @@ import { panda } from './factory.mjs';
 import { getVisuallyHiddenStyle } from '../patterns/visually-hidden.mjs';
 
 export const VisuallyHidden = /* @__PURE__ */ forwardRef(function VisuallyHidden(props, ref) {
-  const styleProps = getVisuallyHiddenStyle()
-return createElement(panda.div, { ref, ...styleProps, ...props })
-})
+  const restProps = props
+const styleProps = getVisuallyHiddenStyle()
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/vstack.mjs
+++ b/packages/studio/styled-system/jsx/vstack.mjs
@@ -5,5 +5,8 @@ import { getVstackStyle } from '../patterns/vstack.mjs';
 export const VStack = /* @__PURE__ */ forwardRef(function VStack(props, ref) {
   const { justify, gap, ...restProps } = props
 const styleProps = getVstackStyle({justify, gap})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/jsx/wrap.mjs
+++ b/packages/studio/styled-system/jsx/wrap.mjs
@@ -5,5 +5,8 @@ import { getWrapStyle } from '../patterns/wrap.mjs';
 export const Wrap = /* @__PURE__ */ forwardRef(function Wrap(props, ref) {
   const { gap, rowGap, columnGap, align, justify, ...restProps } = props
 const styleProps = getWrapStyle({gap, rowGap, columnGap, align, justify})
-return createElement(panda.div, { ref, ...styleProps, ...restProps })
-})
+const cssProps = styleProps
+const mergedProps = { ref, ...cssProps, ...restProps }
+
+return createElement(panda.div, mergedProps)
+  })

--- a/packages/studio/styled-system/types/recipe.d.ts
+++ b/packages/studio/styled-system/types/recipe.d.ts
@@ -1,5 +1,4 @@
 /* eslint-disable */
-import type {  RecipeRule  } from './static-css';
 import type {  SystemStyleObject, DistributiveOmit, Pretty  } from './system-types';
 
 type StringToBoolean<T> = T extends 'true' | 'false' ? boolean : T
@@ -64,10 +63,6 @@ export interface RecipeDefinition<T extends RecipeVariantRecord> {
    * The styles to apply when a combination of variants is selected.
    */
   compoundVariants?: Pretty<RecipeCompoundVariant<RecipeCompoundSelection<T>>>[]
-  /**
-   * Variants to pre-generate, will be include in the final `config.staticCss`
-   */
-  staticCss?: RecipeRule[]
 }
 
 export type RecipeCreatorFn = <T extends RecipeVariantRecord>(config: RecipeDefinition<T>) => RecipeRuntimeFn<T>


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1777

## 📝 Description

Fix static extraction issue when using JSX attributes (props) that are other JSX nodes

```tsx
const Component = () => {
  return (
    <>
      {/* ❌ this wasn't extracting ml="2" */}
      <Flex icon={<svg className="icon" />} ml="2" />

      {/* ✅ this was fine */}
      <Stack ml="4" icon={<div className="icon" />} />
    </>
  )
}
```

Now both will be fine again.

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

While parsing over the AST Nodes, due to an optimization where we skipped retrieving the current JSX element and instead
kept track of the latest one, the logic was flawed and did not extract other properties after encountering a JSX
attribute that was another JSX node.
