### PR TITLE
fix(staticCss): auto generate compoundVariants

### DIFF
--- a/.changeset/four-turtles-refuse.md
+++ b/.changeset/four-turtles-refuse.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/core': patch
+---
+
+Automatically generate a recipe `compoundVariants` when using `staticCss`

--- a/packages/core/__tests__/static-css.test.ts
+++ b/packages/core/__tests__/static-css.test.ts
@@ -1961,7 +1961,11 @@ describe('static-css', () => {
       }
       }",
         "results": {
-          "css": [],
+          "css": [
+            {
+              "color": "ButtonHighlight",
+            },
+          ],
           "patterns": [],
           "recipes": [
             {
@@ -2040,6 +2044,113 @@ describe('static-css', () => {
             {
               "badge": {
                 "raised": "true",
+              },
+            },
+          ],
+        },
+      }
+    `)
+  })
+
+  test('recipe + compoundVariants', () => {
+    const ctx = new Context({
+      ...conf,
+      config: {
+        ...conf.config,
+        theme: {
+          recipes: {
+            ...conf.config?.theme?.recipes,
+            withCompound: {
+              className: 'withCompound',
+              base: {
+                fontSize: '1px',
+              },
+              variants: {
+                size: {
+                  sm: {
+                    fontSize: '2px',
+                  },
+                },
+              },
+              compoundVariants: [
+                {
+                  size: ['sm'],
+                  css: {
+                    fontSize: '3px',
+                    _hover: {
+                      fontSize: '4px',
+                      _dark: {
+                        fontSize: '5px',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    })
+    const getStaticCss = (options: StaticCssOptions) => {
+      const engine = ctx.staticCss.clone().process(options)
+      return { results: engine.results, css: engine.sheet.toCss({ optimize: true }) }
+    }
+
+    expect(
+      getStaticCss({
+        recipes: {
+          withCompound: ['*'],
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "css": "@layer recipes {
+        @layer _base {
+          .withCompound {
+            font-size: 1px;
+      }
+      }
+
+        .withCompound--size_sm {
+          font-size: 2px;
+      }
+      }
+
+      @layer utilities {
+        .fs_3px {
+          font-size: 3px;
+      }
+
+        .hover\\:fs_4px:is(:hover, [data-hover]) {
+          font-size: 4px;
+      }
+
+        [data-theme=dark] .hover\\:dark\\:fs_5px:is(:hover, [data-hover]),.dark .hover\\:dark\\:fs_5px:is(:hover, [data-hover]),.hover\\:dark\\:fs_5px:is(:hover, [data-hover]).dark,.hover\\:dark\\:fs_5px:is(:hover, [data-hover])[data-theme=dark] {
+          font-size: 5px;
+      }
+      }",
+        "results": {
+          "css": [
+            {
+              "fontSize": "3px",
+            },
+            {
+              "_hover": {
+                "_dark": {
+                  "fontSize": "5px",
+                },
+                "fontSize": "4px",
+              },
+            },
+          ],
+          "patterns": [],
+          "recipes": [
+            {
+              "withCompound": {},
+            },
+            {
+              "withCompound": {
+                "size": "sm",
               },
             },
           ],

--- a/packages/core/src/static-css.ts
+++ b/packages/core/src/static-css.ts
@@ -51,9 +51,9 @@ export class StaticCss {
     const { config, utility, patterns: _patterns } = this.context
     const breakpoints = Object.keys(config.theme?.breakpoints ?? {})
 
-    const getRecipeKeys = (recipeName: string) => {
-      const recipeConfig = this.context.recipes.details.find((detail) => detail.baseName === recipeName)
-      return recipeConfig?.variantKeyMap
+    const getRecipe = (recipeName: string) => {
+      const node = this.context.recipes.details.find((detail) => detail.baseName === recipeName)
+      return node
     }
 
     const { css = [], patterns = {} } = options
@@ -88,11 +88,33 @@ export class StaticCss {
     })
 
     Object.entries(recipes).forEach(([recipe, rules]) => {
+      const recipeNode = getRecipe(recipe)
+      if (!recipeNode) return
+
       // adds the recipe.base to the results
       results.recipes.push({ [recipe]: {} })
 
+      if (recipeNode.config.compoundVariants) {
+        recipeNode.config.compoundVariants.forEach((compoundRule) => {
+          const css = compoundRule.css
+          const isSlot = 'slots' in recipeNode.config && recipeNode.config.slots.length
+
+          if (isSlot) {
+            Object.entries(css).forEach(([slot, styles]) => {
+              Object.entries(styles).forEach(([prop, value]) => {
+                results.css.push({ [prop]: value })
+              })
+            })
+          } else {
+            Object.entries(css).forEach(([prop, value]) => {
+              results.css.push({ [prop]: value })
+            })
+          }
+        })
+      }
+
       rules.forEach((rule) => {
-        const recipeKeys = getRecipeKeys(recipe)
+        const recipeKeys = recipeNode?.variantKeyMap
         if (!recipeKeys) return
 
         const useAllKeys = rule === '*'


### PR DESCRIPTION
## 📝 Description

Automatically generate a recipe `compoundVariants` when using `staticCss`

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
