### PR TITLE
fix: add missing types folder in config dependencies

### DIFF
--- a/.changeset/thick-laws-rhyme.md
+++ b/.changeset/thick-laws-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/config': patch
+'@pandacss/types': patch
+'@pandacss/node': patch
+---
+
+Add missing config dependencies for some `styled-system/types` files

--- a/packages/config/__tests__/merge-hooks.test.ts
+++ b/packages/config/__tests__/merge-hooks.test.ts
@@ -114,36 +114,36 @@ describe('mergeConfigs / theme', () => {
 
             expect(args.original).toBe(original)
             expect(args.original).toMatchInlineSnapshot(`
-                [
-                  {
-                    "files": [
-                      {
-                        "code": "aaa aaa aaa",
-                        "file": "aaa.js",
-                      },
-                    ],
-                    "id": "1",
-                  },
-                  {
-                    "files": [
-                      {
-                        "code": "bbb bbb bbb",
-                        "file": "bbb.js",
-                      },
-                    ],
-                    "id": "2",
-                  },
-                  {
-                    "files": [
-                      {
-                        "code": "ccc ccc ccc",
-                        "file": "ccc.js",
-                      },
-                    ],
-                    "id": "3",
-                  },
-                ]
-              `)
+              [
+                {
+                  "files": [
+                    {
+                      "code": "aaa aaa aaa",
+                      "file": "aaa.js",
+                    },
+                  ],
+                  "id": "recipes.1",
+                },
+                {
+                  "files": [
+                    {
+                      "code": "bbb bbb bbb",
+                      "file": "bbb.js",
+                    },
+                  ],
+                  "id": "recipes.2",
+                },
+                {
+                  "files": [
+                    {
+                      "code": "ccc ccc ccc",
+                      "file": "ccc.js",
+                    },
+                  ],
+                  "id": "recipes.3",
+                },
+              ]
+            `)
             return args.artifacts.map((art) => {
               return { ...art, files: art.files.map((f) => ({ ...f, code: (f.code || '').replace('bbb', 'zzz') })) }
             })
@@ -155,9 +155,9 @@ describe('mergeConfigs / theme', () => {
     const result = hooks['codegen:prepare']?.({
       changed: [],
       artifacts: [
-        { id: '1', files: [{ code: 'aaa aaa aaa', file: 'aaa.js' }] },
-        { id: '2', files: [{ code: 'bbb bbb bbb', file: 'bbb.js' }] },
-        { id: '3', files: [{ code: 'ccc ccc ccc', file: 'ccc.js' }] },
+        { id: 'recipes.1', files: [{ code: 'aaa aaa aaa', file: 'aaa.js' }] },
+        { id: 'recipes.2', files: [{ code: 'bbb bbb bbb', file: 'bbb.js' }] },
+        { id: 'recipes.3', files: [{ code: 'ccc ccc ccc', file: 'ccc.js' }] },
       ],
     })
 
@@ -176,7 +176,7 @@ describe('mergeConfigs / theme', () => {
               "file": "aaa.js",
             },
           ],
-          "id": "1",
+          "id": "recipes.1",
         },
         {
           "files": [
@@ -185,7 +185,7 @@ describe('mergeConfigs / theme', () => {
               "file": "bbb.js",
             },
           ],
-          "id": "2",
+          "id": "recipes.2",
         },
         {
           "files": [
@@ -194,7 +194,7 @@ describe('mergeConfigs / theme', () => {
               "file": "ccc.js",
             },
           ],
-          "id": "3",
+          "id": "recipes.3",
         },
       ]
     `)

--- a/packages/config/src/config-deps.ts
+++ b/packages/config/src/config-deps.ts
@@ -63,6 +63,12 @@ const artifactConfigDeps: Record<ArtifactId, ConfigPath[]> = {
   'jsx-patterns-index': jsx.concat('patterns'),
   'css-index': ['syntax'],
   'package.json': ['emitPackage', 'forceConsistentTypeExtension', 'outExtension'],
+  'types-styles': ['shorthands'],
+  'types-conditions': ['conditions'],
+  'types-jsx': jsx,
+  'types-entry': [],
+  'types-gen': [],
+  'types-gen-system': [],
 }
 
 // Prepare a list of regex that resolves to an artifact id from a list of config paths

--- a/packages/config/src/diff-config.ts
+++ b/packages/config/src/diff-config.ts
@@ -43,13 +43,13 @@ export function diffConfigs(config: ConfigOrFn, prevConfig: Config | undefined):
       // same for recipes, use dashCase since those will be used as filenames
       if (id === 'recipes') {
         // ['theme', 'recipes', 'xxx'] => recipes.xxx
-        const name = dashCase(change.path.slice(1, 3).join('.') as ArtifactId)
+        const name = dashCase(change.path.slice(1, 3).join('.')) as ArtifactId
         affected.artifacts.add(name)
       }
 
       if (id === 'patterns') {
         // ['patterns', 'xxx'] => patterns.xxx
-        const name = dashCase(change.path.slice(0, 2).join('.') as ArtifactId)
+        const name = dashCase(change.path.slice(0, 2).join('.')) as ArtifactId
         affected.artifacts.add(name)
       }
 

--- a/packages/node/src/create-context.ts
+++ b/packages/node/src/create-context.ts
@@ -102,7 +102,7 @@ export class PandaContext extends Generator {
   writeCss = (sheet?: Stylesheet) => {
     logger.info('css', this.runtime.path.join(...this.paths.root, 'styles.css'))
     return this.output.write({
-      id: 'styles.css',
+      id: 'styles.css' as any,
       dir: this.paths.root,
       files: [{ file: 'styles.css', code: this.getCss(sheet) }],
     })

--- a/packages/types/src/artifact.ts
+++ b/packages/types/src/artifact.ts
@@ -26,7 +26,14 @@ export type ArtifactId =
   | 'jsx-patterns-index'
   | 'css-index'
   | 'package.json'
-  | (string & {})
+  | 'types-jsx'
+  | 'types-entry'
+  | 'types-styles'
+  | 'types-conditions'
+  | 'types-gen'
+  | 'types-gen-system'
+  | `recipes.${string}`
+  | `patterns.${string}`
 
 export type CssArtifactType = 'preflight' | 'tokens' | 'static' | 'global' | 'keyframes'
 


### PR DESCRIPTION
Add missing config dependencies for some `styled-system/types` files