### PR TITLE
♻️ Remove unnecessary body line-height

### DIFF
--- a/packages/generator/__tests__/generate-reset.test.ts
+++ b/packages/generator/__tests__/generate-reset.test.ts
@@ -47,7 +47,6 @@ describe('generate reset', () => {
 
         body {
           height: 100%;
-          line-height: inherit;
       }
 
         img {
@@ -232,7 +231,6 @@ describe('generate reset', () => {
 
         .pd-reset body {
           height: 100%;
-          line-height: inherit;
       }
 
         .pd-reset img,.pd-reset svg,.pd-reset video,.pd-reset canvas,.pd-reset audio,.pd-reset iframe,.pd-reset embed,.pd-reset object {

--- a/packages/generator/src/artifacts/css/reset-css.ts
+++ b/packages/generator/src/artifacts/css/reset-css.ts
@@ -18,7 +18,7 @@ export function generateResetCss(ctx: Context, sheet: Stylesheet) {
     },
 
     hr: { height: '0px', color: 'inherit', borderTopWidth: '1px' },
-    body: { height: '100%', lineHeight: 'inherit' },
+    body: { height: '100%' },
     img: { borderStyle: 'none' },
     'img,  svg,  video,  canvas,  audio,  iframe,  embed,  object': {
       display: 'block',


### PR DESCRIPTION
## 📝 Description

As the title says.

## ⛳️ Current behavior (updates)

Basically no effect.
body already has line-height applied with `* { font: inherit }`.

~~If there was a problem before, when we defined the `scope` of `preflight`,  
it would deviate from the scope and rewrite the style of the body.~~
(According to the test results, this is incorrect🙈)

## 🚀 New behavior

body `lign-height` will not be set.

## 💣 Is this a breaking change (Yes/No):

~~Maybe~~ No

## 📝 Additional Information

—