### PR TITLE
feat(sva): automatically generate CSS for sva with unresolved slots

### DIFF
--- a/.changeset/pretty-hounds-smell.md
+++ b/.changeset/pretty-hounds-smell.md
@@ -1,0 +1,37 @@
+---
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Automatically extract/generate CSS for `sva` even if `slots` are not statically extractable, since it will only produce
+atomic styles, we don't care much about slots for `sva` specifically
+
+Currently the CSS won't be generated if the `slots` are missing which can be problematic when getting them from another
+file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`
+
+```ts
+import { sva } from '../styled-system/css'
+import { slots } from './slots'
+
+const card = sva({
+  slots, // ❌ did NOT work -> ✅ will now work as expected
+  base: {
+    root: {
+      p: '6',
+      m: '4',
+      w: 'md',
+      boxShadow: 'md',
+      borderRadius: 'md',
+      _dark: { bg: '#262626', color: 'white' },
+    },
+    content: {
+      textStyle: 'lg',
+    },
+    title: {
+      textStyle: 'xl',
+      fontWeight: 'semibold',
+      pb: '2',
+    },
+  },
+})
+```

--- a/packages/core/src/stylesheet.ts
+++ b/packages/core/src/stylesheet.ts
@@ -72,16 +72,7 @@ export class Stylesheet {
     recipe: Pick<SlotRecipeConfig, 'base' | 'variants' | 'compoundVariants'> & Partial<Pick<SlotRecipeConfig, 'slots'>>,
   ) => {
     if (!recipe.slots) {
-      const slots = new Set<string>()
-      Object.keys(recipe.base ?? {}).forEach((name) => {
-        slots.add(name)
-      })
-
-      Object.keys(recipe.variants ?? {}).forEach((name) => {
-        slots.add(name)
-      })
-
-      recipe.slots = Array.from(slots)
+      recipe.slots = Array.from(inferSlots(recipe as any))
     }
 
     const slots = getSlotRecipes(recipe)
@@ -164,4 +155,19 @@ export class Stylesheet {
   clean = () => {
     this.context.layers.clean()
   }
+}
+
+const inferSlots = (recipe: SlotRecipeConfig) => {
+  const slots = new Set<string>()
+  Object.keys(recipe.base ?? {}).forEach((name) => {
+    slots.add(name)
+  })
+
+  Object.values(recipe.variants ?? {}).forEach((variants) => {
+    Object.keys(variants).forEach((name) => {
+      slots.add(name)
+    })
+  })
+
+  return slots
 }

--- a/packages/core/src/stylesheet.ts
+++ b/packages/core/src/stylesheet.ts
@@ -68,7 +68,9 @@ export class Stylesheet {
     this.processCompoundVariants(config)
   }
 
-  processAtomicSlotRecipe = (recipe: Pick<SlotRecipeConfig, 'base' | 'variants' | 'compoundVariants' | 'slots'>) => {
+  processAtomicSlotRecipe = (
+    recipe: Pick<SlotRecipeConfig, 'base' | 'variants' | 'compoundVariants'> & Partial<Pick<SlotRecipeConfig, 'slots'>>,
+  ) => {
     if (!recipe.slots) {
       const slots = new Set<string>()
       Object.keys(recipe.base ?? {}).forEach((name) => {

--- a/packages/core/src/stylesheet.ts
+++ b/packages/core/src/stylesheet.ts
@@ -68,8 +68,22 @@ export class Stylesheet {
     this.processCompoundVariants(config)
   }
 
-  processAtomicSlotRecipe = (recipe: Pick<SlotRecipeConfig, 'base' | 'variants' | 'compoundVariants'>) => {
+  processAtomicSlotRecipe = (recipe: Pick<SlotRecipeConfig, 'base' | 'variants' | 'compoundVariants' | 'slots'>) => {
+    if (!recipe.slots) {
+      const slots = new Set<string>()
+      Object.keys(recipe.base ?? {}).forEach((name) => {
+        slots.add(name)
+      })
+
+      Object.keys(recipe.variants ?? {}).forEach((name) => {
+        slots.add(name)
+      })
+
+      recipe.slots = Array.from(slots)
+    }
+
     const slots = getSlotRecipes(recipe)
+
     for (const slotRecipe of Object.values(slots)) {
       this.processAtomicRecipe(slotRecipe)
     }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3087,4 +3087,120 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('sva with unresolvable slots', () => {
+    const code = `
+    import { sva } from '.panda/css'
+    import { slots } from './slots'
+
+    const card = sva({
+      slots,
+      base: {
+        root: {
+          p: '6',
+          m: '4',
+          w: 'md',
+          boxShadow: 'md',
+          borderRadius: 'md',
+          _dark: { bg: '#262626', color: 'white' },
+        },
+        content: {
+          textStyle: 'lg',
+        },
+        title: {
+          textStyle: 'xl',
+          fontWeight: 'semibold',
+          pb: '2',
+        },
+      },
+    })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "base": {
+                "content": {
+                  "textStyle": "lg",
+                },
+                "root": {
+                  "_dark": {
+                    "bg": "#262626",
+                    "color": "white",
+                  },
+                  "borderRadius": "md",
+                  "boxShadow": "md",
+                  "m": "4",
+                  "p": "6",
+                  "w": "md",
+                },
+                "title": {
+                  "fontWeight": "semibold",
+                  "pb": "2",
+                  "textStyle": "xl",
+                },
+              },
+              "slots": [
+                "root",
+                "content",
+                "title",
+              ],
+            },
+          ],
+          "name": "sva",
+          "type": "object",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .p_6 {
+          padding: var(--spacing-6)
+          }
+
+        .m_4 {
+          margin: var(--spacing-4)
+          }
+
+        .w_md {
+          width: var(--sizes-md)
+          }
+
+        .shadow_md {
+          box-shadow: var(--shadows-md)
+          }
+
+        .rounded_md {
+          border-radius: var(--radii-md)
+          }
+
+        [data-theme=dark] .dark\\\\:bg_\\\\#262626, .dark .dark\\\\:bg_\\\\#262626, .dark\\\\:bg_\\\\#262626.dark, .dark\\\\:bg_\\\\#262626[data-theme=dark] {
+          background: #262626
+              }
+
+        [data-theme=dark] .dark\\\\:text_white, .dark .dark\\\\:text_white, .dark\\\\:text_white.dark, .dark\\\\:text_white[data-theme=dark] {
+          color: var(--colors-white)
+              }
+
+        .text-style_lg {
+          text-style: lg
+          }
+
+        .text-style_xl {
+          text-style: xl
+          }
+
+        .font_semibold {
+          font-weight: var(--font-weights-semibold)
+          }
+
+        .pb_2 {
+          padding-bottom: var(--spacing-2)
+          }
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
## 📝 Description

Automatically extract/generate CSS for `sva` even if `slots` are not statically extractable, since it will only produce
atomic styles, we don't care much about slots for `sva` specifically

Currently the CSS won't be generated if the `slots` are missing which can be problematic when getting them from another
file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`

```ts
import { sva } from '../styled-system/css'
import { slots } from './slots'

const card = sva({
  slots, // ❌ did NOT work -> ✅ will now work as expected
  base: {
    root: {
      p: '6',
      m: '4',
      w: 'md',
      boxShadow: 'md',
      borderRadius: 'md',
      _dark: { bg: '#262626', color: 'white' },
    },
    content: {
      textStyle: 'lg',
    },
    title: {
      textStyle: 'xl',
      fontWeight: 'semibold',
      pb: '2',
    },
  },
})
```

## 💣 Is this a breaking change (Yes/No):

no
