### PR TITLE
fix(preset): a missing bracket in _indeterminate condition

### DIFF
--- a/.changeset/spotty-spoons-compete.md
+++ b/.changeset/spotty-spoons-compete.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/preset-base': patch
+'@pandacss/studio': patch
+---
+
+Fixes a missing bracket in \_indeterminate condition

--- a/packages/preset-base/src/conditions.ts
+++ b/packages/preset-base/src/conditions.ts
@@ -55,7 +55,7 @@ export const conditions = {
   groupExpanded: '.group:is([aria-expanded=true], [data-expanded], [data-state="expanded"]) &',
   groupInvalid: '.group:invalid &',
 
-  indeterminate: '&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate")',
+  indeterminate: '&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate"])',
   required: '&:is(:required, [data-required], [aria-required=true])',
   valid: '&:is(:valid, [data-valid])',
   invalid: '&:is(:invalid, [data-invalid])',

--- a/packages/studio/styled-system/types/conditions.d.ts
+++ b/packages/studio/styled-system/types/conditions.d.ts
@@ -102,7 +102,7 @@ export interface Conditions {
 	"_groupExpanded": string
 	/** `.group:invalid &` */
 	"_groupInvalid": string
-	/** `&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate")` */
+	/** `&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate"])` */
 	"_indeterminate": string
 	/** `&:is(:required, [data-required], [aria-required=true])` */
 	"_required": string


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The `_indeterminate` condition causes a syntax error due to a missing square bracket.

## ⛳️ Current behavior (updates)

```
<css input> Unclosed bracket

  21 |     }
  22 |     .indeterminate\:bg_alias\.bg\.brand\.default {
> 23 |         &:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate") {
     |             ^
  24 |             background-color: var(--colors-alias-bg-brand-default)
  25 |         }
```

## 🚀 New behavior

No Unclosed Bracket error. 😄 

## 💣 Is this a breaking change (Yes/No):

No