### PR TITLE
fix(cli): init with existing gitignore

### DIFF
--- a/.changeset/loud-jokes-teach.md
+++ b/.changeset/loud-jokes-teach.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/dev': patch
+---
+
+Fix an issue with the `panda init` command which didn't update existing `.gitignore` to include the `styled-system`

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -76,7 +76,7 @@ export async function main() {
 
       await setupConfig(cwd, { force, outExtension, jsxFramework, syntax })
 
-      const ctx = await loadConfigAndCreateContext({ cwd, configPath })
+      const ctx = await loadConfigAndCreateContext({ cwd, configPath, config: { gitignore } })
       const { msg, box } = await codegen(ctx)
 
       if (gitignore) {


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/1909

## 📝 Description

Fix an issue with the `panda init` command which didn't update existing `.gitignore` to include the `styled-system`


## 💣 Is this a breaking change (Yes/No):

no