### PR TITLE
feat(hooks): configure imports aliases for css/jsxFactory

### DIFF
--- a/.changeset/nice-panthers-poke.md
+++ b/.changeset/nice-panthers-poke.md
@@ -1,0 +1,34 @@
+---
+'@pandacss/generator': patch
+'@pandacss/parser': patch
+'@pandacss/studio': patch
+'@pandacss/types': patch
+'@pandacss/core': patch
+---
+
+Add a `imports:created` hook where you can configure additional aliases for the `css` or `styled` factory functions.
+
+They must mirror the same function signature as the default functions and still need to contain static arguments.
+
+```ts
+// panda.config.ts
+configure({
+  matchers: {
+    css: ['xcss'], // match `xcss` as a `css` fn
+    jsxFactory: ['xstyled'], // match `xstyled` as a `styled` fn
+  },
+})
+```
+
+```ts
+// file.tsx
+const className = xcss({ color: 'red' })
+// this will be extracted just like the default `css` function
+
+const className = xstyled('div', { base: { color: 'red' } })
+// this will be extracted just like the default `styled` function
+
+// or if using the template-literal syntax
+const className = xcss`color: red;`
+const className2 = xstyled.div`color: red;`
+```

--- a/packages/core/__tests__/file-matcher.test.ts
+++ b/packages/core/__tests__/file-matcher.test.ts
@@ -14,9 +14,18 @@ describe('file matcher', () => {
 
     expect(file.cvaAlias).toMatchInlineSnapshot('"cva"')
 
-    expect(file.cssAlias).toMatchInlineSnapshot('"xcss"')
     expect(file.getAlias('css')).toMatchInlineSnapshot('"xcss"')
     expect(file.getName('xcss')).toMatchInlineSnapshot('"css"')
+
+    expect(file.aliases).toMatchInlineSnapshot(`
+      {
+        "css": [
+          "css",
+          "xcss",
+        ],
+        "jsxFactory": [],
+      }
+    `)
   })
 
   test('isPandaComponent', () => {
@@ -51,12 +60,13 @@ describe('file matcher', () => {
     const ctx = createContext()
 
     const file = ctx.imports.file([
+      { mod: 'styled-system/jsx', name: 'styled', alias: 'styled' },
       { mod: 'styled-system/jsx', name: 'Stack', alias: 'Stack' },
       { mod: 'styled-system/jsx', name: 'VStack', alias: '__VStack' },
     ])
 
-    expect(file.isJsxFactory('styled')).toMatchInlineSnapshot('true')
-    expect(file.isJsxFactory('styled.div')).toMatchInlineSnapshot('true')
+    expect(file.isJsxFactory('styled')).toMatchInlineSnapshot(`true`)
+    expect(file.isJsxFactory('styled.div')).toMatchInlineSnapshot(`true`)
     expect(file.isJsxFactory('Comp')).toMatchInlineSnapshot('false')
   })
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -161,6 +161,14 @@ export class Context {
       recipes: this.recipes,
       isValidProperty: this.isValidProperty,
     })
+    this.hooks['imports:created']?.({
+      configure: (opts) => {
+        if (opts.aliases) {
+          this.imports.aliases = opts.aliases
+        }
+      },
+    })
+    this.imports.setup()
 
     this.paths = new PathEngine({
       config: this.config,

--- a/packages/parser/src/parser-result.ts
+++ b/packages/parser/src/parser-result.ts
@@ -37,7 +37,8 @@ export class ParserResult implements ParserResultInterface {
         this.setSva(result)
         break
       default:
-        throw new PandaError('UNKNOWN_TYPE', `Unknown result type ${name}`)
+        this.setCss(result)
+        break
     }
   }
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -79,7 +79,7 @@ export function createParser(context: ParserOptions) {
         matchProp: () => true,
         matchArg: (prop) => {
           // skip resolving `badge` here: `panda("span", badge)`
-          if (prop.fnName === file.jsxFactoryAlias && prop.index === 1 && Node.isIdentifier(prop.argNode)) return false
+          if (file.isJsxFactory(prop.fnName) && prop.index === 1 && Node.isIdentifier(prop.argNode)) return false
           return true
         },
       },
@@ -182,7 +182,7 @@ export function createParser(context: ParserOptions) {
           // panda("span", { ... }) or panda("div", badge)
           // or panda("span", { color: "red.100", ... })
           // or panda('span')` color: red; `
-          .when(jsx.isJsxFactory, () => {
+          .when(file.isJsxFactoryFn, () => {
             result.queryList.forEach((query) => {
               if (query.kind === 'call-expression' && query.box.value[1]) {
                 const map = query.box.value[1]

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -19,6 +19,10 @@ export interface PandaHooks {
    */
   'utility:created': (args: UtilityCreatedHookArgs) => MaybeAsyncReturn
   /**
+   * Called when the imports engine has been created
+   */
+  'imports:created': (args: ImportMapCreatedHookArgs) => MaybeAsyncReturn
+  /**
    * Called when the Panda context has been created and the API is ready to be used.
    */
   'context:created': (args: ContextCreatedHookArgs) => void
@@ -90,6 +94,50 @@ export interface UtilityConfigureOptions {
 
 export interface UtilityCreatedHookArgs {
   configure(opts: UtilityConfigureOptions): void
+}
+
+/* -----------------------------------------------------------------------------
+ * Import map hooks
+ * -----------------------------------------------------------------------------*/
+
+export interface ImportMapConfigureOptions {
+  /**
+   * Custom additional aliases for the `css` or `styled` factory functions.
+   * They must mirror the same function signature as the default functions and still need to contain static arguments.
+   * The default functions are `css` and `config.factoryName` (`styled` by default) and are always provided.
+   *
+   * @example
+   * ```ts
+   * // panda.config.ts
+   * configure({
+   *   matchers: {
+   *     css: ['xcss'], // match `xcss` as a `css` fn
+   *     jsxFactory: ['xstyled'], // match `xstyled` as a `styled` fn
+   *   }
+   * })
+   * ```
+   *
+   * ```ts
+   * // file.tsx usage example
+   * const className = xcss({ color: 'red' })
+   * // this will be extracted just like the default `css` function
+   *
+   * const className = xstyled('div', { base: { color: 'red' } })
+   * // this will be extracted just like the default `styled` function
+   *
+   * // or if using the template-literal syntax
+   * const className = xcss`color: red;`
+   * const className2 = xstyled.div`color: red;`
+   * ```
+   */
+  aliases?: {
+    css?: string[]
+    jsxFactory?: string[]
+  }
+}
+
+export interface ImportMapCreatedHookArgs {
+  configure(opts: ImportMapConfigureOptions): void
 }
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
## 📝 Description


Add a `imports:created` hook where you can configure additional aliases for the `css` or `styled` factory functions.

They must mirror the same function signature as the default functions and still need to contain static arguments.

```ts
// panda.config.ts
configure({
  matchers: {
    css: ['xcss'], // match `xcss` as a `css` fn
    jsxFactory: ['xstyled'], // match `xstyled` as a `styled` fn
  },
})
```

```ts
// file.tsx
const className = xcss({ color: 'red' })
// this will be extracted just like the default `css` function

const className = xstyled('div', { base: { color: 'red' } })
// this will be extracted just like the default `styled` function

// or if using the template-literal syntax
const className = xcss`color: red;`
const className2 = xstyled.div`color: red;`
```


## 💣 Is this a breaking change (Yes/No):

no
