### PR TITLE
fix: add missing `borderWidths` category where needed

### DIFF
--- a/.changeset/quiet-fans-matter.md
+++ b/.changeset/quiet-fans-matter.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/generator': patch
+---
+
+Fix a typing issue where the `borderWidths` wasn't specified in the generated `TokenCategory` type

--- a/packages/generator/src/artifacts/types/token-types.ts
+++ b/packages/generator/src/artifacts/types/token-types.ts
@@ -18,6 +18,7 @@ const categories = [
   'spacing',
   'radii',
   'borders',
+  'borderWidths',
   'durations',
   'easings',
   'animations',

--- a/packages/studio/styled-system/tokens/tokens.d.ts
+++ b/packages/studio/styled-system/tokens/tokens.d.ts
@@ -63,4 +63,4 @@ export type Tokens = {
 		animationName: AnimationName
 } & { [token: string]: never }
 
-export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "durations" | "easings" | "animations" | "blurs" | "gradients" | "breakpoints" | "assets"
+export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "gradients" | "breakpoints" | "assets"

--- a/packages/token-dictionary/src/token.ts
+++ b/packages/token-dictionary/src/token.ts
@@ -233,6 +233,7 @@ const TOKEN_TYPES = {
   gradients: 'gradient',
   easings: 'cubicBezier',
   borders: 'border',
+  borderWidths: 'borderWidth',
   components: 'cti',
   assets: 'asset',
   aspectRatios: 'aspectRatio',


### PR DESCRIPTION
## 📝 Description

Fix a typing issue where the `borderWidths` wasn't specified in the generated `TokenCategory` type

## 💣 Is this a breaking change (Yes/No):

no
