### PR TITLE
Playground: reset errors when code wuthout preset becomes valid

### DIFF
--- a/playground/src/hooks/useConfig.ts
+++ b/playground/src/hooks/useConfig.ts
@@ -48,6 +48,7 @@ export const useConfig = (configStr: string) => {
       try {
         const newConfig = evalConfig(configStr)
         if (newConfig) setConfig(newConfig)
+        setError(null)
       } catch (error) {
         setError(error as Error)
       }


### PR DESCRIPTION
Playground: reset errors when code wuthout preset becomes valid