### PR TITLE
fix: always generate `all` CSS rules before the others

### DIFF
--- a/.changeset/mean-flies-tan.md
+++ b/.changeset/mean-flies-tan.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/shared': patch
+---
+
+Always sort `all` to be first, so that other properties can easily override it

--- a/packages/shared/__tests__/property-priority.test.ts
+++ b/packages/shared/__tests__/property-priority.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+import { getPropertyPriority } from '../src'
+
+test('property priotity', () => {
+  expect(getPropertyPriority('all')).toMatchInlineSnapshot(`0`)
+  expect(getPropertyPriority('paddingTop')).toMatchInlineSnapshot(`2`)
+  expect(getPropertyPriority('background')).toMatchInlineSnapshot(`1`)
+  expect(getPropertyPriority('backgroundColor')).toMatchInlineSnapshot(`2`)
+  expect(getPropertyPriority('padding')).toMatchInlineSnapshot(`1`)
+
+  expect(
+    ['backgroundColor', 'padding', 'background', 'all', 'paddingTop'].sort(
+      (a, b) => getPropertyPriority(a) - getPropertyPriority(b),
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "all",
+      "padding",
+      "background",
+      "backgroundColor",
+      "paddingTop",
+    ]
+  `)
+})

--- a/packages/shared/src/shorthand-properties.ts
+++ b/packages/shared/src/shorthand-properties.ts
@@ -132,5 +132,6 @@ const longhands = Object.values(shorthandProperties).reduce((a, b) => [...a, ...
  * @see https://github.com/callstack/linaria/blob/049a4ccb77e29f3628353352db21bd446fa04a2e/packages/atomic/src/processors/helpers/propertyPriority.ts
  */
 export function getPropertyPriority(property: string) {
+  if (property === 'all') return 0
   return longhands.includes(property) ? 2 : 1
 }


### PR DESCRIPTION
## 📝 Description

Always sort `all` to be first, so that other properties can easily override it

## 💣 Is this a breaking change (Yes/No):

no
