### PR TITLE
feat: mixed conditions

### DIFF
--- a/.changeset/curvy-doors-protect.md
+++ b/.changeset/curvy-doors-protect.md
@@ -1,0 +1,38 @@
+---
+'@pandacss/generator': patch
+'@pandacss/config': patch
+'@pandacss/types': patch
+'@pandacss/core': patch
+---
+
+Add a way to create config conditions with nested at-rules/selectors
+
+```ts
+export default defaultConfig({
+  conditions: {
+    extend: {
+      supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
+    },
+  },
+})
+```
+
+```ts
+import { css } from '../styled-system/css'
+
+css({
+  _supportHover: {
+    color: 'red',
+  },
+})
+```
+
+will generate the following CSS:
+
+```css
+@media (hover: hover) and (pointer: fine) {
+  &:hover {
+    color: red;
+  }
+}
+```

--- a/packages/config/src/validation/validate-condition.ts
+++ b/packages/config/src/validation/validate-condition.ts
@@ -19,13 +19,5 @@ export const validateConditions = (conditions: Conditions | undefined, addError:
         addError('conditions', `Selectors should contain the \`&\` character: \`${c}\``)
       }
     })
-
-    const hasAtLeastOneAmperand = condition.some((c) => c.includes('&'))
-    if (!hasAtLeastOneAmperand) {
-      addError(
-        'conditions',
-        `Mixed selectors should contain the \`&\` character in at least one segment: \`${condition.join(', ')}\``,
-      )
-    }
   })
 }

--- a/packages/config/src/validation/validate-condition.ts
+++ b/packages/config/src/validation/validate-condition.ts
@@ -1,12 +1,31 @@
 import type { Conditions } from '@pandacss/types'
 import type { AddError } from '../types'
