### PR TITLE
fix(docs): defineKeyframes usage

### DIFF
--- a/website/pages/docs/customization/config-functions.md
+++ b/website/pages/docs/customization/config-functions.md
@@ -169,9 +169,11 @@ Function for [keyframes](/docs/customization/theme#keyframes) definitions.
 ```ts
 import { defineKeyframes } from '@pandacss/dev'
 
-export const fadein = defineKeyframes({
-  '0%': { opacity: '0' },
-  '100%': { opacity: '1' }
+export const keyframes = defineKeyframes({
+  fadeIn: {
+    '0%': { opacity: '0' },
+    '100%': { opacity: '1' }
+  }
 })
 ```
 


### PR DESCRIPTION
should mirror the same format as in the theme.extend.keyframes
closes https://github.com/chakra-ui/panda/issues/2027