### PR TITLE
feat(config): using `null` will remove the key entirely

### DIFF
--- a/.changeset/metal-otters-develop.md
+++ b/.changeset/metal-otters-develop.md
@@ -1,0 +1,109 @@
+---
+'@pandacss/config': patch
+---
+
+Using `null` in one of the extendable keys will omit that key from the final config. This is useful for when you want to
+use most of a preset but want to completely omit a few things, while keeping the rest.
+
+```ts
+const myPreset = {
+  theme: {
+    extend: {
+      tokens: {
+        colors: {
+          blue: { value: 'blue' },
+          orange: { value: 'orange' },
+        },
+      },
+    },
+  },
+  utilities: {
+    extend: {
+      gridRow: {
+        className: 'row-span',
+        values: {
+          full: '1 / -1',
+          1: 'span 1 / span 1',
+          2: 'span 2 / span 2',
+          3: 'span 3 / span 3',
+          4: 'span 4 / span 4',
+          5: 'span 5 / span 5',
+          6: 'span 6 / span 6',
+          7: 'span 7 / span 7',
+          8: 'span 8 / span 8',
+          9: 'span 9 / span 9',
+          10: 'span 10 / span 10',
+          11: 'span 11 / span 11',
+          12: 'span 12 / span 12',
+        },
+      },
+    },
+  },
+}
+
+export default defineConfig({
+  presets: [myPreset],
+  theme: {
+    extend: {
+      tokens: {
+        colors: {
+          red: { value: 'green' },
+          blue: { value: 'yellow' },
+          // @ts-expect-error
+          orange: null,
+        },
+      },
+    },
+  },
+  utilities: {
+    extend: {
+      gridRow: {
+        className: 'row-span',
+        // @ts-expect-error
+        values: {
+          full: '1 / -1',
+          1: null,
+          2: null,
+          3: null,
+          4: null,
+          5: null,
+          6: null,
+          7: null,
+          8: null,
+          9: null,
+        },
+      },
+    },
+  },
+})
+```
+
+will result in:
+
+```ts
+export default {
+  theme: {
+    tokens: {
+      colors: {
+        blue: {
+          value: 'yellow',
+        },
+        red: {
+          value: 'green',
+        },
+      },
+    },
+  },
+  utilities: {
+    gridRow: {
+      className: 'row-span',
+      values: {
+        10: 'span 10 / span 10',
+        11: 'span 11 / span 11',
+        12: 'span 12 / span 12',
+        full: '1 / -1',
+      },
+    },
+  },
+}
+```

--- a/.changeset/metal-otters-develop.md
+++ b/.changeset/metal-otters-develop.md
@@ -128,5 +128,12 @@ export default {
       },
     },
   },
