### PR TITLE
fix(postcss): config change sometimes didnt trigger files extraction

### DIFF
--- a/.changeset/odd-pumas-try.md
+++ b/.changeset/odd-pumas-try.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Fix an issue with the postcss plugin when a config change sometimes didn't trigger files extraction


### PR DESCRIPTION
## 📝 Description

Fix an issue with the postcss plugin when a config change sometimes didn't trigger files extraction

## 💣 Is this a breaking change (Yes/No):

no