### PR TITLE
feat(hooks): allow configuring the matchTag/matchTagProp extractor fns

### DIFF
--- a/.changeset/strange-beds-fly.md
+++ b/.changeset/strange-beds-fly.md
@@ -8,6 +8,13 @@ Allow configuring the `matchTag` / `matchTagProp` functions to customize the way
 especially useful when working with libraries that have properties that look like CSS properties but are not and should
 be ignored.
 
+> **Note**: This feature mostly affects users who have `jsxStyleProps` set to `all`. This is currently the default.
+>
+> Setting it to `minimal` (which also allows passing the css prop) or `none` (which disables the extraction of CSS
+> properties) will make this feature less useful.
+
+Here's an example with Radix UI where the `Select.Content` component has a `position` property that should be ignored:
+
 ```tsx
 // Here, the `position` property will be extracted because `position` is a valid CSS property
 <Select.Content position="popper" sideOffset={5}>
@@ -17,11 +24,10 @@ be ignored.
 export default defineConfig({
   // ...
   hooks: {
-    'parser:before': (args) => {
-      args.configure({
+    'parser:before': ({ configure }) => {
+      configure({
         // ignore the Select.Content entirely
         matchTag: (tag) => tag !== 'Select.Content',
-
         // ...or specifically ignore the `position` property
         matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
       })

--- a/.changeset/strange-beds-fly.md
+++ b/.changeset/strange-beds-fly.md
@@ -1,0 +1,31 @@
+---
+'@pandacss/parser': patch
+'@pandacss/types': patch
+'@pandacss/core': patch
+---
+
+Allow configuring the `matchTag` / `matchTagProp` functions to customize the way Panda extracts your JSX. This can be
+especially useful when working with libraries that have properties that look like CSS properties but are not and should
+be ignored.
+
+```tsx
+// Here, the `position` property will be extracted because `position` is a valid CSS property
+<Select.Content position="popper" sideOffset={5}>
+```
+
+```tsx
+export default defineConfig({
+  // ...
+  hooks: {
+    'parser:before': (args) => {
+      args.configure({
+        // ignore the Select.Content entirely
+        matchTag: (tag) => tag !== 'Select.Content',
+
+        // ...or specifically ignore the `position` property
+        matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
+      })
+    },
+  },
+})
+```

--- a/packages/core/__tests__/file-matcher.test.ts
+++ b/packages/core/__tests__/file-matcher.test.ts
@@ -19,6 +19,20 @@ describe('file matcher', () => {
     expect(file.getName('xcss')).toMatchInlineSnapshot('"css"')
   })
 
+  test('isPandaComponent', () => {
+    const ctx = createContext()
+
+    const file = ctx.imports.file([
+      { mod: 'styled-system/jsx', name: 'Stack', alias: 'Stack' },
+      { mod: 'styled-system/jsx', name: 'VStack', alias: '__VStack' },
+    ])
+
+    expect(file.isPandaComponent('Stack')).toMatchInlineSnapshot('true')
+    // should match arbitrary tag names (so we can track style props)
+    expect(file.isPandaComponent('RandomJsx')).toMatchInlineSnapshot(`false`)
+    expect(file.isPandaComponent('random')).toMatchInlineSnapshot('false')
+  })
+
   test('match tag', () => {
     const ctx = createContext()
 

--- a/packages/core/src/file-matcher.ts
+++ b/packages/core/src/file-matcher.ts
@@ -147,17 +147,20 @@ export class FileMatcher {
     return Boolean(jsx.isEnabled && tagName.startsWith(this.jsxFactoryAlias))
   })
 
-  matchTag = memo((tagName: string) => {
+  isPandaComponent = memo((tagName: string) => {
     // ignore fragments
     if (!tagName) return false
     const { jsx } = this.context
     return (
       this.components.has(tagName) ||
-      isUpperCase(tagName) ||
       this.isJsxFactory(tagName) ||
       jsx.isJsxTagRecipe(tagName) ||
       jsx.isJsxTagPattern(tagName)
     )
+  })
+
+  matchTag = memo((tagName: string) => {
+    return this.isPandaComponent(tagName) || isUpperCase(tagName)
   })
 
   matchTagProp = memo((tagName: string, propName: string) => {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -3,7 +3,7 @@ import { BoxNodeMap, box, extract, unbox, type EvaluateOptions, type Unboxed } f
 import type { Generator } from '@pandacss/generator'
 import { logger } from '@pandacss/logger'
 import { astish } from '@pandacss/shared'
-import type { ResultItem } from '@pandacss/types'
+import type { ParserResultConfigureOptions, ResultItem } from '@pandacss/types'
 import type { SourceFile } from 'ts-morph'
 import { Node } from 'ts-morph'
 import { match } from 'ts-pattern'
@@ -25,7 +25,11 @@ const evaluateOptions: EvaluateOptions = {
 export function createParser(context: ParserOptions) {
   const { jsx, imports, recipes, syntax } = context
 
-  return function parse(sourceFile: SourceFile | undefined, encoder?: Generator['encoder']) {
+  return function parse(
+    sourceFile: SourceFile | undefined,
+    encoder?: Generator['encoder'],
+    options?: ParserResultConfigureOptions,
+  ) {
     if (!sourceFile) return
 
     const importDeclarations: ImportResult[] = getImportDeclarations(context, sourceFile)
@@ -49,8 +53,25 @@ export function createParser(context: ParserOptions) {
       ast: sourceFile,
       components: jsx.isEnabled
         ? {
-            matchTag: (prop) => !!file.matchTag(prop.tagName),
-            matchProp: (prop) => !!file.matchTagProp(prop.tagName, prop.propName),
+            matchTag: (prop) => {
+              if (options?.matchTag) {
+                // If the user has a custom matchTag function,
+                // we're not going to match every uppercased tag
+                const isPandaComponent = file.isPandaComponent(prop.tagName)
+                return isPandaComponent || options.matchTag(prop.tagName, isPandaComponent)
+              }
+
+              return !!file.matchTag(prop.tagName)
+            },
+            matchProp: (prop) => {
+              const isPandaProp = file.matchTagProp(prop.tagName, prop.propName)
+
+              if (options?.matchTagProp) {
+                return isPandaProp && options.matchTagProp(prop.tagName, prop.propName)
+              }
+
+              return isPandaProp
+            },
           }
         : undefined,
       functions: {

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -31,7 +31,7 @@ export interface PandaHooks {
    * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
    * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
    */
-  'parser:before': (args: { filePath: string; content: string }) => string | void
+  'parser:before': (args: ParserResultBeforeArgs) => string | void
   /**
    * Called after the file styles are extracted and processed into the resulting ParserResult object.
    * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
@@ -97,6 +97,17 @@ export interface ConfigResolvedHookArgs {
   path: string
   dependencies: string[]
   utils: ConfigResolvedHookUtils
+}
+
+export interface ParserResultConfigureOptions {
+  matchTag?: (tag: string, isPandaComponent: boolean) => boolean
+  matchTagProp?: (tag: string, prop: string) => boolean
+}
+
+export interface ParserResultBeforeArgs {
+  filePath: string
+  content: string
+  configure: (opts: ParserResultConfigureOptions) => void
 }
 
 type CallbackFn = (args: CallbackItem) => void

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -21,43 +21,44 @@ export interface PandaHooks {
   /**
    * Called when the Panda context has been created and the API is ready to be used.
    */
-  'context:created': (args: { ctx: HooksApiInterface; logger: LoggerInterface }) => void
+  'context:created': (args: ContextCreatedHookArgs) => void
   /**
    * Called when the config file or one of its dependencies (imports) has changed.
    */
-  'config:change': (args: { config: UserConfig; changes: DiffConfigResult }) => MaybeAsyncReturn
+  'config:change': (args: ConfigChangeHookArgs) => MaybeAsyncReturn
   /**
    * Called after reading the file content but before parsing it.
    * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
    * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
    */
-  'parser:before': (args: ParserResultBeforeArgs) => string | void
+  'parser:before': (args: ParserResultBeforeHookArgs) => string | void
   /**
    * Called after the file styles are extracted and processed into the resulting ParserResult object.
    * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
    */
-  'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
+  'parser:after': (args: ParserResultAfterHookArgs) => void
   /**
    * Called right before writing the codegen files to disk.
    * You can use this hook to tweak the codegen files before they are written to disk.
    */
-  'codegen:prepare': (args: { artifacts: Artifact[]; changed: ArtifactId[] | undefined }) => MaybeAsyncReturn
+  'codegen:prepare': (args: CodegenPrepareHookArgs) => MaybeAsyncReturn
   /**
    * Called after the codegen is completed
    */
-  'codegen:done': (args: { changed: ArtifactId[] | undefined }) => MaybeAsyncReturn
+  'codegen:done': (args: CodegenDoneHookArgs) => MaybeAsyncReturn
   /**
    * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
    * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
    * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
    */
-  'cssgen:done': (args: {
-    artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
-    content: string
-  }) => string | void
+  'cssgen:done': (args: CssgenDoneHookArgs) => string | void
 }
 
 type MaybeAsyncReturn<T = void> = Promise<T> | T
+
+/* -----------------------------------------------------------------------------
+ * Token hooks
+ * -----------------------------------------------------------------------------*/
 
 interface TokenCssVarOptions {
   fallback?: string
@@ -79,12 +80,39 @@ export interface TokenCreatedHookArgs {
   configure(opts: TokenConfigureOptions): void
 }
 
+/* -----------------------------------------------------------------------------
+ * Utility hooks
+ * -----------------------------------------------------------------------------*/
+
 export interface UtilityConfigureOptions {
   toHash?(path: string[], toHash: (str: string) => string): string
 }
 
 export interface UtilityCreatedHookArgs {
   configure(opts: UtilityConfigureOptions): void
+}
+
+/* -----------------------------------------------------------------------------
+ * Config hooks
+ * -----------------------------------------------------------------------------*/
+
+interface CallbackItem {
+  value: any
+  path: string
+  depth: number
+  parent: any[] | Record<string, unknown>
+  key: string
+}
+
+type CallbackFn = (args: CallbackItem) => void
+
+interface TraverseOptions {
+  separator: string
+  maxDepth?: number | undefined
+}
+
+interface TraverseFn {
+  (obj: any, callback: CallbackFn, options?: TraverseOptions): void
 }
 
 interface ConfigResolvedHookUtils {
@@ -99,27 +127,60 @@ export interface ConfigResolvedHookArgs {
   utils: ConfigResolvedHookUtils
 }
 
+export interface ConfigChangeHookArgs {
+  config: UserConfig
+  changes: DiffConfigResult
+}
+
+/* -----------------------------------------------------------------------------
+ * Parser hooks
+ * -----------------------------------------------------------------------------*/
+
 export interface ParserResultConfigureOptions {
   matchTag?: (tag: string, isPandaComponent: boolean) => boolean
   matchTagProp?: (tag: string, prop: string) => boolean
 }
 
-export interface ParserResultBeforeArgs {
+export interface ParserResultBeforeHookArgs {
   filePath: string
   content: string
   configure: (opts: ParserResultConfigureOptions) => void
 }
 
-type CallbackFn = (args: CallbackItem) => void
-type CallbackItem = { value: any; path: string; depth: number; parent: any[] | Record<string, unknown>; key: string }
+export interface ParserResultAfterHookArgs {
+  filePath: string
+  result: ParserResultInterface | undefined
+}
 
-interface TraverseFn {
-  (
-    obj: any,
-    callback: CallbackFn,
-    options?: {
-      separator: string
-      maxDepth?: number | undefined
-    },
-  ): void
+/* -----------------------------------------------------------------------------
+ * Codegen hooks
+ * -----------------------------------------------------------------------------*/
+
+export interface CodegenPrepareHookArgs {
+  artifacts: Artifact[]
+  changed: ArtifactId[] | undefined
+}
+
+export interface CodegenDoneHookArgs {
+  changed: ArtifactId[] | undefined
+}
+
+/* -----------------------------------------------------------------------------
+ * Cssgen hooks
+ * -----------------------------------------------------------------------------*/
+
+type CssgenArtifact = 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+
+export interface CssgenDoneHookArgs {
+  artifact: CssgenArtifact
+  content: string
+}
+
+/* -----------------------------------------------------------------------------
+ * Context hooks
+ * -----------------------------------------------------------------------------*/
+
+export interface ContextCreatedHookArgs {
+  ctx: HooksApiInterface
+  logger: LoggerInterface
 }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/2132

## 📝 Description

Allow configuring the `matchTag` / `matchTagProp` functions to customize the way Panda extracts your JSX. This can be
especially useful when working with libraries that have properties that look like CSS properties but are not and should
be ignored.

```tsx
// Here, the `position` property will be extracted because `position` is a valid CSS property
<Select.Content position="popper" sideOffset={5}>
```

```tsx
export default defineConfig({
  // ...
  hooks: {
    'parser:before': (args) => {
      args.configure({
        // ignore the Select.Content entirely
        matchTag: (tag) => tag !== 'Select.Content',

        // ...or specifically ignore the `position` property
        matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
      })
    },
  },
})
```


## 💣 Is this a breaking change (Yes/No):

no