+  patterns: {
+    box: {
+      transform(props) {
+        return props
+      },
+    },
+  },
 }
 ```

--- a/.changeset/metal-otters-develop.md
+++ b/.changeset/metal-otters-develop.md
@@ -39,6 +39,23 @@ const myPreset = {
       },
     },
   },
+  patterns: {
+    extend: {
+      box: {
+        transform(props) {
+          return props
+        },
+      },
+      visuallyHidden: {
+        transform(props) {
+          return {
+            srOnly: true,
+            ...props,
+          }
+        },
+      },
+    },
+  },
 }
 
 export default defineConfig({
@@ -73,6 +90,12 @@ export default defineConfig({
           9: null,
         },
       },
+    },
+  },
+  patterns: {
+    extend: {
+      // @ts-expect-error
+      visuallyHidden: null,
     },
   },
 })

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -393,6 +393,12 @@ describe('mergeConfigs / theme', () => {
             },
           },
         },
+        patterns: {
+          extend: {
+            // @ts-expect-error
+            visuallyHidden: null,
+          },
+        },
       }),
       // Preset
       defineConfig({
@@ -428,11 +434,33 @@ describe('mergeConfigs / theme', () => {
             },
           },
         },
+        patterns: {
+          extend: {
+            box: {
+              transform(props) {
+                return props
+              },
+            },
+            visuallyHidden: {
+              transform(props) {
+                return {
+                  srOnly: true,
+                  ...props,
+                }
+              },
+            },
+          },
+        },
       }),
     ])
 
     expect(result).toMatchInlineSnapshot(`
       {
+        "patterns": {
+          "box": {
+            "transform": [Function],
+          },
+        },
         "theme": {
           "tokens": {
             "colors": {

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -356,6 +356,109 @@ describe('mergeConfigs / theme', () => {
       }
     `)
   })
+
+  test('omit keys with explicit `null`', () => {
+    const result = mergeConfigs([
+      // User config
+      defineConfig({
+        theme: {
+          extend: {
+            tokens: {
+              colors: {
+                red: { value: 'green' },
+                blue: { value: 'yellow' },
+                // @ts-expect-error
+                orange: null,
+              },
+            },
+          },
+        },
+        utilities: {
+          extend: {
+            gridRow: {
+              className: 'row-span',
+              // @ts-expect-error
+              values: {
+                full: '1 / -1',
+                '1': null,
+                '2': null,
+                '3': null,
+                '4': null,
+                '5': null,
+                '6': null,
+                '7': null,
+                '8': null,
+                '9': null,
+              },
+            },
+          },
+        },
+      }),
+      // Preset
+      defineConfig({
+        theme: {
+          extend: {
+            tokens: {
+              colors: {
+                blue: { value: 'blue' },
+                orange: { value: 'orange' },
+              },
+            },
+          },
+        },
+        utilities: {
+          extend: {
+            gridRow: {
+              className: 'row-span',
+              values: {
+                full: '1 / -1',
+                '1': 'span 1 / span 1',
+                '2': 'span 2 / span 2',
+                '3': 'span 3 / span 3',
+                '4': 'span 4 / span 4',
+                '5': 'span 5 / span 5',
+                '6': 'span 6 / span 6',
+                '7': 'span 7 / span 7',
+                '8': 'span 8 / span 8',
+                '9': 'span 9 / span 9',
+                '10': 'span 10 / span 10',
+                '11': 'span 11 / span 11',
+                '12': 'span 12 / span 12',
+              },
+            },
+          },
+        },
+      }),
+    ])
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "theme": {
+          "tokens": {
+            "colors": {
+              "blue": {
+                "value": "yellow",
+              },
+              "red": {
+                "value": "green",
+              },
+            },
+          },
+        },
+        "utilities": {
+          "gridRow": {
+            "className": "row-span",
+            "values": {
+              "10": "span 10 / span 10",
+              "11": "span 11 / span 11",
+              "12": "span 12 / span 12",
+              "full": "1 / -1",
+            },
+          },
+        },
+      }
+    `)
+  })
 })
 
 describe('mergeConfigs / utilities', () => {


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/1902
Closes https://github.com/chakra-ui/panda/discussions/1784 

Using `null` in one of the extendable keys will omit that key from the final config. This is useful for when you want to
use most of a preset but want to completely omit a few things, while keeping the rest.

```ts
const myPreset = {
  theme: {
    extend: {
      tokens: {
        colors: {
          blue: { value: 'blue' },
          orange: { value: 'orange' },
        },
      },
    },
  },
  utilities: {
    extend: {
      gridRow: {
        className: 'row-span',
        values: {
          full: '1 / -1',
          1: 'span 1 / span 1',
          2: 'span 2 / span 2',
          3: 'span 3 / span 3',
          4: 'span 4 / span 4',
          5: 'span 5 / span 5',
          6: 'span 6 / span 6',
          7: 'span 7 / span 7',
          8: 'span 8 / span 8',
          9: 'span 9 / span 9',
          10: 'span 10 / span 10',
          11: 'span 11 / span 11',
          12: 'span 12 / span 12',
        },
      },
    },
  },
  patterns: {
    extend: {
      box: {
        transform(props) {
          return props
        },
      },
      visuallyHidden: {
        transform(props) {
          return {
            srOnly: true,
            ...props,
          }
        },
      },
    },
  },
}

export default defineConfig({
  presets: [myPreset],
  theme: {
    extend: {
      tokens: {
        colors: {
          red: { value: 'green' },
          blue: { value: 'yellow' },
          // @ts-expect-error
          orange: null,
        },
      },
    },
  },
  utilities: {
    extend: {
      gridRow: {
        className: 'row-span',
        // @ts-expect-error
        values: {
          full: '1 / -1',
          1: null,
          2: null,
          3: null,
          4: null,
          5: null,
          6: null,
          7: null,
          8: null,
          9: null,
        },
      },
    },
  },
  patterns: {
    extend: {
      // @ts-expect-error
      visuallyHidden: null,
    },
  },
})
```

will result in:

```ts
export default {
  theme: {
    tokens: {
      colors: {
        blue: {
          value: 'yellow',
        },
        red: {
          value: 'green',
        },
      },
    },
  },
  utilities: {
    gridRow: {
      className: 'row-span',
      values: {
        10: 'span 10 / span 10',
        11: 'span 11 / span 11',
        12: 'span 12 / span 12',
        full: '1 / -1',
      },
    },
  },
patterns: {
    box: {
      transform(props) {
        return props
      },
    },
  },
}
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
