### PR TITLE
fix: config resolve regression

### DIFF
--- a/.changeset/perfect-rats-act.md
+++ b/.changeset/perfect-rats-act.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/config': patch
+---
+
+Fix the regression caused by the downstream bundle-n-require package, which tries to load custom conditions first. This
+led to a `could not resolve @pandacss/dev` error

--- a/packages/config/__tests__/bundle-config.test.ts
+++ b/packages/config/__tests__/bundle-config.test.ts
@@ -38,7 +38,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/with-tsconfig-paths/src/theme/tokens.ts",
           "packages/config/__tests__/samples/with-tsconfig-paths/panda.config.ts",
         ],
@@ -75,7 +75,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/nested-files/src/theme/colors.ts",
           "packages/config/__tests__/samples/nested-files/src/theme/tokens.ts",
           "packages/config/__tests__/samples/nested-files/src/theme/index.ts",
@@ -163,7 +163,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/with-preset/src/ts-import-preset.ts",
           "packages/config/__tests__/samples/with-preset/src/required-preset.ts",
           "packages/config/__tests__/samples/with-preset/panda.config.ts",
@@ -204,7 +204,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/common/tokens.ts",
           "packages/config/__tests__/samples/ts/panda.config.ts",
         ],
@@ -244,7 +244,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/common/tokens.ts",
           "packages/config/__tests__/samples/cts/panda.config.cts",
         ],
@@ -284,7 +284,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/common/tokens.ts",
           "packages/config/__tests__/samples/mts/panda.config.mts",
         ],
@@ -324,7 +324,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/common/tokens.ts",
           "packages/config/__tests__/samples/js/panda.config.js",
         ],
@@ -364,7 +364,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.js",
           "packages/config/__tests__/samples/common/tokens.ts",
           "packages/config/__tests__/samples/cjs/panda.config.cjs",
         ],
@@ -404,7 +404,7 @@ describe('bundle config', () => {
           },
         },
         "dependencies": [
-          "packages/cli/src/index.ts",
+          "packages/cli/dist/index.mjs",
           "packages/config/__tests__/samples/common/tokens.ts",
           "packages/config/__tests__/samples/mjs/panda.config.mjs",
         ],

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -69,11 +69,11 @@
     "@pandacss/preset-panda": "workspace:*",
     "@pandacss/shared": "workspace:*",
     "@pandacss/types": "workspace:*",
-    "bundle-n-require": "^1.1.0",
+    "bundle-n-require": "1.1.1",
     "escalade": "3.1.1",
-    "merge-anything": "^5.1.7",
-    "microdiff": "^1.3.2",
-    "typescript": "^5.3.3"
+    "merge-anything": "5.1.7",
+    "microdiff": "1.3.2",
+    "typescript": "5.3.3"
   },
   "devDependencies": {
     "pkg-types": "1.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,19 +159,19 @@ importers:
         specifier: workspace:*
         version: link:../types
       bundle-n-require:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: 1.1.1
+        version: 1.1.1
       escalade:
         specifier: 3.1.1
         version: 3.1.1
       merge-anything:
-        specifier: ^5.1.7
+        specifier: 5.1.7
         version: 5.1.7
       microdiff:
-        specifier: ^1.3.2
+        specifier: 1.3.2
         version: 1.3.2
       typescript:
-        specifier: ^5.3.3
+        specifier: 5.3.3
         version: 5.3.3
     devDependencies:
       pkg-types:
@@ -14869,8 +14869,8 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /bundle-n-require@1.1.0:
-    resolution: {integrity: sha512-MqlhKkkzfGqyLDR1kNBnfMI2HryoBts05NYUlXWI809jc7405WHf/RIxXbVgev1tOR5roo3qWZpyZO5aYWWbZg==}
+  /bundle-n-require@1.1.1:
+    resolution: {integrity: sha512-EB2wFjXF106LQLe/CYnKCMCdLeTW47AtcEtUfiqAOgr2a08k0+YgRklur2aLfEYHlhz6baMskZ8L2U92Hh0vyA==}
     dependencies:
       esbuild: 0.20.0
       node-eval: 2.0.0


### PR DESCRIPTION
Closes #2144

## 📝 Description

Fix the regression caused by the downstream `bundle-n-require` package, which tries to load custom conditions first.