### PR TITLE
fix: playground tabs order

### DIFF
--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -121,7 +121,7 @@ export function usePanda(state: State) {
     context.appendLayerParams()
     context.appendBaselineCss()
 
-    const cssArtifacts: CssFileArtifact[] = [
+    const cssArtifacts = [
       { file: 'Tokens', code: context.stylesheet.getLayerCss('tokens') },
       { file: 'Reset', code: context.stylesheet.getLayerCss('reset') },
       { file: 'Global', code: context.stylesheet.getLayerCss('base') },
@@ -153,12 +153,10 @@ export function usePanda(state: State) {
       .map((f) => f.code?.replaceAll(/import .*/g, '').replaceAll(/export \* from '(.+?)';/g, ''))
       ?.join('\n')
 
-    const cssArtifacts = (
-      [
-        { file: 'Utilities', code: context.stylesheet.getLayerCss('utilities') },
-        { file: 'Recipes', code: context.stylesheet.getLayerCss('recipes') },
-      ] as CssFileArtifact[]
-    ).concat(staticArtifacts)
+    const cssArtifacts: CssFileArtifact[] = [
+      { file: 'Utilities', code: context.stylesheet.getLayerCss('utilities') },
+      { file: 'Recipes', code: context.stylesheet.getLayerCss('recipes') },
+    ].concat(staticArtifacts)
     const previewCss = [css, ...cssArtifacts.map((a) => a.code ?? '')].join('\n')
 
     const panda = {

--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -153,10 +153,12 @@ export function usePanda(state: State) {
       .map((f) => f.code?.replaceAll(/import .*/g, '').replaceAll(/export \* from '(.+?)';/g, ''))
       ?.join('\n')
 
-    const cssArtifacts = staticArtifacts.concat([
-      { file: 'Utilities', code: context.stylesheet.getLayerCss('utilities') },
-      { file: 'Recipes', code: context.stylesheet.getLayerCss('recipes') },
-    ])
+    const cssArtifacts = (
+      [
+        { file: 'Utilities', code: context.stylesheet.getLayerCss('utilities') },
+        { file: 'Recipes', code: context.stylesheet.getLayerCss('recipes') },
+      ] as CssFileArtifact[]
+    ).concat(staticArtifacts)
     const previewCss = [css, ...cssArtifacts.map((a) => a.code ?? '')].join('\n')
 
     const panda = {


### PR DESCRIPTION
Revert order

**Before**:
![CleanShot 2023-12-12 at 23 09 16@2x](https://github.com/chakra-ui/panda/assets/30869823/4fd1724c-27f3-44b3-b8de-a251473491f6)


**After**:
![CleanShot 2023-12-12 at 23 09 09@2x](https://github.com/chakra-ui/panda/assets/30869823/df9630fc-7dfd-4f31-95d9-c6afa82535e2)
