### PR TITLE
docs: fixes several broken links to the minimal setup page

### DIFF
--- a/website/pages/docs/concepts/extend.md
+++ b/website/pages/docs/concepts/extend.md
@@ -143,7 +143,7 @@ export default defineConfig({
 
 ## Minimal setup
 
-If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guide/minimal-setup)
+If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guides/minimal-setup)
 
 ## FAQ
 

--- a/website/pages/docs/customization/conditions.mdx
+++ b/website/pages/docs/customization/conditions.mdx
@@ -112,4 +112,4 @@ Then you can run the following command to update the conditions JS code:
 
 ## Minimal setup
 
-If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guide/minimal-setup)
+If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guides/minimal-setup)

--- a/website/pages/docs/customization/patterns.mdx
+++ b/website/pages/docs/customization/patterns.mdx
@@ -154,4 +154,4 @@ Then you can run the following command to update the pattern JS code:
 
 ## Minimal setup
 
-If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guide/minimal-setup)
+If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guides/minimal-setup)

--- a/website/pages/docs/customization/presets.md
+++ b/website/pages/docs/customization/presets.md
@@ -118,4 +118,4 @@ export default defineConfig({
 
 ## Minimal setup
 
-If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guide/minimal-setup)
+If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guides/minimal-setup)

--- a/website/pages/docs/customization/theme.mdx
+++ b/website/pages/docs/customization/theme.mdx
@@ -199,4 +199,4 @@ Panda ships with the following keyframes by default:
 
 ## Minimal setup
 
-If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guide/minimal-setup)
+If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guides/minimal-setup)

--- a/website/pages/docs/customization/utilities.mdx
+++ b/website/pages/docs/customization/utilities.mdx
@@ -171,4 +171,4 @@ export default defineConfig({
 
 ## Minimal setup
 
-If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guide/minimal-setup)
+If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it [here](/docs/guides/minimal-setup)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->



## 📝 Description

> Fixes several broken links to the minimal setup page in the documentation.

## ⛳️ Current behavior (updates)

> When you follow the link in the text "If you want to use Panda with the bare minimum, without any of the defaults, you can read more about it here", a 404 error occurs.

## 🚀 New behavior

> The link leads to the corresponding documentation page.

## 💣 Is this a breaking change (Yes/No):

> No

