### PR TITLE
docs: add notice for customizing the panda css setup

### DIFF
--- a/website/pages/docs/installation/astro.mdx
+++ b/website/pages/docs/installation/astro.mdx
@@ -137,6 +137,13 @@ import { css } from '../../styled-system/css';
 ---
 <div class={css({ fontSize: "2xl", fontWeight: 'bold' })}>Hello !</div>
 ```
+
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/cli.mdx
+++ b/website/pages/docs/installation/cli.mdx
@@ -139,6 +139,12 @@ export function App() {
 }
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/gatsby.mdx
+++ b/website/pages/docs/installation/gatsby.mdx
@@ -149,6 +149,13 @@ export default IndexPage
 
 export const Head: HeadFC = () => <title>Home Page</title>
 ```
+
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/nextjs.mdx
+++ b/website/pages/docs/installation/nextjs.mdx
@@ -301,6 +301,12 @@ If you don't have Next.js app installed, you can follow the [Create a Next.js ap
 
   Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+  ### Customize your Panda CSS setup (optional)
+
+  It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+  This allows you to create a more tailored configuration according to your preferences. 
+  For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
   </Steps>
 </RouteSwitch>
 

--- a/website/pages/docs/installation/nuxt.mdx
+++ b/website/pages/docs/installation/nuxt.mdx
@@ -216,5 +216,11 @@ import { css } from "styled-system/css";
 </template>
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 

--- a/website/pages/docs/installation/postcss.mdx
+++ b/website/pages/docs/installation/postcss.mdx
@@ -131,7 +131,13 @@ export function App() {
 }
 ```
 
-  </Steps>
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
+</Steps>
 
 ## Troubleshooting
 

--- a/website/pages/docs/installation/preact.mdx
+++ b/website/pages/docs/installation/preact.mdx
@@ -129,6 +129,12 @@ const Home = () => {
 export default Home;
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/qwik.mdx
+++ b/website/pages/docs/installation/qwik.mdx
@@ -117,6 +117,12 @@ export default component$(() => {
 })
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/redwood.mdx
+++ b/website/pages/docs/installation/redwood.mdx
@@ -164,6 +164,12 @@ const HomePage = () => {
 export default HomePage
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/remix.mdx
+++ b/website/pages/docs/installation/remix.mdx
@@ -255,6 +255,13 @@ export default function Index() {
   );
 }
 ```
+
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/solidjs.mdx
+++ b/website/pages/docs/installation/solidjs.mdx
@@ -174,6 +174,12 @@ const App: Component = () => {
 export default App;
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/storybook.mdx
+++ b/website/pages/docs/installation/storybook.mdx
@@ -244,6 +244,12 @@ export const Default: Story = {
 };
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ### Troubleshooting

--- a/website/pages/docs/installation/svelte.mdx
+++ b/website/pages/docs/installation/svelte.mdx
@@ -277,6 +277,13 @@ Here is the snippet of code that you can use in your `src/routes/+page.svelte` f
 	Hello 🐼!
 </div>
 ```
+
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/vite.mdx
+++ b/website/pages/docs/installation/vite.mdx
@@ -172,6 +172,13 @@ function App() {
 
 export default App;
 ```
+
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>
 
 ## Troubleshooting

--- a/website/pages/docs/installation/vue.mdx
+++ b/website/pages/docs/installation/vue.mdx
@@ -207,4 +207,10 @@ import { css } from "../styled-system/css";
 </template>
 ```
 
+### Customize your Panda CSS setup (optional)
+
+It's worth noting that you have the flexibility to customize your setup by opting out of specific features and concepts in Panda CSS. 
+This allows you to create a more tailored configuration according to your preferences. 
+For step-by-step instructions on creating a minimal setup, please refer to this [guide](/docs/guides/minimal-setup).
+
 </Steps>

--- a/website/pages/docs/overview/getting-started.mdx
+++ b/website/pages/docs/overview/getting-started.mdx
@@ -32,6 +32,10 @@ Start using Panda CSS in your JavaScript framework using our framework-specific 
 
 Get familiar with the core features and concepts in Panda.
 
+> All of the features and concepts listed below are readily available with Panda CSS. <br/>
+> However, it's important to note that you have the option to opt-out of each of them to tailor your setup according to your preferences. 
+> For example, you can create a minimal setup following this [guide](/docs/guides/minimal-setup).
+
 <Cards>
   <Card
     arrow


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

It wasn't very clear how many options you have to customize your Panda CSS setup. 
I feel like adding this on a few places in the docs, this would help the users discover this option.

## ⛳️ Current behavior (updates)

/ 

## 🚀 New behavior

Added notice of the option to opt-out of features and concepts of Panda CSS to customize the setup.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Feel free to be more creative and change the content. 
