### PR TITLE
perf(parser): skip jsx/template literal syntax parsing if disabled

### DIFF
--- a/.changeset/silver-cherries-walk.md
+++ b/.changeset/silver-cherries-walk.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/generator': patch
+'@pandacss/parser': patch
+---
+
+Fix & perf improvement: skip JSX parsing when not using `config.jsxFramework` / skip tagged template literal parsing
+when not using `config.syntax` set to "template-literal"

--- a/packages/generator/src/parser-options.ts
+++ b/packages/generator/src/parser-options.ts
@@ -42,6 +42,7 @@ export const getParserOptions = (ctx: Context): ParserOptions => {
       isStyleProp: isValidProperty,
       nodes: [...patterns.details, ...recipes.details],
     },
+    isTemplateLiteralSyntax: ctx.isTemplateLiteralSyntax,
     patternKeys: patterns.keys,
     recipeKeys: recipes.keys,
     getRecipesByJsxName: recipes.filter,

--- a/packages/generator/src/parser-options.ts
+++ b/packages/generator/src/parser-options.ts
@@ -70,6 +70,7 @@ export interface ParserJsxOptions {
 export interface ParserOptions {
   importMap: ParserImportMap
   jsx: ParserJsxOptions
+  isTemplateLiteralSyntax: boolean
   patternKeys: Context['patterns']['keys']
   recipeKeys: Context['recipes']['keys']
   getRecipesByJsxName: Context['recipes']['filter']

--- a/packages/parser/__tests__/css-raw.test.ts
+++ b/packages/parser/__tests__/css-raw.test.ts
@@ -40,77 +40,77 @@ describe('{fn}.raw', () => {
     const result = parseAndExtract(code)
 
     expect(result.json).toMatchInlineSnapshot(`
-          [
+      [
+        {
+          "data": [
             {
-              "data": [
-                {
-                  "color": "amber.100",
-                  "mx": "3",
-                  "paddingTop": "4",
-                },
-                {
-                  "color": "blue.950",
-                  "mx": "10",
-                  "pt": "6",
-                },
-              ],
-              "name": "css",
-              "type": "object",
+              "color": "amber.100",
+              "mx": "3",
+              "paddingTop": "4",
             },
             {
-              "data": [
-                {
-                  "bg": "red.400",
-                },
-              ],
-              "name": "css",
-              "type": "object",
+              "color": "blue.950",
+              "mx": "10",
+              "pt": "6",
             },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
             {
-              "data": [
-                {},
-              ],
-              "name": "ButtonStyle",
-              "type": "jsx-recipe",
+              "bg": "red.400",
             },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "ButtonStyle",
+          "type": "jsx-recipe",
+        },
+        {
+          "data": [
             {
-              "data": [
-                {
-                  "shape": "circle",
-                  "size": "sm",
-                  "visual": "funky",
-                },
-              ],
-              "name": "buttonStyle",
-              "type": "recipe",
+              "shape": "circle",
+              "size": "sm",
+              "visual": "funky",
             },
+          ],
+          "name": "buttonStyle",
+          "type": "recipe",
+        },
+        {
+          "data": [
             {
-              "data": [
-                {
-                  "direction": "column",
-                },
-              ],
-              "name": "stack",
-              "type": "pattern",
+              "direction": "column",
             },
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+        {
+          "data": [
             {
-              "data": [
-                {
-                  "direction": "row",
-                },
-              ],
-              "name": "stack",
-              "type": "pattern",
+              "direction": "row",
             },
-            {
-              "data": [
-                {},
-              ],
-              "name": "stack",
-              "type": "pattern",
-            },
-          ]
-        `)
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+      ]
+    `)
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer recipes {

--- a/packages/parser/__tests__/fixture.ts
+++ b/packages/parser/__tests__/fixture.ts
@@ -70,7 +70,6 @@ export function getFixtureProject(code: string, userConfig?: Config, tsconfig?: 
     getFiles: () => [staticFilePath],
     readFile: () => code,
     parserOptions: {
-      isTemplateLiteralSyntax: false,
       join(...paths) {
         return paths.join('/')
       },

--- a/packages/parser/__tests__/fixture.ts
+++ b/packages/parser/__tests__/fixture.ts
@@ -41,6 +41,7 @@ const defaults: Omit<LoadConfigResult, 'serialized' | 'deserialize'> = {
     },
     outdir: '.panda',
     jsxFactory: 'panda',
+    jsxFramework: 'react',
   },
   path: '',
 }
@@ -69,6 +70,7 @@ export function getFixtureProject(code: string, userConfig?: Config, tsconfig?: 
     getFiles: () => [staticFilePath],
     readFile: () => code,
     parserOptions: {
+      isTemplateLiteralSyntax: false,
       join(...paths) {
         return paths.join('/')
       },
@@ -93,6 +95,14 @@ export function importParser(code: string, option: { name: string; module: strin
 
 export function cssParser(code: string) {
   const project = getProject(code)
+  const data = project.parseSourceFile(staticFilePath)!
+  return {
+    css: data.css,
+  }
+}
+
+export function cssTemplateLiteralParser(code: string) {
+  const project = getProject(code, { syntax: 'template-literal' })
   const data = project.parseSourceFile(staticFilePath)!
   return {
     css: data.css,

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -663,7 +663,7 @@ describe('extract to css output pipeline', () => {
         }
     \`
      `
-    const result = parseAndExtract(code)
+    const result = parseAndExtract(code, { syntax: 'template-literal' })
     expect(result.json).toMatchInlineSnapshot(`
       [
         {
@@ -712,16 +712,16 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
-        .text_lightgreen {
+        .color_lightgreen {
           color: lightgreen
           }
 
-        .\\\\[\\\\&_\\\\>_strong\\\\]\\\\:text_hotpink > strong {
+        .\\\\[\\\\&_\\\\>_strong\\\\]\\\\:color_hotpink > strong {
           color: hotpink
               }
 
-        .bg_transparent {
-          background: var(--colors-transparent)
+        .background_transparent {
+          background: transparent
           }
 
         .border-radius_3px {
@@ -732,19 +732,19 @@ describe('extract to css output pipeline', () => {
           border: 1px solid var(--accent-color)
           }
 
-        .text_token\\\\(colors\\\\.blue\\\\.100\\\\) {
+        .color_token\\\\(colors\\\\.blue\\\\.100\\\\) {
           color: var(--colors-blue-100)
           }
 
-        .d_inline-block {
+        .display_inline-block {
           display: inline-block
           }
 
-        .m_0\\\\.5rem_1rem {
+        .margin_0\\\\.5rem_1rem {
           margin: 0.5rem 1rem
           }
 
-        .p_0\\\\.5rem_0 {
+        .padding_0\\\\.5rem_0 {
           padding: 0.5rem 0
           }
 
@@ -752,7 +752,7 @@ describe('extract to css output pipeline', () => {
           transition: all 200ms ease-in-out
           }
 
-        .w_11rem {
+        .width_11rem {
           width: 11rem
           }
 
@@ -771,7 +771,7 @@ describe('extract to css output pipeline', () => {
                   }
 
         @media (min-width: 768px) {
-          .\\\\[\\\\@media_\\\\(min-width\\\\:_768px\\\\)\\\\]\\\\:p_1rem_0 {
+          .\\\\[\\\\@media_\\\\(min-width\\\\:_768px\\\\)\\\\]\\\\:padding_1rem_0 {
             padding: 1rem 0
           }
               }
@@ -790,7 +790,7 @@ describe('extract to css output pipeline', () => {
         color: token(colors.blue.100);
     \`
      `
-    const result = parseAndExtract(code)
+    const result = parseAndExtract(code, { syntax: 'template-literal' })
     expect(result.json).toMatchInlineSnapshot(`
       [
         {
@@ -810,8 +810,8 @@ describe('extract to css output pipeline', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
-        .bg_transparent {
-          background: var(--colors-transparent)
+        .background_transparent {
+          background: transparent
           }
 
         .border-radius_3px {
@@ -822,7 +822,7 @@ describe('extract to css output pipeline', () => {
           border: 1px solid var(--accent-color)
           }
 
-        .text_token\\\\(colors\\\\.blue\\\\.100\\\\) {
+        .color_token\\\\(colors\\\\.blue\\\\.100\\\\) {
           color: var(--colors-blue-100)
           }
       }"
@@ -1356,15 +1356,6 @@ describe('extract to css output pipeline', () => {
         {
           "data": [
             {
-              "color": "var(--colors-purple-100)",
-            },
-          ],
-          "name": "panda.div",
-          "type": "object",
-        },
-        {
-          "data": [
-            {
               "color": "yellow.100",
             },
           ],
@@ -1380,12 +1371,41 @@ describe('extract to css output pipeline', () => {
           color: var(--colors-red-100)
           }
 
-        .text_var\\\\(--colors-purple-100\\\\) {
-          color: var(--colors-purple-100)
-          }
-
         .text_yellow\\\\.100 {
           color: var(--colors-yellow-100)
+          }
+      }"
+    `)
+  })
+
+  test('factory css - tagged template literal', () => {
+    const code = `
+    import { panda } from ".panda/jsx"
+
+    // TaggedTemplateExpression factory css
+    panda.div\`
+      color: var(--colors-purple-100);
+    \`
+   `
+    const result = parseAndExtract(code, { syntax: 'template-literal' })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "color": "var(--colors-purple-100)",
+            },
+          ],
+          "name": "panda.div",
+          "type": "object",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .color_var\\\\(--colors-purple-100\\\\) {
+          color: var(--colors-purple-100)
           }
       }"
     `)

--- a/packages/parser/__tests__/string-literal.test.ts
+++ b/packages/parser/__tests__/string-literal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { cssParser } from './fixture'
+import { cssTemplateLiteralParser } from './fixture'
 
 describe('ast parser / string literal', () => {
   test('should parse', () => {
@@ -19,7 +19,7 @@ describe('ast parser / string literal', () => {
     \`
      `
 
-    expect(cssParser(code)).toMatchInlineSnapshot(`
+    expect(cssTemplateLiteralParser(code)).toMatchInlineSnapshot(`
       {
         "css": Set {
           {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -19,7 +19,7 @@ const isNodePattern = (node: ParserNodeOptions): node is ParserPatternNode => no
 
 const cvaProps = ['compoundVariants', 'defaultVariants', 'variants', 'base']
 const isCva = (map: BoxNodeMap['value']) => cvaProps.some((prop) => map.has(prop))
-const noop = (..._args: any[]) => ({} as any)
+const noop = (..._args: any[]) => void 0 as any
 
 export interface ParserOptions {
   importMap: Record<'css' | 'recipe' | 'pattern' | 'jsx', string[]>
@@ -145,24 +145,22 @@ export function createParser(options: ParserOptions) {
     }
 
     const patternPropertiesByName = new Map<string, Set<string>>()
+    const initialpatterns = { string: new Set<string>(), regex: [] as RegExp[] }
     const patternJsxLists = isJsxEnabled
-      ? (jsx?.nodes ?? []).filter(isNodePattern).reduce(
-          (acc, pattern) => {
-            patternPropertiesByName.set(pattern.jsxName, new Set(pattern.props ?? []))
+      ? (jsx?.nodes ?? []).filter(isNodePattern).reduce((acc, pattern) => {
+          patternPropertiesByName.set(pattern.jsxName, new Set(pattern.props ?? []))
 
-            pattern.jsx?.forEach((jsx) => {
-              if (typeof jsx === 'string') {
-                acc.string.add(jsx)
-              } else if (jsx) {
-                acc.regex.push(jsx)
-              }
-            })
+          pattern.jsx?.forEach((jsx) => {
+            if (typeof jsx === 'string') {
+              acc.string.add(jsx)
+            } else if (jsx) {
+              acc.regex.push(jsx)
+            }
+          })
 
-            return acc
-          },
-          { string: new Set<string>(), regex: [] as RegExp[] },
-        )
-      : { string: new Set<string>(), regex: [] as RegExp[] }
+          return acc
+        }, initialpatterns)
+      : initialpatterns
 
     const recipes = new Set<string>()
     const patterns = new Set<string>()
@@ -184,24 +182,22 @@ export function createParser(options: ParserOptions) {
     const propertiesMap = new Map<string, boolean>()
     const recipePropertiesByJsxName = new Map<string, Set<string>>()
 
+    const initialRecipes = { string: new Set<string>(), regex: [] as RegExp[] }
     const recipeJsxLists = isJsxEnabled
-      ? (jsx?.nodes ?? []).filter(isNodeRecipe).reduce(
-          (acc, recipe) => {
-            recipePropertiesByJsxName.set(recipe.jsxName, new Set(recipe.props ?? []))
+      ? (jsx?.nodes ?? []).filter(isNodeRecipe).reduce((acc, recipe) => {
+          recipePropertiesByJsxName.set(recipe.jsxName, new Set(recipe.props ?? []))
 
-            recipe.jsx?.forEach((jsx) => {
-              if (typeof jsx === 'string') {
-                acc.string.add(jsx)
-              } else {
-                acc.regex.push(jsx)
-              }
-            })
+          recipe.jsx?.forEach((jsx) => {
+            if (typeof jsx === 'string') {
+              acc.string.add(jsx)
+            } else {
+              acc.regex.push(jsx)
+            }
+          })
 
-            return acc
-          },
-          { string: new Set<string>(), regex: [] as RegExp[] },
-        )
-      : { string: new Set<string>(), regex: [] as RegExp[] }
+          return acc
+        }, initialRecipes)
+      : initialRecipes
 
     const cvaAlias = imports.getAlias('cva')
     const cssAlias = imports.getAlias('css')

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -19,6 +19,7 @@ const isNodePattern = (node: ParserNodeOptions): node is ParserPatternNode => no
 
 const cvaProps = ['compoundVariants', 'defaultVariants', 'variants', 'base']
 const isCva = (map: BoxNodeMap['value']) => cvaProps.some((prop) => map.has(prop))
+const noop = (..._args: any[]) => ({} as any)
 
 export interface ParserOptions {
   importMap: Record<'css' | 'recipe' | 'pattern' | 'jsx', string[]>
@@ -29,6 +30,7 @@ export interface ParserOptions {
     nodes: ParserNodeOptions[]
     isStyleProp: (prop: string) => boolean
   }
+  isTemplateLiteralSyntax: boolean
   patternKeys: string[]
   recipeKeys: string[]
   getRecipesByJsxName: (jsxName: string) => ParserRecipeNode[]
@@ -68,8 +70,10 @@ const identityFn = (styles: any) => styles
 const evaluateOptions: EvalOptions = { environment: defaultEnv }
 
 export function createParser(options: ParserOptions) {
-  const { jsx, getRecipesByJsxName, getPatternsByJsxName, tsOptions, join } = options
+  const { jsx, getRecipesByJsxName, getPatternsByJsxName, tsOptions, join, isTemplateLiteralSyntax } = options
   const importMap = Object.fromEntries(Object.entries(options.importMap).map(([key, value]) => [key, join(...value)]))
+
+  const isJsxEnabled = jsx.framework
 
   // Create regex for each import map
   const importRegex = [
@@ -78,7 +82,7 @@ export function createParser(options: ParserOptions) {
     createImportMatcher(importMap.pattern),
   ]
 
-  if (jsx.framework) {
+  if (isJsxEnabled) {
     importRegex.push(createImportMatcher(importMap.jsx, [jsx.factory, ...jsx.nodes.map((node) => node.jsxName)]))
   }
 
@@ -124,35 +128,41 @@ export function createParser(options: ParserOptions) {
       imports.value.length ? `Found import { ${imports} } in ${filePath}` : `No import found in ${filePath}`,
     )
 
+    if (!imports.value.length && !isJsxEnabled) {
+      return collector
+    }
+
     const [css] = importRegex
-    const jsxFactoryAlias = jsx ? imports.getAlias(jsx.factory) : 'styled'
+    const jsxFactoryAlias = isJsxEnabled ? imports.getAlias(jsx.factory) : 'styled'
 
     const isValidPattern = imports.createMatch(importMap.pattern, options.patternKeys)
     const isValidRecipe = imports.createMatch(importMap.recipe, options.recipeKeys)
     const isValidStyleFn = (name: string) => name === jsx?.factory
-    const isFactory = (name: string) => Boolean(jsx && name.startsWith(jsxFactoryAlias))
+    const isFactory = (name: string) => Boolean(isJsxEnabled && name.startsWith(jsxFactoryAlias))
     const isRawFn = (fullName: string) => {
       const name = fullName.split('.raw')[0] ?? ''
       return name === 'css' || isValidPattern(name) || isValidRecipe(name)
     }
 
     const patternPropertiesByName = new Map<string, Set<string>>()
-    const patternJsxLists = (jsx?.nodes ?? []).filter(isNodePattern).reduce(
-      (acc, pattern) => {
-        patternPropertiesByName.set(pattern.jsxName, new Set(pattern.props ?? []))
+    const patternJsxLists = isJsxEnabled
+      ? (jsx?.nodes ?? []).filter(isNodePattern).reduce(
+          (acc, pattern) => {
+            patternPropertiesByName.set(pattern.jsxName, new Set(pattern.props ?? []))
 
-        pattern.jsx?.forEach((jsx) => {
-          if (typeof jsx === 'string') {
-            acc.string.add(jsx)
-          } else if (jsx) {
-            acc.regex.push(jsx)
-          }
-        })
+            pattern.jsx?.forEach((jsx) => {
+              if (typeof jsx === 'string') {
+                acc.string.add(jsx)
+              } else if (jsx) {
+                acc.regex.push(jsx)
+              }
+            })
 
-        return acc
-      },
-      { string: new Set<string>(), regex: [] as RegExp[] },
-    )
+            return acc
+          },
+          { string: new Set<string>(), regex: [] as RegExp[] },
+        )
+      : { string: new Set<string>(), regex: [] as RegExp[] }
 
     const recipes = new Set<string>()
     const patterns = new Set<string>()
@@ -174,22 +184,24 @@ export function createParser(options: ParserOptions) {
     const propertiesMap = new Map<string, boolean>()
     const recipePropertiesByJsxName = new Map<string, Set<string>>()
 
-    const recipeJsxLists = (jsx?.nodes ?? []).filter(isNodeRecipe).reduce(
-      (acc, recipe) => {
-        recipePropertiesByJsxName.set(recipe.jsxName, new Set(recipe.props ?? []))
+    const recipeJsxLists = isJsxEnabled
+      ? (jsx?.nodes ?? []).filter(isNodeRecipe).reduce(
+          (acc, recipe) => {
+            recipePropertiesByJsxName.set(recipe.jsxName, new Set(recipe.props ?? []))
 
-        recipe.jsx?.forEach((jsx) => {
-          if (typeof jsx === 'string') {
-            acc.string.add(jsx)
-          } else {
-            acc.regex.push(jsx)
-          }
-        })
+            recipe.jsx?.forEach((jsx) => {
+              if (typeof jsx === 'string') {
+                acc.string.add(jsx)
+              } else {
+                acc.regex.push(jsx)
+              }
+            })
 
-        return acc
-      },
-      { string: new Set<string>(), regex: [] as RegExp[] },
-    )
+            return acc
+          },
+          { string: new Set<string>(), regex: [] as RegExp[] },
+        )
+      : { string: new Set<string>(), regex: [] as RegExp[] }
 
     const cvaAlias = imports.getAlias('cva')
     const cssAlias = imports.getAlias('css')
@@ -206,35 +218,41 @@ export function createParser(options: ParserOptions) {
       })
     }
 
-    const isJsxTagRecipe = memo(
-      (tagName: string) =>
-        recipeJsxLists.string.has(tagName) || recipeJsxLists.regex.some((regex) => regex.test(tagName)),
-    )
-    const isJsxTagPattern = memo(
-      (tagName: string) =>
-        patternJsxLists.string.has(tagName) || patternJsxLists.regex.some((regex) => regex.test(tagName)),
-    )
+    const isJsxTagRecipe = isJsxEnabled
+      ? memo(
+          (tagName: string) =>
+            recipeJsxLists.string.has(tagName) || recipeJsxLists.regex.some((regex) => regex.test(tagName)),
+        )
+      : noop
+    const isJsxTagPattern = isJsxEnabled
+      ? memo(
+          (tagName: string) =>
+            patternJsxLists.string.has(tagName) || patternJsxLists.regex.some((regex) => regex.test(tagName)),
+        )
+      : noop
 
-    const matchTag = memo((tagName: string) => {
-      // ignore fragments
-      if (!tagName) return false
+    const matchTag = isJsxEnabled
+      ? memo((tagName: string) => {
+          // ignore fragments
+          if (!tagName) return false
 
-      return (
-        components.has(tagName) ||
-        isUpperCase(tagName) ||
-        isFactory(tagName) ||
-        isJsxTagRecipe(tagName) ||
-        isJsxTagPattern(tagName)
-      )
-    })
+          return (
+            components.has(tagName) ||
+            isUpperCase(tagName) ||
+            isFactory(tagName) ||
+            isJsxTagRecipe(tagName) ||
+            isJsxTagPattern(tagName)
+          )
+        })
+      : noop
 
     const isRecipeOrPatternProp = memo((tagName: string, propName: string) => {
-      if (isJsxTagRecipe(tagName)) {
+      if (isJsxEnabled && isJsxTagRecipe(tagName)) {
         const recipeList = getRecipesByJsxName(tagName)
         return recipeList.some((recipe) => recipePropertiesByJsxName.get(recipe.jsxName)?.has(propName))
       }
 
-      if (isJsxTagPattern(tagName)) {
+      if (isJsxEnabled && isJsxTagPattern(tagName)) {
         const patternList = getPatternsByJsxName(tagName)
         return patternList.some((pattern) => patternPropertiesByName.get(pattern.baseName)?.has(propName))
       }
@@ -242,21 +260,23 @@ export function createParser(options: ParserOptions) {
       return false
     })
 
-    const matchTagProp = match(jsx?.styleProps)
-      .with('all', () =>
-        memo((tagName: string, propName: string) => {
-          return (
-            Boolean(components.get(tagName)?.has(propName)) ||
-            options.jsx?.isStyleProp(propName) ||
-            propertiesMap.has(propName) ||
-            isRecipeOrPatternProp(tagName, propName)
+    const matchTagProp = isJsxEnabled
+      ? match(jsx?.styleProps)
+          .with('all', () =>
+            memo((tagName: string, propName: string) => {
+              return (
+                Boolean(components.get(tagName)?.has(propName)) ||
+                options.jsx?.isStyleProp(propName) ||
+                propertiesMap.has(propName) ||
+                isRecipeOrPatternProp(tagName, propName)
+              )
+            }),
           )
-        }),
-      )
-      .with('minimal', () => (tagName: string, propName: string) => {
-        return propName === 'css' || isRecipeOrPatternProp(tagName, propName)
-      })
-      .otherwise(() => (tagName: string, propName: string) => isRecipeOrPatternProp(tagName, propName))
+          .with('minimal', () => (tagName: string, propName: string) => {
+            return propName === 'css' || isRecipeOrPatternProp(tagName, propName)
+          })
+          .otherwise(() => (tagName: string, propName: string) => isRecipeOrPatternProp(tagName, propName))
+      : noop
 
     const matchFn = memo((fnName: string) => {
       if (recipes.has(fnName) || patterns.has(fnName)) return true
@@ -269,10 +289,12 @@ export function createParser(options: ParserOptions) {
 
     const extractResultByName = extract({
       ast: sourceFile,
-      components: {
-        matchTag: (prop) => matchTag(prop.tagName),
-        matchProp: (prop) => matchTagProp(prop.tagName, prop.propName),
-      },
+      components: isJsxEnabled
+        ? {
+            matchTag: (prop) => matchTag(prop.tagName),
+            matchProp: (prop) => matchTagProp(prop.tagName, prop.propName),
+          }
+        : undefined,
       functions: {
         matchFn: (prop) => matchFn(prop.fnName),
         matchProp: () => true,
@@ -282,9 +304,7 @@ export function createParser(options: ParserOptions) {
           return true
         },
       },
-      taggedTemplates: {
-        matchTaggedTemplate: (tag) => matchFn(tag.fnName),
-      },
+      taggedTemplates: isTemplateLiteralSyntax ? { matchTaggedTemplate: (tag) => matchFn(tag.fnName) } : undefined,
       getEvaluateOptions: (node) => {
         if (!Node.isCallExpression(node)) return evaluateOptions
         const propAccessExpr = node.getExpression()
@@ -456,7 +476,7 @@ export function createParser(options: ParserOptions) {
             //
           })
         //
-      } else if (result.kind === 'component') {
+      } else if (isJsxEnabled && result.kind === 'component') {
         //
         result.queryList.forEach((query) => {
           //

--- a/sandbox/astro/src/components/Card.astro
+++ b/sandbox/astro/src/components/Card.astro
@@ -1,0 +1,64 @@
+---
+interface Props {
+	title: string;
+	body: string;
+	href: string;
+	position: string;
+}
+
+const { href, title, body, position } = Astro.props;
+---
+
+<li class="link-card">
+	<a href={href}>
+		<h2>
+			{title}
+
+			Variable named position {position}
+			<span>&rarr;</span>
+		</h2>
+		<p>
+			{body}
+		</p>
+	</a>
+</li>
+<style>
+	.link-card {
+		list-style: none;
+		display: flex;
+		padding: 1px;
+		background-color: #23262d;
+		background-image: none;
+		background-size: 400%;
+		border-radius: 7px;
+		background-position: 100%;
+		transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+	}
+	.link-card > a {
+		width: 100%;
+		text-decoration: none;
+		line-height: 1.4;
+		padding: calc(1.5rem - 1px);
+		border-radius: 8px;
+		color: white;
+		background-color: #23262d;
+		opacity: 0.8;
+	}
+	h2 {
+		margin: 0;
+		font-size: 1.25rem;
+		transition: color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+	}
+	p {
+		margin-top: 0.5rem;
+		margin-bottom: 0;
+	}
+	.link-card:is(:hover, :focus-within) {
+		background-position: 0;
+		background-image: var(--accent-gradient);
+	}
+	.link-card:is(:hover, :focus-within) h2 {
+		color: rgb(var(--accent-light));
+	}
+</style>

--- a/sandbox/astro/src/pages/index.astro
+++ b/sandbox/astro/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro'
 import { Button } from '../components/button.jsx'
+import Card from '../components/Card.astro';
 import { css } from '../../styled-system/css'
 import { circle, hstack } from '../../panda/patterns'
 ---
@@ -28,6 +29,12 @@ import { circle, hstack } from '../../panda/patterns'
           })}>4</span
         >
       </div>
+      <Card
+				href="https://docs.astro.build/"
+				title="Documentation"
+				body="Learn how Astro works and explore the official API docs."
+				position="Test 12345"
+			/>
     </div>
   </main>
 </Layout>


### PR DESCRIPTION
Closes  https://github.com/chakra-ui/panda/issues/1800

## 📝 Description

Fix & perf improvement: skip JSX parsing when not using `config.jsxFramework` / skip tagged template literal parsing
when not using `config.syntax` set to "template-literal"

## 💣 Is this a breaking change (Yes/No):

no
