### PR TITLE
fix: allow multiple aliases from /css entrypoint

### DIFF
--- a/.changeset/shiny-eagles-love.md
+++ b/.changeset/shiny-eagles-love.md
@@ -1,0 +1,16 @@
+---
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+- Prevent extracting style props of `styled` when not explicitly imported
+
+- Allow using multiple aliases for the same identifier for the `/css` entrypoints just like `/patterns` and `/recipes`
+
+```ts
+import { css } from '../styled-system/css'
+import { css as css2 } from '../styled-system/css'
+
+css({ display: 'flex' })
+css2({ flexDirection: 'column' }) // this wasn't working before, now it does
+```

--- a/packages/core/__tests__/file-matcher.test.ts
+++ b/packages/core/__tests__/file-matcher.test.ts
@@ -6,16 +6,24 @@ describe('file matcher', () => {
     const ctx = createContext()
 
     const file = ctx.imports.file([
+      { mod: 'styled-system/css', name: 'css', alias: 'css' },
       // import { css as xcss } from 'styled-system/css'
       { mod: 'styled-system/css', name: 'css', alias: 'xcss' },
       // import { cva } from 'styled-system/css'
       { mod: 'styled-system/css', name: 'cva', alias: 'cva' },
     ])
 
-    expect(file.cvaAlias).toMatchInlineSnapshot('"cva"')
-
-    expect(file.cssAlias).toMatchInlineSnapshot('"xcss"')
-    expect(file.getAlias('css')).toMatchInlineSnapshot('"xcss"')
+    expect(file.getAliases('cva')).toMatchInlineSnapshot(`
+      [
+        "cva",
+      ]
+    `)
+    expect(file.getAliases('css')).toMatchInlineSnapshot(`
+      [
+        "css",
+        "xcss",
+      ]
+    `)
     expect(file.getName('xcss')).toMatchInlineSnapshot('"css"')
   })
 
@@ -51,13 +59,14 @@ describe('file matcher', () => {
     const ctx = createContext()
 
     const file = ctx.imports.file([
+      { mod: 'styled-system/jsx', name: 'styled', alias: 'styled' },
       { mod: 'styled-system/jsx', name: 'Stack', alias: 'Stack' },
       { mod: 'styled-system/jsx', name: 'VStack', alias: '__VStack' },
     ])
 
-    expect(file.isJsxFactory('styled')).toMatchInlineSnapshot('true')
-    expect(file.isJsxFactory('styled.div')).toMatchInlineSnapshot('true')
-    expect(file.isJsxFactory('Comp')).toMatchInlineSnapshot('false')
+    expect(file.isJsxFactory('styled')).toMatchInlineSnapshot(`true`)
+    expect(file.isJsxFactory('styled.div')).toMatchInlineSnapshot(`true`)
+    expect(file.isJsxFactory('Comp')).toMatchInlineSnapshot(`undefined`)
   })
 
   test('is valid pattern', () => {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -1717,25 +1717,6 @@ describe('extract to css output pipeline', () => {
         {
           "data": [
             {
-              "marginBottom": "42px",
-              "marginTop": "40px",
-            },
-          ],
-          "name": "styled.button",
-          "type": "jsx-factory",
-        },
-        {
-          "data": [
-            {
-              "bg": "red.200",
-            },
-          ],
-          "name": "styled.div",
-          "type": "jsx-factory",
-        },
-        {
-          "data": [
-            {
               "size": "md",
               "variant": "danger",
             },
@@ -1805,20 +1786,8 @@ describe('extract to css output pipeline', () => {
           gap: 10px;
       }
 
-        .bg_red\\.200 {
-          background: var(--colors-red-200);
-      }
-
         .flex_column {
           flex-direction: column;
-      }
-
-        .mt_40px {
-          margin-top: 40px;
-      }
-
-        .mb_42px {
-          margin-bottom: 42px;
       }
       }"
     `)
@@ -3466,6 +3435,51 @@ describe('extract to css output pipeline', () => {
 
         .p_4 {
           padding: var(--spacing-4);
+      }
+
+        .flex_column {
+          flex-direction: column;
+      }
+      }"
+    `)
+  })
+
+  test('multiple css alias', () => {
+    const code = `
+    import { css } from '../styled-system/css'
+    import { css as css2 } from '../styled-system/css'
+
+    css({ display: 'flex' });
+    css2({ flexDirection: 'column' });
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "display": "flex",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+        {
+          "data": [
+            {
+              "flexDirection": "column",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .d_flex {
+          display: flex;
       }
 
         .flex_column {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -79,7 +79,7 @@ export function createParser(context: ParserOptions) {
         matchProp: () => true,
         matchArg: (prop) => {
           // skip resolving `badge` here: `panda("span", badge)`
-          if (prop.fnName === file.jsxFactoryAlias && prop.index === 1 && Node.isIdentifier(prop.argNode)) return false
+          if (file.isJsxFactory(prop.fnName) && prop.index === 1 && Node.isIdentifier(prop.argNode)) return false
           return true
         },
       },


### PR DESCRIPTION
## 📝 Description

- Prevent extracting style props of `styled` when not explicitly imported

- Allow using multiple aliases for the same identifier for the `/css` entrypoints just like `/patterns` and `/recipes`

```ts
import { css } from '../styled-system/css'
import { css as css2 } from '../styled-system/css'

css({ display: 'flex' })
css2({ flexDirection: 'column' }) // this wasn't working before, now it does
```

## 💣 Is this a breaking change (Yes/No):

as long as you're importing the `styled` factory, it shouldnt matter
