### PR TITLE
feat: color opacity modifier in token references (runtime & config)

### DIFF
--- a/.changeset/curvy-bikes-peel.md
+++ b/.changeset/curvy-bikes-peel.md
@@ -1,0 +1,64 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/core': patch
+---
+
+Allow using the color opacity modifier syntax (`blue.300/70`) in token references:
+
+- `{colors.blue.300/70}`
+- `token(colors.blue.300/70)`
+
+Note that this works both in style usage and in build-time config.
+
+```ts
+// runtime usage
+
+import { css } from '../styled-system/css'
+
+css({ bg: '{colors.blue.300/70}' })
+// => @layer utilities {
+//    .bg_token\(colors\.blue\.300\/70\) {
+//      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
+//    }
+//  }
+
+css({ bg: 'token(colors.blue.300/70)' })
+// => @layer utilities {
+//    .bg_token\(colors\.blue\.300\/70\) {
+//      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
+//    }
+//  }
+```
+
+```ts
+// build-time usage
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  theme: {
+    tokens: {
+      colors: {
+        blue: {
+          300: { value: '#00f' },
+        },
+      },
+    },
+    semanticTokens: {
+      colors: {
+        primary: {
+          value: '{colors.blue.300/70}',
+        },
+      },
+    },
+  },
+})
+```
+
+```css
+@layer tokens {
+  :where(:root, :host) {
+    --colors-blue-300: #00f;
+    --colors-primary: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
+  }
+}
+```

--- a/packages/core/__tests__/color-mix.test.ts
+++ b/packages/core/__tests__/color-mix.test.ts
@@ -129,6 +129,36 @@ describe('color-mix', () => {
     `)
   })
 
+  test('in token fn', () => {
+    expect(css({ bg: 'token(colors.pink.400/30)' })).toMatchInlineSnapshot(`
+      {
+        "className": [
+          "bg_token\\(colors\\.pink\\.400\\/30\\)",
+        ],
+        "css": "@layer utilities {
+        .bg_token\\(colors\\.pink\\.400\\/30\\) {
+          background: color-mix(in srgb, var(--colors-pink-400) 30%, transparent);
+      }
+      }",
+      }
+    `)
+  })
+
+  test('in token reference with curly brackets', () => {
+    expect(css({ color: '{colors.pink.400/30}' })).toMatchInlineSnapshot(`
+      {
+        "className": [
+          "text_\\{colors\\.pink\\.400\\/30\\}",
+        ],
+        "css": "@layer utilities {
+        .text_\\{colors\\.pink\\.400\\/30\\} {
+          color: color-mix(in srgb, var(--colors-pink-400) 30%, transparent);
+      }
+      }",
+      }
+    `)
+  })
+
   // below are invalid cases
 
   test('wrong format', () => {

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -789,4 +789,48 @@ describe('generator', () => {
       }"
     `)
   })
+
+  test('color-mix', () => {
+    const css = tokenCss(<any>{
+      dependencies: [],
+      config: {
+        cwd: '',
+        include: [],
+        theme: {
+          tokens: {
+            colors: {
+              pink: { value: '#ff00ff' },
+              border: { value: '{colors.pink/30}' },
+              ref: { value: '{colors.border/40}' },
+            },
+            opacity: {
+              half: { value: 0.5 },
+            },
+          },
+          semanticTokens: {
+            colors: {
+              primary: {
+                value: '{colors.blue.300/70}',
+              },
+            },
+          },
+        },
+        outdir: '',
+      },
+      path: '',
+      hooks: {},
+    })
+
+    expect(css).toMatchInlineSnapshot(`
+      "@layer tokens {
+        :where(:root, :host) {
+          --colors-pink: #ff00ff;
+          --colors-border: color-mix(in srgb, var(--colors-pink) 30%, transparent);
+          --colors-ref: color-mix(in srgb, var(--colors-border) 40%, transparent);
+          --opacity-half: 0.5;
+          --colors-primary: color-mix(in srgb, colors.blue.300 70%, transparent);
+      }
+      }"
+    `)
+  })
 })

--- a/packages/token-dictionary/__tests__/color-mix.test.ts
+++ b/packages/token-dictionary/__tests__/color-mix.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import { TokenDictionary } from '../src/dictionary'
+
+test('color-mix', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        pink: { value: '#ff00ff' },
+        border: { value: '{colors.pink/30}' },
+        ref: { value: '{colors.border/40}' },
+      },
+      opacity: {
+        half: { value: 0.5 },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('{colors.pink/30}')).toMatchInlineSnapshot(
+    `"color-mix(in srgb, var(--colors-pink) 30%, transparent)"`,
+  )
+  expect(dictionary.expandReferenceInValue('{colors.border/40}')).toMatchInlineSnapshot(
+    `"color-mix(in srgb, var(--colors-border) 40%, transparent)"`,
+  )
+  expect(dictionary.expandReferenceInValue('{colors.border/half}')).toMatchInlineSnapshot(
+    `"color-mix(in srgb, var(--colors-border) 50%, transparent)"`,
+  )
+})


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/discussions/2110#discussioncomment-8323928

## 📝 Description

Allow using the color opacity modifier syntax (`blue.300/70`) in token references:

- `{colors.blue.300/70}`
- `token(colors.blue.300/70)`

Note that this works both in style usage and in build-time config.

```ts
// runtime usage

import { css } from '../styled-system/css'

css({ bg: '{colors.blue.300/70}' })
// => @layer utilities {
//    .bg_token\(colors\.blue\.300\/70\) {
//      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
//    }
//  }

css({ bg: 'token(colors.blue.300/70)' })
// => @layer utilities {
//    .bg_token\(colors\.blue\.300\/70\) {
//      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
//    }
//  }
```

```ts
// build-time usage
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  theme: {
    tokens: {
      colors: {
        blue: {
          300: { value: '#00f' },
        },
      },
    },
    semanticTokens: {
      colors: {
        primary: {
          value: '{colors.blue.300/70}',
        },
      },
    },
  },
})
```

```css
@layer tokens {
  :where(:root, :host) {
    --colors-blue-300: #00f;
    --colors-primary: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
  }
}
```

