### PR TITLE
docs: md format to vue

### DIFF
--- a/website/pages/docs/installation/vue.mdx
+++ b/website/pages/docs/installation/vue.mdx
@@ -197,7 +197,7 @@ Run the following command to start your development server.
 Now you can start using Panda CSS in your project.
 Here is the snippet of code that you can use in your `src/App.vue` file.
 
-```vue filename="src/App.vue"
+```vue-html filename="src/App.vue"
 <script setup lang="ts">
 import { css } from "../styled-system/css";
 </script>

--- a/website/pages/docs/installation/vue.mdx
+++ b/website/pages/docs/installation/vue.mdx
@@ -197,7 +197,7 @@ Run the following command to start your development server.
 Now you can start using Panda CSS in your project.
 Here is the snippet of code that you can use in your `src/App.vue` file.
 
-```md filename="src/App.vue"
+```vue filename="src/App.vue"
 <script setup lang="ts">
 import { css } from "../styled-system/css";
 </script>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

Change Syntax Highlighting for [installation/vue page](https://panda-css.com/docs/installation/vue#start-using-panda)

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

<img width="819" alt="스크린샷 2023-12-24 오전 3 51 44" src="https://github.com/chakra-ui/panda/assets/57122180/5221ae11-765f-4e5b-baee-67797c382c10">

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Change `md` to `vue-html`

<img width="800" alt="스크린샷 2023-12-24 오전 4 02 48" src="https://github.com/chakra-ui/panda/assets/57122180/2592c4f7-8be4-4865-8c72-1b6f8d6367c5">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information

The highlighting will be different when set to `vue` and when set to `vue-html`. 
`vue-html` doesn't allow `import` syntax, and the `css` method calls in `vue` are different from `vetur` highlighting. 

<img width="794" alt="스크린샷 2023-12-24 오전 3 52 32" src="https://github.com/chakra-ui/panda/assets/57122180/bcf1bbf4-d37b-421e-a1a1-fa85961428dd">

> changed to `vue` case

I personally think the `css` method calls are important, so I set it to `vue-html`, and I think it's more readable than the previous version with no highlighting at all.
