### PR TITLE
fix: allow @pandacss/astro/base.css in postcss plugin

### DIFF
--- a/.changeset/moody-schools-live.md
+++ b/.changeset/moody-schools-live.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/postcss': patch
+'@pandacss/astro': patch
+---
+
+Fix a regression with the @pandacss/astro integration where the automatically provided `base.css` would be ignored by
+the @pandacss/postcss plugin

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -20,6 +20,13 @@ function isValidCss(file: string) {
   return path.extname(filePath) === '.css'
 }
 
+const shouldSkip = (fileName: string | undefined) => {
+  if (!fileName) return true
+  if (!isValidCss(fileName)) return true
+  if (fileName.includes('@pandacss/astro/base.css')) return false
+  return nodeModulesRegex.test(fileName)
+}
+
 export const pandacss: PluginCreator<{ configPath?: string; cwd?: string }> = (options = {}) => {
   const { configPath, cwd } = options
 
@@ -29,7 +36,7 @@ export const pandacss: PluginCreator<{ configPath?: string; cwd?: string }> = (o
       async function (root, result) {
         const fileName = result.opts.from
 
-        const skip = fileName ? !isValidCss(fileName) || nodeModulesRegex.test(fileName) : true
+        const skip = shouldSkip(fileName)
         if (skip) return
 
         await builder.setup({ configPath, cwd })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1827

## 📝 Description

Fix a regression with the @pandacss/astro integration where the automatically provided `base.css` would be ignored by
the @pandacss/postcss plugin

## 💣 Is this a breaking change (Yes/No):

no
