### PR TITLE
fix: global css selector order

### DIFF
--- a/.changeset/healthy-insects-travel.md
+++ b/.changeset/healthy-insects-travel.md
@@ -1,0 +1,55 @@
+---
+'@pandacss/core': patch
+---
+
+Fix a regression with globalCss selector order
+
+```ts
+{
+    globalCss: {
+        html: {
+          ".aaa": {
+            color: "red.100",
+            "& .bbb": {
+              color: "red.200",
+              "& .ccc": {
+                color: "red.300"
+              }
+            }
+          }
+        },
+    }
+}
+```
+
+would incorrectly generate (regression introduced in v0.26.2)
+
+```css
+.aaa html {
+  color: var(--colors-red-100);
+}
+
+.aaa html .bbb {
+  color: var(--colors-red-200);
+}
+
+.aaa html .bbb .ccc {
+  color: var(--colors-red-300);
+}
+```
+
+will now correctly generate again:
+
+```css
+.aaa html {
+  color: var(--colors-red-100);
+}
+
+.aaa html .bbb {
+  color: var(--colors-red-200);
+}
+
+.aaa html .bbb .ccc {
+  color: var(--colors-red-300);
+}
+```

--- a/packages/core/__tests__/global-css.test.ts
+++ b/packages/core/__tests__/global-css.test.ts
@@ -29,6 +29,24 @@ describe('Global css', () => {
         sm: {
           fontSize: '12px',
         },
+        '& .aaa': {
+          color: 'blue.200',
+          '& .bbb': {
+            color: 'blue.300',
+            '& .ccc': {
+              color: 'blue.400',
+            },
+          },
+        },
+        '.yyy': {
+          color: 'blue.300',
+          '.zzz': {
+            color: 'green.400',
+            '.zzzzzzz': {
+              color: 'green.500',
+            },
+          },
+        },
       },
     })
 
@@ -36,6 +54,30 @@ describe('Global css', () => {
       "@layer base {
         .btn {
           width: 40px;
+      }
+
+        .btn .aaa {
+          color: var(--colors-blue-200);
+      }
+
+        .btn .aaa .bbb {
+          color: var(--colors-blue-300);
+      }
+
+        .btn .aaa .bbb .ccc {
+          color: var(--colors-blue-400);
+      }
+
+        .btn .yyy {
+          color: var(--colors-blue-300);
+      }
+
+        .btn .yyy .zzz {
+          color: var(--colors-green-400);
+      }
+
+        .btn .yyy .zzz .zzzzzzz {
+          color: var(--colors-green-500);
       }
 
         .btn:is(:focus, [data-focus]) {

--- a/packages/core/src/serialize.ts
+++ b/packages/core/src/serialize.ts
@@ -34,10 +34,10 @@ export function serializeStyles(context: SerializeContext, groupedObject: Dict) 
       getKey: (prop) => {
         // Rewrite html selectors to include the parent selector so that it can be parsed later on
         // ASSUMPTION: an object that has a key that is not a valid property/condition is a html selector
-        // ex: 'body, :root' => 'body &, :root &'
+        // ex: 'body, :root' => '& body, & :root'
         if (!context.conditions.isCondition(prop) && !context.isValidProperty(prop)) {
           const selectors = parseSelectors(prop)
-          return selectors.map((s) => s + ' &').join(', ')
+          return selectors.map((s) => '& ' + s).join(', ')
         }
 
         return prop

--- a/packages/core/src/stringify.ts
+++ b/packages/core/src/stringify.ts
@@ -44,7 +44,7 @@ export function stringify(
     // Then selectors
     if (selectors.length && !used.has(selectors)) {
       used.add(selectors)
-      cssText += `${selectors.map((s) => s.replace(' &', ''))} {`
+      cssText += `${selectors.map((s) => s.replace('& ', ''))} {`
     }
 
     let value = data


### PR DESCRIPTION
## 📝 Description

Fix a regression (introduced in v0.26.2) with globalCss selector order

```ts
{
    globalCss: {
        html: {
          ".aaa": {
            color: "red.100",
            ".bbb": {
              color: "red.200",
              ".ccc": {
                color: "red.300"
              }
            }
          }
        },
    }
}
```

would incorrectly generate (regression introduced in v0.26.2)

```css
  .aaa html {
    color: var(--colors-red-100);
  }

  .bbb .aaa html {
    color: var(--colors-red-200);
  }

  .ccc .bbb .aaa html {
    color: var(--colors-red-300);
  }
```

will now correctly generate again:

```css
.aaa html {
  color: var(--colors-red-100);
}

.aaa html .bbb {
  color: var(--colors-red-200);
}

.aaa html .bbb .ccc {
  color: var(--colors-red-300);
}
```

a temporary workaround is to manually specify the `&` character like so:

```ts
{
    globalCss: {
        html: {
          ".aaa": {
            color: "red.100",
            "& .bbb": {
              color: "red.200",
              "& .ccc": {
                color: "red.300"
              }
            }
          }
        },
    }
}
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
