### PR TITLE
feat: definePlugin & missing config-deps on `plugins` key

### DIFF
--- a/.changeset/poor-lamps-look.md
+++ b/.changeset/poor-lamps-look.md
@@ -1,0 +1,6 @@
+---
+"@pandacss/config": patch
+"@pandacss/dev": patch
+---
+
+Add `definePlugin` config functions for type-safety around plugins, add missing `plugins` in config dependencies to trigger a config reload on `plugins` change

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import type {
   SystemStyleObject,
   TextStyles,
   Tokens,
+  PandaPlugin,
 } from '@pandacss/types'
 
 /* -----------------------------------------------------------------------------
@@ -71,6 +72,10 @@ export function defineGlobalStyles(definition: GlobalStyleObject) {
 
 export function defineUtility(utility: PropertyConfig) {
   return utility
+}
+
+export function definePlugin(plugin: PandaPlugin) {
+  return plugin
 }
 
 /* -----------------------------------------------------------------------------

--- a/packages/config/src/config-deps.ts
+++ b/packages/config/src/config-deps.ts
@@ -15,6 +15,7 @@ const all: ConfigPath[] = [
   'emitPackage',
   'emitTokensOnly',
   'presets',
+  'plugins',
   'hooks',
 ]
 


### PR DESCRIPTION
## 📝 Description

Add `definePlugin` config functions for type-safety around plugins, add missing `plugins` in config dependencies to trigger a config reload on `plugins` change
