### PR TITLE
fix: solid jsx factory

### DIFF
--- a/.changeset/shy-carrots-teach.md
+++ b/.changeset/shy-carrots-teach.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix issue where styled factory in Solid.js could results in `Maximum call stack exceeded` when composing with another
+library that uses the `as` prop.


### PR DESCRIPTION
Closes #2156

## 📝 Description

Fix the issue where styled factory in Solid.js could result in `Maximum call stack exceeded` when composing with another
libraries that use the `as` prop.

## 📝 Additional Information

This was related to how we split props within the factory. The previous approach could lead to extraneous props like "as" being passed to the underlying component.