### PR TITLE
feat: resolve token reference everywhere

### DIFF
--- a/.changeset/neat-pianos-cry.md
+++ b/.changeset/neat-pianos-cry.md
@@ -1,0 +1,45 @@
+---
+'@pandacss/token-dictionary': minor
+'@pandacss/core': minor
+---
+
+Support token reference syntax when authoring styles object, text styles and layer styles.
+
+```jsx
+import { css } from '../styled-system/css'
+
+const styles = css({
+  border: '2px solid {colors.primary}',
+})
+```
+
+This will resolve the token reference and convert it to css variables.
+
+```css
+.border_2px_solid_\{colors\.primary\} {
+  border: 2px solid var(--colors-primary);
+}
+```
+
+The alternative to this was to use the `token(...)` css function which will be resolved.
+
+### `token(...)` vs `{...}`
+
+Both approaches return the css variable
+
+```jsx
+const styles = css({
+  // token reference syntax
+  border: '2px solid {colors.primary}',
+  // token function syntax
+  border: '2px solid token(colors.primary)',
+})
+```
+
+However, The `token(...)` syntax allows you to set a fallback value.
+
+```jsx
+const styles = css({
+  border: '2px solid token(colors.primary, red)',
+})
+```

--- a/.changeset/soft-snails-smile.md
+++ b/.changeset/soft-snails-smile.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Fix issue where `base` doesn't work within css function
+
+```jsx
+css({
+  // This didn't work, but now it does
+  base: { color: 'blue' },
+})
+```

