### PR TITLE
💄 Revert em style and strong

### DIFF
--- a/packages/generator/src/artifacts/css/reset-css.ts
+++ b/packages/generator/src/artifacts/css/reset-css.ts
@@ -170,7 +170,11 @@ export function generateResetCss(ctx: Context, sheet: Stylesheet) {
 
   ${selector}b,
   ${selector}strong {
-    font-weight: bolder;
+    font-weight: revert;
+  }
+
+  ${selector}em {
+    font-style: revert;
   }
 
   ${selector}code,


### PR DESCRIPTION
## 📝 Description

Changed because italics were not applied to the markdown generation page (Storybook).
I set `revert` because I think setting `revert` is better for accessibility than setting any other value.

## ⛳️ Current behavior (updates)

Italics were not applied.

## 🚀 New behavior

Italics will applied.

## 💣 Is this a breaking change (Yes/No):

Which one...? 🤔 

## 📝 Additional Information

**Can I use...**

- CSS revert value  
  https://caniuse.com/css-revert-value
- `@layer` (used in Panda CSS)
  https://caniuse.com/css-cascade-layers