### PR TITLE
fix: utility shorthand

### DIFF
--- a/.changeset/cuddly-poems-sort.md
+++ b/.changeset/cuddly-poems-sort.md
@@ -2,7 +2,8 @@
 '@pandacss/core': patch
 ---
 
-Fix issue in utility config where shorthands without `className` returns incorrect css when use the shorthand version.
+Fix the issue in the utility configuration where shorthand without `className` returns incorrect CSS when using the
+shorthand version.
 
 ```js
 utilities: {

--- a/.changeset/cuddly-poems-sort.md
+++ b/.changeset/cuddly-poems-sort.md
@@ -1,0 +1,21 @@
+---
+'@pandacss/core': patch
+---
+
+Fix issue in utility config where shorthands without `className` returns incorrect css when use the shorthand version.
+
+```js
+utilities: {
+  extend: {
+    coloredBorder: {
+      shorthand: 'cb', // no classname, returns incorrect css
+      values: ['red', 'green', 'blue'],
+      transform(value) {
+        return {
+          border: `1px solid ${value}`,
+        };
+      },
+    },
+  },
+},
+```

--- a/packages/core/__tests__/custom-utility.test.ts
+++ b/packages/core/__tests__/custom-utility.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { createRuleProcessor } from './fixture'
+
+describe('custom utility', () => {
+  test('shorthand + no className', () => {
+    const css = (styles: any) =>
+      createRuleProcessor({
+        utilities: {
+          extend: {
+            coloredBorder: {
+              shorthand: 'cb',
+              values: ['red', 'green', 'blue'],
+              transform(value) {
+                return {
+                  border: `1px solid ${value}`,
+                }
+              },
+            },
+          },
+        },
+      })
+        .css(styles)
+        .toCss()
+
+    expect(css({ coloredBorder: 'red' })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .cb_red {
+          border: 1px solid red;
+      }
+      }"
+    `)
+
+    expect(css({ cb: 'red' })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .cb_red {
+          border: 1px solid red;
+      }
+      }"
+    `)
+  })
+
+  test('multiple shorthand + no className', () => {
+    const css = (styles: any) =>
+      createRuleProcessor({
+        utilities: {
+          extend: {
+            coloredBorder: {
+              shorthand: ['cbd', 'cbxxp'],
+              values: ['red', 'green', 'blue'],
+              transform(value) {
+                return {
+                  border: `1px solid ${value}`,
+                }
+              },
+            },
+          },
+        },
+      })
+        .css(styles)
+        .toCss()
+
+    expect(css({ coloredBorder: 'red' })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .cbd_red {
+          border: 1px solid red;
+      }
+      }"
+    `)
+
+    expect(css({ cbd: 'red' })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .cbd_red {
+          border: 1px solid red;
+      }
+      }"
+    `)
+
+    expect(css({ cbxxp: 'red' })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .cbd_red {
+          border: 1px solid red;
+      }
+      }"
+    `)
+  })
+})


### PR DESCRIPTION
Closes #2064

## 📝 Description

Fix the issue in the utility configuration where shorthand without `className` returns incorrect CSS when using the shorthand version.

## ⛳️ Current behavior (updates)

Doesn't work

## 🚀 New behavior

We gracefully set the className fallback to the shorthand

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
