### PR TITLE
fix: condition + pseudo element combination

### DIFF
--- a/.changeset/dull-parents-ring.md
+++ b/.changeset/dull-parents-ring.md
@@ -1,0 +1,27 @@
+---
+'@pandacss/core': patch
+---
+
+Fix conditions sorting issue in generated CSS when nesting pseudo selectors
+
+```ts
+css({
+  '&.light': { '&::hover': { color: 'green' } },
+  '&::hover': { '&.light': { color: 'yellow' } },
+})
+```
+
+will generate the following CSS:
+
+```diff
+@layer utilities {
+  .[&.light]:[&::hover]:text_green.light::hover {
+    color: green;
+  }
+
+-  .[&::hover]:[&.light]:text_yellow::hover.light {
++  .[&::hover]:[&.light]:text_yellow.light::hover {
+    color: yellow;
+  }
+}
+```

--- a/packages/core/__tests__/sort-style-rules.test.ts
+++ b/packages/core/__tests__/sort-style-rules.test.ts
@@ -291,7 +291,7 @@ describe('sort style rules', () => {
     `)
   })
 
-  test.only('css', () => {
+  test('css pseudo sorting', () => {
     const ctx = createContext()
 
     ctx.encoder.processAtomic({
@@ -312,16 +312,52 @@ describe('sort style rules', () => {
           color: green;
       }
 
+        .\\[\\&\\:\\:hover\\]\\:\\[\\&\\.light\\]\\:text_yellow.light::hover {
+          color: yellow;
+      }
+
         .\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:\\[\\&\\:\\:backdrop\\]\\:text_red.dark::backdrop,.dark .\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:\\[\\&\\:\\:backdrop\\]\\:text_red::backdrop {
           color: red;
       }
 
-        .\\[\\&\\:\\:backdrop\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::backdrop.dark,.dark .\\[\\&\\:\\:backdrop\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::backdrop {
+        .\\[\\&\\:\\:backdrop\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue.dark::backdrop,.dark .\\[\\&\\:\\:backdrop\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::backdrop {
           color: blue;
       }
+      }"
+    `)
+  })
 
