### PR TITLE
fix(parser): handle {xxx}.raw aliasing

### DIFF
--- a/.changeset/serious-llamas-play.md
+++ b/.changeset/serious-llamas-play.md
@@ -1,0 +1,20 @@
+---
+'@pandacss/parser': patch
+---
+
+Fix a parser issue where we didn't handle import aliases when using a {xxx}.raw() function.
+
+ex:
+
+```ts
+// button.stories.ts
+import { button as buttonRecipe } from '@ui/styled-system/recipes'
+
+export const Primary: Story = {
+  // ❌ this wouldn't be parsed as a recipe because of the alias + .raw()
+  //  -> ✅ it's now fixed
+  args: buttonRecipe.raw({
+    color: 'primary',
+  }),
+}
+```

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3054,4 +3054,37 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('extract aliased {xxx}.raw', () => {
+    const code = `
+    import { css } from '.panda/css';
+    import { styled } from '.panda/jsx';
+    import { cardStyle as aliasedCard } from '.panda/recipes';
+
+    const className = aliasedCard.raw({ rounded: true })
+
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "rounded": true,
+            },
+          ],
+          "name": "cardStyle",
+          "type": "recipe",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes {
+        .card--rounded_true {
+          border-radius: 0.375rem
+          }
+      }"
+    `)
+  })
 })

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -308,8 +308,9 @@ export function createParser(options: ParserOptions) {
     measure()
 
     extractResultByName.forEach((result, alias) => {
-      let name = imports.getName(alias)
+      let name = alias
       if (isRawFn(name)) name = name.replace('.raw', '')
+      name = imports.getName(name)
 
       logger.debug(`ast:${name}`, name !== alias ? { kind: result.kind, alias } : { kind: result.kind })
 


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1801

## 📝 Description

Fix a parser issue where we didn't handle import aliases when using a {xxx}.raw() function.

ex:

```ts
// button.stories.ts
import { button as buttonRecipe } from '@ui/styled-system/recipes'

export const Primary: Story = {
  // ❌ this wouldn't be parsed as a recipe because of the alias + .raw()
  //  -> ✅ it's now fixed
  args: buttonRecipe.raw({
    color: 'primary',
  }),
}
```
