### PR TITLE
docs: update the accepted values for aspectRatio property

### DIFF
--- a/website/pages/docs/utilities/layout.md
+++ b/website/pages/docs/utilities/layout.md
@@ -11,7 +11,7 @@ Panda provides style properties for styling layout of an element
 
 Use the `aspectRatio` utilities to set the desired aspect ratio of an element.
 
-Values can be `square`, `portrait`, `landscape`, `widescreen`, `cinema`, `golden` or a number.
+Values can be `square`, `portrait`, `landscape`, `wide`, `ultrawide`, `golden` or a number.
 
 ```jsx
 <div className={css({ aspectRatio: 'square' })} />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The accepted values for the aspectRatio property seem to have changed since the doc was written.

## ⛳️ Current behavior (updates)

I can't see the properties listed by the documentation when autocompleting the available values in VS Code.

## 🚀 New behavior

I replace the old values with the new one.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

![CleanShot 2024-01-11 at 00 19 47@2x](https://github.com/chakra-ui/panda/assets/29370468/21933710-2f64-42eb-9924-a1dc9a01ec4f)
![CleanShot 2024-01-11 at 00 23 22@2x](https://github.com/chakra-ui/panda/assets/29370468/9711cad2-9ab0-40cb-9022-243b35e4c99f)
