### PR TITLE
feat(cli): profiler shortcuts, type `p` to start/stop when watching

### DIFF
--- a/.changeset/friendly-eggs-live.md
+++ b/.changeset/friendly-eggs-live.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/node': patch
+'@pandacss/dev': patch
+---
+
+Allow dynamically recording profiling session by pressing the `p` key in your terminal when using the `--cpu-prof` flag
+for long-running sessions (with `-w` or `--watch` for `panda` / `panda cssgen` / `panda codegen`).

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -115,7 +115,7 @@ export async function main() {
 
       let stopProfiling: Function = () => void 0
       if (flags.cpuProf) {
-        stopProfiling = await startProfiling(cwd, 'codegen')
+        stopProfiling = await startProfiling(cwd, 'codegen', flags.watch)
       }
 
       if (silent) {
@@ -177,7 +177,7 @@ export async function main() {
 
       let stopProfiling: Function = () => void 0
       if (flags.cpuProf) {
-        stopProfiling = await startProfiling(cwd, 'cssgen')
+        stopProfiling = await startProfiling(cwd, 'cssgen', flags.watch)
       }
 
       const cssArtifact = ['preflight', 'tokens', 'static', 'global', 'keyframes'].find(
@@ -239,9 +239,8 @@ export async function main() {
         })
       } else {
         stream.end()
+        stopProfiling()
       }
-
-      stopProfiling()
     })
 
   cli
@@ -270,7 +269,7 @@ export async function main() {
 
       let stopProfiling: Function = () => void 0
       if (flags.cpuProf) {
-        stopProfiling = await startProfiling(cwd, 'cli')
+        stopProfiling = await startProfiling(cwd, 'cli', flags.watch)
       }
 
       if (silent) {

--- a/packages/node/src/cpu-profile.ts
+++ b/packages/node/src/cpu-profile.ts
@@ -1,36 +1,93 @@
 import { logger } from '@pandacss/logger'
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
+import readline from 'node:readline'
 
-export const startProfiling = async (cwd: string, prefix: string) => {
+export const startProfiling = async (cwd: string, prefix: string, isWatching?: boolean) => {
   const inspector = await import('node:inspector').then((r) => r.default)
 
   const session = new inspector.Session()
   session.connect()
 
+  let state: ProfileState = 'idle'
+  const setState = (s: ProfileState) => {
+    state = s
+  }
+
   await new Promise<void>((resolve) => {
     session.post('Profiler.enable', () => {
-      session.post('Profiler.start', resolve)
+      session.post('Profiler.start', () => {
+        setState('profiling')
+        resolve()
+      })
     })
   })
 
-  const stopProfiling = () => {
-    session.post('Profiler.stop', (err, { profile }) => {
+  const toggleProfiler = () => {
+    if (state === 'idle') {
+      console.log('Starting CPU profiling...')
+      setState('starting')
+      session.post('Profiler.start', () => {
+        setState('profiling')
+        console.log("Press 'p' to stop profiling...")
+      })
+    } else if (state === 'profiling') {
+      console.log('Stopping CPU profiling...')
+      stopProfiling()
+    }
+  }
+
+  if (isWatching) {
+    readline.emitKeypressEvents(process.stdin)
+    if (process.stdin.isTTY) process.stdin.setRawMode(true)
+    console.log("Press 'p' to stop profiling...")
+
+    process.stdin.on('keypress', (str, key) => {
+      // Start/stop profiling on 'p'
+      if (key.name === 'p') {
+        toggleProfiler()
+      }
+
+      // Exit the process on Ctrl+C
+      if (key.ctrl && key.name === 'c') {
+        stopProfiling(() => process.exit())
+      }
+    })
+  }
+
+  const stopProfiling = (cb?: () => void) => {
+    if (state !== 'profiling') {
+      cb?.()
+      return
+    }
+
+    setState('stopping')
+    session.post('Profiler.stop', (err, params) => {
+      setState('idle')
+
       if (err) {
         logger.error('cpu-prof', err)
+        cb?.()
         return
       }
-      if (!profile) return
+
+      if (!params?.profile) {
+        cb?.()
+        return
+      }
 
       const date = new Date()
       const timestamp = date.toISOString().replace(/[-:.]/g, '')
       const title = `panda-${prefix}-${timestamp}`
 
       const outfile = path.join(cwd, `${title}.cpuprofile`)
-      fs.writeFileSync(outfile, JSON.stringify(profile))
+      fs.writeFileSync(outfile, JSON.stringify(params.profile))
       logger.info('cpu-prof', outfile)
+      cb?.()
     })
   }
 
   return stopProfiling
 }
+
+type ProfileState = 'idle' | 'starting' | 'profiling' | 'stopping'


### PR DESCRIPTION
## 📝 Description

Allow dynamically recording profiling session by pressing the `p` key in your terminal when using the `--cpu-prof` flag
for long-running sessions (with `-w` or `--watch` for `panda` / `panda cssgen` / `panda codegen`).


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

mostly useful for [performance profling](https://panda-css.com/docs/guides/debugging#performance-profiling) as a maintainer
