### PR TITLE
fix: playground crashing when there's an error

### DIFF
--- a/playground/src/hooks/usePanda.ts
+++ b/playground/src/hooks/usePanda.ts
@@ -43,7 +43,11 @@ export function usePanda(state: State, config: Config | null) {
     const sheet = context.createSheet()
 
     const decoder = context.decoder.clone().collect(encoder)
-    sheet.processDecoder(decoder)
+    try {
+      sheet.processDecoder(decoder)
+    } catch (error) {
+      console.log(error)
+    }
 
     const artifacts = context.getArtifacts() ?? []
 

--- a/playground/src/hooks/usePandaContext.ts
+++ b/playground/src/hooks/usePandaContext.ts
@@ -8,21 +8,27 @@ import { getResolvedConfig, resolveConfig } from '@/src/lib/config/resolve-confi
 export const usePandaContext = (userConfig: Config | null) => {
   const previousContext = useRef<Generator | null>(null)
 
-  const config = getResolvedConfig(
-    resolveConfig({
-      cwd: '',
-      include: [],
-      outdir: 'styled-system',
-      preflight: true,
-      optimize: true,
-      ...userConfig,
-      staticCss: merge(userConfig?.staticCss, {
-        recipes: { playgroundError: ['*'] } as StaticCssOptions['recipes'],
-      }),
+  let config
 
-      jsxFramework: userConfig?.jsxFramework ? 'react' : undefined,
-    }),
-  )
+  try {
+    config = getResolvedConfig(
+      resolveConfig({
+        cwd: '',
+        include: [],
+        outdir: 'styled-system',
+        preflight: true,
+        optimize: true,
+        ...userConfig,
+        staticCss: merge(userConfig?.staticCss, {
+          recipes: { playgroundError: ['*'] } as StaticCssOptions['recipes'],
+        }),
+
+        jsxFramework: userConfig?.jsxFramework ? 'react' : undefined,
+      }),
+    )
+  } catch (error) {
+    console.log(error)
+  }
 
   try {
     // in event of error (invalid token format), use previous generator


### PR DESCRIPTION
sometimes the playground crashes for seemingly random reasons, let's future proof it with some try/catch

one of the reasons it happens is when there's a CSS syntax error and this `showSourceCode` gets called
https://github.com/chakra-ui/panda/blob/fix/playground-crash/packages/core/src/stylesheet.ts#L34

which then tries to do nodejs specific stuff apparently
https://github.com/postcss/postcss/blob/763d57b78a57b7abb6aaf745ab046ad9380cca9c/lib/css-syntax-error.js#L55-L57