### PR TITLE
fix(cli): missing outdir param for studio

### DIFF
--- a/.changeset/three-squids-approve.md
+++ b/.changeset/three-squids-approve.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/dev": patch
+---
+
+Fix issue where the param for `--outdir` was missing, leading to errors

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -295,7 +295,7 @@ export async function main() {
     .option('--host', 'Host')
     .option('-c, --config <path>', 'Path to panda config file')
     .option('--cwd <cwd>', 'Current working directory', { default: cwd })
-    .option('--outdir', 'Output directory for static files')
+    .option('--outdir <dir>', 'Output directory for static files')
     .action(async (flags: StudioCommandFlags) => {
       const { build, preview, port, host, outdir, config } = flags
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes https://github.com/chakra-ui/panda/issues/2166

## 📝 Description

This fix adds the missing outdir param that goes with the `--outdir` flag of the `panda studio` command.

## ⛳️ Current behavior (updates)

The command `panda studio --build --outdir my-folder`
throws this error :
```
🐼 error [cli] TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received type boolean (true)
    at new NodeError (node:internal/errors:406:5)
    at validateString (node:internal/validators:162:11)
    at resolve (node:path:1101:7)
    at CAC.<anonymous> (/Users/julienglorieux/Dev/cocolis-front/apps/web/node_modules/@pandacss/dev/dist/cli-default.js:18741:40)
    at async main (/Users/julienglorieux/Dev/cocolis-front/apps/web/node_modules/@pandacss/dev/dist/cli-default.js:18914:5)
```

## 🚀 New behavior

This builds with the param as the output.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
