### PR TITLE
fix: _active condition was triggering when data-active=false

### DIFF
--- a/.changeset/_active-condition-mistaken.md
+++ b/.changeset/_active-condition-mistaken.md
@@ -1,0 +1,7 @@
+---
+"@pandacss/preset-base": patch
+---
+
+_active condition was triggering when data-active=false
+
+There is a problem with the "_active" condition. If the component has the attribute data-active=false, it is triggered. Just the presence of it triggers the condition, regardless of its value. I had to override it to make it work properly.

--- a/packages/preset-base/src/conditions.ts
+++ b/packages/preset-base/src/conditions.ts
@@ -4,7 +4,7 @@ export const conditions = {
   focusWithin: '&:focus-within',
   focusVisible: '&:is(:focus-visible, [data-focus-visible])',
   disabled: '&:is(:disabled, [disabled], [data-disabled])',
-  active: '&:is(:active, [data-active])',
+  active: '&:is(:active, [data-active]):not([data-active=false])',
   visited: '&:visited',
   target: '&:target',
   readOnly: '&:is(:read-only, [data-read-only])',


### PR DESCRIPTION
There is a problem with the "_active" condition. If the component has the attribute data-active=false, it is triggered. Just the presence of it triggers the condition, regardless of its value. I had to override it to make it work properly.

This correction probably should be made in many other default conditions later.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
