### PR TITLE
fix: config validation with DEFAULT and nesting in value

### DIFF
--- a/.changeset/wicked-crews-turn.md
+++ b/.changeset/wicked-crews-turn.md
@@ -1,0 +1,51 @@
+---
+'@pandacss/config': patch
+---
+
+Fix "missing token" warning when using DEFAULT in tokens path
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  validation: 'error',
+  theme: {
+    semanticTokens: {
+      colors: {
+        primary: {
+          DEFAULT: { value: '#ff3333' },
+          lighter: { value: '#ff6666' },
+        },
+        background: { value: '{colors.primary}' }, // <-- ⚠️ wrong warning
+        background2: { value: '{colors.primary.lighter}' }, // <-- no warning, correct
+      },
+    },
+  },
+})
+```
+
+---
+
+Add a warning when using `value` twice
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  validation: 'error',
+  theme: {
+    tokens: {
+      colors: {
+        primary: { value: '#ff3333' },
+      },
+    },
+    semanticTokens: {
+      colors: {
+        primary: {
+          value: { value: '{colors.primary}' }, // <-- ⚠️ new warning for this
+        },
+      },
+    },
+  },
+})
+```

--- a/packages/config/__tests__/validate-config.test.ts
+++ b/packages/config/__tests__/validate-config.test.ts
@@ -537,4 +537,34 @@ describe('validateConfig', () => {
 
     expect(() => validateConfig(config)).not.toThrow()
   })
+
+  // https://github.com/chakra-ui/panda/issues/2284
+  test('warn about nesting in "value" twice', () => {
+    const config: Partial<UserConfig> = {
+      validation: 'warn',
+      theme: {
+        tokens: {
+          colors: {
+            red: {
+              300: { value: 'red' },
+            },
+          },
+        },
+        semanticTokens: {
+          colors: {
+            primary: {
+              // should probably not wrap twice in value
+              value: { value: '{colors.red.300}' },
+            },
+          },
+        },
+      },
+    }
+
+    expect(validateConfig(config)).toMatchInlineSnapshot(`
+      Set {
+        "[tokens] You used \`value\` twice resulting in an invalid token \`theme.tokens.colors.primary.value.value\`",
+      }
+    `)
+  })
 })

--- a/packages/config/__tests__/validate-config.test.ts
+++ b/packages/config/__tests__/validate-config.test.ts
@@ -516,4 +516,25 @@ describe('validateConfig', () => {
     `,
     )
   })
+
+  // https://github.com/chakra-ui/panda/issues/2283
+  test('"missing token" warning when using nested tokens', () => {
+    const config: Partial<UserConfig> = {
+      validation: 'error',
+      theme: {
+        semanticTokens: {
+          colors: {
+            primary: {
+              DEFAULT: { value: '#ff3333' },
+              lighter: { value: '#ff6666' },
+            },
+            background: { value: '{colors.primary}' }, // <-- ⚠️ wrong warning
+            background2: { value: '{colors.primary.lighter}' }, // <-- no warning, correct
+          },
+        },
+      },
+    }
+
+    expect(() => validateConfig(config)).not.toThrow()
+  })
 })

--- a/packages/config/src/validation/validate-tokens.ts
+++ b/packages/config/src/validation/validate-tokens.ts
@@ -76,9 +76,16 @@ export const validateTokens = (options: Options) => {
 
         if (!isValidToken(value)) return
 
-        walkObject(value, (itemValue) => {
+        walkObject(value, (itemValue, paths) => {
+          const valuePath = paths.join(SEP)
+          const formattedPath = formatPath(path)
+          const fullPath = formattedPath + '.' + paths.join(SEP)
+
+          if (valuePath.includes('value' + SEP + 'value')) {
+            addError('tokens', `You used \`value\` twice resulting in an invalid token \`theme.tokens.${fullPath}\``)
+          }
+
           if (isTokenReference(itemValue)) {
-            const formattedPath = formatPath(path)
             if (!refsByPath.has(formattedPath)) {
               refsByPath.set(formattedPath, new Set())
             }

--- a/packages/config/src/validation/validate-tokens.ts
+++ b/packages/config/src/validation/validate-tokens.ts
@@ -33,6 +33,10 @@ export const validateTokens = (options: Options) => {
         tokenPaths.add(path)
 
         valueAtPath.set(path, value)
+
+        if (path.includes('DEFAULT')) {
+          valueAtPath.set(path.replace('DEFAULT', ''), value)
+        }
       },
       {
         stop: isValidToken,
@@ -65,6 +69,10 @@ export const validateTokens = (options: Options) => {
         semanticTokenNames.add(path)
         valueAtPath.set(path, value)
         tokenPaths.add(path)
+
+        if (path.includes('DEFAULT')) {
+          valueAtPath.set(path.replace(SEP + 'DEFAULT', ''), value)
+        }
 
         if (!isValidToken(value)) return
 


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/2283 https://github.com/chakra-ui/panda/issues/2284

## 📝 Description

Fix "missing token" warning when using DEFAULT in tokens path

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  validation: 'error',
  theme: {
    semanticTokens: {
      colors: {
        primary: {
          DEFAULT: { value: '#ff3333' },
          lighter: { value: '#ff6666' },
        },
        background: { value: '{colors.primary}' }, // <-- ⚠️ wrong warning
        background2: { value: '{colors.primary.lighter}' }, // <-- no warning, correct
      },
    },
  },
})
```

---

Add a warning when using `value` twice

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  validation: 'error',
  theme: {
    tokens: {
      colors: {
        primary: { value: '#ff3333' },
      },
    },
    semanticTokens: {
      colors: {
        primary: {
          value: { value: '{colors.primary}' }, // <-- ⚠️ new warning for this
        },
      },
    },
  },
})
```