--- a/packages/core/__tests__/serialize.test.ts
+++ b/packages/core/__tests__/serialize.test.ts
@@ -1,0 +1,68 @@
+import { createContext } from '@pandacss/fixture'
+import type { Dict } from '@pandacss/types'
+import { describe, expect, test } from 'vitest'
+import { serializeStyle } from '../src/serialize'
+
+const css = (style: Dict) => {
+  return serializeStyle(style, createContext())
+}
+
+describe('serialize', () => {
+  test('should serialize', () => {
+    const result = css({
+      html: {
+        color: 'red',
+        border: '2px solid {colors.red.200}',
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "html": {
+          "border": "2px solid var(--colors-red-200)",
+          "color": "red",
+        },
+      }
+    `)
+  })
+
+  test('skip non-existent', () => {
+    const result = css({
+      html: {
+        border: '2px solid {colors.red.xxx}',
+        bg: '{colors.xxx}',
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "html": {
+          "background": "colors.xxx",
+          "border": "2px solid colors.red.xxx",
+        },
+      }
+    `)
+  })
+
+  test('expand multiple references', () => {
+    const result = css({
+      html: {
+        padding: '{spacing.3} {spacing.5}',
+        _hover: {
+          padding: '{spacing.7}',
+        },
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "html": {
+          "&:is(:hover, [data-hover])": {
+            "padding": "var(--spacing-7)",
+          },
+          "padding": "var(--spacing-3) var(--spacing-5)",
+        },
+      }
+    `)
+  })
+})

--- a/packages/core/__tests__/style-decoder.test.ts
+++ b/packages/core/__tests__/style-decoder.test.ts
@@ -40,6 +40,32 @@ const sva = (styles: Dict) => {
  * -----------------------------------------------------------------------------*/
 
 describe('style decoder', () => {
+  test('should resolve references', () => {
+    const result = css({
+      border: '2px solid {colors.red.300}',
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Set {
+        {
+          "className": "border_2px_solid_\\\\{colors\\\\.red\\\\.300\\\\}",
+          "conditions": undefined,
+          "entry": {
+            "prop": "border",
+            "value": "2px solid {colors.red.300}",
+          },
+          "hash": "border]___[value:2px solid {colors.red.300}",
+          "layer": undefined,
+          "result": {
+            ".border_2px_solid_\\\\{colors\\\\.red\\\\.300\\\\}": {
+              "border": "2px solid var(--colors-red-300)",
+            },
+          },
+        },
+      }
+    `)
+  })
+
   test('css', () => {
     const result = css({
       color: 'red !important',

--- a/packages/core/__tests__/style-decoder.test.ts
+++ b/packages/core/__tests__/style-decoder.test.ts
@@ -66,6 +66,60 @@ describe('style decoder', () => {
     `)
   })
 
+  test('css with base', () => {
+    const result = css({
+      base: { color: 'blue' },
+      md: { color: 'red' },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Set {
+        {
+          "className": "text_blue",
+          "conditions": undefined,
+          "entry": {
+            "prop": "color",
+            "value": "blue",
+          },
+          "hash": "color]___[value:blue",
+          "layer": undefined,
+          "result": {
+            ".text_blue": {
+              "color": "blue",
+            },
+          },
+        },
+        {
+          "className": "md\\\\:text_red",
+          "conditions": [
+            {
+              "name": "breakpoint",
+              "params": "screen and (min-width: 48em)",
+              "raw": "md",
+              "rawValue": "@media screen and (min-width: 48em)",
+              "type": "at-rule",
+              "value": "md",
+            },
+          ],
+          "entry": {
+            "cond": "md",
+            "prop": "color",
+            "value": "red",
+          },
+          "hash": "color]___[value:red]___[cond:md",
+          "layer": undefined,
+          "result": {
+            ".md\\\\:text_red": {
+              "@media screen and (min-width: 48em)": {
+                "color": "red",
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
+
   test('css', () => {
     const result = css({
       color: 'red !important',

--- a/packages/core/__tests__/style-encoder.test.ts
+++ b/packages/core/__tests__/style-encoder.test.ts
@@ -1,6 +1,6 @@
 import { createGeneratorContext } from '@pandacss/fixture'
 import type { Dict, SlotRecipeDefinition, SystemStyleObject } from '@pandacss/types'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { createAnatomy } from './create-anatomy'
 import { createRuleProcessor } from './fixture'
 
@@ -35,6 +35,10 @@ const sva = (styles: SlotRecipeDefinition) => {
 /* -----------------------------------------------------------------------------
  * Actual Tests
  * -----------------------------------------------------------------------------*/
+
+vi.mock('../package.json', () => {
+  return { version: 'x.x.x' }
+})
 
 describe('style encoder', () => {
   test('simple', () => {
@@ -692,7 +696,7 @@ describe('style encoder', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "schemaVersion": "0.24.1",
+        "schemaVersion": "x.x.x",
         "styles": {
           "atomic": [
             "color]___[value:red",

--- a/packages/core/__tests__/style-encoder.test.ts
+++ b/packages/core/__tests__/style-encoder.test.ts
@@ -63,6 +63,20 @@ describe('style encoder', () => {
     `)
   })
 
+  test('css with base', () => {
+    const result = css({
+      base: { color: 'blue' },
+      md: { color: 'red' },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Set {
+        "color]___[value:blue",
+        "color]___[value:red]___[cond:md",
+      }
+    `)
+  })
+
   test('css', () => {
     const result = css({
       color: 'red !important',

--- a/packages/core/src/utility.ts
+++ b/packages/core/src/utility.ts
@@ -403,12 +403,18 @@ export class Utility {
     if (value == null) {
       return { className: '', styles: {} }
     }
+
     const key = this.resolveShorthand(prop)
+
+    let styleValue = getArbitraryValue(value)
+    if (isString(styleValue)) {
+      styleValue = this.tokens.expandReference(styleValue)
+    }
 
     return compact({
       layer: this.configs.get(key)?.layer,
       className: this.getOrCreateClassName(key, withoutSpace(value)),
-      styles: this.getOrCreateStyle(key, getArbitraryValue(value)),
+      styles: this.getOrCreateStyle(key, styleValue),
     })
   }
 

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2,6 +2,52 @@ import { describe, expect, test } from 'vitest'
 import { parseAndExtract } from './fixture'
 
 describe('extract to css output pipeline', () => {
+  test('css with base', () => {
+    const code = `
+    import { css } from "styled-system/css"
+    
+    css({
+      base: { color: "blue" },
+      md: { color: "red" }
+    })
+    `
+
+    const result = parseAndExtract(code)
+
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "base": {
+                "color": "blue",
+              },
+              "md": {
+                "color": "red",
+              },
+            },
+          ],
+          "name": "css",
+          "type": "object",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_blue {
+          color: blue
+      }
+
+        @media screen and (min-width: 48em) {
+          .md\\\\:text_red {
+            color: red
+          }
+      }
+      }"
+    `)
+  })
+
   test('basic usage', () => {
     const code = `
       import { styled } from "styled-system/jsx"

--- a/packages/parser/src/parser-result.ts
+++ b/packages/parser/src/parser-result.ts
@@ -30,7 +30,7 @@ export class ParserResult implements ParserResultInterface {
 
     const encoder = this.encoder
     if (name == 'css') {
-      result.data.forEach((obj) => encoder.processStyleProps(obj))
+      result.data.forEach((obj) => encoder.processAtomic(obj))
       return
     }
 

--- a/packages/token-dictionary/src/create-dictionary.ts
+++ b/packages/token-dictionary/src/create-dictionary.ts
@@ -3,6 +3,7 @@ import { TokenDictionary as BaseDictionary, type TokenDictionaryOptions } from '
 import { formats } from './format'
 import { middlewares } from './middleware'
 import { transforms } from './transform'
+import { expandReferences } from './utils'
 
 export class TokenDictionary extends BaseDictionary {
   constructor(options: TokenDictionaryOptions) {
@@ -46,5 +47,9 @@ export class TokenDictionary extends BaseDictionary {
   getTokenVar(path: string) {
     const json = mapToJson(this.values)
     return getDotPath(json, path)
+  }
+
+  expandReference(value: string) {
+    return expandReferences(value, (key) => this.get(key))
   }
 }

--- a/packages/token-dictionary/src/utils.ts
+++ b/packages/token-dictionary/src/utils.ts
@@ -29,6 +29,15 @@ export function hasReference(value: string) {
   return REFERENCE_REGEX.test(value)
 }
 
+export function expandReferences(value: string, fn: (key: string) => string) {
+  if (!hasReference(value)) return value
+  const references = getReferences(value)
+  return references.reduce((valueStr, key) => {
+    const value = fn(key) ?? key
+    return valueStr.replace(`{${key}}`, value)
+  }, value)
+}
+
 /* -----------------------------------------------------------------------------
  * Shared token utilities
  * -----------------------------------------------------------------------------*/


### PR DESCRIPTION
## 📝 Description

Closes #1934
Closes #1928 

Support token reference syntax when authoring styles object, text styles and layer styles.

```jsx
import { css } from '../styled-system/css'

const styles = css({
  border: '2px solid {colors.primary}',
})
```

This will resolve the token reference and convert it to css variables.

```css
.border_2px_solid_\{colors\.primary\} {
  border: 2px solid var(--colors-primary);
}
```

The alternative to this was to use the `token(...)` css function which will be resolved.

### `token(...)` vs `{...}`

Both approaches return the css variable

```jsx
const styles = css({
  // token reference syntax
  border: '2px solid {colors.primary}',
  // token function syntax
  border: '2px solid token(colors.primary)',
})
```

However, The `token(...)` syntax allows you to set a fallback value.

```jsx
const styles = css({
  border: '2px solid token(colors.primary, red)',
})
```

## ⛳️ Current behavior (updates)

Token reference only works within tokens/semantic token definitions

## 🚀 New behavior

Works everywhere

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