+import { isString } from '@pandacss/shared'
 
 export const validateConditions = (conditions: Conditions | undefined, addError: AddError) => {
   if (!conditions) return
 
   Object.values(conditions).forEach((condition) => {
-    if (!condition.startsWith('@') && !condition.includes('&')) {
-      addError('conditions', `Selectors should contain the \`&\` character: \`${condition}\``)
+    if (isString(condition)) {
+      if (!condition.startsWith('@') && !condition.includes('&')) {
+        addError('conditions', `Selectors should contain the \`&\` character: \`${condition}\``)
+      }
+
+      return
+    }
+
+    condition.forEach((c) => {
+      if (!c.startsWith('@') && !c.includes('&')) {
+        addError('conditions', `Selectors should contain the \`&\` character: \`${c}\``)
+      }
+    })
+
+    const hasAtLeastOneAmperand = condition.some((c) => c.includes('&'))
+    if (!hasAtLeastOneAmperand) {
+      addError(
+        'conditions',
+        `Mixed selectors should contain the \`&\` character in at least one segment: \`${condition.join(', ')}\``,
+      )
     }
   })
 }

--- a/packages/core/__tests__/conditions.test.ts
+++ b/packages/core/__tests__/conditions.test.ts
@@ -80,12 +80,12 @@ describe('Conditions', () => {
     const conditions = ['sm', 'md', 'lg', '_hover', '_focus', '_focus-visible', '_focus-within', '_active']
     expect(css.sort(conditions).map((c) => c.raw)).toMatchInlineSnapshot(`
       [
-        "&:is(:hover, [data-hover])",
-        "&:is(:focus, [data-focus])",
-        "&:is(:active, [data-active])",
         "@media screen and (min-width: 40em)",
         "@media screen and (min-width: 48em)",
         "@media screen and (min-width: 64em)",
+        "&:is(:hover, [data-hover])",
+        "&:is(:focus, [data-focus])",
+        "&:is(:active, [data-active])",
       ]
     `)
   })

--- a/packages/core/__tests__/conditions.test.ts
+++ b/packages/core/__tests__/conditions.test.ts
@@ -1,7 +1,7 @@
 import { fixturePreset } from '@pandacss/fixture'
 import { describe, expect, test } from 'vitest'
 import { Conditions } from '../src/conditions'
-import { compareAtRuleOrMixed } from '../src/sort-style-rules'
+import { compareAtRuleOrMixed as _compareAtRuleOrMixed } from '../src/sort-style-rules'
 
 describe('Conditions', () => {
   test('condition transformation', () => {
@@ -91,6 +91,7 @@ describe('Conditions', () => {
   })
 
   test('compare at-rule or mixed', () => {
+    const compareAtRuleOrMixed = _compareAtRuleOrMixed as (a: any, b: any) => number
     const conds = new Conditions({})
     const a = {
       conditions: [

--- a/packages/core/__tests__/conditions.test.ts
+++ b/packages/core/__tests__/conditions.test.ts
@@ -8,8 +8,8 @@ describe('Conditions', () => {
     expect(css.normalize('@media (min-width: 768px)')).toMatchInlineSnapshot(`
       {
         "name": "media",
+        "params": "(min-width: 768px)",
         "raw": "@media (min-width: 768px)",
-        "rawValue": "@media (min-width: 768px)",
         "type": "at-rule",
         "value": "(min-width: 768px)",
       }
@@ -18,9 +18,8 @@ describe('Conditions', () => {
     expect(css.getRaw('sm')).toMatchInlineSnapshot(`
       {
         "name": "breakpoint",
-        "params": "screen and (min-width: 40rem)",
-        "raw": "sm",
-        "rawValue": "@media screen and (min-width: 40rem)",
+        "params": "screen and (min-width: 40em)",
+        "raw": "@media screen and (min-width: 40em)",
         "type": "at-rule",
         "value": "sm",
       }

--- a/packages/core/__tests__/conditions.test.ts
+++ b/packages/core/__tests__/conditions.test.ts
@@ -19,8 +19,8 @@ describe('Conditions', () => {
     expect(css.getRaw('sm')).toMatchInlineSnapshot(`
       {
         "name": "breakpoint",
-        "params": "screen and (min-width: 40em)",
-        "raw": "@media screen and (min-width: 40em)",
+        "params": "screen and (min-width: 40rem)",
+        "raw": "@media screen and (min-width: 40rem)",
         "type": "at-rule",
         "value": "sm",
       }
@@ -80,9 +80,9 @@ describe('Conditions', () => {
     const conditions = ['sm', 'md', 'lg', '_hover', '_focus', '_focus-visible', '_focus-within', '_active']
     expect(css.sort(conditions).map((c) => c.raw)).toMatchInlineSnapshot(`
       [
-        "@media screen and (min-width: 40em)",
-        "@media screen and (min-width: 48em)",
-        "@media screen and (min-width: 64em)",
+        "@media screen and (min-width: 40rem)",
+        "@media screen and (min-width: 48rem)",
+        "@media screen and (min-width: 64rem)",
         "&:is(:hover, [data-hover])",
         "&:is(:focus, [data-focus])",
         "&:is(:active, [data-active])",

--- a/packages/core/__tests__/global-css.test.ts
+++ b/packages/core/__tests__/global-css.test.ts
@@ -303,6 +303,7 @@ describe('Global css', () => {
             body {
               color: var(--colors-red-200);
       }
+
             body a {
               color: var(--colors-red-400);
       }

--- a/packages/core/__tests__/rule-processor.test.ts
+++ b/packages/core/__tests__/rule-processor.test.ts
@@ -1522,4 +1522,132 @@ describe('js to css', () => {
       }"
     `)
   })
+
+  test('mixed conditions sorting', () => {
+    const result = css(
+      {
+        width: {
+          _supportHover: '6px',
+          base: '0px',
+          _mdHover: '8px',
+          sm: '4px',
+          md: '4.5px',
+          _smHover: '7px',
+          _hover: {
+            base: '2px',
+            md: '5px',
+            _focus: '3px',
+          },
+          _dark: '1px',
+        },
+        _suppportHover: {
+          _custom: {
+            color: 'red',
+          },
+        },
+        _hover: {
+          _custom: {
+            color: 'blue',
+          },
+        },
+      },
+      {
+        conditions: {
+          custom: ['&[data-attr="custom"]'],
+          supportHover: ['@media (hover: hover) and (pointer: fine)', '@supports (display: table-cell)', '&:hover'],
+          smHover: ['@media screen and (min-width: 40em)', '@supports (display: grid)', '&:hover'],
+          mdHover: ['@media screen and (min-width: 48em)', '@supports (display: flex)', '&:hover'],
+        },
+      },
+    )
+
+    expect(result.className).toMatchInlineSnapshot(
+      `
+      [
+        "w_0px",
+        "dark\\:w_1px",
+        "hover\\:w_2px",
+        "hover\\:focus\\:w_3px",
+        "sm\\:w_4px",
+        "md\\:w_4\\.5px",
+        "custom\\:text_red",
+        "hover\\:md\\:w_5px",
+        "hover\\:custom\\:text_blue",
+        "smHover\\:w_7px",
+        "mdHover\\:w_8px",
+        "supportHover\\:w_6px",
+      ]
+    `,
+    )
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .w_0px {
+          width: 0px;
+      }
+
+        [data-theme=dark] .dark\\:w_1px,.dark .dark\\:w_1px,.dark\\:w_1px.dark,.dark\\:w_1px[data-theme=dark] {
+          width: 1px;
+      }
+
+        .hover\\:w_2px:is(:hover, [data-hover]) {
+          width: 2px;
+      }
+
+        .hover\\:focus\\:w_3px:is(:hover, [data-hover]):is(:focus, [data-focus]) {
+          width: 3px;
+      }
+
+        .custom\\:text_red[data-attr="custom"] {
+          color: red;
+      }
+
+        .hover\\:custom\\:text_blue[data-attr="custom"]:is(:hover, [data-hover]) {
+          color: blue;
+      }
+
+        @media screen and (min-width: 40em) {
+          .sm\\:w_4px {
+            width: 4px;
+      }
+      }
+
+        @media screen and (min-width: 40em) {
+          @supports (display: grid) {
+            .smHover\\:w_7px:hover {
+              width: 7px;
+      }
+      }
+      }
+
+        @media screen and (min-width: 48em) {
+          .md\\:w_4\\.5px {
+            width: 4.5px;
+      }
+      }
+
+        @media screen and (min-width: 48em) {
+          .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
+            width: 5px;
+      }
+      }
+
+        @media screen and (min-width: 48em) {
+          @supports (display: flex) {
+            .mdHover\\:w_8px:hover {
+              width: 8px;
+      }
+      }
+      }
+
+        @media (hover: hover) and (pointer: fine) {
+          @supports (display: table-cell) {
+            .supportHover\\:w_6px:hover {
+              width: 6px;
+      }
+      }
+      }
+      }"
+    `)
+  })
 })

--- a/packages/core/__tests__/rule-processor.test.ts
+++ b/packages/core/__tests__/rule-processor.test.ts
@@ -1616,25 +1616,25 @@ describe('js to css', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
-        @media screen and (min-width: 40em) {
+        @media screen and (min-width: 40rem) {
           .sm\\:custom\\:w_33px[data-attr="custom"] {
             width: 33px;
       }
       }
 
-        @media screen and (min-width: 40em) {
+        @media screen and (min-width: 40rem) {
           .sm\\:focus\\:w_22px:is(:focus, [data-focus]) {
             width: 22px;
       }
       }
 
-        @media screen and (min-width: 40em) {
+        @media screen and (min-width: 40rem) {
           .sm\\:hover\\:w_11px:is(:hover, [data-hover]) {
             width: 11px;
       }
       }
 
-        @media screen and (min-width: 40em) {
+        @media screen and (min-width: 40rem) {
           .sm\\:active\\:w_44px:is(:active, [data-active]) {
             width: 44px;
       }
@@ -1689,13 +1689,13 @@ describe('js to css', () => {
           color: blue;
       }
 
-        @media screen and (min-width: 48em) {
+        @media screen and (min-width: 48rem) {
           .md\\:w_3px {
             width: 3px;
       }
       }
 
-        @media screen and (min-width: 48em) {
+        @media screen and (min-width: 48rem) {
           .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
             width: 5px;
       }
@@ -1736,8 +1736,8 @@ describe('js to css', () => {
       [
         "hover\\:custom\\:text_blue",
         "hover\\:mixed\\:text_green",
-        "hover\\:md\\:w_5px",
         "hover\\:mixedMd\\:text_6px",
+        "hover\\:md\\:w_5px",
       ]
     `,
     )
@@ -1753,14 +1753,14 @@ describe('js to css', () => {
       }
 
         @media screen and (min-width: 48em) {
-          .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
-            width: 5px;
+          .hover\\:mixedMd\\:text_6px[data-attr="custom"]:is(:hover, [data-hover]) {
+            color: 6px;
       }
       }
 
-        @media screen and (min-width: 48em) {
-          .hover\\:mixedMd\\:text_6px[data-attr="custom"]:is(:hover, [data-hover]) {
-            color: 6px;
+        @media screen and (min-width: 48rem) {
+          .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
+            width: 5px;
       }
       }
       }"
@@ -1796,25 +1796,25 @@ describe('js to css', () => {
 
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
-        @media screen and (min-width: 40em) {
+        @media screen and (min-width: 40rem) {
           .sm\\:w_1px {
             width: 1px;
       }
       }
 
-        @media screen and (min-width: 48em) {
+        @media screen and (min-width: 48rem) {
           .md\\:text_3px {
             color: 3px;
       }
       }
 
-        @media screen and (min-width: 64em) {
+        @media screen and (min-width: 64rem) {
           .lg\\:text_2px {
             color: 2px;
       }
       }
 
-        @media screen and (min-width: 80em) {
+        @media screen and (min-width: 80rem) {
           .xl\\:w_4px {
             width: 4px;
       }
@@ -1864,12 +1864,12 @@ describe('js to css', () => {
     expect(result.className).toMatchInlineSnapshot(
       `
       [
-        "sm\\:w_1px",
         "mixedSm\\:text_red",
         "mixedSupportSm\\:text_green",
-        "md\\:text_3px",
+        "sm\\:w_1px",
         "mixedMd\\:text_blue",
         "mixedSupportMd\\:text_yellow",
+        "md\\:text_3px",
         "lg\\:text_2px",
         "xl\\:w_4px",
       ]
@@ -1879,9 +1879,6 @@ describe('js to css', () => {
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
         @media screen and (min-width: 40em) {
-          .sm\\:w_1px {
-            width: 1px;
-      }
           .mixedSm\\:text_red[data-attr="custom"] {
             color: red;
       }
@@ -1895,10 +1892,13 @@ describe('js to css', () => {
       }
       }
 
-        @media screen and (min-width: 48em) {
-          .md\\:text_3px {
-            color: 3px;
+        @media screen and (min-width: 40rem) {
+          .sm\\:w_1px {
+            width: 1px;
       }
+      }
+
+        @media screen and (min-width: 48em) {
           .mixedMd\\:text_blue[data-attr="custom"] {
             color: blue;
       }
@@ -1912,13 +1912,19 @@ describe('js to css', () => {
       }
       }
 
-        @media screen and (min-width: 64em) {
+        @media screen and (min-width: 48rem) {
+          .md\\:text_3px {
+            color: 3px;
+      }
+      }
+
+        @media screen and (min-width: 64rem) {
           .lg\\:text_2px {
             color: 2px;
       }
       }
 
-        @media screen and (min-width: 80em) {
+        @media screen and (min-width: 80rem) {
           .xl\\:w_4px {
             width: 4px;
       }
@@ -1948,9 +1954,9 @@ describe('js to css', () => {
     expect(result.className).toMatchInlineSnapshot(
       `
       [
+        "mdHover\\:w_6px",
         "md\\:w_4\\.5px",
         "hover\\:md\\:w_5px",
-        "mdHover\\:w_6px",
       ]
     `,
     )
@@ -1958,22 +1964,22 @@ describe('js to css', () => {
     expect(result.css).toMatchInlineSnapshot(`
       "@layer utilities {
         @media screen and (min-width: 48em) {
+          @supports (display: flex) {
+            .mdHover\\:w_6px:hover {
+              width: 6px;
+      }
+      }
+      }
+
+        @media screen and (min-width: 48rem) {
           .md\\:w_4\\.5px {
             width: 4.5px;
       }
       }
 
-        @media screen and (min-width: 48em) {
+        @media screen and (min-width: 48rem) {
           .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
             width: 5px;
-      }
-      }
-
-        @media screen and (min-width: 48em) {
-          @supports (display: flex) {
-            .mdHover\\:w_6px:hover {
-              width: 6px;
-      }
       }
       }
       }"
@@ -2027,11 +2033,11 @@ describe('js to css', () => {
         "hover\\:focus\\:w_3px",
         "custom\\:text_red",
         "hover\\:custom\\:text_blue",
-        "sm\\:w_4px",
         "smHover\\:w_7px",
+        "sm\\:w_4px",
+        "mdHover\\:w_8px",
         "md\\:w_4\\.5px",
         "hover\\:md\\:w_5px",
-        "mdHover\\:w_8px",
         "supportHover\\:w_6px",
       ]
     `,
@@ -2064,12 +2070,6 @@ describe('js to css', () => {
       }
 
         @media screen and (min-width: 40em) {
-          .sm\\:w_4px {
-            width: 4px;
-      }
-      }
-
-        @media screen and (min-width: 40em) {
           @supports (display: grid) {
             .smHover\\:w_7px:hover {
               width: 7px;
@@ -2077,15 +2077,9 @@ describe('js to css', () => {
       }
       }
 
-        @media screen and (min-width: 48em) {
-          .md\\:w_4\\.5px {
-            width: 4.5px;
-      }
-      }
-
-        @media screen and (min-width: 48em) {
-          .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
-            width: 5px;
+        @media screen and (min-width: 40rem) {
+          .sm\\:w_4px {
+            width: 4px;
       }
       }
 
@@ -2094,6 +2088,18 @@ describe('js to css', () => {
             .mdHover\\:w_8px:hover {
               width: 8px;
       }
+      }
+      }
+
+        @media screen and (min-width: 48rem) {
+          .md\\:w_4\\.5px {
+            width: 4.5px;
+      }
+      }
+
+        @media screen and (min-width: 48rem) {
+          .hover\\:md\\:w_5px:is(:hover, [data-hover]) {
+            width: 5px;
       }
       }
 

--- a/packages/core/__tests__/style-decoder.test.ts
+++ b/packages/core/__tests__/style-decoder.test.ts
@@ -526,9 +526,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40rem)",
-              "raw": "sm",
-              "rawValue": "@media screen and (min-width: 40rem)",
+              "params": "screen and (min-width: 40em)",
+              "raw": "@media screen and (min-width: 40em)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -575,6 +574,72 @@ describe('style decoder', () => {
           },
         },
         {
+          "className": "sm\\:hover\\:bg_green",
+          "conditions": [
+            {
+              "name": "breakpoint",
+              "params": "screen and (min-width: 40em)",
+              "raw": "@media screen and (min-width: 40em)",
+              "type": "at-rule",
+              "value": "sm",
+            },
+            {
+              "raw": "&:is(:hover, [data-hover])",
+              "type": "self-nesting",
+              "value": "&:is(:hover, [data-hover])",
+            },
+          ],
+          "entry": {
+            "cond": "sm<___>_hover",
+            "prop": "backgroundColor",
+            "value": "green",
+          },
+          "hash": "backgroundColor]___[value:green]___[cond:sm<___>_hover",
+          "layer": undefined,
+          "result": {
+            ".sm\\:hover\\:bg_green": {
+              "@media screen and (min-width: 40em)": {
+                "&:is(:hover, [data-hover])": {
+                  "backgroundColor": "green",
+                },
+              },
+            },
+          },
+        },
+        {
+          "className": "hover\\:md\\:fs_lg",
+          "conditions": [
+            {
+              "name": "breakpoint",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
+              "type": "at-rule",
+              "value": "md",
+            },
+            {
+              "raw": "&:is(:hover, [data-hover])",
+              "type": "self-nesting",
+              "value": "&:is(:hover, [data-hover])",
+            },
+          ],
+          "entry": {
+            "cond": "_hover<___>md",
+            "prop": "fontSize",
+            "value": "lg",
+          },
+          "hash": "fontSize]___[value:lg]___[cond:_hover<___>md",
+          "layer": undefined,
+          "result": {
+            ".hover\\:md\\:fs_lg": {
+              "@media screen and (min-width: 48em)": {
+                "&:is(:hover, [data-hover])": {
+                  "fontSize": "var(--font-sizes-lg)",
+                },
+              },
+            },
+          },
+        },
+        {
           "className": "xl\\:w_3",
           "conditions": [
             {
@@ -601,74 +666,15 @@ describe('style decoder', () => {
           },
         },
         {
-          "className": "sm\\:hover\\:bg_green",
-          "conditions": [
-            {
-              "raw": "&:is(:hover, [data-hover])",
-              "type": "self-nesting",
-              "value": "&:is(:hover, [data-hover])",
-            },
-            {
-              "name": "breakpoint",
-              "params": "screen and (min-width: 40em)",
-              "raw": "@media screen and (min-width: 40em)",
-              "type": "at-rule",
-              "value": "sm",
-            },
-          ],
-          "entry": {
-            "cond": "sm<___>_hover",
-            "prop": "backgroundColor",
-            "value": "green",
-          },
-          "hash": "backgroundColor]___[value:green]___[cond:sm<___>_hover",
-          "layer": undefined,
-          "result": {
-            ".sm\\:hover\\:bg_green": {
-              "&:is(:hover, [data-hover])": {
-                "@media screen and (min-width: 40rem)": {
-                  "backgroundColor": "green",
-                },
-              },
-            },
-          },
-        },
-        {
-          "className": "hover\\:md\\:fs_lg",
-          "conditions": [
-            {
-              "raw": "&:is(:hover, [data-hover])",
-              "type": "self-nesting",
-              "value": "&:is(:hover, [data-hover])",
-            },
-            {
-              "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
-              "type": "at-rule",
-              "value": "md",
-            },
-          ],
-          "entry": {
-            "cond": "_hover<___>md",
-            "prop": "fontSize",
-            "value": "lg",
-          },
-          "hash": "fontSize]___[value:lg]___[cond:_hover<___>md",
-          "layer": undefined,
-          "result": {
-            ".hover\\:md\\:fs_lg": {
-              "&:is(:hover, [data-hover])": {
-                "@media screen and (min-width: 48rem)": {
-                  "fontSize": "var(--font-sizes-lg)",
-                },
-              },
-            },
-          },
-        },
-        {
           "className": "\\[\\&\\[data-attr\\=\\'test\\'\\]\\]\\:expanded\\:\\[\\.target_\\&\\]\\:xl\\:text_pink",
           "conditions": [
+            {
+              "name": "breakpoint",
+              "params": "screen and (min-width: 80em)",
+              "raw": "@media screen and (min-width: 80em)",
+              "type": "at-rule",
+              "value": "xl",
+            },
             {
               "raw": "&[data-attr='test']",
               "type": "self-nesting",
@@ -684,13 +690,6 @@ describe('style decoder', () => {
               "type": "parent-nesting",
               "value": ".target &",
             },
-            {
-              "name": "breakpoint",
-              "params": "screen and (min-width: 80em)",
-              "raw": "@media screen and (min-width: 80em)",
-              "type": "at-rule",
-              "value": "xl",
-            },
           ],
           "entry": {
             "cond": "&[data-attr='test']<___>_expanded<___>.target &<___>xl",
@@ -701,10 +700,10 @@ describe('style decoder', () => {
           "layer": undefined,
           "result": {
             ".\\[\\&\\[data-attr\\=\\'test\\'\\]\\]\\:expanded\\:\\[\\.target_\\&\\]\\:xl\\:text_pink": {
-              "&[data-attr='test']": {
-                "&:is([aria-expanded=true], [data-expanded], [data-state="expanded"])": {
-                  ".target &": {
-                    "@media screen and (min-width: 80rem)": {
+              "@media screen and (min-width: 80em)": {
+                "&[data-attr='test']": {
+                  "&:is([aria-expanded=true], [data-expanded], [data-state="expanded"])": {
+                    ".target &": {
                       "color": "pink",
                     },
                   },

--- a/packages/core/__tests__/style-decoder.test.ts
+++ b/packages/core/__tests__/style-decoder.test.ts
@@ -94,8 +94,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
+              "params": "screen and (min-width: 48rem)",
+              "raw": "@media screen and (min-width: 48rem)",
               "type": "at-rule",
               "value": "md",
             },
@@ -474,8 +474,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40em)",
-              "raw": "@media screen and (min-width: 40em)",
+              "params": "screen and (min-width: 40rem)",
+              "raw": "@media screen and (min-width: 40rem)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -500,8 +500,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40em)",
-              "raw": "@media screen and (min-width: 40em)",
+              "params": "screen and (min-width: 40rem)",
+              "raw": "@media screen and (min-width: 40rem)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -526,8 +526,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40em)",
-              "raw": "@media screen and (min-width: 40em)",
+              "params": "screen and (min-width: 40rem)",
+              "raw": "@media screen and (min-width: 40rem)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -552,8 +552,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40em)",
-              "raw": "@media screen and (min-width: 40em)",
+              "params": "screen and (min-width: 40rem)",
+              "raw": "@media screen and (min-width: 40rem)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -578,8 +578,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40em)",
-              "raw": "@media screen and (min-width: 40em)",
+              "params": "screen and (min-width: 40rem)",
+              "raw": "@media screen and (min-width: 40rem)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -598,7 +598,7 @@ describe('style decoder', () => {
           "layer": undefined,
           "result": {
             ".sm\\:hover\\:bg_green": {
-              "@media screen and (min-width: 40em)": {
+              "@media screen and (min-width: 40rem)": {
                 "&:is(:hover, [data-hover])": {
                   "backgroundColor": "green",
                 },
@@ -611,8 +611,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
+              "params": "screen and (min-width: 48rem)",
+              "raw": "@media screen and (min-width: 48rem)",
               "type": "at-rule",
               "value": "md",
             },
@@ -631,7 +631,7 @@ describe('style decoder', () => {
           "layer": undefined,
           "result": {
             ".hover\\:md\\:fs_lg": {
-              "@media screen and (min-width: 48em)": {
+              "@media screen and (min-width: 48rem)": {
                 "&:is(:hover, [data-hover])": {
                   "fontSize": "var(--font-sizes-lg)",
                 },
@@ -644,8 +644,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 80em)",
-              "raw": "@media screen and (min-width: 80em)",
+              "params": "screen and (min-width: 80rem)",
+              "raw": "@media screen and (min-width: 80rem)",
               "type": "at-rule",
               "value": "xl",
             },
@@ -670,8 +670,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 80em)",
-              "raw": "@media screen and (min-width: 80em)",
+              "params": "screen and (min-width: 80rem)",
+              "raw": "@media screen and (min-width: 80rem)",
               "type": "at-rule",
               "value": "xl",
             },
@@ -700,7 +700,7 @@ describe('style decoder', () => {
           "layer": undefined,
           "result": {
             ".\\[\\&\\[data-attr\\=\\'test\\'\\]\\]\\:expanded\\:\\[\\.target_\\&\\]\\:xl\\:text_pink": {
-              "@media screen and (min-width: 80em)": {
+              "@media screen and (min-width: 80rem)": {
                 "&[data-attr='test']": {
                   "&:is([aria-expanded=true], [data-expanded], [data-state="expanded"])": {
                     ".target &": {
@@ -870,8 +870,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
+              "params": "screen and (min-width: 48rem)",
+              "raw": "@media screen and (min-width: 48rem)",
               "type": "at-rule",
               "value": "md",
             },
@@ -1604,8 +1604,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
+              "params": "screen and (min-width: 48rem)",
+              "raw": "@media screen and (min-width: 48rem)",
               "type": "at-rule",
               "value": "md",
             },
@@ -1630,8 +1630,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
+              "params": "screen and (min-width: 48rem)",
+              "raw": "@media screen and (min-width: 48rem)",
               "type": "at-rule",
               "value": "md",
             },
@@ -1659,8 +1659,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48em)",
-              "raw": "@media screen and (min-width: 48em)",
+              "params": "screen and (min-width: 48rem)",
+              "raw": "@media screen and (min-width: 48rem)",
               "type": "at-rule",
               "value": "md",
             },

--- a/packages/core/__tests__/style-decoder.test.ts
+++ b/packages/core/__tests__/style-decoder.test.ts
@@ -94,9 +94,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48rem)",
-              "raw": "md",
-              "rawValue": "@media screen and (min-width: 48rem)",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
               "type": "at-rule",
               "value": "md",
             },
@@ -475,9 +474,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40rem)",
-              "raw": "sm",
-              "rawValue": "@media screen and (min-width: 40rem)",
+              "params": "screen and (min-width: 40em)",
+              "raw": "@media screen and (min-width: 40em)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -502,9 +500,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40rem)",
-              "raw": "sm",
-              "rawValue": "@media screen and (min-width: 40rem)",
+              "params": "screen and (min-width: 40em)",
+              "raw": "@media screen and (min-width: 40em)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -556,9 +553,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40rem)",
-              "raw": "sm",
-              "rawValue": "@media screen and (min-width: 40rem)",
+              "params": "screen and (min-width: 40em)",
+              "raw": "@media screen and (min-width: 40em)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -583,9 +579,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 80rem)",
-              "raw": "xl",
-              "rawValue": "@media screen and (min-width: 80rem)",
+              "params": "screen and (min-width: 80em)",
+              "raw": "@media screen and (min-width: 80em)",
               "type": "at-rule",
               "value": "xl",
             },
@@ -615,9 +610,8 @@ describe('style decoder', () => {
             },
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 40rem)",
-              "raw": "sm",
-              "rawValue": "@media screen and (min-width: 40rem)",
+              "params": "screen and (min-width: 40em)",
+              "raw": "@media screen and (min-width: 40em)",
               "type": "at-rule",
               "value": "sm",
             },
@@ -649,9 +643,8 @@ describe('style decoder', () => {
             },
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48rem)",
-              "raw": "md",
-              "rawValue": "@media screen and (min-width: 48rem)",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
               "type": "at-rule",
               "value": "md",
             },
@@ -693,9 +686,8 @@ describe('style decoder', () => {
             },
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 80rem)",
-              "raw": "xl",
-              "rawValue": "@media screen and (min-width: 80rem)",
+              "params": "screen and (min-width: 80em)",
+              "raw": "@media screen and (min-width: 80em)",
               "type": "at-rule",
               "value": "xl",
             },
@@ -879,9 +871,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48rem)",
-              "raw": "md",
-              "rawValue": "@media screen and (min-width: 48rem)",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
               "type": "at-rule",
               "value": "md",
             },
@@ -1614,9 +1605,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48rem)",
-              "raw": "md",
-              "rawValue": "@media screen and (min-width: 48rem)",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
               "type": "at-rule",
               "value": "md",
             },
@@ -1641,9 +1631,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48rem)",
-              "raw": "md",
-              "rawValue": "@media screen and (min-width: 48rem)",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
               "type": "at-rule",
               "value": "md",
             },
@@ -1671,9 +1660,8 @@ describe('style decoder', () => {
           "conditions": [
             {
               "name": "breakpoint",
-              "params": "screen and (min-width: 48rem)",
-              "raw": "md",
-              "rawValue": "@media screen and (min-width: 48rem)",
+              "params": "screen and (min-width: 48em)",
+              "raw": "@media screen and (min-width: 48em)",
               "type": "at-rule",
               "value": "md",
             },

--- a/packages/core/__tests__/style-encoder.test.ts
+++ b/packages/core/__tests__/style-encoder.test.ts
@@ -585,13 +585,14 @@ describe('style encoder', () => {
       }
 
           @supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-            [data-theme=dark] .navbar[data-part="blur"],.dark .navbar[data-part="blur"],.navbar[data-part="blur"].dark,.navbar[data-part="blur"][data-theme=dark] {
-              background-color: hsla(0,0%,7%,.8) !important;
-      }
             .navbar[data-part="blur"] {
               backdrop-filter: blur(8px);
               -webkit-backdrop-filter: blur(8px);
               background-color: rgba(255, 255, 255, 0.85) !important;
+      }
+
+            [data-theme=dark] .navbar[data-part="blur"],.dark .navbar[data-part="blur"],.navbar[data-part="blur"].dark,.navbar[data-part="blur"][data-theme=dark] {
+              background-color: hsla(0,0%,7%,.8) !important;
       }
       }
           }

--- a/packages/core/src/breakpoints.ts
+++ b/packages/core/src/breakpoints.ts
@@ -1,5 +1,5 @@
-import { capitalize, toRem, toPx } from '@pandacss/shared'
-import type { RawCondition } from '@pandacss/types'
+import { capitalize, toPx, toRem } from '@pandacss/shared'
+import type { AtRuleCondition, ConditionDetails } from '@pandacss/types'
 import type { Root } from 'postcss'
 
 export class Breakpoints {
@@ -7,7 +7,7 @@ export class Breakpoints {
   values: Record<string, BreakpointEntry>
   keys: string[]
   ranges: Record<string, string>
-  conditions: Record<string, Cond>
+  conditions: Record<string, AtRuleCondition>
 
   constructor(private breakpoints: Record<string, string>) {
     this.sorted = sortBreakpoints(breakpoints)
@@ -65,7 +65,7 @@ export class Breakpoints {
     return Object.fromEntries(values)
   }
 
-  getCondition = (key: string): Cond | undefined => {
+  getCondition = (key: string): ConditionDetails | undefined => {
     return this.conditions[key]
   }
 
@@ -75,6 +75,10 @@ export class Breakpoints {
       if (!value) {
         throw rule.error(`No \`${rule.params}\` screen found.`)
       }
+      if (value.type !== 'at-rule') {
+        throw rule.error(`\`${rule.params}\` is not a valid screen.`)
+      }
+
       rule.name = 'media'
       rule.params = value.params
     })
@@ -109,14 +113,11 @@ function sortBreakpoints(breakpoints: Record<string, string>): Entries {
     })
 }
 
-type Cond = RawCondition & { params: string }
-
-const toCondition = (key: string, value: string): Cond => ({
+const toCondition = (key: string, value: string): AtRuleCondition => ({
   type: 'at-rule',
   name: 'breakpoint',
   value: key,
-  raw: key,
-  rawValue: `@media ${value}`,
+  raw: `@media ${value}`,
   params: value,
 })
 

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -1,6 +1,6 @@
 import { logger } from '@pandacss/logger'
-import { isBaseCondition, toRem, withoutSpace } from '@pandacss/shared'
-import type { ConditionDetails, ConditionType, Conditions as ConditionsConfig } from '@pandacss/types'
+import { isBaseCondition, isObject, toRem, withoutSpace } from '@pandacss/shared'
+import type { ConditionDetails, ConditionQuery, ConditionType, Conditions as ConditionsConfig } from '@pandacss/types'
 import { Breakpoints } from './breakpoints'
 import { parseCondition } from './parse-condition'
 
@@ -119,9 +119,11 @@ export class Conditions {
     return details.raw
   }
 
-  getRaw = (conditionName: string): ConditionDetails | undefined => {
+  getRaw = (condNameOrQuery: ConditionQuery): ConditionDetails | undefined => {
+    if (typeof condNameOrQuery === 'string' && this.values[condNameOrQuery]) return this.values[condNameOrQuery]
+
     try {
-      return this.values[conditionName] ?? parseCondition(conditionName)
+      return parseCondition(condNameOrQuery)
     } catch (error) {
       logger.error('core:condition', error)
     }
@@ -132,8 +134,8 @@ export class Conditions {
     return rawConditions.sort((a, b) => order.indexOf(a.type) - order.indexOf(b.type))
   }
 
-  normalize = (condition: string | ConditionDetails): ConditionDetails | undefined => {
-    return typeof condition === 'string' ? this.getRaw(condition) : condition
+  normalize = (condition: ConditionQuery | ConditionDetails): ConditionDetails | undefined => {
+    return isObject(condition) ? (condition as ConditionDetails) : this.getRaw(condition)
   }
 
   keys = () => {

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -4,7 +4,7 @@ import type { ConditionDetails, ConditionQuery, ConditionType, Conditions as Con
 import { Breakpoints } from './breakpoints'
 import { parseCondition } from './parse-condition'
 
-const order: ConditionType[] = ['self-nesting', 'combinator-nesting', 'parent-nesting', 'at-rule']
+const order: ConditionType[] = ['at-rule', 'self-nesting', 'combinator-nesting', 'parent-nesting']
 
 interface Options {
   conditions?: ConditionsConfig

--- a/packages/core/src/sort-style-rules.ts
+++ b/packages/core/src/sort-style-rules.ts
@@ -1,44 +1,82 @@
-import type { AtomicStyleResult, ConditionDetails } from '@pandacss/types'
+import type { AtRuleCondition, AtomicStyleResult, ConditionDetails, SelectorCondition } from '@pandacss/types'
 import { sortAtRules } from './sort-at-rules'
 import { getPropertyPriority } from '@pandacss/shared'
 
-const hasAtRule = (conditions: ConditionDetails[]) => conditions.some((details) => details.type === 'at-rule')
+const hasAtRule = (conditions: ConditionDetails[]) =>
+  conditions.some((details) => details.type === 'at-rule' || details.type === 'mixed')
 const styleOrder = [':link', ':visited', ':focus-within', ':focus', ':focus-visible', ':hover', ':active']
 
 const pseudoSelectorScore = (selector: string) => {
   const index = styleOrder.findIndex((pseudoClass) => selector.includes(pseudoClass))
   return index + 1
 }
+const compareSelectors = (a: WithConditions, b: WithConditions) => {
+  const aConds = a.conditions! as SelectorCondition[]
+  const bConds = b.conditions! as SelectorCondition[]
 
-const compareConditions = (a: WithConditions, b: WithConditions) => {
-  if (a.conditions!.length === b.conditions!.length) {
-    const selector1 = a.conditions![0].value
-    const selector2 = b.conditions![0].value
+  if (aConds.length === bConds.length) {
+    const selector1 = aConds[0].value
+    const selector2 = bConds[0].value
+
     return pseudoSelectorScore(selector1) - pseudoSelectorScore(selector2)
   }
 
-  return a.conditions!.length - b.conditions!.length
+  return aConds.length - bConds.length
 }
 
-const compareAtRuleConditions = (a: WithConditions, b: WithConditions) => {
-  if (a.conditions!.length === b.conditions!.length) {
-    const lastA = a.conditions![a.conditions!.length - 1]
-    const lastB = b.conditions![b.conditions!.length - 1]
+const flatten = (conds: ConditionDetails[]) => conds.flatMap((cond) => (cond.type === 'mixed' ? cond.value : cond))
 
-    const atRule1 = lastA.params ?? lastA.rawValue
-    const atRule2 = lastB.params ?? lastB.rawValue
+const compareAtRuleOrMixed = (a: WithConditions, b: WithConditions) => {
+  const aConds = flatten(a.conditions!) as Array<AtRuleCondition>
+  const bConds = flatten(b.conditions!) as Array<AtRuleCondition>
 
-    if (!atRule1 || !atRule2) return 0
-
-    const score = sortAtRules(atRule1, atRule2)
-    if (score !== 0) return score
-
-    const selector1 = a.conditions![0].value
-    const selector2 = b.conditions![0].value
-    return pseudoSelectorScore(selector1) - pseudoSelectorScore(selector2)
+  // Compare lengths first, return difference if not equal
+  if (aConds.length !== bConds.length) {
+    return aConds.length - bConds.length
   }
 
-  return a.conditions!.length - b.conditions!.length
+  let score = 0,
+    aCond,
+    bCond
+
+  // Compare each AtRuleCondition
+  for (let i = 0; i < aConds.length; i++) {
+    aCond = aConds[i]
+    bCond = bConds[i]
+
+    if (!aCond || !bCond) {
+      continue
+    }
+
+    const atRule1 = aConds[i].params ?? aConds[i].raw
+    const atRule2 = bConds[i].params ?? bConds[i].raw
+
+    if (!atRule1 || !atRule2) {
+      continue
+    }
+
+    score = sortAtRules(atRule1, atRule2)
+    if (score !== 0) {
+      return score
+    }
+  }
+
+  // If score is still 0, compare pseudo-selectors
+  for (let i = 0; i < aConds.length; i++) {
+    aCond = aConds[i]
+    bCond = bConds[i]
+
+    if (!aCond || !bCond) {
+      continue
+    }
+
+    score = pseudoSelectorScore(aConds[i].value) - pseudoSelectorScore(bConds[i].value)
+    if (score !== 0) {
+      return score
+    }
+  }
+
+  return 0 // Return 0 if all comparisons resulted in a score of 0
 }
 
 export interface WithConditions extends Pick<AtomicStyleResult, 'conditions' | 'entry'> {}
@@ -76,13 +114,13 @@ export const sortStyleRules = <T extends WithConditions>(styleRules: Array<T>): 
   }
 
   withSelectorsOnly.sort((a, b) => {
-    const conditionDiff = compareConditions(a, b)
+    const conditionDiff = compareSelectors(a, b)
     if (conditionDiff !== 0) return conditionDiff
 
     return sortByPropertyPriority(a, b)
   })
   withAtRules.sort((a, b) => {
-    const conditionDiff = compareAtRuleConditions(a, b)
+    const conditionDiff = compareAtRuleOrMixed(a, b)
     if (conditionDiff !== 0) return conditionDiff
 
     return sortByPropertyPriority(a, b)

--- a/packages/core/src/sort-style-rules.ts
+++ b/packages/core/src/sort-style-rules.ts
@@ -26,7 +26,18 @@ const compareSelectors = (a: WithConditions, b: WithConditions) => {
 
 const flatten = (conds: ConditionDetails[]) => conds.flatMap((cond) => (cond.type === 'mixed' ? cond.value : cond))
 
-const compareAtRuleOrMixed = (a: WithConditions, b: WithConditions) => {
+/**
+ * Compare 2 Array<AtRuleCondition | MixedCondition>
+ * - sort by condition length (shorter first)
+ * - sort at-rules by predefined order (sort-mq postcss plugin order)
+ * - sort selectors by predefined pseudo selector order
+ * - return 0 if equal
+ *
+ * do this for item in the array against the same index in the other array
+ * -> exit early if not equal
+ * -> if all comparisons result in a score of 0, return 0
+ */
+export const compareAtRuleOrMixed = (a: WithConditions, b: WithConditions) => {
   const aConds = flatten(a.conditions!) as Array<AtRuleCondition>
   const bConds = flatten(b.conditions!) as Array<AtRuleCondition>
 
@@ -92,7 +103,7 @@ const sortByPropertyPriority = (a: WithConditions, b: WithConditions) => {
  * - with at-rules last
  *
  * for each of them:
- * - sort by condition length (shorter first)
+ * - sort by condition length (shorter first, the more you nest the more specific it is)
  * - sort selectors by predefined pseudo selector order
  * - sort at-rules by predefined order (sort-mq postcss plugin order)
  * - sort by property priority (longhands first)

--- a/packages/generator/src/artifacts/css/token-css.ts
+++ b/packages/generator/src/artifacts/css/token-css.ts
@@ -29,11 +29,12 @@ export function generateTokenCss(ctx: Context, sheet: Stylesheet) {
         .map((key) => conditions.get(key))
         .filter(Boolean)
         .map((condition) => {
-          const parent = extractParentSelectors(condition)
+          const lastSegment = Array.isArray(condition) ? condition.at(-1)! : condition
+          const parent = extractParentSelectors(lastSegment)
           // ASSUMPTION: the nature of parent selectors with tokens is that they're merged
           // [data-color-mode=dark][data-theme=pastel]
           // If we really want it nested, we remove the `&`
-          return parent ? `&${parent}` : condition
+          return parent ? `&${parent}` : lastSegment
         })
 
       const rule = getDeepestRule(root, mapped)

--- a/packages/generator/src/artifacts/js/conditions.ts
+++ b/packages/generator/src/artifacts/js/conditions.ts
@@ -51,7 +51,7 @@ export function generateConditions(ctx: Context) {
             key === 'base'
               ? `/** The base (=no conditions) styles to apply  */\n`
               : ctx.conditions.get(key)
-              ? `/** \`${ctx.conditions.get(key)}\` */\n`
+              ? `/** \`${([] as string[]).concat(ctx.conditions.get(key)).join(' ')}\` */\n`
               : ''
           }\t${JSON.stringify(key)}: string`,
       )

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -216,17 +216,17 @@ describe('extract to css output pipeline', () => {
       }
       }
 
-        @media screen and (min-width: 48rem) {
-          @media screen and (min-width: 40rem) {
-            .md\\:sm\\:m_4px {
-              margin: 4px;
-      }
+        @media screen and (min-width: 48em) {
+          [data-theme=dark] .md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]),.dark .md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]),.md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]).dark,.md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover])[data-theme=dark] {
+            margin: calc(var(--spacing-2) * -1);
       }
       }
 
-        @media screen and (min-width: 48rem) {
-          [data-theme=dark] .md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]),.dark .md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]),.md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]).dark,.md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover])[data-theme=dark] {
-            margin: calc(var(--spacing-2) * -1);
+        @media screen and (min-width: 48em) {
+          @media screen and (min-width: 40em) {
+            .md\\:sm\\:m_4px {
+              margin: 4px;
+      }
       }
       }
       }"

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3488,4 +3488,49 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('weird conditions mixing', () => {
+    const code = `
+    import { css } from "styled-system/css"
+
+    const App = () => {
+      return (
+        <div className={css({
+          _weirdCondition: {
+            color: "red"
+          }
+        })} />
+      )
+     `
+    const result = parseAndExtract(code, {
+      conditions: {
+        weirdCondition: ['@media (hover: hover) and (pointer: fine)', '&:hover', '& > div', 'span &', '& ~ &'],
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "_weirdCondition": {
+                "color": "red",
+              },
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        @media (hover: hover) and (pointer: fine) {
+          :is(span .weirdCondition\\:text_red:hover > div) ~ :is(span .weirdCondition\\:text_red:hover > div) {
+            color: red;
+      }
+      }
+      }"
+    `)
+  })
 })

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -216,14 +216,14 @@ describe('extract to css output pipeline', () => {
       }
       }
 
-        @media screen and (min-width: 48em) {
+        @media screen and (min-width: 48rem) {
           [data-theme=dark] .md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]),.dark .md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]),.md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover]).dark,.md\\:dark\\:hover\\:m_-2:is(:hover, [data-hover])[data-theme=dark] {
             margin: calc(var(--spacing-2) * -1);
       }
       }
 
-        @media screen and (min-width: 48em) {
-          @media screen and (min-width: 40em) {
+        @media screen and (min-width: 48rem) {
+          @media screen and (min-width: 40rem) {
             .md\\:sm\\:m_4px {
               margin: 4px;
       }

--- a/packages/types/src/conditions.ts
+++ b/packages/types/src/conditions.ts
@@ -1,27 +1,40 @@
 import type { AnySelector, Selectors } from './selectors'
 
-export type ConditionType = 'at-rule' | 'parent-nesting' | 'self-nesting' | 'combinator-nesting'
+export type ConditionType = 'at-rule' | 'parent-nesting' | 'self-nesting' | 'combinator-nesting' | 'mixed'
 
-export interface ConditionDetails {
-  type: ConditionType
+export type ConditionDetails = AtRuleCondition | SelectorCondition | MixedCondition
+
+export interface AtRuleCondition {
+  type: 'at-rule'
   value: string
-  name?: string
-  rawValue?: string
+  raw: string
+  name: string
+  params: string
 }
 
-export interface RawCondition extends ConditionDetails {
+export interface SelectorCondition {
+  type: 'self-nesting' | 'parent-nesting' | 'combinator-nesting'
+  value: string
   raw: string
+}
+
+export interface MixedCondition {
+  type: 'mixed'
+  value: ConditionDetails[]
+  raw: string[]
 }
 
 /* -----------------------------------------------------------------------------
  * Shadowed export (in CLI): DO NOT REMOVE
  * -----------------------------------------------------------------------------*/
 
+export type ConditionQuery = string | string[]
+
 export interface Conditions {
-  [condition: string]: string
+  [condition: string]: ConditionQuery
 }
 export interface ExtendableConditions {
-  [condition: string]: string | Conditions | undefined
+  [condition: string]: ConditionQuery | Conditions | undefined
   extend?: Conditions | undefined
 }
 

--- a/packages/types/src/style-rules.ts
+++ b/packages/types/src/style-rules.ts
@@ -1,4 +1,4 @@
-import type { RawCondition } from './conditions'
+import type { ConditionDetails } from './conditions'
 
 export interface StyleResultObject {
   [key: string]: any
@@ -17,16 +17,12 @@ export interface StyleEntry {
   variants?: boolean
 }
 
-interface ExpandedCondition extends RawCondition {
-  params?: string
-}
-
 export interface AtomicStyleResult {
   result: StyleResultObject
   entry: StyleEntry
   hash: string
   className: string
-  conditions?: ExpandedCondition[]
+  conditions?: ConditionDetails[]
   layer?: string
 }
 

--- a/sandbox/preact-ts/panda.config.ts
+++ b/sandbox/preact-ts/panda.config.ts
@@ -1,11 +1,6 @@
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
-  conditions: {
-    mq: '@media (min-width: 640px)',
-    custom: '&[data-custom]',
-    supportHover: ['@media (hover: hover) and (pointer: fine)', '@supports (display: grid)', '&:hover'],
-  },
   preflight: true,
   include: ['./src/**/*.{tsx,jsx}', './pages/**/*.{jsx,tsx}'],
   exclude: [],

--- a/sandbox/preact-ts/panda.config.ts
+++ b/sandbox/preact-ts/panda.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
+  conditions: {
+    mq: '@media (min-width: 640px)',
+    custom: '&[data-custom]',
+    supportHover: ['@media (hover: hover) and (pointer: fine)', '@supports (display: grid)', '&:hover'],
+  },
   preflight: true,
   include: ['./src/**/*.{tsx,jsx}', './pages/**/*.{jsx,tsx}'],
   exclude: [],

--- a/sandbox/preact-ts/src/app.tsx
+++ b/sandbox/preact-ts/src/app.tsx
@@ -3,22 +3,23 @@ import { bleed, cq, stack } from '../styled-system/patterns'
 
 export const App = () => {
   return (
-    <div style={{ '--gap': '40px' }} className={css({ h: 'full' })}>
-      <div className={css({ h: 'full', p: 'var(--gap)', bg: 'cyan' })}>
-        <div className={bleed({ bg: 'magenta', inline: 'var(--gap)' })}>
-          <span>🐼</span>
-          <span>Hello from Panda</span>
-        </div>
-
-        <div className={stack({ debug: true, mt: '3', gap: '4' })}>
-          <p>Welcome home</p>
-          <p>Welcome home</p>
-        </div>
-
-        <div className={cq()}>
-          <a className={css({ bg: { '@/sm': 'red.300' } })}>Click me</a>
-        </div>
+    <>
+      <div className={cq()}>
+        <a className={css({ bg: { '@/sm': 'red.300' } })}>Click me</a>
       </div>
-    </div>
+      <div
+        className={css({
+          sm: {
+            color: 'yellow',
+          },
+          _focus: {
+            color: 'blue',
+          },
+          _supportHover: {
+            color: 'red.200',
+          },
+        })}
+      ></div>
+    </>
   )
 }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/1216

## 📝 Description

Add a way to create config conditions with nested at-rules/selectors

```ts
export default defaultConfig({
  conditions: {
    extend: {
      supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
    },
  },
})
```

```ts
import { css } from '../styled-system/css'

css({
  _supportHover: {
    color: 'red',
  },
})
```

will generate the following CSS:

```css
@media (hover: hover) and (pointer: fine) {
  &:hover {
    color: red;
  }
}
```

## 💣 Is this a breaking change (Yes/No):

no