-        .\\[\\&\\:\\:hover\\]\\:\\[\\&\\.light\\]\\:text_yellow::hover.light {
+  test('css pseudo sorting 2', () => {
+    const ctx = createContext()
+
+    ctx.encoder.processAtomic({
+      '&.light': { '&::backdrop, &.backdrop': { color: 'green' } },
+      '&::backdrop, &.backdrop': { '&.light': { color: 'yellow' } },
+      //
+      '&.dark, .dark &': { '&::part(card)': { color: 'red' } },
+      '&::part(card)': { '&.dark, .dark &': { color: 'blue' } },
+    })
+
+    ctx.decoder.collect(ctx.encoder)
+    const sheet = ctx.createSheet()
+    sheet.processDecoder(ctx.decoder)
+
+    expect(sheet.toCss({ optimize: true })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .\\[\\&\\.light\\]\\:\\[\\&\\:\\:backdrop\\,_\\&\\.backdrop\\]\\:text_green.light::backdrop,.\\[\\&\\.light\\]\\:\\[\\&\\:\\:backdrop\\,_\\&\\.backdrop\\]\\:text_green.light.backdrop {
+          color: green;
+      }
+
+        .\\[\\&\\:\\:backdrop\\,_\\&\\.backdrop\\]\\:\\[\\&\\.light\\]\\:text_yellow.light::backdrop,.\\[\\&\\:\\:backdrop\\,_\\&\\.backdrop\\]\\:\\[\\&\\.light\\]\\:text_yellow.light.backdrop {
           color: yellow;
+      }
+
+        .\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:\\[\\&\\:\\:part\\(card\\)\\]\\:text_red.dark::part(card),.dark .\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:\\[\\&\\:\\:part\\(card\\)\\]\\:text_red::part(card) {
+          color: red;
+      }
+
+        .\\[\\&\\:\\:part\\(card\\)\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::part(card).dark,.dark .\\[\\&\\:\\:part\\(card\\)\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::part(card) {
+          color: blue;
       }
       }"
     `)

--- a/packages/core/__tests__/sort-style-rules.test.ts
+++ b/packages/core/__tests__/sort-style-rules.test.ts
@@ -290,4 +290,40 @@ describe('sort style rules', () => {
       }"
     `)
   })
+
+  test.only('css', () => {
+    const ctx = createContext()
+
+    ctx.encoder.processAtomic({
+      '&.light': { '&::hover': { color: 'green' } },
+      '&::hover': { '&.light': { color: 'yellow' } },
+      //
+      '&.dark, .dark &': { '&::backdrop': { color: 'red' } },
+      '&::backdrop': { '&.dark, .dark &': { color: 'blue' } },
+    })
+
+    ctx.decoder.collect(ctx.encoder)
+    const sheet = ctx.createSheet()
+    sheet.processDecoder(ctx.decoder)
+
+    expect(sheet.toCss({ optimize: true })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .\\[\\&\\.light\\]\\:\\[\\&\\:\\:hover\\]\\:text_green.light::hover {
+          color: green;
+      }
+
+        .\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:\\[\\&\\:\\:backdrop\\]\\:text_red.dark::backdrop,.dark .\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:\\[\\&\\:\\:backdrop\\]\\:text_red::backdrop {
+          color: red;
+      }
+
+        .\\[\\&\\:\\:backdrop\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::backdrop.dark,.dark .\\[\\&\\:\\:backdrop\\]\\:\\[\\&\\.dark\\,_\\.dark_\\&\\]\\:text_blue::backdrop {
+          color: blue;
+      }
+
+        .\\[\\&\\:\\:hover\\]\\:\\[\\&\\.light\\]\\:text_yellow::hover.light {
+          color: yellow;
+      }
+      }"
+    `)
+  })
 })

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -132,7 +132,25 @@ export class Conditions {
 
   sort = (conditions: string[]): ConditionDetails[] => {
     const rawConditions = conditions.map(this.getRaw).filter(Boolean) as ConditionDetails[]
-    return rawConditions.sort((a, b) => order.indexOf(a.type) - order.indexOf(b.type))
+    return rawConditions.sort((a, b) => {
+      const score = order.indexOf(a.type) - order.indexOf(b.type)
+      if (score !== 0) return score
+
+      if (a.type !== 'at-rule' && a.type !== 'mixed' && b.type !== 'at-rule' && b.type !== 'mixed') {
+        const aIsPseudo = this.isPseudo(a.raw)
+        const bIsPseudo = this.isPseudo(b.raw)
+
+        if (aIsPseudo && !bIsPseudo) return 1
+        if (!aIsPseudo && bIsPseudo) return -1
+        return 0
+      }
+
+      return 0
+    })
+  }
+
+  isPseudo = (selector: string) => {
+    return selector.startsWith('&::') && !selector.startsWith('&::part(') && !selector.startsWith('&::slotted(')
   }
 
   normalize = (condition: ConditionQuery | ConditionDetails): ConditionDetails | undefined => {


### PR DESCRIPTION
## 📝 Description

Fix conditions sorting issue in generated CSS when nesting pseudo selectors

```ts
css({
  '&.light': { '&::hover': { color: 'green' } },
  '&::hover': { '&.light': { color: 'yellow' } },
  //
  '&.dark, .dark &': { '&::backdrop': { color: 'red' } },
  '&::backdrop': { '&.dark, .dark &': { color: 'blue' } },
})
```

will generate the following CSS:

```diff
@layer utilities {
  .[&.light]:[&::hover]:text_green.light::hover {
    color: green;
  }

-  .[&::hover]:[&.light]:text_yellow::hover.light {
+  .[&::hover]:[&.light]:text_yellow.light::hover {
    color: yellow;
  }
}
```
