### PR TITLE
fix(diffs): avoid mutating config object

### DIFF
--- a/.changeset/thick-moles-flow.md
+++ b/.changeset/thick-moles-flow.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/generator': patch
+'@pandacss/core': patch
+'@pandacss/node': patch
+---
+
+Fix an issue with config change detection when using a custom `config.slotRecipes[xxx].jsx` array

--- a/packages/core/src/recipes.ts
+++ b/packages/core/src/recipes.ts
@@ -108,7 +108,7 @@ export class Recipes {
   private assignRecipe = (name: string, recipe: RecipeConfig | SlotRecipeConfig) => {
     const variantKeys = Object.keys(recipe.variants ?? {})
     const capitalized = capitalize(name)
-    const jsx = recipe.jsx ?? [capitalized]
+    const jsx = Array.from(recipe.jsx ?? [capitalized])
     if ('slots' in recipe) {
       jsx.push(...recipe.slots.map((slot) => capitalized + '.' + capitalize(slot)))
     }

--- a/packages/generator/src/engines/index.ts
+++ b/packages/generator/src/engines/index.ts
@@ -129,7 +129,7 @@ export class Context {
     return new Utility({
       prefix: this.prefix.className,
       tokens: this.tokens,
-      config: this.isTemplateLiteralSyntax ? {} : config.utilities,
+      config: this.isTemplateLiteralSyntax ? {} : Object.assign({}, config.utilities),
       separator: config.separator,
       shorthands: config.shorthands,
       strictTokens: config.strictTokens,

--- a/packages/node/__tests__/diff-engine.test.ts
+++ b/packages/node/__tests__/diff-engine.test.ts
@@ -70,84 +70,6 @@ describe('DiffEngine affecteds', () => {
       [
         {
           "path": [
-            "utilities",
-            "colorPalette",
-          ],
-          "type": "CREATE",
-          "value": {
-            "transform": "transform(value) {
-              return values[value];
-            }",
-            "values": [
-              "current",
-              "black",
-              "white",
-              "transparent",
-              "rose",
-              "pink",
-              "fuchsia",
-              "purple",
-              "violet",
-              "indigo",
-              "blue",
-              "sky",
-              "cyan",
-              "teal",
-              "emerald",
-              "green",
-              "lime",
-              "yellow",
-              "amber",
-              "orange",
-              "red",
-              "neutral",
-              "stone",
-              "zinc",
-              "gray",
-              "slate",
-              "deep",
-              "deep.test",
-              "deep.test.pool",
-              "primary",
-              "secondary",
-              "complex",
-              "surface",
-              "button",
-              "button.card",
-            ],
-          },
-        },
-        {
-          "path": [
-            "utilities",
-            "textStyle",
-          ],
-          "type": "CREATE",
-          "value": {
-            "className": "textStyle",
-            "layer": "compositions",
-            "transform": "(value) => {
-              return __vite_ssr_import_1__.serializeStyle(flatValues[value], ctx);
-            }",
-            "values": [
-              "xs",
-              "sm",
-              "md",
-              "lg",
-              "xl",
-              "2xl",
-              "3xl",
-              "4xl",
-              "5xl",
-              "6xl",
-              "7xl",
-              "8xl",
-              "9xl",
-            ],
-          },
-        },
-        {
-          "path": [
             "theme",
             "tokens",
             "colors",
@@ -742,5 +664,28 @@ describe('DiffEngine affecteds', () => {
         },
       ]
     `)
+  })
+
+  test('nothing changes', () => {
+    const defaultConfig = (): Config => ({
+      outdir: '',
+      cwd: '',
+      cssVarRoot: ':where(html)',
+      ...fixtureConfig,
+    })
+
+    const config = defaultConfig() as UserConfig
+    const generator = new Generator(createConfigResult(config))
+    const diffEngine = new DiffEngine(generator)
+    const nextConfig = mergeConfigs([{}, config, {}])
+
+    const affecteds = diffEngine.refresh(createConfigResult(nextConfig))
+    expect(affecteds.artifacts).toMatchInlineSnapshot('Set {}')
+    expect(affecteds.diffs).toMatchInlineSnapshot('[]')
+
+    const resetConfig = mergeConfigs([defaultConfig()])
+    const affectedsAfterReset = diffEngine.refresh(createConfigResult(resetConfig))
+    expect(affectedsAfterReset.artifacts).toMatchInlineSnapshot('Set {}')
+    expect(affecteds.diffs).toMatchInlineSnapshot('[]')
   })
 })

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -55,6 +55,8 @@ export class Builder {
       this.context.appendBaselineCss()
     })
 
+    logger.debug('builder', this.affecteds)
+
     // config change
     if (this.affecteds.hasConfigChanged) {
       logger.debug('builder', '⚙️ Config changed, reloading')
@@ -65,6 +67,7 @@ export class Builder {
     // file change
     this.hasFilesChanged = this.checkFilesChanged(ctx.getFiles())
     if (this.hasFilesChanged) {
+      logger.debug('builder', 'Files changed, invalidating them')
       ctx.project.reloadSourceFiles()
     }
   }
@@ -72,6 +75,7 @@ export class Builder {
   async emit() {
     // ensure emit is only called when the config is changed
     if (this.hasEmitted && this.affecteds?.hasConfigChanged) {
+      logger.debug('builder', 'Emit artifacts after config change')
       await emitArtifacts(this.getContextOrThrow(), Array.from(this.affecteds.artifacts))
     }
 
@@ -125,7 +129,10 @@ export class Builder {
 
   extract = async () => {
     const hasConfigChanged = this.affecteds ? this.affecteds.hasConfigChanged : true
-    if (!this.hasFilesChanged && !hasConfigChanged) return
+    if (!this.hasFilesChanged && !hasConfigChanged) {
+      logger.debug('builder', 'No files or config changed, skipping extract')
+      return
+    }
 
     const ctx = this.getContextOrThrow()
     const files = ctx.getFiles()


### PR DESCRIPTION
## 📝 Description

there was a nasty infinite loop caused by the diff-engine always detecting the same changes reproduction here: https://github.com/animareflection/ui/pull/181

```
{
  artifacts: Set(3) { 'recipes-index', 'slot-recipes.drawer', 'recipes' },
  hasConfigChanged: true,
  diffs: [
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.Trigger' },
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.Backdrop' },
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.Positioner' },
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.Content' },
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.Title' },
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.Description' },
    { type: 'CREATE', path: ["theme", "slotRecipes", dDrawer", "jsx"], value: 'Drawer.CloseTrigger' }
  ]
}
🐼 debug [builder] ⚙️ Config changed, reloading
🐼 debug [write:file] recipes/index.mjs
🐼 debug [write:file] recipes/index.d.ts
🐼 debug [write:file] recipes/drawer.mjs
🐼 debug [write:file] recipes/drawer.d.ts
🐼 info [hrtime] Extracted in (88.99ms)
```

the main issue is that:
1. our diff engine serialize the resolved config right after loading/bundling it (when it's finalized: after each presets has been merged)
2. we add these defaults jsx component names for each slot recipes (so that users have their recipes "just work" most of the time without specifying anything) directly on the `jsx` array coming from the config, essentially mutating it

-> this will create diffs and will be seen as if they were added by an actual config change

---

by mutating on another object/array reference (cloned with Array.from or Object.assign) than those coming from the resolved config, we should avoid this problem
