### PR TITLE
fix: 0.29 issue with panda init & color mix on object values

### DIFF
--- a/.changeset/friendly-wolves-fix.md
+++ b/.changeset/friendly-wolves-fix.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/core': patch
+'@pandacss/node': patch
+---
+
+Fix an issue (introduced in v0.29) with `panda init` and add an assert on the new `colorMix` utility function

--- a/packages/core/src/color-mix.ts
+++ b/packages/core/src/color-mix.ts
@@ -1,12 +1,11 @@
 import type { TransformArgs } from '@pandacss/types'
 
 export const colorMix = (value: string, token: TransformArgs['token']) => {
-  if (!value) return { invalid: true, value }
   if (typeof value !== 'string') return { invalid: true, value }
 
   const [rawColor, rawOpacity] = value.split('/')
 
-  if (!rawOpacity) {
+  if (!rawColor || !rawOpacity) {
     return { invalid: true, value: rawColor }
   }
 

--- a/packages/core/src/color-mix.ts
+++ b/packages/core/src/color-mix.ts
@@ -1,7 +1,7 @@
 import type { TransformArgs } from '@pandacss/types'
 
 export const colorMix = (value: string, token: TransformArgs['token']) => {
-  if (typeof value !== 'string') return { invalid: true, value }
+  if (!value || typeof value !== 'string') return { invalid: true, value }
 
   const [rawColor, rawOpacity] = value.split('/')
 

--- a/packages/core/src/color-mix.ts
+++ b/packages/core/src/color-mix.ts
@@ -2,6 +2,7 @@ import type { TransformArgs } from '@pandacss/types'
 
 export const colorMix = (value: string, token: TransformArgs['token']) => {
   if (!value) return { invalid: true, value }
+  if (typeof value !== 'string') return { invalid: true, value }
 
   const [rawColor, rawOpacity] = value.split('/')
 

--- a/packages/node/src/setup-config.ts
+++ b/packages/node/src/setup-config.ts
@@ -1,6 +1,7 @@
 import { findConfig } from '@pandacss/config'
 import { messages } from '@pandacss/core'
 import { logger, quote } from '@pandacss/logger'
+import { PandaError } from '@pandacss/shared'
 import type { Config } from '@pandacss/types'
 import fsExtra from 'fs-extra'
 import { lookItUpSync } from 'look-it-up'
@@ -16,7 +17,15 @@ type SetupOptions = Partial<Config> & {
 export async function setupConfig(cwd: string, opts: SetupOptions = {}) {
   const { force, outExtension, jsxFramework, syntax } = opts
 
-  const configFile = findConfig({ cwd })
+  let configFile
+  try {
+    configFile = findConfig({ cwd })
+  } catch (err) {
+    // ignore config not found error
+    if (!(err instanceof PandaError)) {
+      throw err
+    }
+  }
 
   const pmResult = await getPackageManager(cwd)
   const pm = pmResult?.name ?? 'npm'

--- a/packages/node/src/setup-config.ts
+++ b/packages/node/src/setup-config.ts
@@ -17,7 +17,7 @@ type SetupOptions = Partial<Config> & {
 export async function setupConfig(cwd: string, opts: SetupOptions = {}) {
   const { force, outExtension, jsxFramework, syntax } = opts
 
-  let configFile
+  let configFile: string | undefined
   try {
     configFile = findConfig({ cwd })
   } catch (err) {


### PR DESCRIPTION
## 📝 Description

Fix an issue (introduced in v0.29) with `panda init` and add an assert on the new `colorMix` utility function

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
