### PR TITLE
Playground presets

### DIFF
--- a/playground/src/components/Editor.tsx
+++ b/playground/src/components/Editor.tsx
@@ -1,4 +1,4 @@
-import { FormatCode, WrapText } from '@/src/components/icons'
+import { FormatCode, LoaderIcon, WrapText } from '@/src/components/icons'
 import { css, cva, cx } from '@/styled-system/css'
 import { Flex } from '@/styled-system/jsx'
 import { segmentGroup } from '@/styled-system/recipes'
@@ -69,6 +69,16 @@ export const Editor = (props: PandaEditorProps) => {
           ))}
 
           <div className={css({ ml: 'auto', display: 'flex', gap: '0.5' })}>
+            <button
+              hidden={!props.isLoading}
+              className={cx(
+                actionButton(),
+                css({ bg: 'transparent!', animation: 'spin', _hidden: { display: 'none' } }),
+              )}
+              data-active
+            >
+              <LoaderIcon />
+            </button>
             <button
               className={actionButton()}
               title="Toggle word wrap (Alt + Z)"

--- a/playground/src/components/Examples/data.ts
+++ b/playground/src/components/Examples/data.ts
@@ -11,21 +11,14 @@ export const EXAMPLES = [
   {
     id: 'css',
     label: 'Writing styles (css)',
-    code: outdent`import { css } from 'styled-system/css';
-    import { center } from 'styled-system/patterns';
+    code: outdent`import { center } from 'styled-system/patterns';
+    import { button } from 'styled-system/recipes';
     
     export const App = () => {
       return (
         <div className={center({ h: 'full' })}>
           <div
-            className={css({
-              display: 'flex',
-              flexDirection: 'column',
-              fontWeight: 'semibold',
-              color: 'yellow.300',
-              textAlign: 'center',
-              textStyle: '4xl',
-            })}
+            className={button()}
           >
             <span>🐼</span>
             <span>Hello from Panda</span>
@@ -33,6 +26,7 @@ export const EXAMPLES = [
         </div>
       );
     };
+    
     
         `,
     config: getConfig(`theme: { extend: {} },`),

--- a/playground/src/components/Examples/utils.ts
+++ b/playground/src/components/Examples/utils.ts
@@ -17,8 +17,9 @@ export const getConfig = (
   return formatText(`${imports ?? ''}
 
   ${otherCode ?? ''}
-  
+
   export const config = defineConfig({
+    presets: ["@pandacss/preset-panda", "@shadow-panda/preset"],
       ${config ?? ''}${config?.endsWith(',') ? '' : ','}
       globalCss: {
         html: {

--- a/playground/src/components/Playground.tsx
+++ b/playground/src/components/Playground.tsx
@@ -37,7 +37,7 @@ export const Playground = (props: UsePlayGroundProps) => {
 
   const _state = props.diffState ?? state
 
-  const { config } = useConfig(_state.config)
+  const { config, isLoading, error } = useConfig(_state.config)
   const panda = usePanda(_state, config)
   const responsiveView = useResponsiveView(panda)
 
@@ -121,6 +121,7 @@ export const Playground = (props: UsePlayGroundProps) => {
                   recipes: Array.from(panda.context.recipes.rules.keys()),
                 }}
                 diffState={diffState}
+                isLoading={isLoading}
               />
             </SplitterPanel>
 
@@ -137,6 +138,7 @@ export const Playground = (props: UsePlayGroundProps) => {
             responsiveView={responsiveView}
             isResponsive={isResponsive}
             isConfigReady={!!config}
+            error={error}
           />
         </SplitterPanel>
       </Splitter>

--- a/playground/src/components/Playground.tsx
+++ b/playground/src/components/Playground.tsx
@@ -14,6 +14,7 @@ import { Examples } from '@/src/components/Examples'
 import { useResponsiveView } from '@/src/hooks/useResponsiveView'
 import { GitCompareArrowsIcon } from '@/src/components/icons'
 import { flex } from '@/styled-system/patterns'
+import { useConfig } from '@/src/hooks/useConfig'
 
 export const Playground = (props: UsePlayGroundProps) => {
   const {
@@ -33,10 +34,12 @@ export const Playground = (props: UsePlayGroundProps) => {
     isResponsive,
     setExample,
   } = usePlayground(props)
-  const panda = usePanda(props.diffState ?? state)
-  const responsiveView = useResponsiveView(panda)
 
-  const { artifacts } = panda
+  const _state = props.diffState ?? state
+
+  const { config } = useConfig(_state.config)
+  const panda = usePanda(_state, config)
+  const responsiveView = useResponsiveView(panda)
 
   return (
     <>
@@ -112,7 +115,7 @@ export const Playground = (props: UsePlayGroundProps) => {
               <Editor
                 value={state}
                 onChange={setState}
-                artifacts={artifacts}
+                artifacts={panda.artifacts}
                 context={{
                   patterns: panda.context.patterns.details,
                   recipes: Array.from(panda.context.recipes.rules.keys()),
@@ -128,7 +131,13 @@ export const Playground = (props: UsePlayGroundProps) => {
           <div />
         </SplitterResizeTrigger>
         <SplitterPanel id="preview" className={css({ zIndex: 3, pos: 'relative' })}>
-          <Preview source={state.code} panda={panda} responsiveView={responsiveView} isResponsive={isResponsive} />
+          <Preview
+            source={state.code}
+            panda={panda}
+            responsiveView={responsiveView}
+            isResponsive={isResponsive}
+            isConfigReady={!!config}
+          />
         </SplitterPanel>
       </Splitter>
     </>

--- a/playground/src/components/Playground.tsx
+++ b/playground/src/components/Playground.tsx
@@ -112,17 +112,7 @@ export const Playground = (props: UsePlayGroundProps) => {
             className={splitter()}
           >
             <SplitterPanel id="editor">
-              <Editor
-                value={state}
-                onChange={setState}
-                artifacts={panda.artifacts}
-                context={{
-                  patterns: panda.context.patterns.details,
-                  recipes: Array.from(panda.context.recipes.rules.keys()),
-                }}
-                diffState={diffState}
-                isLoading={isLoading}
-              />
+              <Editor value={state} onChange={setState} panda={panda} diffState={diffState} isLoading={isLoading} />
             </SplitterPanel>
 
             <ArtifactsPanel panda={panda} />
@@ -137,7 +127,6 @@ export const Playground = (props: UsePlayGroundProps) => {
             panda={panda}
             responsiveView={responsiveView}
             isResponsive={isResponsive}
-            isConfigReady={!!config}
             error={error}
           />
         </SplitterPanel>

--- a/playground/src/components/Preview/index.tsx
+++ b/playground/src/components/Preview/index.tsx
@@ -15,10 +15,11 @@ export type PreviewProps = {
   isResponsive: boolean
   panda: UsePanda
   responsiveView: UseResponsiveView
+  isConfigReady: boolean
 }
 
 export const Preview = (props: PreviewProps) => {
-  const { source, isResponsive, responsiveView, panda } = props
+  const { source, isResponsive, responsiveView, panda, isConfigReady } = props
   const { previewCss = '', previewJs } = panda
 
   const isClient = useIsClient()
@@ -56,8 +57,18 @@ export const Preview = (props: PreviewProps) => {
   } as const
 
   function renderContent() {
-    if (!isReady) {
-      return null
+    const doc = contentRef?.contentDocument
+    if (!isReady || !isConfigReady) {
+      return [
+        doc?.head &&
+          createPortal(
+            <style>{`  body.dark,
+      .dark body {
+        background: #2c2c2c;
+      }`}</style>,
+            doc.head,
+          ),
+      ]
     }
 
     const defaultExportName = extractDefaultExportedFunctionName(source) ?? 'App'
@@ -71,8 +82,6 @@ export const Preview = (props: PreviewProps) => {
         <LivePreview />
       </LiveProvider>
     )
-
-    const doc = contentRef?.contentDocument
 
     return [
       doc?.head && createPortal(<style>{previewCss}</style>, doc.head),

--- a/playground/src/components/Preview/index.tsx
+++ b/playground/src/components/Preview/index.tsx
@@ -16,10 +16,11 @@ export type PreviewProps = {
   panda: UsePanda
   responsiveView: UseResponsiveView
   isConfigReady: boolean
+  error: Error | null
 }
 
 export const Preview = (props: PreviewProps) => {
-  const { source, isResponsive, responsiveView, panda, isConfigReady } = props
+  const { source, isResponsive, responsiveView, panda, isConfigReady, error } = props
   const { previewCss = '', previewJs } = panda
 
   const isClient = useIsClient()
@@ -75,9 +76,9 @@ export const Preview = (props: PreviewProps) => {
     const transformed = `${previewJs.replaceAll(/export /g, '')}\n${source
       .replaceAll(/(?<!!)import.*/g, '')
       .concat(`\nrender(<${defaultExportName} />)`)}`
-
+    const errorThrow = error ? `throw new Error("${error.message}");\n` : ''
     const contents = (
-      <LiveProvider code={transformed} scope={React}>
+      <LiveProvider code={errorThrow + transformed} scope={React}>
         <LiveError />
         <LivePreview />
       </LiveProvider>

--- a/playground/src/components/Preview/index.tsx
+++ b/playground/src/components/Preview/index.tsx
@@ -15,12 +15,11 @@ export type PreviewProps = {
   isResponsive: boolean
   panda: UsePanda
   responsiveView: UseResponsiveView
-  isConfigReady: boolean
   error: Error | null
 }
 
 export const Preview = (props: PreviewProps) => {
-  const { source, isResponsive, responsiveView, panda, isConfigReady, error } = props
+  const { source, isResponsive, responsiveView, panda, error } = props
   const { previewCss = '', previewJs } = panda
 
   const isClient = useIsClient()
@@ -59,7 +58,7 @@ export const Preview = (props: PreviewProps) => {
 
   function renderContent() {
     const doc = contentRef?.contentDocument
-    if (!isReady || !isConfigReady) {
+    if (!isReady) {
       return [
         doc?.head &&
           createPortal(

--- a/playground/src/components/icons.tsx
+++ b/playground/src/components/icons.tsx
@@ -194,3 +194,21 @@ export function GitCompareArrowsIcon() {
     </svg>
   )
 }
+
+export function LoaderIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  )
+}

--- a/playground/src/dts/@pandacss_types.d.ts
+++ b/playground/src/dts/@pandacss_types.d.ts
@@ -2,7 +2,6 @@
 
 import { HookKeys, Hookable } from 'hookable';
 import { TSConfig } from 'pkg-types';
-import * as ts_morph from 'ts-morph';
 import { Node } from 'ts-morph';
 
 export interface WithNode {

--- a/playground/src/hooks/useConfig.ts
+++ b/playground/src/hooks/useConfig.ts
@@ -1,0 +1,27 @@
+import { Config } from '@pandacss/types'
+import { useEffect, useRef, useState } from 'react'
+
+export const useConfig = (_config: string) => {
+  const [config, setConfig] = useState<Config | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const compileWorkerRef = useRef<Worker>()
+  useEffect(() => {
+    compileWorkerRef.current = new Worker(new URL('../lib/compile-config/compile-worker.ts', import.meta.url))
+    compileWorkerRef.current.onmessage = (event: MessageEvent<{ config: string }>) => {
+      const newConfig = JSON.parse(event.data.config)
+      if (newConfig) setConfig(newConfig)
+      setIsLoading(true)
+    }
+
+    return () => {
+      compileWorkerRef.current?.terminate()
+    }
+  }, [])
+
+  useEffect(() => {
+    compileWorkerRef.current?.postMessage(_config)
+  }, [_config])
+
+  return { config, isLoading }
+}

--- a/playground/src/hooks/useConfig.ts
+++ b/playground/src/hooks/useConfig.ts
@@ -1,8 +1,13 @@
+import { evalConfig } from '@/src/lib/compile-config/eval-config'
+import { extractImports } from '@/src/lib/compile-config/extract-imports'
 import { Config } from '@pandacss/types'
 import { useEffect, useRef, useState } from 'react'
 
 export const useConfig = (_config: string) => {
-  const [config, setConfig] = useState<Config | null>(null)
+  const imports = extractImports(_config)
+  const initialConfig = imports.length ? null : evalConfig(_config)
+
+  const [config, setConfig] = useState<Config | null>(initialConfig)
   const [isLoading, setIsLoading] = useState(true)
 
   const compileWorkerRef = useRef<Worker>()

--- a/playground/src/hooks/useEditor.ts
+++ b/playground/src/hooks/useEditor.ts
@@ -23,6 +23,7 @@ export interface PandaEditorProps {
   onChange: (state: State) => void
   artifacts: Artifact[]
   context: AutoImportContext
+  isLoading: boolean
   diffState?: State | null
 }
 

--- a/playground/src/hooks/useEditor.ts
+++ b/playground/src/hooks/useEditor.ts
@@ -79,6 +79,10 @@ export function useEditor(props: PandaEditorProps) {
 
   const [wordWrap, setWordwrap] = useState<'on' | 'off'>('off')
 
+  const refreshModel = () => {
+    monacoEditorRef.current?.getModel()?.setValue(value[activeTab])
+  }
+
   const onToggleWrap = useCallback(() => {
     setWordwrap((prev) => (prev === 'on' ? 'off' : 'on'))
   }, [])
@@ -97,7 +101,6 @@ export function useEditor(props: PandaEditorProps) {
           editor.trigger('editor', 'editor.action.formatDocument', undefined)
         })
         editor.addCommand(monaco.KeyMod.Alt | monaco.KeyCode.KeyZ, () => {
-          // const wrapState = editor.getOption(monaco.editor.EditorOption.wordWrap)
           onToggleWrap()
         })
       }
@@ -205,6 +208,7 @@ export function useEditor(props: PandaEditorProps) {
 
   useUpdateEffect(() => {
     setupLibs(monacoRef.current!)
+    refreshModel()
   }, [artifacts])
 
   return {

--- a/playground/src/hooks/useEditor.ts
+++ b/playground/src/hooks/useEditor.ts
@@ -79,10 +79,6 @@ export function useEditor(props: PandaEditorProps) {
 
   const [wordWrap, setWordwrap] = useState<'on' | 'off'>('off')
 
-  const refreshModel = () => {
-    monacoEditorRef.current?.getModel()?.setValue(value[activeTab])
-  }
-
   const onToggleWrap = useCallback(() => {
     setWordwrap((prev) => (prev === 'on' ? 'off' : 'on'))
   }, [])
@@ -208,7 +204,6 @@ export function useEditor(props: PandaEditorProps) {
 
   useUpdateEffect(() => {
     setupLibs(monacoRef.current!)
-    refreshModel()
   }, [artifacts])
 
   return {

--- a/playground/src/hooks/useEditor.ts
+++ b/playground/src/hooks/useEditor.ts
@@ -91,7 +91,6 @@ export function useEditor(props: PandaEditorProps) {
   const configureEditor: OnMount = useCallback(
     (editor, monaco) => {
       activateMonacoJSXHighlighter(editor, monaco)
-      configureAutoImports({ context, monaco, editor })
 
       function registerKeybindings() {
         editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
@@ -126,7 +125,7 @@ export function useEditor(props: PandaEditorProps) {
         typeRoots: ['node_modules/@types'],
       })
     },
-    [onToggleWrap, context],
+    [onToggleWrap],
   )
 
   const setupLibs = useCallback(
@@ -164,6 +163,7 @@ export function useEditor(props: PandaEditorProps) {
 
       configureEditor(editor, monaco)
       setupLibs(monaco)
+      configureAutoImports({ context, monaco, editor })
 
       const typeSources = [
         {
@@ -206,6 +206,14 @@ export function useEditor(props: PandaEditorProps) {
   useUpdateEffect(() => {
     setupLibs(monacoRef.current!)
   }, [artifacts])
+
+  useUpdateEffect(() => {
+    const autoImport = configureAutoImports({ context, monaco: monacoRef.current!, editor: monacoEditorRef.current! })
+
+    return () => {
+      autoImport?.dispose()
+    }
+  }, [context])
 
   return {
     activeTab,

--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -5,7 +5,7 @@ import { Generator } from '@pandacss/generator'
 import { createProject } from '@pandacss/parser'
 import presetBase from '@pandacss/preset-base'
 import presetTheme from '@pandacss/preset-panda'
-import { Config, Preset, StaticCssOptions } from '@pandacss/types'
+import { Preset, StaticCssOptions } from '@pandacss/types'
 import { createHooks } from 'hookable'
 import { merge } from 'merge-anything'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -54,7 +54,7 @@ const playgroundPreset: Preset = {
 
 export function usePanda(state: State) {
   const { code: source, css, config } = state
-  const [userConfig, setUserConfig] = useState<Config | null>(evalConfig(config))
+  const [userConfig, setUserConfig] = useState(evalConfig(config))
   const previousContext = useRef<Generator | null>(null)
   const compileWorkerRef = useRef<Worker>()
 

--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -5,7 +5,7 @@ import { Generator } from '@pandacss/generator'
 import { createProject } from '@pandacss/parser'
 import presetBase from '@pandacss/preset-base'
 import presetTheme from '@pandacss/preset-panda'
-import { Preset, StaticCssOptions } from '@pandacss/types'
+import { Config, Preset, StaticCssOptions } from '@pandacss/types'
 import { createHooks } from 'hookable'
 import { merge } from 'merge-anything'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -54,14 +54,14 @@ const playgroundPreset: Preset = {
 
 export function usePanda(state: State) {
   const { code: source, css, config } = state
-  const [userConfig, setUserConfig] = useState(evalConfig(config))
+  const [userConfig, setUserConfig] = useState<Config | null>(evalConfig(config))
   const previousContext = useRef<Generator | null>(null)
   const compileWorkerRef = useRef<Worker>()
 
   useEffect(() => {
     compileWorkerRef.current = new Worker(new URL('../lib/compile-config/compile-worker.ts', import.meta.url))
-    compileWorkerRef.current.onmessage = (event: MessageEvent<string>) => {
-      const newUserConfig = JSON.parse(event.data)
+    compileWorkerRef.current.onmessage = (event: MessageEvent<{ config: string }>) => {
+      const newUserConfig = JSON.parse(event.data.config)
       if (newUserConfig) setUserConfig(newUserConfig)
     }
 
@@ -75,7 +75,7 @@ export function usePanda(state: State) {
   }, [config])
 
   const context = useMemo(() => {
-    const { presets, ...restConfig } = userConfig ?? {}
+    const { presets, ...restConfig } = userConfig
 
     const config = getResolvedConfig({
       cwd: '',

--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -75,7 +75,7 @@ export function usePanda(state: State) {
   }, [config])
 
   const context = useMemo(() => {
-    const { presets, ...restConfig } = userConfig
+    const { presets, ...restConfig } = userConfig ?? {}
 
     const config = getResolvedConfig({
       cwd: '',

--- a/playground/src/lib/auto-import.ts
+++ b/playground/src/lib/auto-import.ts
@@ -23,7 +23,7 @@ interface ImportObject {
 export const configureAutoImports = (opts: AutoImportOpts) => {
   const { monaco, editor, context } = opts
 
-  monaco.languages.registerCompletionItemProvider('typescript', {
+  return monaco?.languages.registerCompletionItemProvider('typescript', {
     provideCompletionItems(model, position) {
       const word = model.getWordUntilPosition(position)
       const range = {

--- a/playground/src/lib/compile-config/compile-worker.ts
+++ b/playground/src/lib/compile-config/compile-worker.ts
@@ -1,54 +1,7 @@
-import { evalConfig } from './eval-config'
-import { extractImports } from './extract-imports'
-
-const importShim = (0, eval)('u=>import(u)')
-
-const require = async (module: string) => {
-  if (typeof module !== 'string') {
-    throw new Error('The "id" argument must be of type string. Received ' + typeof module)
-  }
-  if (module === '') {
-    throw new Error("The argument 'id' must be a non-empty string. Received ''")
-  }
-  const href = 'https://cdn.skypack.dev/' + module + '?min'
-  let res
-  try {
-    res = await importShim(href)
-  } catch (error) {
-    throw new Error("Cannot find module '" + module + "'")
-  }
-  return res
-}
+import { compile } from '@/src/lib/compile-config/compile'
 
 addEventListener('message', async (event: MessageEvent<string>) => {
-  const _config = event.data
-  const imports = extractImports(_config)
+  const config = await compile(event.data)
 
-  const modules = await Promise.all(
-    imports.map(async (_mod) => {
-      const mod = await require(_mod.pkg)
-      return Object.entries(_mod.exps).map(([key, val]) => {
-        if (key === 'default') return { [val]: mod.default ?? mod }
-        if (val === '*') return { [key]: mod }
-        return { [val ?? key]: mod[key] }
-      })
-    }),
-  )
-
-  const scope = modules.flat().reduce((acc, cur) => Object.assign({}, acc, cur), {})
-
-  const newConfig = evalConfig(_config, scope)
-  const _presets = newConfig?.presets?.filter(Boolean) ?? []
-  const presets = await Promise.all(
-    _presets.map(async (_preset) => {
-      if (typeof _preset !== 'string') return _preset
-
-      const preset = await require(_preset)
-      return preset.default
-    }),
-  )
-
-  const config = Object.assign({}, newConfig, presets.length ? { presets } : {})
-  console.log('conf', config)
-  postMessage(JSON.stringify(config))
+  postMessage({ config: JSON.stringify(config) })
 })

--- a/playground/src/lib/compile-config/compile-worker.ts
+++ b/playground/src/lib/compile-config/compile-worker.ts
@@ -1,7 +1,10 @@
 import { compile } from '@/src/lib/compile-config/compile'
 
 addEventListener('message', async (event: MessageEvent<string>) => {
-  const config = await compile(event.data)
-
-  postMessage({ config: JSON.stringify(config) })
+  try {
+    const config = await compile(event.data)
+    postMessage({ config: JSON.stringify(config) })
+  } catch (error) {
+    postMessage({ error })
+  }
 })

--- a/playground/src/lib/compile-config/compile-worker.ts
+++ b/playground/src/lib/compile-config/compile-worker.ts
@@ -1,0 +1,42 @@
+import { evalConfig } from './eval-config'
+import { extractImports } from './extract-imports'
+
+const importShim = (0, eval)('u=>import(u)')
+
+const require = async (module: string) => {
+  if (typeof module !== 'string') {
+    throw new Error('The "id" argument must be of type string. Received ' + typeof module)
+  }
+  if (module === '') {
+    throw new Error("The argument 'id' must be a non-empty string. Received ''")
+  }
+  const href = 'https://cdn.skypack.dev/' + module + '?min'
+  let res
+  try {
+    res = await importShim(href)
+  } catch (error) {
+    throw new Error("Cannot find module '" + module + "'")
+  }
+  return res
+}
+
+addEventListener('message', async (event: MessageEvent<string>) => {
+  const config = event.data
+  const imports = extractImports(config)
+
+  const modules = await Promise.all(
+    imports.map(async (_mod) => {
+      const mod = await require(_mod.pkg)
+      return Object.entries(_mod.exps).map(([key, val]) => {
+        if (key === 'default') return { [val]: mod.default ?? mod }
+        if (val === '*') return { [key]: mod }
+        return { [val ?? key]: mod[key] }
+      })
+    }),
+  )
+
+  const scope = modules.flat().reduce((acc, cur) => Object.assign({}, acc, cur), {})
+
+  const newUserConfig = evalConfig(config, scope)
+  postMessage(JSON.stringify(newUserConfig))
+})

--- a/playground/src/lib/compile-config/compile.ts
+++ b/playground/src/lib/compile-config/compile.ts
@@ -1,0 +1,49 @@
+import { evalConfig } from '@/src/lib/compile-config/eval-config'
+import { extractImports } from '@/src/lib/compile-config/extract-imports'
+
+export const compile = async (_config: string) => {
+  const importShim = (0, eval)('u=>import(u)')
+
+  const require = async (module: string) => {
+    if (typeof module !== 'string') {
+      throw new Error('The "id" argument must be of type string. Received ' + typeof module)
+    }
+    if (module === '') {
+      throw new Error("The argument 'id' must be a non-empty string. Received ''")
+    }
+    const href = 'https://cdn.skypack.dev/' + module + '?min'
+    const res = await importShim(href)
+
+    return res
+  }
+
+  const imports = extractImports(_config)
+
+  const modules = await Promise.all(
+    imports.map(async (_mod) => {
+      const mod = await require(_mod.pkg)
+      return Object.entries(_mod.exps).map(([key, val]) => {
+        if (key === 'default') return { [val]: mod.default ?? mod }
+        if (val === '*') return { [key]: mod }
+        return { [val ?? key]: mod[key] }
+      })
+    }),
+  )
+
+  const scope = modules.flat().reduce((acc, cur) => Object.assign({}, acc, cur), {})
+  const newConfig = evalConfig(_config, scope)
+
+  const _presets = newConfig?.presets?.filter(Boolean) ?? []
+  const presets = await Promise.all(
+    _presets.map(async (_preset) => {
+      if (typeof _preset !== 'string') return _preset
+
+      const preset = await require(_preset)
+      return preset.default
+    }),
+  )
+
+  const config = Object.assign({}, newConfig, presets.length ? { presets } : {})
+
+  return config
+}

--- a/playground/src/lib/compile-config/compile.ts
+++ b/playground/src/lib/compile-config/compile.ts
@@ -12,7 +12,12 @@ export const compile = async (_config: string) => {
       throw new Error("The argument 'id' must be a non-empty string. Received ''")
     }
     const href = 'https://cdn.skypack.dev/' + module + '?min'
-    const res = await importShim(href)
+    let res: any
+    try {
+      res = await importShim(href)
+    } catch (error) {
+      throw new Error("Failed to fetch module '" + module + "'")
+    }
 
     return res
   }

--- a/playground/src/lib/compile-config/eval-config.ts
+++ b/playground/src/lib/compile-config/eval-config.ts
@@ -1,5 +1,5 @@
 import * as pandaDefs from '@pandacss/dev'
-import { Dict } from '@pandacss/types'
+import { Config, Dict } from '@pandacss/types'
 
 const evalCode = (code: string, scope: Record<string, unknown>) => {
   const scopeKeys = Object.keys(scope)
@@ -7,7 +7,7 @@ const evalCode = (code: string, scope: Record<string, unknown>) => {
   return new Function(...scopeKeys, code)(...scopeValues)
 }
 
-export const evalConfig = (config: string, _scope?: Dict) => {
+export const evalConfig = (config: string, _scope?: Dict): Config | null => {
   const codeTrimmed = config
     .replace(/export /g, '')
     .replace(/\bimport\b[^;]+;/g, '')

--- a/playground/src/lib/compile-config/eval-config.ts
+++ b/playground/src/lib/compile-config/eval-config.ts
@@ -1,0 +1,22 @@
+import * as pandaDefs from '@pandacss/dev'
+import { Dict } from '@pandacss/types'
+
+const evalCode = (code: string, scope: Record<string, unknown>) => {
+  const scopeKeys = Object.keys(scope)
+  const scopeValues = scopeKeys.map((key) => scope[key])
+  return new Function(...scopeKeys, code)(...scopeValues)
+}
+
+export const evalConfig = (config: string, _scope?: Dict) => {
+  const codeTrimmed = config
+    .replace(/export /g, '')
+    .replace(/\bimport\b[^;]+;/g, '')
+    .trim()
+
+  try {
+    const scope = Object.assign({}, pandaDefs, _scope)
+    return evalCode(`return (() => {${codeTrimmed}; return config})()`, scope)
+  } catch (e) {
+    return null
+  }
+}

--- a/playground/src/lib/compile-config/eval-config.ts
+++ b/playground/src/lib/compile-config/eval-config.ts
@@ -15,7 +15,9 @@ export const evalConfig = (config: string, _scope?: Dict): Config | null => {
 
   try {
     const scope = Object.assign({}, pandaDefs, _scope)
-    return evalCode(`return (() => {${codeTrimmed}; return config})()`, scope)
+    const config = evalCode(`return (() => {${codeTrimmed}; return config})()`, scope)
+    if (!_scope) delete config.presets
+    return config
   } catch (e) {
     return null
   }

--- a/playground/src/lib/compile-config/extract-imports.ts
+++ b/playground/src/lib/compile-config/extract-imports.ts
@@ -1,0 +1,42 @@
+import { Dict } from '@pandacss/types'
+
+export const extractImports = (code: string) => {
+  const codeWithoutComments = code.replace(/\/\/[^\r\n]*|\/\*[\s\S]*?\*\//g, '')
+  const importRegex = /^\s*import\s+(?:\{([\s\S]*?)\}|\*\s+as\s+(\w+)|(\w+))\s+from\s+["']([^"']+)["']\s*;?/gm
+  const imports: Dict[] = []
+
+  let match
+  while ((match = importRegex.exec(codeWithoutComments)) !== null) {
+    const [, namedImports, namespaceImport, defaultImport, pkg] = match
+
+    if (pkg === '@pandacss/dev') {
+      continue
+    }
+
+    const importObj: Dict = { pkg }
+
+    if (namedImports) {
+      const namedExports = namedImports.split(',').map((e) => e.trim().split(/\s+as\s+/))
+      importObj.exps = namedExports.reduce((acc, [exp, alias]) => {
+        acc[exp] = alias || null
+        return acc
+      }, {} as Dict)
+    } else if (namespaceImport) {
+      importObj.exps = { [namespaceImport]: '*' }
+    } else if (defaultImport) {
+      importObj.exps = { default: defaultImport }
+    } else {
+      importObj.exps = null
+    }
+
+    const existingImport = imports.find((item) => item.pkg === pkg)
+
+    if (existingImport) {
+      Object.assign(existingImport.exps, importObj.exps)
+    } else {
+      imports.push(importObj)
+    }
+  }
+
+  return imports as { pkg: string; exps: Dict }[]
+}


### PR DESCRIPTION
What's left? 😉 

- [ ] Types for imported presets
    - We could tell the editor to ignore checking the imports for validity, not sure how this would fare for typescript for the `@pandacss/dev package
    - We could check out [Monaco Auto typings](https://github.com/lukasbach/monaco-editor-auto-typings)
- [x] We should show some sort of loading state when fetching packages.
    - We could put a loader in the editor toolbar
- [x] Show config errors e.g. Preset package failure in the preview
- [ ] Initial Config state (We've got race conditions here now)
    - Code that relies on presets, e.g. a recipe, will be invalid on initial render because the presets aren't loaded when the page loads initially. 
    - ~~Could we load the config on the server?~~ (Not possible).