### PR TITLE
fix: getArbitraryValue function to handle empty and non-string values properly

### DIFF
--- a/.changeset/large-suits-notice.md
+++ b/.changeset/large-suits-notice.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/shared': patch
+---
+
+Update `getArbitraryValue` so it works for values that start on a new line

--- a/packages/shared/__tests__/arbitrary-value.test.ts
+++ b/packages/shared/__tests__/arbitrary-value.test.ts
@@ -34,8 +34,37 @@ describe('arbitrary className', () => {
                 minmax(0, 16px)
               [breakout-end]
             minmax(16px, 1fr)
-          [full-end]
-        "
+          [full-end]"
+    `)
+
+    expect(
+      getArbitraryValue(`
+    [
+      [full-start]
+        minmax(16px, 1fr)
+          [breakout-start]
+            minmax(0, 16px)
+              [content-start]
+                minmax(min-content, 1024px)
+              [content-end]
+            minmax(0, 16px)
+          [breakout-end]
+        minmax(16px, 1fr)
+      [full-end]
+    ]
+  `),
+    ).toMatchInlineSnapshot(`
+      "[full-start]
+              minmax(16px, 1fr)
+                [breakout-start]
+                  minmax(0, 16px)
+                    [content-start]
+                      minmax(min-content, 1024px)
+                    [content-end]
+                  minmax(0, 16px)
+                [breakout-end]
+              minmax(16px, 1fr)
+            [full-end]"
     `)
   })
 })

--- a/packages/shared/__tests__/arbitrary-value.test.ts
+++ b/packages/shared/__tests__/arbitrary-value.test.ts
@@ -23,8 +23,7 @@ describe('arbitrary className', () => {
     [full-end]
   `),
     ).toMatchInlineSnapshot(`
-      "
-          [full-start]
+      "[full-start]
             minmax(16px, 1fr)
               [breakout-start]
                 minmax(0, 16px)

--- a/packages/shared/src/arbitrary-value.ts
+++ b/packages/shared/src/arbitrary-value.ts
@@ -1,5 +1,6 @@
-export const getArbitraryValue = (value: string) => {
-  if (!value) return value
+export const getArbitraryValue = (_value: string) => {
+  if (!_value || typeof _value !== 'string') return _value
+  const value = _value.trim()
 
   if (value[0] === '[' && value[value.length - 1] === ']') {
     const innerValue = value.slice(1, -1)
@@ -19,7 +20,7 @@ export const getArbitraryValue = (value: string) => {
 
     if (bracketCount === 0) {
       // All brackets are balanced
-      return innerValue
+      return innerValue.trim()
     }
   }
 


### PR DESCRIPTION
Refactor getArbitraryValue function to handle empty and non-string values properly