### PR TITLE
docs: fix link to tailwind-variant website

### DIFF
--- a/website/pages/docs/concepts/slot-recipes.md
+++ b/website/pages/docs/concepts/slot-recipes.md
@@ -15,7 +15,7 @@ A slot recipe consists of these properties:
 - `defaultVariants`: The default variant for the component
 - `compoundVariants`: The compound variant combination and style overrides for each slot.
 
-> **Credit:** This API was inspired by multipart components in [Chakra UI](https://chakra-ui.com/docs/styled-system/component-style) and slot variants in [Tailwind Variants](tailwind-variants.org)
+> **Credit:** This API was inspired by multipart components in [Chakra UI](https://chakra-ui.com/docs/styled-system/component-style) and slot variants in [Tailwind Variants](https://tailwind-variants.org)
 
 ## Atomic Slot Recipe (or sva)
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I found a broken link in https://panda-css.com/docs/concepts/slot-recipes page. The link to [Tailwind Variant](https://www.tailwind-variants.org/) is broken. The URL should be absolute.

## ⛳️ Current behavior (updates)

The link redirects to the 404 page of Panda CSS website.

## 🚀 New behavior

Link points to tailwind-variant website.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I read the contributing guidelines but didn't know if a changeset was necessary as I just modified the documentation.