### PR TITLE
playground: add wordwrap control

### DIFF
--- a/playground/src/components/Editor.tsx
+++ b/playground/src/components/Editor.tsx
@@ -1,4 +1,4 @@
-import { FormatCode } from '@/src/components/icons'
+import { FormatCode, WrapText } from '@/src/components/icons'
 import { css, cva, cx } from '@/styled-system/css'
 import { Flex } from '@/styled-system/jsx'
 import { segmentGroup } from '@/styled-system/recipes'
@@ -22,8 +22,16 @@ const tabs = [
 ]
 
 export const Editor = (props: PandaEditorProps) => {
-  const { activeTab, setActiveTab, onBeforeMount, onCodeEditorChange, onCodeEditorMount, onCodeEditorFormat } =
-    useEditor(props)
+  const {
+    activeTab,
+    setActiveTab,
+    onBeforeMount,
+    onCodeEditorChange,
+    onCodeEditorMount,
+    onCodeEditorFormat,
+    wordWrap,
+    onToggleWrap,
+  } = useEditor(props)
 
   const editorPaths = {
     code: 'code.tsx',
@@ -60,26 +68,24 @@ export const Editor = (props: PandaEditorProps) => {
             </Segment>
           ))}
 
-          <button
-            className={css({
-              ml: 'auto',
-              borderRadius: 'sm',
-              cursor: 'pointer',
-              p: '1',
-              color: 'text.default',
-              _hover: {
-                color: { base: 'gray.700', _dark: 'gray.100' },
-                bg: { base: 'gray.100', _dark: '#3A3A3AFF' },
-              },
-              transition: 'all 0.2s ease-in-out',
-              _disabled: { cursor: 'not-allowed' },
-            })}
-            title="Format code"
-            disabled={!!props.diffState}
-            onClick={onCodeEditorFormat}
-          >
-            <FormatCode />
-          </button>
+          <div className={css({ ml: 'auto', display: 'flex', gap: '0.5' })}>
+            <button
+              className={actionButton()}
+              title="Toggle word wrap (Alt + Z)"
+              data-active={wordWrap === 'on' ? '' : undefined}
+              onClick={onToggleWrap}
+            >
+              <WrapText />
+            </button>
+            <button
+              className={actionButton()}
+              title="Format code (Shift + Alt + F)"
+              disabled={!!props.diffState}
+              onClick={onCodeEditorFormat}
+            >
+              <FormatCode />
+            </button>
+          </div>
         </SegmentGroup>
         <div className={cx(css({ flex: '1', pt: '2' }), editorTokenizer())}>
           {props.diffState ? (
@@ -109,6 +115,26 @@ export const Editor = (props: PandaEditorProps) => {
     </Flex>
   )
 }
+
+const actionButton = cva({
+  base: {
+    borderRadius: 'sm',
+    cursor: 'pointer',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    h: '8',
+    w: '8',
+    '& > svg': { h: '5' },
+    color: 'text.default',
+    transition: 'all 0.2s ease-in-out',
+    '&:hover, &[data-active]': {
+      color: { base: 'gray.700', _dark: 'gray.100' },
+      bg: { base: 'gray.100', _dark: '#3A3A3AFF' },
+    },
+    _disabled: { cursor: 'not-allowed' },
+  },
+})
 
 const editorTokenizer = cva({
   base: {

--- a/playground/src/components/icons.tsx
+++ b/playground/src/components/icons.tsx
@@ -85,6 +85,27 @@ export function FormatCode() {
   )
 }
 
+export function WrapText() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="3" x2="21" y1="6" y2="6" />
+      <path d="M3 12h15a3 3 0 1 1 0 6h-4" />
+      <polyline points="16 16 14 18 16 20" />
+      <line x1="3" x2="10" y1="18" y2="18" />
+    </svg>
+  )
+}
+
 export function SuccessIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">


### PR DESCRIPTION
Add wordwrap control to playground

https://github.com/chakra-ui/panda/assets/30869823/deea5917-48b3-43e1-a6b9-ec7191be78b4

