### PR TITLE
Fix: `prettier` parser warning in panda config setup

### DIFF
--- a/.changeset/late-weeks-tickle.md
+++ b/.changeset/late-weeks-tickle.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Fix `prettier` parser warning in panda config setup.

--- a/packages/node/src/setup-config.ts
+++ b/packages/node/src/setup-config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
 })
     `
 
-    await fsExtra.writeFile(join(cwd, file), prettier.format(content))
+    await fsExtra.writeFile(join(cwd, file), prettier.format(content, { parser: 'babel' }))
     logger.log(messages.thankYou())
   }
 }


### PR DESCRIPTION
Fix `prettier` parser warning in panda config setup

**Before:**

![CleanShot 2024-01-17 at 14 29 37@2x](https://github.com/chakra-ui/panda/assets/30869823/d7716945-6efa-4ad4-9170-59246eaa4312)

**After:**

![CleanShot 2024-01-17 at 14 29 12@2x](https://github.com/chakra-ui/panda/assets/30869823/0d701150-f8a6-43c3-af97-c5331947e6f3)
