### PR TITLE
refactor: preserve underlines while hashing and decrease hashing length

### DIFF
--- a/packages/core/__tests__/prefix.test.ts
+++ b/packages/core/__tests__/prefix.test.ts
@@ -14,22 +14,22 @@ describe('atomic-rule / prefix', () => {
   test('should product consistent hash', () => {
     expect(backend({ color: 'red' })).toMatchInlineSnapshot(`
       "@layer utilities {
-        .tw-eIKWVi {
+        .tw-bgaoI_ftuE {
           color: red;
       }
       }"
     `)
-    expect(frontend({ color: 'red' })).toMatchInlineSnapshot('"tw-eIKWVi"')
+    expect(frontend({ color: 'red' })).toMatchInlineSnapshot('"tw-bgaoI_ftuE"')
 
     expect(backend({ color: { sm: 'red' } })).toMatchInlineSnapshot(`
       "@layer utilities {
         @media screen and (min-width: 40em) {
-          .tw-geqOyW {
+          .tw-KGNB_ftuE {
             color: red;
       }
       }
       }"
     `)
-    expect(frontend({ color: { sm: 'red' } })).toMatchInlineSnapshot('"tw-geqOyW"')
+    expect(frontend({ color: { sm: 'red' } })).toMatchInlineSnapshot('"tw-KGNB_ftuE"')
   })
 })

--- a/packages/core/src/style-decoder.ts
+++ b/packages/core/src/style-decoder.ts
@@ -51,7 +51,10 @@ export class StyleDecoder {
 
     if (hash.className) {
       conds.push(className)
-      result = utility.formatClassName(toHash(conds.join(':')))
+      const stringConds = conds.join(':')
+      const splitConds = stringConds.split('_')
+      const hashConds = splitConds.map(toHash)
+      result = utility.formatClassName(hashConds.join('_'))
     } else {
       conds.push(utility.formatClassName(className))
       result = conds.join(':')

--- a/packages/shared/__tests__/css-var.test.ts
+++ b/packages/shared/__tests__/css-var.test.ts
@@ -14,8 +14,8 @@ describe('css var', () => {
   test('with hash', () => {
     expect(cssVar('colors-red-200', { hash: true })).toMatchInlineSnapshot(`
       {
-        "ref": "var(--bLdQLg)",
-        "var": "--bLdQLg",
+        "ref": "var(--seRF)",
+        "var": "--seRF",
       }
     `)
   })
@@ -23,8 +23,8 @@ describe('css var', () => {
   test('with hash + prefix', () => {
     expect(cssVar('colors-red-200', { hash: true, prefix: 'pd' })).toMatchInlineSnapshot(`
       {
-        "ref": "var(--pd-bLdQLg)",
-        "var": "--pd-bLdQLg",
+        "ref": "var(--pd-seRF)",
+        "var": "--pd-seRF",
       }
     `)
   })

--- a/packages/shared/src/classname.ts
+++ b/packages/shared/src/classname.ts
@@ -46,7 +46,10 @@ export function createCss(context: CreateCssContext) {
     let result: string
     if (hash) {
       const baseArray = [...conds.finalize(conditions), className]
-      result = formatClassName(toHash(baseArray.join(':')))
+      const stringBaseArray = baseArray.join(':')
+      const splitBaseArray = stringBaseArray.split('_')
+      const hashBaseArray = splitBaseArray.map(toHash)
+      result = formatClassName(hashBaseArray.join('_'))
     } else {
       const baseArray = [...conds.finalize(conditions), formatClassName(className)]
       result = baseArray.join(':')

--- a/packages/shared/src/hash.ts
+++ b/packages/shared/src/hash.ts
@@ -16,5 +16,5 @@ function toPhash(h: number, x: string) {
 }
 
 export function toHash(value: string) {
-  return toName(toPhash(5381, value) >>> 0)
+  return toName(toPhash(5381, value) >>> 8)
 }

--- a/packages/token-dictionary/__tests__/middleware-negative.test.ts
+++ b/packages/token-dictionary/__tests__/middleware-negative.test.ts
@@ -52,7 +52,7 @@ test('middleware / add negative', () => {
           "-sm",
         ],
         "type": "dimension",
-        "value": "calc(var(--jolVMp) * -1)",
+        "value": "calc(var(--bTXCt) * -1)",
       },
     ]
   `)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We wanted to keep the last className of the same CSS property passed to a component and remove the other ones. So we decided to use a different method than `cx` that does this for us, we developed a method like [`tailwind-merge`](https://www.npmjs.com/package/tailwind-merge) but for PandaCSS.

The algorithm was based on splitting className by `_` and then keeping the last className of a CSS property and removing the others.
So the bottleneck was that the algorithm was useless while we activated `hash` on production because all `_` became hashed as well!

## ⛳️ Current behavior (updates)

The hashing had been done regardless of the `_` between the className.

## 🚀 New behavior

the className is split based on `_` and then hash each part of it separately.
I also decreased the length of the hash strings since we now have two hash strings per class that are joined together at the end.

## 💣 Is this a breaking change (Yes/No):

No. hashing is an internal process and the end-user should not change anything manually.

## 📝 Additional Information
