### PR TITLE
chore(logs): use CssSyntaxError showSourceCode method

### DIFF
--- a/.changeset/pretty-geese-cry.md
+++ b/.changeset/pretty-geese-cry.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/core': patch
+---
+
+Display better CssSyntaxError logs

--- a/packages/core/src/stylesheet.ts
+++ b/packages/core/src/stylesheet.ts
@@ -31,7 +31,7 @@ export class Stylesheet {
       layer.append(toCss(styles).toString())
     } catch (error) {
       if (error instanceof CssSyntaxError) {
-        logger.error('sheet:process', error)
+        logger.error('sheet:process', error.showSourceCode(true))
       }
     }
     return
@@ -91,13 +91,7 @@ export class Stylesheet {
       return optimize ? optimizeCss(css, { minify }) : css
     } catch (error) {
       if (error instanceof CssSyntaxError) {
-        logger.error('sheet:toCss', error.message)
-        error.plugin && logger.error('sheet:toCss', `By plugin: ${error.plugin}:`)
-
-        if (error.source) {
-          logger.error('sheet:toCss', `Line ${error.line}:${error.column}, in:`)
-          logger.error('sheet:toCss', error.source)
-        }
+        logger.error('sheet:toCss', error.showSourceCode(true))
       }
 
       throw error


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/1920

## 📝 Description

Display better CssSyntaxError logs

## ⛳️ Current behavior (updates)

```
🐼 error [sheet:toCss] <css input>:2:20: Missed semicolon
🐼 error [sheet:toCss] Line 2:20, in:
🐼 error [sheet:toCss] .bg_111\:\:green\.600 {
    background: 111::green.600
}
```

## 🚀 New behavior


```
🐼 error [sheet:toCss]   1 | .bg_111\:\:green\.600 {
> 2 |     background: 111::green.600
    |                    ^
  3 | }
  ```
  
  it's colored now
![Screenshot 2024-01-07 at 12 04 11](https://github.com/chakra-ui/panda/assets/47224540/aa009286-bc08-4c11-987c-3cec87a11cd3)



