### PR TITLE
chore: add package metadata

### DIFF
--- a/packages/astro-plugin-studio/package.json
+++ b/packages/astro-plugin-studio/package.json
@@ -7,6 +7,12 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/astro-plugin-studio"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -12,6 +12,12 @@
     "dev": "pnpm build-fast --watch"
   },
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/astro"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/config"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,12 @@
     "dist"
   ],
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/core"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -7,6 +7,12 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/error"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/extractor"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/generator"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/is-valid-prop/package.json
+++ b/packages/is-valid-prop/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/is-valid-prop"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,6 +24,12 @@
     "dev": "pnpm build-fast --watch"
   },
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/logger"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,6 +27,12 @@
     "dist"
   ],
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/node"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -18,6 +18,12 @@
   },
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/parser"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -24,6 +24,12 @@
     "dev": "pnpm build-fast --watch"
   },
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/postcss"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset-atlaskit/package.json
+++ b/packages/preset-atlaskit/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/preset-atlaskit"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset-base/package.json
+++ b/packages/preset-base/package.json
@@ -7,6 +7,12 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/preset-base"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset-open-props/package.json
+++ b/packages/preset-open-props/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Abraham Aremu <anubra266@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/preset-open-props"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset-panda/package.json
+++ b/packages/preset-panda/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/preset-panda"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/shared"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -6,6 +6,12 @@
   "module": "dist/studio.mjs",
   "types": "dist/studio.d.ts",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/studio"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/token-dictionary/package.json
+++ b/packages/token-dictionary/package.json
@@ -7,6 +7,12 @@
   "types": "dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/token-dictionary"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,6 +18,12 @@
     "build": "PANDA_BUILD=1 tsx scripts/postbuild.ts && tsx scripts/build.ts"
   },
   "sideEffects": false,
+  "homepage": "https://panda-css.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/types"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION


## 📝 Description

This change is a must-have for Renovate support added in renovatebot/renovate#26306 as it [compares](https://docs.renovatebot.com/presets-monorepo/#monorepopanda-css) URLs in package.json

## ⛳️ Current behavior (updates)

> Monorepo branch:
![image](https://github.com/chakra-ui/panda/assets/6079265/92c1f793-b869-4138-a969-f63fdbbb20bc)
![image](https://github.com/chakra-ui/panda/assets/6079265/b2b7e9f8-4e0f-4b13-9b95-8f7a1ea6849a)

> Another branch:
![image](https://github.com/chakra-ui/panda/assets/6079265/e615b0f6-8a8e-4dac-81d0-795c1f7b770b)
> Missing source:
![image](https://github.com/chakra-ui/panda/assets/6079265/a6531abf-0f20-433d-b0cc-ee53570f82e2)


## 🚀 New behavior


## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information
