### PR TITLE
docs(nuxt): add app.vue as default file for config example

### DIFF
--- a/website/pages/docs/installation/nuxt.mdx
+++ b/website/pages/docs/installation/nuxt.mdx
@@ -124,7 +124,7 @@ export default defineConfig({
  preflight: true,
 
  // Where to look for your css declarations
- include: ["./components/**/*.{js,jsx,ts,tsx,vue}", "./pages/**/*.{js,jsx,ts,tsx,vue}"],
+ include: ["./app.vue", "./components/**/*.{js,jsx,ts,tsx,vue}", "./pages/**/*.{js,jsx,ts,tsx,vue}"],
 
  // Files to exclude
  exclude: [],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The setup guide for Nuxt doesn't mention adding `app.vue` to `includes`. If one just carelessly copies the example (like me), then styles will work, except in `app.vue`. Since `app.vue` is a default Nuxt file, it should be included.

## 💣 Is this a breaking change (Yes/No):

No
