### PR TITLE
feat(preset-base): add data-placeholder, data-placeholder-shown condition

### DIFF
--- a/.changeset/breezy-cars-rescue.md
+++ b/.changeset/breezy-cars-rescue.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/preset-base': patch
+---
+
+Add `data-placeholder` and `data-placeholder-shown` conditions

--- a/packages/preset-base/src/conditions.ts
+++ b/packages/preset-base/src/conditions.ts
@@ -62,8 +62,8 @@ export const conditions = {
   autofill: '&:autofill',
   inRange: '&:in-range',
   outOfRange: '&:out-of-range',
-  placeholder: '&::placeholder',
-  placeholderShown: '&:placeholder-shown',
+  placeholder: '&:is(:placeholder, [data-placeholder])',
+  placeholderShown: '&:is(:placeholder-shown, [data-placeholder-shown])',
   pressed: '&:is([aria-pressed=true], [data-pressed])',
   selected: '&:is([aria-selected=true], [data-selected])',
 

--- a/packages/studio/styled-system/types/conditions.d.ts
+++ b/packages/studio/styled-system/types/conditions.d.ts
@@ -116,9 +116,9 @@ export interface Conditions {
 	"_inRange": string
 	/** `&:out-of-range` */
 	"_outOfRange": string
-	/** `&::placeholder` */
+	/** `&:is(:placeholder, [data-placeholder])` */
 	"_placeholder": string
-	/** `&:placeholder-shown` */
+	/** `&:is(:placeholder-shown, [data-placeholder-shown])` */
 	"_placeholderShown": string
 	/** `&:is([aria-pressed=true], [data-pressed])` */
 	"_pressed": string

--- a/website/pages/docs/concepts/conditional-styles.md
+++ b/website/pages/docs/concepts/conditional-styles.md
@@ -460,8 +460,8 @@ Here's a list of all the condition shortcuts you can use in Panda:
 | \_autofill             | `&:autofill`                                                       |
 | \_inRange              | `&:in-range`                                                       |
 | \_outOfRange           | `&:out-of-range`                                                   |
-| \_placeholder          | `&:is(:placeholder, [data-placeholder])`                                                    |
-| \_placeholderShown     | `&:is(:placeholder-shown, [data-placeholder-shown])`                                              |
+| \_placeholder          | `&:is(:placeholder, [data-placeholder])`                           |
+| \_placeholderShown     | `&:is(:placeholder-shown, [data-placeholder-shown])`               |
 | \_pressed              | `&:is([aria-pressed=true], [data-pressed])`                        |
 | \_selected             | `&:is([aria-selected=true], [data-selected])`                      |
 | \_default              | `&:default`                                                        |

--- a/website/pages/docs/concepts/conditional-styles.md
+++ b/website/pages/docs/concepts/conditional-styles.md
@@ -460,8 +460,8 @@ Here's a list of all the condition shortcuts you can use in Panda:
 | \_autofill             | `&:autofill`                                                       |
 | \_inRange              | `&:in-range`                                                       |
 | \_outOfRange           | `&:out-of-range`                                                   |
-| \_placeholder          | `&:placeholder`                                                    |
-| \_placeholderShown     | `&:placeholder-shown`                                              |
+| \_placeholder          | `&:is(:placeholder, [data-placeholder])`                                                    |
+| \_placeholderShown     | `&:is(:placeholder-shown, [data-placeholder-shown])`                                              |
 | \_pressed              | `&:is([aria-pressed=true], [data-pressed])`                        |
 | \_selected             | `&:is([aria-selected=true], [data-selected])`                      |
 | \_default              | `&:default`                                                        |


### PR DESCRIPTION
## 📝 Description

Adds condition data-placeholder, data-placeholder-shown.

used on zagjs, ark-ui, radix and in react-aria widely. would be nice to support that.

## ⛳️ Current behavior (updates)

Placeholder condition only targets native placeholder selector

## 🚀 New behavior

Placeholder condition additionally targets data-placeholder and data-placeholder shown conditions

## 💣 Is this a breaking change (Yes/No):

No.
