### PR TITLE
fix: prevent space in token keys, show better log on token CSS parsin…

### DIFF
--- a/.changeset/breezy-books-glow.md
+++ b/.changeset/breezy-books-glow.md
@@ -1,0 +1,6 @@
+---
+"@pandacss/generator": patch
+"@pandacss/config": patch
+---
+
+Add a config validation check to prevent using spaces in token keys, show better error logs when there's a CSS parsing error

--- a/packages/config/__tests__/validate-config.test.ts
+++ b/packages/config/__tests__/validate-config.test.ts
@@ -567,4 +567,31 @@ describe('validateConfig', () => {
       }
     `)
   })
+
+  test('prevent space in token keys', () => {
+    const config: Partial<UserConfig> = {
+      validation: 'warn',
+      theme: {
+        tokens: {
+          fonts: {
+            'Press Start 1P': { value: 'Press Start 1P' },
+            PressStart2P: { value: 'Press Start 2P' },
+          },
+        },
+        semanticTokens: {
+          fonts: {
+            'Press Start 3P': { value: 'Press Start 3P' },
+            PressStart4P: { value: 'Press Start 4P' },
+          },
+        },
+      },
+    }
+
+    expect(validateConfig(config)).toMatchInlineSnapshot(`
+      Set {
+        "[tokens] Token key must not contain spaces: \`theme.tokens.fonts.Press Start 1P\`",
+        "[tokens] Token key must not contain spaces: \`theme.tokens.fonts.Press Start 3P\`",
+      }
+    `)
+  })
 })

--- a/packages/config/src/validation/validate-tokens.ts
+++ b/packages/config/src/validation/validate-tokens.ts
@@ -52,6 +52,11 @@ export const validateTokens = (options: Options) => {
         return
       }
 
+      if (path.includes(' ')) {
+        addError('tokens', `Token key must not contain spaces: \`theme.tokens.${formattedPath}\``)
+        return
+      }
+
       if (isTokenReference(value)) {
         refsByPath.set(formattedPath, new Set([]))
       }
@@ -104,6 +109,11 @@ export const validateTokens = (options: Options) => {
     tokenPaths.forEach((path) => {
       const formattedPath = formatPath(path)
       const value = valueAtPath.get(path)
+
+      if (path.includes(' ')) {
+        addError('tokens', `Token key must not contain spaces: \`theme.tokens.${formattedPath}\``)
+        return
+      }
 
       if (!isObject(value) && !path.includes('value')) {
         addError('tokens', `Token must contain 'value': \`theme.semanticTokens.${formattedPath}\``)


### PR DESCRIPTION
…g error


Add a config validation check to prevent using spaces in token keys, show better error logs when there's a CSS parsing error


from: 
![image](https://github.com/chakra-ui/panda/assets/47224540/c4e1714d-3e90-4237-ae53-5fc1931a2160)

to
![image](https://github.com/chakra-ui/panda/assets/47224540/147afd40-13b2-475b-bf19-bd1bcc29bcce)
