### PR TITLE
fix(utilities): boolean value parsing

### DIFF
--- a/.changeset/eighty-months-give.md
+++ b/.changeset/eighty-months-give.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/shared': patch
+'@pandacss/types': patch
+'@pandacss/core': patch
+---
+
+Fix a regression with utility where boolean values would be treated as a string, resulting in "false" being seen as a
+truthy value

--- a/packages/core/__tests__/rule-processor.test.ts
+++ b/packages/core/__tests__/rule-processor.test.ts
@@ -950,4 +950,73 @@ describe('rule processor', () => {
       }"
     `)
   })
+
+  test('css - boolean utility', () => {
+    const result = css({ truncate: false })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "className": [
+          "truncate_false",
+        ],
+        "css": "",
+      }
+    `)
+
+    const result2 = css({ truncate: true })
+    expect(result2).toMatchInlineSnapshot(`
+      {
+        "className": [
+          "truncate_true",
+        ],
+        "css": "@layer utilities {
+        .truncate_true {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap
+      }
+      }",
+      }
+    `)
+  })
+
+  test('cva - boolean variant', () => {
+    const result = cva({
+      base: {
+        color: '#fff',
+      },
+      variants: {
+        checked: {
+          true: {
+            display: 'block',
+          },
+          false: {
+            display: 'none',
+          },
+        },
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "className": [
+          "text_\\\\#fff",
+          "d_block",
+          "d_none",
+        ],
+        "css": "@layer utilities {
+        .text_\\\\#fff {
+          color: #fff
+      }
+
+        .d_block {
+          display: block
+      }
+
+        .d_none {
+          display: none
+      }
+      }",
+      }
+    `)
+  })
 })

--- a/packages/core/__tests__/style-decoder.test.ts
+++ b/packages/core/__tests__/style-decoder.test.ts
@@ -3,7 +3,6 @@ import type { Dict } from '@pandacss/types'
 import { describe, expect, test } from 'vitest'
 import { createRuleProcessor } from './fixture'
 
-// ???
 const css = (styles: Dict) => {
   const ctx = createGeneratorContext()
   ctx.encoder.processAtomic(styles)
@@ -11,7 +10,6 @@ const css = (styles: Dict) => {
   return ctx.decoder.atomic
 }
 
-// ???
 const recipe = (name: string, styles: Dict) => {
   const ctx = createGeneratorContext()
   const recipeConfig = ctx.recipes.getConfig(name)
@@ -2541,6 +2539,119 @@ describe('style decoder', () => {
                 },
               },
               "slot": "label",
+            },
+          },
+        },
+      }
+    `)
+  })
+
+  test('css - boolean utility', () => {
+    const result = css({ truncate: false })
+
+    expect(result).toMatchInlineSnapshot(`
+      Set {
+        {
+          "className": "truncate_false",
+          "conditions": undefined,
+          "entry": {
+            "prop": "truncate",
+            "value": false,
+          },
+          "hash": "truncate]___[value:false",
+          "layer": undefined,
+          "result": {
+            ".truncate_false": {},
+          },
+        },
+      }
+    `)
+
+    const result2 = css({ truncate: true })
+    expect(result2).toMatchInlineSnapshot(`
+      Set {
+        {
+          "className": "truncate_true",
+          "conditions": undefined,
+          "entry": {
+            "prop": "truncate",
+            "value": true,
+          },
+          "hash": "truncate]___[value:true",
+          "layer": undefined,
+          "result": {
+            ".truncate_true": {
+              "overflow": "hidden",
+              "textOverflow": "ellipsis",
+              "whiteSpace": "nowrap",
+            },
+          },
+        },
+      }
+    `)
+  })
+
+  test('cva - boolean variant', () => {
+    const result = cva({
+      base: {
+        color: '#fff',
+      },
+      variants: {
+        checked: {
+          true: {
+            display: 'block',
+          },
+          false: {
+            display: 'none',
+          },
+        },
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Set {
+        {
+          "className": "text_\\\\#fff",
+          "conditions": undefined,
+          "entry": {
+            "prop": "color",
+            "value": "#fff",
+          },
+          "hash": "color]___[value:#fff",
+          "layer": undefined,
+          "result": {
+            ".text_\\\\#fff": {
+              "color": "#fff",
+            },
+          },
+        },
+        {
+          "className": "d_block",
+          "conditions": undefined,
+          "entry": {
+            "prop": "display",
+            "value": "block",
+          },
+          "hash": "display]___[value:block",
+          "layer": undefined,
+          "result": {
+            ".d_block": {
+              "display": "block",
+            },
+          },
+        },
+        {
+          "className": "d_none",
+          "conditions": undefined,
+          "entry": {
+            "prop": "display",
+            "value": "none",
+          },
+          "hash": "display]___[value:none",
+          "layer": undefined,
+          "result": {
+            ".d_none": {
+              "display": "none",
             },
           },
         },

--- a/packages/core/__tests__/style-encoder.test.ts
+++ b/packages/core/__tests__/style-encoder.test.ts
@@ -4,14 +4,12 @@ import type { Dict, SystemStyleObject } from '@pandacss/types'
 import { createGeneratorContext } from '@pandacss/fixture'
 import { createAnatomy } from './create-anatomy'
 
-// ???
 const css = (styles: Dict) => {
   const ctx = createGeneratorContext()
   ctx.encoder.processAtomic(styles)
   return ctx.encoder.atomic
 }
 
-// ???
 const recipe = (name: string, styles: Dict) => {
   const ctx = createGeneratorContext()
   const recipeConfig = ctx.recipes.getConfig(name)
@@ -611,6 +609,16 @@ describe('hash factory', () => {
             "marginInlineStart]___[value:2]___[recipe:checkbox",
           },
         },
+      }
+    `)
+  })
+
+  test('css - boolean utility', () => {
+    const result = css({ truncate: false })
+
+    expect(result).toMatchInlineSnapshot(`
+      Set {
+        "truncate]___[value:false",
       }
     `)
   })

--- a/packages/core/src/style-decoder.ts
+++ b/packages/core/src/style-decoder.ts
@@ -71,7 +71,7 @@ export class StyleDecoder implements StyleDecoderInterface {
       : undefined
 
     const transform = recipeName ? this.context.recipes.getTransform(recipeName) : this.context.utility.transform
-    const transformed = transform(entry.prop, withoutImportant(entry.value))
+    const transformed = transform(entry.prop, withoutImportant(entry.value) as string)
 
     if (!transformed.className) {
       return
@@ -123,7 +123,7 @@ export class StyleDecoder implements StyleDecoderInterface {
       const entry = getEntryFromHash(hash)
 
       const transform = this.context.utility.transform
-      const transformed = transform(entry.prop, withoutImportant(entry.value))
+      const transformed = transform(entry.prop, withoutImportant(entry.value) as string)
 
       if (!transformed.className) return
 
@@ -238,8 +238,7 @@ const getEntryFromHash = (hash: string) => {
   const prop = parts[0]
 
   const rawValue = parts[1].replace('value:', '')
-  const parsed = Number(rawValue)
-  const value = parsed ? parsed : rawValue
+  const value = parseValue(rawValue)
 
   const entry = { prop, value } as StyleEntry
 
@@ -251,4 +250,19 @@ const getEntryFromHash = (hash: string) => {
   })
 
   return entry
+}
+
+const parseValue = (value: string) => {
+  const asNumber = Number(value)
+  if (!isNaN(asNumber)) {
+    return asNumber
+  }
+
+  return castBoolean(value)
+}
+
+const castBoolean = (value: string) => {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return value
 }

--- a/packages/shared/src/css-important.ts
+++ b/packages/shared/src/css-important.ts
@@ -1,14 +1,14 @@
 const importantRegex = /!(important)?/
 
-export function isImportant(value: string | number | boolean) {
+export function isImportant<T extends string | number | boolean>(value: T) {
   return typeof value === 'string' ? importantRegex.test(value) : false
 }
 
-export function withoutImportant(value: string | number | boolean) {
+export function withoutImportant<T extends string | number | boolean>(value: T) {
   return typeof value === 'string' ? value.replace(importantRegex, '').trim() : value
 }
 
-export function withoutSpace(str: string | number | boolean) {
+export function withoutSpace<T extends string | number | boolean>(str: T) {
   return typeof str === 'string' ? str.replaceAll(' ', '_') : str
 }
 

--- a/packages/shared/src/css-important.ts
+++ b/packages/shared/src/css-important.ts
@@ -1,14 +1,14 @@
 const importantRegex = /!(important)?/
 
-export function isImportant(value: string) {
+export function isImportant(value: string | number | boolean) {
   return typeof value === 'string' ? importantRegex.test(value) : false
 }
 
-export function withoutImportant(value: string) {
+export function withoutImportant(value: string | number | boolean) {
   return typeof value === 'string' ? value.replace(importantRegex, '').trim() : value
 }
 
-export function withoutSpace(str: string) {
+export function withoutSpace(str: string | number | boolean) {
   return typeof str === 'string' ? str.replaceAll(' ', '_') : str
 }
 

--- a/packages/types/src/style-rules.ts
+++ b/packages/types/src/style-rules.ts
@@ -9,7 +9,7 @@ export interface StyleProps extends StyleResultObject {
 
 export interface StyleEntry {
   prop: string
-  value: string
+  value: string | number | boolean
   cond: string
   recipe?: string
   slot?: string


### PR DESCRIPTION
## 📝 Description

Fix a regression with utility where boolean values would be treated as a string, resulting in "false" being seen as a
truthy value

## 💣 Is this a breaking change (Yes/No):

no
