### PR TITLE
docs: Update recipes.md to include comparison of responsive styling

### DIFF
--- a/website/pages/docs/concepts/recipes.md
+++ b/website/pages/docs/concepts/recipes.md
@@ -665,5 +665,6 @@ When dealing with simple use cases, or if you need code colocation, or even avoi
 | Can both use any theme tokens, utilities or conditions | ✅ yes                                                                      | ✅ yes                                                                   |
 | Are generated just in time (JIT) based on usage        | ✅ yes, only the recipe variants found in your code will be generated       | ❌ no, all variants found in your `cva` recipes will always be generated |
 | Can be shared in a preset                              | ✅ yes, you can include it in your `preset.theme.recipes`                   | ❌ no                                                                    |
+| Can be applied responsively                            | ✅ yes, `button({ size: { base: 'sm', md: 'lg' } })`                        | ❌ no, only the styles in the recipe can be responsive                   |
 | Can be colocated in your markup code                   | ❌ no, they must be defined or imported in your `panda.config`              | ✅ yes, you can place it anywhere in your app                            |
 | Generate atomic classes                                | ❌ no, a specific className will be generated using your `recipe.className` | ✅ yes                                                                   |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

It appears that config recipes can be applied responsively, while CVA recipes cannot. To make a button large/small based on a media query with a CVA recipe, the responsiveness would either need to be part of the recipe itself, or you would need to show/hide two separate buttons based on a media query.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
