### PR TITLE
fix: splitCssProps typings

### DIFF
--- a/.changeset/sixty-trains-mix.md
+++ b/.changeset/sixty-trains-mix.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/generator": patch
+---
+
+Fix `splitCssProps` typings, it would sometimes throw `Expression produces a union type that is too complex to represent"`

--- a/packages/generator/src/artifacts/js/is-valid-prop.ts
+++ b/packages/generator/src/artifacts/js/is-valid-prop.ts
@@ -41,12 +41,11 @@ export function generateIsValidProp(ctx: Context) {
     import type { DistributiveOmit, HTMLPandaProps, JsxStyleProps, Pretty } from '../types';
 
     declare const isCssProperty: (value: string) => boolean;
-    
+
     type CssPropKey = keyof JsxStyleProps
-    type PickedCssProps<T> = Pretty<Pick<T, CssPropKey>>
     type OmittedCssProps<T> = Pretty<DistributiveOmit<T, CssPropKey>>
 
-    declare const splitCssProps: <T>(props: T) => [PickedCssProps<T>, OmittedCssProps<T>]
+    declare const splitCssProps: <T>(props: T) => [JsxStyleProps, OmittedCssProps<T>]
 
     export { isCssProperty, splitCssProps };
     `,

--- a/packages/studio/styled-system/jsx/is-valid-prop.d.ts
+++ b/packages/studio/styled-system/jsx/is-valid-prop.d.ts
@@ -4,9 +4,8 @@ import type { DistributiveOmit, HTMLPandaProps, JsxStyleProps, Pretty } from '..
 declare const isCssProperty: (value: string) => boolean;
 
 type CssPropKey = keyof JsxStyleProps
-type PickedCssProps<T> = Pretty<Pick<T, CssPropKey>>
 type OmittedCssProps<T> = Pretty<DistributiveOmit<T, CssPropKey>>
 
-declare const splitCssProps: <T>(props: T) => [PickedCssProps<T>, OmittedCssProps<T>]
+declare const splitCssProps: <T>(props: T) => [JsxStyleProps, OmittedCssProps<T>]
 
 export { isCssProperty, splitCssProps };


### PR DESCRIPTION
## 📝 Description

Fix `splitCssProps` typings, it would sometimes throw `Expression produces a union type that is too complex to represent"`

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
