### PR TITLE
🐛 Fix preflight default value 

### DIFF
--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -230,7 +230,7 @@ interface JsxOptions {
 interface CssgenOptions {
   /**
    * Whether to include css reset styles in the generated css.
-   * @default true
+   * @default false
    */
   preflight?: boolean | { scope: string; level?: 'element' | 'parent' }
   /**

--- a/website/pages/docs/references/config.md
+++ b/website/pages/docs/references/config.md
@@ -52,15 +52,15 @@ Whether to opt-out of the defaults config presets: [`@pandacss/preset-base`, `@p
 
 **Type**: `boolean` | `{ scope: string; }`
 
-**Default**: `true`
+**Default**: `false`
 
 Whether to enable css reset styles.
 
-Disable preflight:
+Enable preflight:
 
 ```json
 {
-  "preflight": false
+  "preflight": true
 }
 ```
 


### PR DESCRIPTION
## 📝 Description

The default value of preflight is probably written incorrectly.

## ⛳️ Current behavior (updates)

"body" has a `margin` etc.  
https://stackblitz.com/edit/vitejs-vite-iltv13?file=panda.config.ts

<kbd> ![image](https://github.com/chakra-ui/panda/assets/13148112/f9e02610-7952-42ea-bfb8-5f8dfa8d5d5e)

## 🚀 New behavior

If not set, `Preflight` will not be applied.  
The documentation should also be rewritten as such.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
