### PR TITLE
fix: builder initial css + static

### DIFF
--- a/.changeset/short-files-exist.md
+++ b/.changeset/short-files-exist.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/generator': patch
+'@pandacss/node': patch
+---
+
+- Fix an issue with the `@pandacss/postcss` (and therefore `@pandacss/astro`) where the initial @layer CSS wasn't
+  applied correctly
+- Fix an issue with `staticCss` where it was only generated when it was included in the config (we can generate it
+  through the config recipes)

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -45,7 +45,7 @@ export class Generator extends Context {
   appendBaselineCss = (sheet: Stylesheet) => {
     if (this.config.preflight) this.appendCssOfType('preflight', sheet)
     if (!this.tokens.isEmpty) this.appendCssOfType('tokens', sheet)
-    if (this.config.staticCss) this.appendCssOfType('static', sheet)
+    this.appendCssOfType('static', sheet)
     this.appendCssOfType('global', sheet)
     if (this.config.theme?.keyframes) this.appendCssOfType('keyframes', sheet)
   }

--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -153,21 +153,25 @@ export class Builder {
     return valid
   }
 
+  private initialRoot: string | undefined
+
   write = (root: Root) => {
-    const rootCssContent = root.toString()
+    if (!this.initialRoot) {
+      this.initialRoot = root.toString()
+    }
+
     root.removeAll()
 
     const ctx = this.getContextOrThrow()
 
     const sheet = ctx.createSheet()
-    ctx.appendLayerParams(sheet)
     ctx.appendBaselineCss(sheet)
     ctx.appendParserCss(sheet)
     const css = ctx.getCss(sheet)
 
     root.append(
       optimizeCss(`
-    ${rootCssContent}
+    ${this.initialRoot}
     ${css}
     `),
     )


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1897

## 📝 Description

- Fix an issue with the `@pandacss/postcss` (and therefore `@pandacss/astro`) where the initial @layer CSS wasn't
  applied correctly
- Fix an issue with `staticCss` where it was only generated when it was included in the config (we can generate it
  through the config recipes)

## 💣 Is this a breaking change (Yes/No):

no