### PR TITLE
fix: color-mix in semanticTokens conditions

### DIFF
--- a/.changeset/proud-dogs-flash.md
+++ b/.changeset/proud-dogs-flash.md
@@ -1,0 +1,60 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/generator': patch
+---
+
+Fix the color opacity modifier syntax for `semanticTokens` inside of conditions
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  conditions: {
+    light: '.light &',
+    dark: '.dark &',
+  },
+  theme: {
+    tokens: {
+      colors: {
+        blue: { 500: { value: 'blue' } },
+        green: { 500: { value: 'green' } },
+      },
+      opacity: {
+        half: { value: 0.5 },
+      },
+    },
+    semanticTokens: {
+      colors: {
+        secondary: {
+          value: {
+            base: 'red',
+            _light: '{colors.blue.500/32}', // <-- wasn't working as expected
+            _dark: '{colors.green.500/half}',
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+will now correctly generate the following CSS:
+
+```css
+@layer tokens {
+  :where(:root, :host) {
+    --colors-blue-500: blue;
+    --colors-green-500: green;
+    --opacity-half: 0.5;
+    --colors-secondary: red;
+  }
+
+  .light {
+    --colors-secondary: color-mix(in srgb, var(--colors-blue-500) 32%, transparent);
+  }
+
+  .dark {
+    --colors-secondary: color-mix(in srgb, var(--colors-green-500) 50%, transparent);
+  }
+}
+```

--- a/packages/astro-plugin-studio/CHANGELOG.md
+++ b/packages/astro-plugin-studio/CHANGELOG.md
@@ -66,11 +66,11 @@
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [05686b9d]

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -147,11 +147,11 @@
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [0dd45b6a]
@@ -198,8 +198,8 @@
   ```ts
   export default defineConfig({
     // ...
-    dependencies: ["path/to/files/**.ts"],
-  });
+    dependencies: ['path/to/files/**.ts'],
+  })
   ```
 
   - Invoke `config:change` hook in more situations (when the `--watch` flag is passed to `panda codegen`,
@@ -248,54 +248,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -1193,12 +1178,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -1206,33 +1191,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -4,27 +4,28 @@
 
 ### Patch Changes
 
-- 1c63216: Add a config validation check to prevent using spaces in token keys, show better error logs when there's a CSS parsing error
+- 1c63216: Add a config validation check to prevent using spaces in token keys, show better error logs when there's a
+  CSS parsing error
 - 9f04427: Fix "missing token" warning when using DEFAULT in tokens path
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
-    validation: "error",
+    validation: 'error',
     theme: {
       semanticTokens: {
         colors: {
           primary: {
-            DEFAULT: { value: "#ff3333" },
-            lighter: { value: "#ff6666" },
+            DEFAULT: { value: '#ff3333' },
+            lighter: { value: '#ff6666' },
           },
-          background: { value: "{colors.primary}" }, // <-- ⚠️ wrong warning
-          background2: { value: "{colors.primary.lighter}" }, // <-- no warning, correct
+          background: { value: '{colors.primary}' }, // <-- ⚠️ wrong warning
+          background2: { value: '{colors.primary.lighter}' }, // <-- no warning, correct
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -32,25 +33,25 @@
   Add a warning when using `value` twice
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
-    validation: "error",
+    validation: 'error',
     theme: {
       tokens: {
         colors: {
-          primary: { value: "#ff3333" },
+          primary: { value: '#ff3333' },
         },
       },
       semanticTokens: {
         colors: {
           primary: {
-            value: { value: "{colors.primary}" }, // <-- ⚠️ new warning for this
+            value: { value: '{colors.primary}' }, // <-- ⚠️ new warning for this
           },
         },
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [d1516c8]
@@ -84,20 +85,20 @@
   export default defaultConfig({
     conditions: {
       extend: {
-        supportHover: ["@media (hover: hover) and (pointer: fine)", "&:hover"],
+        supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
       },
     },
-  });
+  })
   ```
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     _supportHover: {
-      color: "red",
+      color: 'red',
     },
-  });
+  })
   ```
 
   will generate the following CSS:
@@ -153,10 +154,10 @@
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -234,16 +235,16 @@
   keeping the rest. Let's say we want to remove the `stack` pattern from the built-in `@pandacss/preset-base`:
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     hooks: {
-      "config:resolved": ({ config, utils }) => {
-        return utils.omit(config, ["patterns.stack"]);
+      'config:resolved': ({ config, utils }) => {
+        return utils.omit(config, ['patterns.stack'])
       },
     },
-  });
+  })
   ```
 
 - ab32d1d7: Fix issue where errors were thrown when semantic tokens are overriden in tokens.
@@ -261,11 +262,11 @@
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -302,8 +303,8 @@
   ```ts
   export default defineConfig({
     // ...
-    dependencies: ["path/to/files/**.ts"],
-  });
+    dependencies: ['path/to/files/**.ts'],
+  })
   ```
 
   - Invoke `config:change` hook in more situations (when the `--watch` flag is passed to `panda codegen`,
@@ -361,54 +362,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -500,12 +486,12 @@
 
   ```ts
   // apps/storybook/panda.config.ts
-  import { defineConfig } from "@pandacss/dev";
-  import preset from "@acme/preset";
+  import { defineConfig } from '@pandacss/dev'
+  import preset from '@acme/preset'
 
   export default defineConfig({
     // ...
-  });
+  })
   ```
 
   This would not work before, but now it does.
@@ -719,10 +705,10 @@
     staticCss: {
       recipes: {
         // generate all button styles and variants
-        button: ["*"],
+        button: ['*'],
       },
     },
-  });
+  })
 
   export default defineConfig({
     presets: [presetWithStaticCss],
@@ -730,11 +716,11 @@
       extend: {
         recipes: {
           // extend and pre-generate all sizes for card
-          card: [{ size: ["small", "medium", "large"] }],
+          card: [{ size: ['small', 'medium', 'large'] }],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -929,42 +915,42 @@
     theme: {
       tokens: {
         colors: {
-          "first-main": { value: "override" },
+          'first-main': { value: 'override' },
         },
       },
       extend: {
         tokens: {
           colors: {
-            orange: { value: "orange" },
-            gray: { value: "from-first-config" },
+            orange: { value: 'orange' },
+            gray: { value: 'from-first-config' },
           },
         },
       },
     },
-  });
+  })
 
   const secondConfig = definePreset({
     theme: {
       tokens: {
         colors: {
-          pink: { value: "pink" },
+          pink: { value: 'pink' },
         },
       },
       extend: {
         tokens: {
           colors: {
-            blue: { value: "blue" },
-            gray: { value: "gray" },
+            blue: { value: 'blue' },
+            gray: { value: 'gray' },
           },
         },
       },
     },
-  });
+  })
 
   // Final config
   export default defineConfig({
     presets: [firstConfig, secondConfig],
-  });
+  })
   ```
 
   Here's the difference between the old and new behavior:
@@ -1192,7 +1178,7 @@
 - 33198907: Create separate entrypoint for merge configs
 
   ```ts
-  import { mergeConfigs } from "@pandacss/config/merge";
+  import { mergeConfigs } from '@pandacss/config/merge'
   ```
 
 - 1a2c0e2b: Fix `panda.config.xxx` file dependencies detection when using the builder (= with PostCSS or with the VSCode

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -14,16 +14,16 @@
   ```ts
   // runtime usage
 
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
-  css({ bg: "{colors.blue.300/70}" });
+  css({ bg: '{colors.blue.300/70}' })
   // => @layer utilities {
   //    .bg_token\(colors\.blue\.300\/70\) {
   //      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
   //    }
   //  }
 
-  css({ bg: "token(colors.blue.300/70)" });
+  css({ bg: 'token(colors.blue.300/70)' })
   // => @layer utilities {
   //    .bg_token\(colors\.blue\.300\/70\) {
   //      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
@@ -33,37 +33,33 @@
 
   ```ts
   // build-time usage
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     theme: {
       tokens: {
         colors: {
           blue: {
-            300: { value: "#00f" },
+            300: { value: '#00f' },
           },
         },
       },
       semanticTokens: {
         colors: {
           primary: {
-            value: "{colors.blue.300/70}",
+            value: '{colors.blue.300/70}',
           },
         },
       },
     },
-  });
+  })
   ```
 
   ```css
   @layer tokens {
     :where(:root, :host) {
       --colors-blue-300: #00f;
-      --colors-primary: color-mix(
-        in srgb,
-        var(--colors-blue-300) 70%,
-        transparent
-      );
+      --colors-primary: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
     }
   }
   ```
@@ -104,20 +100,20 @@
   export default defaultConfig({
     conditions: {
       extend: {
-        supportHover: ["@media (hover: hover) and (pointer: fine)", "&:hover"],
+        supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
       },
     },
-  });
+  })
   ```
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     _supportHover: {
-      color: "red",
+      color: 'red',
     },
-  });
+  })
   ```
 
   will generate the following CSS:
@@ -133,25 +129,25 @@
 - 31071ba: Fix an issue for token names starting with '0'
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     theme: {
       tokens: {
         spacing: {
-          "025": {
-            value: "0.125rem",
+          '025': {
+            value: '0.125rem',
           },
         },
       },
     },
-  });
+  })
   ```
 
   and then using it like
 
   ```ts
-  css({ margin: "025" });
+  css({ margin: '025' })
   ```
 
   This would not generate the expected CSS because the parser would try to parse `025` as a number (`25`) instead of
@@ -162,11 +158,11 @@
   - Allow using multiple aliases for the same identifier for the `/css` entrypoints just like `/patterns` and `/recipes`
 
   ```ts
-  import { css } from "../styled-system/css";
-  import { css as css2 } from "../styled-system/css";
+  import { css } from '../styled-system/css'
+  import { css as css2 } from '../styled-system/css'
 
-  css({ display: "flex" });
-  css2({ flexDirection: "column" }); // this wasn't working before, now it does
+  css({ display: 'flex' })
+  css2({ flexDirection: 'column' }) // this wasn't working before, now it does
   ```
 
 - Updated dependencies [a032375]
@@ -210,10 +206,10 @@
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -274,17 +270,16 @@
   export default defineConfig({
     // ...
     hooks: {
-      "parser:before": ({ configure }) => {
+      'parser:before': ({ configure }) => {
         configure({
           // ignore the Select.Content entirely
-          matchTag: (tag) => tag !== "Select.Content",
+          matchTag: (tag) => tag !== 'Select.Content',
           // ...or specifically ignore the `position` property
-          matchTagProp: (tag, prop) =>
-            tag === "Select.Content" && prop !== "position",
-        });
+          matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
+        })
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [6b829cab]
@@ -352,9 +347,9 @@
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -362,11 +357,7 @@
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -390,21 +381,21 @@
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -413,21 +404,21 @@
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -453,24 +444,24 @@
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 - 250b4d11: ### Container Query Theme
@@ -484,34 +475,34 @@
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -595,10 +586,10 @@
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -637,54 +628,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -891,11 +867,11 @@
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -915,18 +891,18 @@
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -937,8 +913,8 @@
   ```jsx
   css({
     // This didn't work, but now it does
-    base: { color: "blue" },
-  });
+    base: { color: 'blue' },
+  })
   ```
 
 - Updated dependencies [59fd291c]
@@ -997,38 +973,38 @@
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -1154,30 +1130,30 @@
   another file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`
 
   ```ts
-  import { sva } from "../styled-system/css";
-  import { slots } from "./slots";
+  import { sva } from '../styled-system/css'
+  import { slots } from './slots'
 
   const card = sva({
     slots, // ❌ did NOT work -> ✅ will now work as expected
     base: {
       root: {
-        p: "6",
-        m: "4",
-        w: "md",
-        boxShadow: "md",
-        borderRadius: "md",
-        _dark: { bg: "#262626", color: "white" },
+        p: '6',
+        m: '4',
+        w: 'md',
+        boxShadow: 'md',
+        borderRadius: 'md',
+        _dark: { bg: '#262626', color: 'white' },
       },
       content: {
-        textStyle: "lg",
+        textStyle: 'lg',
       },
       title: {
-        textStyle: "xl",
-        fontWeight: "semibold",
-        pb: "2",
+        textStyle: 'xl',
+        fontWeight: 'semibold',
+        pb: '2',
       },
     },
-  });
+  })
   ```
 
 - 840ed66b: Fix an issue with config change detection when using a custom `config.slotRecipes[xxx].jsx` array
@@ -1234,18 +1210,18 @@
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -1258,8 +1234,8 @@
     // here the content property is a valid CSS property, so Panda will try to generate the CSS for it
     // but since it's an URL, it would produce invalid CSS
     // we now check if the property value is an URL and skip it if needed
-    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />;
-  };
+    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />
+  }
   ```
 
 - d81dcbe6: - Fix an issue where recipe variants that clash with utility shorthand don't get generated due to the
@@ -1268,36 +1244,36 @@
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [26e6051a]
@@ -1329,13 +1305,13 @@
 
   ```ts
   css({
-    "@container (min-width: token(sizes.xl))": {
-      color: "green.300",
+    '@container (min-width: token(sizes.xl))': {
+      color: 'green.300',
     },
-    "@media (min-width: token(sizes.2xl))": {
-      color: "red.300",
+    '@media (min-width: token(sizes.2xl))': {
+      color: 'red.300',
     },
-  });
+  })
   ```
 
 - Updated dependencies [24ee49a5]
@@ -1387,14 +1363,14 @@
 - 8c76cd0f: - Fix issue where `hideBelow` breakpoints are inclusive of the specified breakpoints
 
   ```jsx
-  css({ hideBelow: "lg" });
+  css({ hideBelow: 'lg' })
   // => @media screen and (max-width: 63.9975em) { background: red; }
   ```
 
   - Support arbitrary breakpoints in `hideBelow` and `hideFrom` utilities
 
   ```jsx
-  css({ hideFrom: "800px" });
+  css({ hideFrom: '800px' })
   // => @media screen and (min-width: 800px) { background: red; }
   ```
 
@@ -1480,10 +1456,10 @@
 
   ```ts
   const button = defineSlotRecipe({
-    className: "button",
-    slots: ["root", "icon", "label"],
+    className: 'button',
+    slots: ['root', 'icon', 'label'],
     // ...
-  });
+  })
   ```
 
   will have a default `jsx` property of: `[Button, Button.Root, Button.Icon, Button.Label]`
@@ -1540,42 +1516,42 @@
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - Updated dependencies [95b06bb1]
@@ -1605,13 +1581,13 @@
 - 848936e0: Allow referencing tokens with the `token()` function in media queries or any other CSS at-rule.
 
   ```js
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const className = css({
-    "@media screen and (min-width: token(sizes.4xl))": {
-      color: "green.400",
+    '@media screen and (min-width: token(sizes.4xl))': {
+      color: 'green.400',
     },
-  });
+  })
   ```
 
 - Updated dependencies [26f6982c]
@@ -1664,7 +1640,7 @@
 
   ```css
   * {
-    color: token("colors.magenta", pink);
+    color: token('colors.magenta', pink);
   }
   ```
 
@@ -1773,12 +1749,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -1786,33 +1762,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -1861,26 +1837,26 @@
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -1944,17 +1920,9 @@
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -2021,7 +1989,7 @@
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -2031,7 +1999,7 @@
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -2067,12 +2035,12 @@
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -2174,11 +2142,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -2195,11 +2163,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -2238,9 +2206,9 @@ export default defineConfig({
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -2248,11 +2216,7 @@ export default defineConfig({
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -2276,21 +2240,21 @@ export default defineConfig({
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -2299,21 +2263,21 @@ export default defineConfig({
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -2339,24 +2303,24 @@ export default defineConfig({
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 - 250b4d11: ### Container Query Theme
@@ -2370,34 +2334,34 @@ export default defineConfig({
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -2481,10 +2445,10 @@ export default defineConfig({
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -2523,54 +2487,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -2777,11 +2726,11 @@ export default defineConfig({
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -2801,18 +2750,18 @@ export default defineConfig({
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -2823,8 +2772,8 @@ export default defineConfig({
   ```jsx
   css({
     // This didn't work, but now it does
-    base: { color: "blue" },
-  });
+    base: { color: 'blue' },
+  })
   ```
 
 - Updated dependencies [59fd291c]
@@ -2883,38 +2832,38 @@ export default defineConfig({
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -3040,30 +2989,30 @@ export default defineConfig({
   another file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`
 
   ```ts
-  import { sva } from "../styled-system/css";
-  import { slots } from "./slots";
+  import { sva } from '../styled-system/css'
+  import { slots } from './slots'
 
   const card = sva({
     slots, // ❌ did NOT work -> ✅ will now work as expected
     base: {
       root: {
-        p: "6",
-        m: "4",
-        w: "md",
-        boxShadow: "md",
-        borderRadius: "md",
-        _dark: { bg: "#262626", color: "white" },
+        p: '6',
+        m: '4',
+        w: 'md',
+        boxShadow: 'md',
+        borderRadius: 'md',
+        _dark: { bg: '#262626', color: 'white' },
       },
       content: {
-        textStyle: "lg",
+        textStyle: 'lg',
       },
       title: {
-        textStyle: "xl",
-        fontWeight: "semibold",
-        pb: "2",
+        textStyle: 'xl',
+        fontWeight: 'semibold',
+        pb: '2',
       },
     },
-  });
+  })
   ```
 
 - 840ed66b: Fix an issue with config change detection when using a custom `config.slotRecipes[xxx].jsx` array
@@ -3120,18 +3069,18 @@ export default defineConfig({
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -3144,8 +3093,8 @@ export default defineConfig({
     // here the content property is a valid CSS property, so Panda will try to generate the CSS for it
     // but since it's an URL, it would produce invalid CSS
     // we now check if the property value is an URL and skip it if needed
-    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />;
-  };
+    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />
+  }
   ```
 
 - d81dcbe6: - Fix an issue where recipe variants that clash with utility shorthand don't get generated due to the
@@ -3154,36 +3103,36 @@ export default defineConfig({
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [26e6051a]
@@ -3215,13 +3164,13 @@ export default defineConfig({
 
   ```ts
   css({
-    "@container (min-width: token(sizes.xl))": {
-      color: "green.300",
+    '@container (min-width: token(sizes.xl))': {
+      color: 'green.300',
     },
-    "@media (min-width: token(sizes.2xl))": {
-      color: "red.300",
+    '@media (min-width: token(sizes.2xl))': {
+      color: 'red.300',
     },
-  });
+  })
   ```
 
 - Updated dependencies [24ee49a5]
@@ -3273,14 +3222,14 @@ export default defineConfig({
 - 8c76cd0f: - Fix issue where `hideBelow` breakpoints are inclusive of the specified breakpoints
 
   ```jsx
-  css({ hideBelow: "lg" });
+  css({ hideBelow: 'lg' })
   // => @media screen and (max-width: 63.9975em) { background: red; }
   ```
 
   - Support arbitrary breakpoints in `hideBelow` and `hideFrom` utilities
 
   ```jsx
-  css({ hideFrom: "800px" });
+  css({ hideFrom: '800px' })
   // => @media screen and (min-width: 800px) { background: red; }
   ```
 
@@ -3366,10 +3315,10 @@ export default defineConfig({
 
   ```ts
   const button = defineSlotRecipe({
-    className: "button",
-    slots: ["root", "icon", "label"],
+    className: 'button',
+    slots: ['root', 'icon', 'label'],
     // ...
-  });
+  })
   ```
 
   will have a default `jsx` property of: `[Button, Button.Root, Button.Icon, Button.Label]`
@@ -3426,42 +3375,42 @@ export default defineConfig({
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - Updated dependencies [95b06bb1]
@@ -3491,13 +3440,13 @@ export default defineConfig({
 - 848936e0: Allow referencing tokens with the `token()` function in media queries or any other CSS at-rule.
 
   ```js
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const className = css({
-    "@media screen and (min-width: token(sizes.4xl))": {
-      color: "green.400",
+    '@media screen and (min-width: token(sizes.4xl))': {
+      color: 'green.400',
     },
-  });
+  })
   ```
 
 - Updated dependencies [26f6982c]
@@ -3550,7 +3499,7 @@ export default defineConfig({
 
   ```css
   * {
-    color: token("colors.magenta", pink);
+    color: token('colors.magenta', pink);
   }
   ```
 
@@ -3659,12 +3608,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -3672,33 +3621,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -3747,26 +3696,26 @@ export default defineConfig({
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -3830,17 +3779,9 @@ export default defineConfig({
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -3907,7 +3848,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -3917,7 +3858,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -3953,12 +3894,12 @@ export default defineConfig({
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -4062,20 +4003,20 @@ Will now allow you to use the following syntax for token path:
   export default defaultConfig({
     conditions: {
       extend: {
-        supportHover: ["@media (hover: hover) and (pointer: fine)", "&:hover"],
+        supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
       },
     },
-  });
+  })
   ```
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     _supportHover: {
-      color: "red",
+      color: 'red',
     },
-  });
+  })
   ```
 
   will generate the following CSS:
@@ -4091,25 +4032,25 @@ Will now allow you to use the following syntax for token path:
 - 31071ba: Fix an issue for token names starting with '0'
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     theme: {
       tokens: {
         spacing: {
-          "025": {
-            value: "0.125rem",
+          '025': {
+            value: '0.125rem',
           },
         },
       },
     },
-  });
+  })
   ```
 
   and then using it like
 
   ```ts
-  css({ margin: "025" });
+  css({ margin: '025' })
   ```
 
   This would not generate the expected CSS because the parser would try to parse `025` as a number (`25`) instead of
@@ -4120,11 +4061,11 @@ Will now allow you to use the following syntax for token path:
   - Allow using multiple aliases for the same identifier for the `/css` entrypoints just like `/patterns` and `/recipes`
 
   ```ts
-  import { css } from "../styled-system/css";
-  import { css as css2 } from "../styled-system/css";
+  import { css } from '../styled-system/css'
+  import { css as css2 } from '../styled-system/css'
 
-  css({ display: "flex" });
-  css2({ flexDirection: "column" }); // this wasn't working before, now it does
+  css({ display: 'flex' })
+  css2({ flexDirection: 'column' }) // this wasn't working before, now it does
   ```
 
 - Updated dependencies [a032375]
@@ -4168,10 +4109,10 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -4232,17 +4173,16 @@ Will now allow you to use the following syntax for token path:
   export default defineConfig({
     // ...
     hooks: {
-      "parser:before": ({ configure }) => {
+      'parser:before': ({ configure }) => {
         configure({
           // ignore the Select.Content entirely
-          matchTag: (tag) => tag !== "Select.Content",
+          matchTag: (tag) => tag !== 'Select.Content',
           // ...or specifically ignore the `position` property
-          matchTagProp: (tag, prop) =>
-            tag === "Select.Content" && prop !== "position",
-        });
+          matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
+        })
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [6b829cab]
@@ -4310,9 +4250,9 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -4320,11 +4260,7 @@ Will now allow you to use the following syntax for token path:
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -4348,21 +4284,21 @@ Will now allow you to use the following syntax for token path:
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -4371,21 +4307,21 @@ Will now allow you to use the following syntax for token path:
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -4411,24 +4347,24 @@ Will now allow you to use the following syntax for token path:
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 - 250b4d11: ### Container Query Theme
@@ -4442,34 +4378,34 @@ Will now allow you to use the following syntax for token path:
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -4553,10 +4489,10 @@ Will now allow you to use the following syntax for token path:
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -4595,54 +4531,39 @@ Will now allow you to use the following syntax for token path:
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -4849,11 +4770,11 @@ Will now allow you to use the following syntax for token path:
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -4873,18 +4794,18 @@ Will now allow you to use the following syntax for token path:
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -4895,8 +4816,8 @@ Will now allow you to use the following syntax for token path:
   ```jsx
   css({
     // This didn't work, but now it does
-    base: { color: "blue" },
-  });
+    base: { color: 'blue' },
+  })
   ```
 
 - Updated dependencies [59fd291c]
@@ -4955,38 +4876,38 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -5112,30 +5033,30 @@ Will now allow you to use the following syntax for token path:
   another file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`
 
   ```ts
-  import { sva } from "../styled-system/css";
-  import { slots } from "./slots";
+  import { sva } from '../styled-system/css'
+  import { slots } from './slots'
 
   const card = sva({
     slots, // ❌ did NOT work -> ✅ will now work as expected
     base: {
       root: {
-        p: "6",
-        m: "4",
-        w: "md",
-        boxShadow: "md",
-        borderRadius: "md",
-        _dark: { bg: "#262626", color: "white" },
+        p: '6',
+        m: '4',
+        w: 'md',
+        boxShadow: 'md',
+        borderRadius: 'md',
+        _dark: { bg: '#262626', color: 'white' },
       },
       content: {
-        textStyle: "lg",
+        textStyle: 'lg',
       },
       title: {
-        textStyle: "xl",
-        fontWeight: "semibold",
-        pb: "2",
+        textStyle: 'xl',
+        fontWeight: 'semibold',
+        pb: '2',
       },
     },
-  });
+  })
   ```
 
 - 840ed66b: Fix an issue with config change detection when using a custom `config.slotRecipes[xxx].jsx` array
@@ -5192,18 +5113,18 @@ Will now allow you to use the following syntax for token path:
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -5216,8 +5137,8 @@ Will now allow you to use the following syntax for token path:
     // here the content property is a valid CSS property, so Panda will try to generate the CSS for it
     // but since it's an URL, it would produce invalid CSS
     // we now check if the property value is an URL and skip it if needed
-    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />;
-  };
+    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />
+  }
   ```
 
 - d81dcbe6: - Fix an issue where recipe variants that clash with utility shorthand don't get generated due to the
@@ -5226,36 +5147,36 @@ Will now allow you to use the following syntax for token path:
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [26e6051a]
@@ -5287,13 +5208,13 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   css({
-    "@container (min-width: token(sizes.xl))": {
-      color: "green.300",
+    '@container (min-width: token(sizes.xl))': {
+      color: 'green.300',
     },
-    "@media (min-width: token(sizes.2xl))": {
-      color: "red.300",
+    '@media (min-width: token(sizes.2xl))': {
+      color: 'red.300',
     },
-  });
+  })
   ```
 
 - Updated dependencies [24ee49a5]
@@ -5345,14 +5266,14 @@ Will now allow you to use the following syntax for token path:
 - 8c76cd0f: - Fix issue where `hideBelow` breakpoints are inclusive of the specified breakpoints
 
   ```jsx
-  css({ hideBelow: "lg" });
+  css({ hideBelow: 'lg' })
   // => @media screen and (max-width: 63.9975em) { background: red; }
   ```
 
   - Support arbitrary breakpoints in `hideBelow` and `hideFrom` utilities
 
   ```jsx
-  css({ hideFrom: "800px" });
+  css({ hideFrom: '800px' })
   // => @media screen and (min-width: 800px) { background: red; }
   ```
 
@@ -5438,10 +5359,10 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   const button = defineSlotRecipe({
-    className: "button",
-    slots: ["root", "icon", "label"],
+    className: 'button',
+    slots: ['root', 'icon', 'label'],
     // ...
-  });
+  })
   ```
 
   will have a default `jsx` property of: `[Button, Button.Root, Button.Icon, Button.Label]`
@@ -5498,42 +5419,42 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - Updated dependencies [95b06bb1]
@@ -5563,13 +5484,13 @@ Will now allow you to use the following syntax for token path:
 - 848936e0: Allow referencing tokens with the `token()` function in media queries or any other CSS at-rule.
 
   ```js
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const className = css({
-    "@media screen and (min-width: token(sizes.4xl))": {
-      color: "green.400",
+    '@media screen and (min-width: token(sizes.4xl))': {
+      color: 'green.400',
     },
-  });
+  })
   ```
 
 - Updated dependencies [26f6982c]
@@ -5622,7 +5543,7 @@ Will now allow you to use the following syntax for token path:
 
   ```css
   * {
-    color: token("colors.magenta", pink);
+    color: token('colors.magenta', pink);
   }
   ```
 
@@ -5731,12 +5652,12 @@ Will now allow you to use the following syntax for token path:
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -5744,33 +5665,33 @@ Will now allow you to use the following syntax for token path:
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -5819,26 +5740,26 @@ Will now allow you to use the following syntax for token path:
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -5902,17 +5823,9 @@ Will now allow you to use the following syntax for token path:
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -5979,7 +5892,7 @@ Will now allow you to use the following syntax for token path:
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -5989,7 +5902,7 @@ Will now allow you to use the following syntax for token path:
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -6025,12 +5938,12 @@ Will now allow you to use the following syntax for token path:
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -6132,11 +6045,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -6153,11 +6066,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -6196,9 +6109,9 @@ export default defineConfig({
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -6206,11 +6119,7 @@ export default defineConfig({
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -6234,21 +6143,21 @@ export default defineConfig({
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -6257,21 +6166,21 @@ export default defineConfig({
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -6297,24 +6206,24 @@ export default defineConfig({
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 - 250b4d11: ### Container Query Theme
@@ -6328,34 +6237,34 @@ export default defineConfig({
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -6439,10 +6348,10 @@ export default defineConfig({
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -6481,54 +6390,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -6735,11 +6629,11 @@ export default defineConfig({
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -6759,18 +6653,18 @@ export default defineConfig({
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -6781,8 +6675,8 @@ export default defineConfig({
   ```jsx
   css({
     // This didn't work, but now it does
-    base: { color: "blue" },
-  });
+    base: { color: 'blue' },
+  })
   ```
 
 - Updated dependencies [59fd291c]
@@ -6841,38 +6735,38 @@ export default defineConfig({
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -6998,30 +6892,30 @@ export default defineConfig({
   another file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`
 
   ```ts
-  import { sva } from "../styled-system/css";
-  import { slots } from "./slots";
+  import { sva } from '../styled-system/css'
+  import { slots } from './slots'
 
   const card = sva({
     slots, // ❌ did NOT work -> ✅ will now work as expected
     base: {
       root: {
-        p: "6",
-        m: "4",
-        w: "md",
-        boxShadow: "md",
-        borderRadius: "md",
-        _dark: { bg: "#262626", color: "white" },
+        p: '6',
+        m: '4',
+        w: 'md',
+        boxShadow: 'md',
+        borderRadius: 'md',
+        _dark: { bg: '#262626', color: 'white' },
       },
       content: {
-        textStyle: "lg",
+        textStyle: 'lg',
       },
       title: {
-        textStyle: "xl",
-        fontWeight: "semibold",
-        pb: "2",
+        textStyle: 'xl',
+        fontWeight: 'semibold',
+        pb: '2',
       },
     },
-  });
+  })
   ```
 
 - 840ed66b: Fix an issue with config change detection when using a custom `config.slotRecipes[xxx].jsx` array
@@ -7078,18 +6972,18 @@ export default defineConfig({
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -7102,8 +6996,8 @@ export default defineConfig({
     // here the content property is a valid CSS property, so Panda will try to generate the CSS for it
     // but since it's an URL, it would produce invalid CSS
     // we now check if the property value is an URL and skip it if needed
-    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />;
-  };
+    return <CopyButton content="https://www.buymeacoffee.com/grizzlycodes" />
+  }
   ```
 
 - d81dcbe6: - Fix an issue where recipe variants that clash with utility shorthand don't get generated due to the
@@ -7112,36 +7006,36 @@ export default defineConfig({
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [26e6051a]
@@ -7173,13 +7067,13 @@ export default defineConfig({
 
   ```ts
   css({
-    "@container (min-width: token(sizes.xl))": {
-      color: "green.300",
+    '@container (min-width: token(sizes.xl))': {
+      color: 'green.300',
     },
-    "@media (min-width: token(sizes.2xl))": {
-      color: "red.300",
+    '@media (min-width: token(sizes.2xl))': {
+      color: 'red.300',
     },
-  });
+  })
   ```
 
 - Updated dependencies [24ee49a5]
@@ -7231,14 +7125,14 @@ export default defineConfig({
 - 8c76cd0f: - Fix issue where `hideBelow` breakpoints are inclusive of the specified breakpoints
 
   ```jsx
-  css({ hideBelow: "lg" });
+  css({ hideBelow: 'lg' })
   // => @media screen and (max-width: 63.9975em) { background: red; }
   ```
 
   - Support arbitrary breakpoints in `hideBelow` and `hideFrom` utilities
 
   ```jsx
-  css({ hideFrom: "800px" });
+  css({ hideFrom: '800px' })
   // => @media screen and (min-width: 800px) { background: red; }
   ```
 
@@ -7324,10 +7218,10 @@ export default defineConfig({
 
   ```ts
   const button = defineSlotRecipe({
-    className: "button",
-    slots: ["root", "icon", "label"],
+    className: 'button',
+    slots: ['root', 'icon', 'label'],
     // ...
-  });
+  })
   ```
 
   will have a default `jsx` property of: `[Button, Button.Root, Button.Icon, Button.Label]`
@@ -7384,42 +7278,42 @@ export default defineConfig({
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - Updated dependencies [95b06bb1]
@@ -7449,13 +7343,13 @@ export default defineConfig({
 - 848936e0: Allow referencing tokens with the `token()` function in media queries or any other CSS at-rule.
 
   ```js
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const className = css({
-    "@media screen and (min-width: token(sizes.4xl))": {
-      color: "green.400",
+    '@media screen and (min-width: token(sizes.4xl))': {
+      color: 'green.400',
     },
-  });
+  })
   ```
 
 - Updated dependencies [26f6982c]
@@ -7508,7 +7402,7 @@ export default defineConfig({
 
   ```css
   * {
-    color: token("colors.magenta", pink);
+    color: token('colors.magenta', pink);
   }
   ```
 
@@ -7617,12 +7511,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -7630,33 +7524,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -7705,26 +7599,26 @@ export default defineConfig({
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -7788,17 +7682,9 @@ export default defineConfig({
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -7865,7 +7751,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -7875,7 +7761,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -7911,12 +7797,12 @@ export default defineConfig({
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/extractor/CHANGELOG.md
+++ b/packages/extractor/CHANGELOG.md
@@ -136,8 +136,8 @@
         {/* ✅ this was fine */}
         <Stack ml="4" icon={<div className="icon" />} />
       </>
-    );
-  };
+    )
+  }
   ```
 
   Now both will be fine again.
@@ -178,11 +178,11 @@
 
   ```ts
   enum Color {
-    Red = "red.400",
-    Blue = "blue.400",
+    Red = 'red.400',
+    Blue = 'blue.400',
   }
 
-  const className = css({ color: Color.Red, backgroundColor: Color["Blue"] });
+  const className = css({ color: Color.Red, backgroundColor: Color['Blue'] })
   ```
 
 ## 0.17.0
@@ -284,20 +284,20 @@
   so this will now work:
 
   ```ts
-  import { css } from "styled-system/css";
+  import { css } from 'styled-system/css'
 
   const paragraphSpacingStyle = css.raw({
-    "&:not(:first-child)": { marginBlockEnd: "1em" },
-  });
+    '&:not(:first-child)': { marginBlockEnd: '1em' },
+  })
 
   export const proseCss = css.raw({
-    maxWidth: "800px",
-    "& p": {
-      "&:not(:first-child)": { marginBlockStart: "1em" },
+    maxWidth: '800px',
+    '& p': {
+      '&:not(:first-child)': { marginBlockStart: '1em' },
     },
-    "& h1": paragraphSpacingStyle,
-    "& h2": paragraphSpacingStyle,
-  });
+    '& h1': paragraphSpacingStyle,
+    '& h2': paragraphSpacingStyle,
+  })
   ```
 
   & use ECMA preset for ts-evaluator: This means that no other globals than those that are defined in the ECMAScript
@@ -305,35 +305,35 @@
   this:
 
   ```ts
-  import { cva } from ".panda/css";
+  import { cva } from '.panda/css'
 
   const variants = () => {
     const spacingTokens = Object.entries({
-      s: "token(spacing.1)",
-      m: "token(spacing.2)",
-      l: "token(spacing.3)",
-    });
+      s: 'token(spacing.1)',
+      m: 'token(spacing.2)',
+      l: 'token(spacing.3)',
+    })
 
     const spacingProps = {
-      px: "paddingX",
-      py: "paddingY",
-    };
+      px: 'paddingX',
+      py: 'paddingY',
+    }
 
     // Generate variants programmatically
     return Object.entries(spacingProps)
       .map(([name, styleProp]) => {
         const variants = spacingTokens
           .map(([variant, token]) => ({ [variant]: { [styleProp]: token } }))
-          .reduce((_agg, kv) => ({ ..._agg, ...kv }));
+          .reduce((_agg, kv) => ({ ..._agg, ...kv }))
 
-        return { [name]: variants };
+        return { [name]: variants }
       })
-      .reduce((_agg, kv) => ({ ..._agg, ...kv }));
-  };
+      .reduce((_agg, kv) => ({ ..._agg, ...kv }))
+  }
 
   const baseStyle = cva({
     variants: variants(),
-  });
+  })
   ```
 
 ## 0.15.0
@@ -345,8 +345,8 @@
 
   ```ts
   const className = css({
-    color: ["black", undefined, "orange", "red"],
-  });
+    color: ['black', undefined, 'orange', 'red'],
+  })
   ```
 
 - 7c1ab170: Fix issue where the `satisfies` would prevent an object from being extracted
@@ -381,12 +381,8 @@
 
   ```tsx
   const CompB = ({ disabled = false }: { disabled: boolean }) => {
-    return (
-      <div className={css({ color: disabled ? "blue" : "yellow" })}>
-        Component B is disabled
-      </div>
-    );
-  };
+    return <div className={css({ color: disabled ? 'blue' : 'yellow' })}>Component B is disabled</div>
+  }
   ```
 
 ## 0.8.0
@@ -458,16 +454,11 @@
 - 21295f2e: Resolve identifier default value from parameter, code like `position` and `inset` here:
 
   ```tsx
-  export const Positioned: React.FC<PositionedProps> = ({
-    children,
-    position = "absolute",
-    inset = 0,
-    ...rest
-  }) => (
+  export const Positioned: React.FC<PositionedProps> = ({ children, position = 'absolute', inset = 0, ...rest }) => (
     <styled.div position={position} inset={inset} {...rest}>
       {children}
     </styled.div>
-  );
+  )
   ```
 
   - @pandacss/logger@0.6.0
@@ -587,16 +578,16 @@
   this was fine:
 
   ```ts
-  const aliased = "green.600";
-  const colorMap = { aliased };
-  const className = css({ color: colorMap["aliased"] });
+  const aliased = 'green.600'
+  const colorMap = { aliased }
+  const className = css({ color: colorMap['aliased'] })
   ```
 
   this was not (weirdly):
 
   ```ts
-  const color = "green.600";
-  const className = css({ color });
+  const color = 'green.600'
+  const className = css({ color })
   ```
 
 - Updated dependencies [f9247e52]
@@ -617,8 +608,8 @@
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`

--- a/packages/fixture/CHANGELOG.md
+++ b/packages/fixture/CHANGELOG.md
@@ -52,9 +52,9 @@
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -62,11 +62,7 @@
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -90,21 +86,21 @@
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -113,21 +109,21 @@
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -168,54 +164,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -555,12 +536,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -568,33 +549,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -641,26 +622,26 @@
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -800,11 +781,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -821,11 +802,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 ## 0.29.1
@@ -844,9 +825,9 @@ export default defineConfig({
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -854,11 +835,7 @@ export default defineConfig({
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -882,21 +859,21 @@ export default defineConfig({
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -905,21 +882,21 @@ export default defineConfig({
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -960,54 +937,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -1347,12 +1309,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -1360,33 +1322,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -1433,26 +1395,26 @@ export default defineConfig({
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/generator/CHANGELOG.md
+++ b/packages/generator/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Patch Changes
 
-- 1c63216: Add a config validation check to prevent using spaces in token keys, show better error logs when there's a CSS parsing error
-- 7e348ae: Fix `splitCssProps` typings, it would sometimes throw `Expression produces a union type that is too complex to represent"`
+- 1c63216: Add a config validation check to prevent using spaces in token keys, show better error logs when there's a
+  CSS parsing error
+- 7e348ae: Fix `splitCssProps` typings, it would sometimes throw
+  `Expression produces a union type that is too complex to represent"`
 - Updated dependencies [64d5144]
 - Updated dependencies [d1516c8]
   - @pandacss/token-dictionary@0.34.0
@@ -26,15 +28,15 @@
   class assigned.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     preflight: {
-      scope: ".my-scope",
-      level: "element", // 'element' | 'parent (default)'
+      scope: '.my-scope',
+      level: 'element', // 'element' | 'parent (default)'
     },
     // ...
-  });
+  })
   ```
 
   This will generate CSS that looks like:
@@ -76,20 +78,20 @@
   export default defaultConfig({
     conditions: {
       extend: {
-        supportHover: ["@media (hover: hover) and (pointer: fine)", "&:hover"],
+        supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
       },
     },
-  });
+  })
   ```
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     _supportHover: {
-      color: "red",
+      color: 'red',
     },
-  });
+  })
   ```
 
   will generate the following CSS:
@@ -160,10 +162,10 @@
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -273,24 +275,24 @@
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -332,54 +334,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -527,18 +514,18 @@
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
   ```
 
   now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will not throw there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will not throw there is no config token for 'abc'
   ```
 
   Instead, if you want the v.19.0 behavior, you can use the new `config.strictPropertyValues` option. You can combine it
@@ -549,79 +536,79 @@
 
   ```ts
   type StrictableProps =
-    | "alignContent"
-    | "alignItems"
-    | "alignSelf"
-    | "all"
-    | "animationComposition"
-    | "animationDirection"
-    | "animationFillMode"
-    | "appearance"
-    | "backfaceVisibility"
-    | "backgroundAttachment"
-    | "backgroundClip"
-    | "borderCollapse"
-    | "border"
-    | "borderBlock"
-    | "borderBlockEnd"
-    | "borderBlockStart"
-    | "borderBottom"
-    | "borderInline"
-    | "borderInlineEnd"
-    | "borderInlineStart"
-    | "borderLeft"
-    | "borderRight"
-    | "borderTop"
-    | "borderBlockEndStyle"
-    | "borderBlockStartStyle"
-    | "borderBlockStyle"
-    | "borderBottomStyle"
-    | "borderInlineEndStyle"
-    | "borderInlineStartStyle"
-    | "borderInlineStyle"
-    | "borderLeftStyle"
-    | "borderRightStyle"
-    | "borderTopStyle"
-    | "boxDecorationBreak"
-    | "boxSizing"
-    | "breakAfter"
-    | "breakBefore"
-    | "breakInside"
-    | "captionSide"
-    | "clear"
-    | "columnFill"
-    | "columnRuleStyle"
-    | "contentVisibility"
-    | "direction"
-    | "display"
-    | "emptyCells"
-    | "flexDirection"
-    | "flexWrap"
-    | "float"
-    | "fontKerning"
-    | "forcedColorAdjust"
-    | "isolation"
-    | "lineBreak"
-    | "mixBlendMode"
-    | "objectFit"
-    | "outlineStyle"
-    | "overflow"
-    | "overflowX"
-    | "overflowY"
-    | "overflowBlock"
-    | "overflowInline"
-    | "overflowWrap"
-    | "pointerEvents"
-    | "position"
-    | "resize"
-    | "scrollBehavior"
-    | "touchAction"
-    | "transformBox"
-    | "transformStyle"
-    | "userSelect"
-    | "visibility"
-    | "wordBreak"
-    | "writingMode";
+    | 'alignContent'
+    | 'alignItems'
+    | 'alignSelf'
+    | 'all'
+    | 'animationComposition'
+    | 'animationDirection'
+    | 'animationFillMode'
+    | 'appearance'
+    | 'backfaceVisibility'
+    | 'backgroundAttachment'
+    | 'backgroundClip'
+    | 'borderCollapse'
+    | 'border'
+    | 'borderBlock'
+    | 'borderBlockEnd'
+    | 'borderBlockStart'
+    | 'borderBottom'
+    | 'borderInline'
+    | 'borderInlineEnd'
+    | 'borderInlineStart'
+    | 'borderLeft'
+    | 'borderRight'
+    | 'borderTop'
+    | 'borderBlockEndStyle'
+    | 'borderBlockStartStyle'
+    | 'borderBlockStyle'
+    | 'borderBottomStyle'
+    | 'borderInlineEndStyle'
+    | 'borderInlineStartStyle'
+    | 'borderInlineStyle'
+    | 'borderLeftStyle'
+    | 'borderRightStyle'
+    | 'borderTopStyle'
+    | 'boxDecorationBreak'
+    | 'boxSizing'
+    | 'breakAfter'
+    | 'breakBefore'
+    | 'breakInside'
+    | 'captionSide'
+    | 'clear'
+    | 'columnFill'
+    | 'columnRuleStyle'
+    | 'contentVisibility'
+    | 'direction'
+    | 'display'
+    | 'emptyCells'
+    | 'flexDirection'
+    | 'flexWrap'
+    | 'float'
+    | 'fontKerning'
+    | 'forcedColorAdjust'
+    | 'isolation'
+    | 'lineBreak'
+    | 'mixBlendMode'
+    | 'objectFit'
+    | 'outlineStyle'
+    | 'overflow'
+    | 'overflowX'
+    | 'overflowY'
+    | 'overflowBlock'
+    | 'overflowInline'
+    | 'overflowWrap'
+    | 'pointerEvents'
+    | 'position'
+    | 'resize'
+    | 'scrollBehavior'
+    | 'touchAction'
+    | 'transformBox'
+    | 'transformStyle'
+    | 'userSelect'
+    | 'visibility'
+    | 'wordBreak'
+    | 'writingMode'
   ```
 
 - Updated dependencies [657ca5da]
@@ -692,38 +679,38 @@
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -870,17 +857,17 @@
 
   ```ts
   css({
-    bg: "[#3B00B9]", // ✅ was okay
+    bg: '[#3B00B9]', // ✅ was okay
     _dark: {
       // ✅ was okay
-      color: "[#3B00B9]",
+      color: '[#3B00B9]',
     },
 
     // ❌ Not okay, will be fixed in this patch
     color: {
-      _dark: "[#3B00B9]",
+      _dark: '[#3B00B9]',
     },
-  });
+  })
   ```
 
 - 647f05c9: Fix a CSS generation issue with `config.strictTokens` when using the `[xxx]` escape-hatch syntax with `!` or
@@ -888,9 +875,9 @@
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -931,18 +918,18 @@
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -976,49 +963,49 @@
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - 052283c2: Fix vue `styled` factory internal class merging, for example:
 
   ```vue
   <script setup>
-  import { styled } from "../styled-system/jsx";
+  import { styled } from '../styled-system/jsx'
 
-  const StyledButton = styled("button", {
+  const StyledButton = styled('button', {
     base: {
-      bgColor: "red.300",
+      bgColor: 'red.300',
     },
-  });
+  })
   </script>
   <template>
     <StyledButton id="test" class="test">
@@ -1087,18 +1074,18 @@
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ didn't throw even though 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ didn't throw even though 'abc' is not a valid value for 'display'
   ```
 
   Now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will throw since 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will throw since 'abc' is not a valid value for 'display'
   ```
 
 - Updated dependencies [61831040]
@@ -1157,28 +1144,22 @@
 - b7cb2073: Add a `splitCssProps` utility exported from the {outdir}/jsx entrypoint
 
   ```tsx
-  import { splitCssProps, styled } from "../styled-system/jsx";
-  import type { HTMLStyledProps } from "../styled-system/types";
+  import { splitCssProps, styled } from '../styled-system/jsx'
+  import type { HTMLStyledProps } from '../styled-system/types'
 
-  function SplitComponent({ children, ...props }: HTMLStyledProps<"div">) {
-    const [cssProps, restProps] = splitCssProps(props);
+  function SplitComponent({ children, ...props }: HTMLStyledProps<'div'>) {
+    const [cssProps, restProps] = splitCssProps(props)
     return (
-      <styled.div
-        {...restProps}
-        className={css(
-          { display: "flex", height: "20", width: "20" },
-          cssProps,
-        )}
-      >
+      <styled.div {...restProps} className={css({ display: 'flex', height: '20', width: '20' }, cssProps)}>
         {children}
       </styled.div>
-    );
+    )
   }
 
   // Usage
 
   function App() {
-    return <SplitComponent margin="2">Click me</SplitComponent>;
+    return <SplitComponent margin="2">Click me</SplitComponent>
   }
   ```
 
@@ -1271,16 +1252,16 @@
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -1293,32 +1274,32 @@
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 - fbf062c6: Added a new type to extract variants out of styled components
 
   ```tsx
-  import { StyledVariantProps } from "../styled-system/jsx";
+  import { StyledVariantProps } from '../styled-system/jsx'
 
-  const Button = styled("button", {
-    base: { color: "black" },
+  const Button = styled('button', {
+    base: { color: 'black' },
     variants: {
       state: {
-        error: { color: "red" },
-        success: { color: "green" },
+        error: { color: 'red' },
+        success: { color: 'green' },
       },
     },
-  });
+  })
 
-  type ButtonVariantProps = StyledVariantProps<typeof Button>;
+  type ButtonVariantProps = StyledVariantProps<typeof Button>
   //   ^ { state?: 'error' | 'success' | undefined }
   ```
 
@@ -1420,9 +1401,9 @@
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -1430,16 +1411,16 @@
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -1447,17 +1428,17 @@
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -1465,20 +1446,19 @@
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
   - @pandacss/types@0.15.4
@@ -1501,42 +1481,42 @@
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - 1eb31118: Automatically allow overriding config recipe compoundVariants styles within the `styled` JSX factory,
@@ -1546,22 +1526,22 @@
 
   ```ts file="panda.config.ts"
   const button = defineRecipe({
-    className: "btn",
-    base: { color: "green", fontSize: "16px" },
+    className: 'btn',
+    base: { color: 'green', fontSize: '16px' },
     variants: {
-      size: { small: { fontSize: "14px" } },
+      size: { small: { fontSize: '14px' } },
     },
-    compoundVariants: [{ size: "small", css: { color: "blue" } }],
-  });
+    compoundVariants: [{ size: 'small', css: { color: 'blue' } }],
+  })
   ```
 
   This would previously not merge the `color` property overrides, but now it does:
 
   ```tsx file="example.tsx"
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button);
+  const Button = styled('button', button)
 
   function App() {
     return (
@@ -1570,7 +1550,7 @@
           Click me
         </Button>
       </>
-    );
+    )
   }
   ```
 
@@ -1749,8 +1729,8 @@
     passed in. This is to allow the `css` function to merge the styles correctly.
 
   ```tsx
-  import { css } from "../styled-system/css";
-  css({ mx: "3", paddingTop: "4" }, { mx: "10", pt: "6" }); // => mx_10 pt_6
+  import { css } from '../styled-system/css'
+  css({ mx: '3', paddingTop: '4' }, { mx: '10', pt: '6' }) // => mx_10 pt_6
   ```
 
   > ⚠️ This approach should be preferred for merging styles over the current `cx` function, which will be reverted to
@@ -1775,29 +1755,26 @@
   be merged correctly.
 
   ```tsx title="src/components/Button.tsx"
-  import { css } from "../../styled-system/css";
+  import { css } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
-    const className = css(
-      { display: "flex", alignItem: "center", color: "black" },
-      cssProp,
-    );
-    return <button className={className}>{children}</button>;
-  };
+    const className = css({ display: 'flex', alignItem: 'center', color: 'black' }, cssProp)
+    return <button className={className}>{children}</button>
+  }
   ```
 
   Then you can use the `Button` component like this:
 
   ```tsx title="src/app/page.tsx"
-  import { css } from "../../styled-system/css";
-  import { Button, Thingy } from "./Button";
+  import { css } from '../../styled-system/css'
+  import { Button, Thingy } from './Button'
 
   export default function Page() {
     return (
-      <Button css={{ color: "pink", _hover: { color: "red" } }}>
+      <Button css={{ color: 'pink', _hover: { color: 'red' } }}>
         will result in `class="d_flex items_center text_pink hover:text_red"`
       </Button>
-    );
+    )
   }
   ```
 
@@ -1809,51 +1786,51 @@
   **Pattern Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { hstack } from "../../styled-system/patterns";
-  import { css, cva } from "../../styled-system/css";
+  import { hstack } from '../../styled-system/patterns'
+  import { css, cva } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
     // using the flex pattern
     const hstackProps = hstack.raw({
-      border: "1px solid",
-      _hover: { color: "blue.400" },
-    });
+      border: '1px solid',
+      _hover: { color: 'blue.400' },
+    })
 
     // merging the styles
-    const className = css(hstackProps, cssProp);
+    const className = css(hstackProps, cssProp)
 
-    return <button className={className}>{children}</button>;
-  };
+    return <button className={className}>{children}</button>
+  }
   ```
 
   **CVA Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { css, cva } from "../../styled-system/css";
+  import { css, cva } from '../../styled-system/css'
 
   const buttonRecipe = cva({
-    base: { display: "flex", fontSize: "lg" },
+    base: { display: 'flex', fontSize: 'lg' },
     variants: {
       variant: {
-        primary: { color: "white", backgroundColor: "blue.500" },
+        primary: { color: 'white', backgroundColor: 'blue.500' },
       },
     },
-  });
+  })
 
   export const Button = ({ css: cssProp = {}, children }) => {
     const className = css(
       // using the button recipe
-      buttonRecipe.raw({ variant: "primary" }),
+      buttonRecipe.raw({ variant: 'primary' }),
 
       // adding style overrides (internal)
-      { _hover: { color: "blue.400" } },
+      { _hover: { color: 'blue.400' } },
 
       // adding style overrides (external)
       cssProp,
-    );
+    )
 
-    return <button className={className}>{props.children}</button>;
-  };
+    return <button className={className}>{props.children}</button>
+  }
   ```
 
 - 36fdff89: Fix bug in generated js code for atomic slot recipe produce where `splitVariantProps` didn't work without
@@ -1900,14 +1877,7 @@
   Example:
 
   ```tsx
-  <h1
-    className={cx(
-      css({ mx: "3", paddingTop: "4" }),
-      css({ mx: "10", pt: "6" }),
-    )}
-  >
-    Will result in "mx_10 pt_6"
-  </h1>
+  <h1 className={cx(css({ mx: '3', paddingTop: '4' }), css({ mx: '10', pt: '6' }))}>Will result in "mx_10 pt_6"</h1>
   ```
 
 - dfb3f85f: Add missing svg props types
@@ -1952,12 +1922,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -1965,33 +1935,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -2056,26 +2026,26 @@
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -2173,17 +2143,9 @@
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -2267,7 +2229,7 @@
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -2277,7 +2239,7 @@
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -2315,8 +2277,8 @@
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -2348,12 +2310,12 @@
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -2473,11 +2435,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - 49c760cd: Fix issue where responsive array in css and cva doesn't generate the correct classname
@@ -2495,11 +2457,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -2538,24 +2500,24 @@ export default defineConfig({
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -2597,54 +2559,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -2792,18 +2739,18 @@ export default defineConfig({
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
   ```
 
   now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will not throw there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will not throw there is no config token for 'abc'
   ```
 
   Instead, if you want the v.19.0 behavior, you can use the new `config.strictPropertyValues` option. You can combine it
@@ -2814,79 +2761,79 @@ export default defineConfig({
 
   ```ts
   type StrictableProps =
-    | "alignContent"
-    | "alignItems"
-    | "alignSelf"
-    | "all"
-    | "animationComposition"
-    | "animationDirection"
-    | "animationFillMode"
-    | "appearance"
-    | "backfaceVisibility"
-    | "backgroundAttachment"
-    | "backgroundClip"
-    | "borderCollapse"
-    | "border"
-    | "borderBlock"
-    | "borderBlockEnd"
-    | "borderBlockStart"
-    | "borderBottom"
-    | "borderInline"
-    | "borderInlineEnd"
-    | "borderInlineStart"
-    | "borderLeft"
-    | "borderRight"
-    | "borderTop"
-    | "borderBlockEndStyle"
-    | "borderBlockStartStyle"
-    | "borderBlockStyle"
-    | "borderBottomStyle"
-    | "borderInlineEndStyle"
-    | "borderInlineStartStyle"
-    | "borderInlineStyle"
-    | "borderLeftStyle"
-    | "borderRightStyle"
-    | "borderTopStyle"
-    | "boxDecorationBreak"
-    | "boxSizing"
-    | "breakAfter"
-    | "breakBefore"
-    | "breakInside"
-    | "captionSide"
-    | "clear"
-    | "columnFill"
-    | "columnRuleStyle"
-    | "contentVisibility"
-    | "direction"
-    | "display"
-    | "emptyCells"
-    | "flexDirection"
-    | "flexWrap"
-    | "float"
-    | "fontKerning"
-    | "forcedColorAdjust"
-    | "isolation"
-    | "lineBreak"
-    | "mixBlendMode"
-    | "objectFit"
-    | "outlineStyle"
-    | "overflow"
-    | "overflowX"
-    | "overflowY"
-    | "overflowBlock"
-    | "overflowInline"
-    | "overflowWrap"
-    | "pointerEvents"
-    | "position"
-    | "resize"
-    | "scrollBehavior"
-    | "touchAction"
-    | "transformBox"
-    | "transformStyle"
-    | "userSelect"
-    | "visibility"
-    | "wordBreak"
-    | "writingMode";
+    | 'alignContent'
+    | 'alignItems'
+    | 'alignSelf'
+    | 'all'
+    | 'animationComposition'
+    | 'animationDirection'
+    | 'animationFillMode'
+    | 'appearance'
+    | 'backfaceVisibility'
+    | 'backgroundAttachment'
+    | 'backgroundClip'
+    | 'borderCollapse'
+    | 'border'
+    | 'borderBlock'
+    | 'borderBlockEnd'
+    | 'borderBlockStart'
+    | 'borderBottom'
+    | 'borderInline'
+    | 'borderInlineEnd'
+    | 'borderInlineStart'
+    | 'borderLeft'
+    | 'borderRight'
+    | 'borderTop'
+    | 'borderBlockEndStyle'
+    | 'borderBlockStartStyle'
+    | 'borderBlockStyle'
+    | 'borderBottomStyle'
+    | 'borderInlineEndStyle'
+    | 'borderInlineStartStyle'
+    | 'borderInlineStyle'
+    | 'borderLeftStyle'
+    | 'borderRightStyle'
+    | 'borderTopStyle'
+    | 'boxDecorationBreak'
+    | 'boxSizing'
+    | 'breakAfter'
+    | 'breakBefore'
+    | 'breakInside'
+    | 'captionSide'
+    | 'clear'
+    | 'columnFill'
+    | 'columnRuleStyle'
+    | 'contentVisibility'
+    | 'direction'
+    | 'display'
+    | 'emptyCells'
+    | 'flexDirection'
+    | 'flexWrap'
+    | 'float'
+    | 'fontKerning'
+    | 'forcedColorAdjust'
+    | 'isolation'
+    | 'lineBreak'
+    | 'mixBlendMode'
+    | 'objectFit'
+    | 'outlineStyle'
+    | 'overflow'
+    | 'overflowX'
+    | 'overflowY'
+    | 'overflowBlock'
+    | 'overflowInline'
+    | 'overflowWrap'
+    | 'pointerEvents'
+    | 'position'
+    | 'resize'
+    | 'scrollBehavior'
+    | 'touchAction'
+    | 'transformBox'
+    | 'transformStyle'
+    | 'userSelect'
+    | 'visibility'
+    | 'wordBreak'
+    | 'writingMode'
   ```
 
 - Updated dependencies [657ca5da]
@@ -2957,38 +2904,38 @@ export default defineConfig({
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -3135,17 +3082,17 @@ export default defineConfig({
 
   ```ts
   css({
-    bg: "[#3B00B9]", // ✅ was okay
+    bg: '[#3B00B9]', // ✅ was okay
     _dark: {
       // ✅ was okay
-      color: "[#3B00B9]",
+      color: '[#3B00B9]',
     },
 
     // ❌ Not okay, will be fixed in this patch
     color: {
-      _dark: "[#3B00B9]",
+      _dark: '[#3B00B9]',
     },
-  });
+  })
   ```
 
 - 647f05c9: Fix a CSS generation issue with `config.strictTokens` when using the `[xxx]` escape-hatch syntax with `!` or
@@ -3153,9 +3100,9 @@ export default defineConfig({
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -3196,18 +3143,18 @@ export default defineConfig({
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -3241,49 +3188,49 @@ export default defineConfig({
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - 052283c2: Fix vue `styled` factory internal class merging, for example:
 
   ```vue
   <script setup>
-  import { styled } from "../styled-system/jsx";
+  import { styled } from '../styled-system/jsx'
 
-  const StyledButton = styled("button", {
+  const StyledButton = styled('button', {
     base: {
-      bgColor: "red.300",
+      bgColor: 'red.300',
     },
-  });
+  })
   </script>
   <template>
     <StyledButton id="test" class="test">
@@ -3352,18 +3299,18 @@ export default defineConfig({
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ didn't throw even though 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ didn't throw even though 'abc' is not a valid value for 'display'
   ```
 
   Now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will throw since 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will throw since 'abc' is not a valid value for 'display'
   ```
 
 - Updated dependencies [61831040]
@@ -3422,28 +3369,22 @@ export default defineConfig({
 - b7cb2073: Add a `splitCssProps` utility exported from the {outdir}/jsx entrypoint
 
   ```tsx
-  import { splitCssProps, styled } from "../styled-system/jsx";
-  import type { HTMLStyledProps } from "../styled-system/types";
+  import { splitCssProps, styled } from '../styled-system/jsx'
+  import type { HTMLStyledProps } from '../styled-system/types'
 
-  function SplitComponent({ children, ...props }: HTMLStyledProps<"div">) {
-    const [cssProps, restProps] = splitCssProps(props);
+  function SplitComponent({ children, ...props }: HTMLStyledProps<'div'>) {
+    const [cssProps, restProps] = splitCssProps(props)
     return (
-      <styled.div
-        {...restProps}
-        className={css(
-          { display: "flex", height: "20", width: "20" },
-          cssProps,
-        )}
-      >
+      <styled.div {...restProps} className={css({ display: 'flex', height: '20', width: '20' }, cssProps)}>
         {children}
       </styled.div>
-    );
+    )
   }
 
   // Usage
 
   function App() {
-    return <SplitComponent margin="2">Click me</SplitComponent>;
+    return <SplitComponent margin="2">Click me</SplitComponent>
   }
   ```
 
@@ -3536,16 +3477,16 @@ export default defineConfig({
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -3558,32 +3499,32 @@ export default defineConfig({
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 - fbf062c6: Added a new type to extract variants out of styled components
 
   ```tsx
-  import { StyledVariantProps } from "../styled-system/jsx";
+  import { StyledVariantProps } from '../styled-system/jsx'
 
-  const Button = styled("button", {
-    base: { color: "black" },
+  const Button = styled('button', {
+    base: { color: 'black' },
     variants: {
       state: {
-        error: { color: "red" },
-        success: { color: "green" },
+        error: { color: 'red' },
+        success: { color: 'green' },
       },
     },
-  });
+  })
 
-  type ButtonVariantProps = StyledVariantProps<typeof Button>;
+  type ButtonVariantProps = StyledVariantProps<typeof Button>
   //   ^ { state?: 'error' | 'success' | undefined }
   ```
 
@@ -3685,9 +3626,9 @@ export default defineConfig({
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -3695,16 +3636,16 @@ export default defineConfig({
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -3712,17 +3653,17 @@ export default defineConfig({
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -3730,20 +3671,19 @@ export default defineConfig({
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
   - @pandacss/types@0.15.4
@@ -3766,42 +3706,42 @@ export default defineConfig({
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - 1eb31118: Automatically allow overriding config recipe compoundVariants styles within the `styled` JSX factory,
@@ -3811,22 +3751,22 @@ export default defineConfig({
 
   ```ts file="panda.config.ts"
   const button = defineRecipe({
-    className: "btn",
-    base: { color: "green", fontSize: "16px" },
+    className: 'btn',
+    base: { color: 'green', fontSize: '16px' },
     variants: {
-      size: { small: { fontSize: "14px" } },
+      size: { small: { fontSize: '14px' } },
     },
-    compoundVariants: [{ size: "small", css: { color: "blue" } }],
-  });
+    compoundVariants: [{ size: 'small', css: { color: 'blue' } }],
+  })
   ```
 
   This would previously not merge the `color` property overrides, but now it does:
 
   ```tsx file="example.tsx"
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button);
+  const Button = styled('button', button)
 
   function App() {
     return (
@@ -3835,7 +3775,7 @@ export default defineConfig({
           Click me
         </Button>
       </>
-    );
+    )
   }
   ```
 
@@ -4014,8 +3954,8 @@ export default defineConfig({
     passed in. This is to allow the `css` function to merge the styles correctly.
 
   ```tsx
-  import { css } from "../styled-system/css";
-  css({ mx: "3", paddingTop: "4" }, { mx: "10", pt: "6" }); // => mx_10 pt_6
+  import { css } from '../styled-system/css'
+  css({ mx: '3', paddingTop: '4' }, { mx: '10', pt: '6' }) // => mx_10 pt_6
   ```
 
   > ⚠️ This approach should be preferred for merging styles over the current `cx` function, which will be reverted to
@@ -4040,29 +3980,26 @@ export default defineConfig({
   be merged correctly.
 
   ```tsx title="src/components/Button.tsx"
-  import { css } from "../../styled-system/css";
+  import { css } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
-    const className = css(
-      { display: "flex", alignItem: "center", color: "black" },
-      cssProp,
-    );
-    return <button className={className}>{children}</button>;
-  };
+    const className = css({ display: 'flex', alignItem: 'center', color: 'black' }, cssProp)
+    return <button className={className}>{children}</button>
+  }
   ```
 
   Then you can use the `Button` component like this:
 
   ```tsx title="src/app/page.tsx"
-  import { css } from "../../styled-system/css";
-  import { Button, Thingy } from "./Button";
+  import { css } from '../../styled-system/css'
+  import { Button, Thingy } from './Button'
 
   export default function Page() {
     return (
-      <Button css={{ color: "pink", _hover: { color: "red" } }}>
+      <Button css={{ color: 'pink', _hover: { color: 'red' } }}>
         will result in `class="d_flex items_center text_pink hover:text_red"`
       </Button>
-    );
+    )
   }
   ```
 
@@ -4074,51 +4011,51 @@ export default defineConfig({
   **Pattern Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { hstack } from "../../styled-system/patterns";
-  import { css, cva } from "../../styled-system/css";
+  import { hstack } from '../../styled-system/patterns'
+  import { css, cva } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
     // using the flex pattern
     const hstackProps = hstack.raw({
-      border: "1px solid",
-      _hover: { color: "blue.400" },
-    });
+      border: '1px solid',
+      _hover: { color: 'blue.400' },
+    })
 
     // merging the styles
-    const className = css(hstackProps, cssProp);
+    const className = css(hstackProps, cssProp)
 
-    return <button className={className}>{children}</button>;
-  };
+    return <button className={className}>{children}</button>
+  }
   ```
 
   **CVA Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { css, cva } from "../../styled-system/css";
+  import { css, cva } from '../../styled-system/css'
 
   const buttonRecipe = cva({
-    base: { display: "flex", fontSize: "lg" },
+    base: { display: 'flex', fontSize: 'lg' },
     variants: {
       variant: {
-        primary: { color: "white", backgroundColor: "blue.500" },
+        primary: { color: 'white', backgroundColor: 'blue.500' },
       },
     },
-  });
+  })
 
   export const Button = ({ css: cssProp = {}, children }) => {
     const className = css(
       // using the button recipe
-      buttonRecipe.raw({ variant: "primary" }),
+      buttonRecipe.raw({ variant: 'primary' }),
 
       // adding style overrides (internal)
-      { _hover: { color: "blue.400" } },
+      { _hover: { color: 'blue.400' } },
 
       // adding style overrides (external)
       cssProp,
-    );
+    )
 
-    return <button className={className}>{props.children}</button>;
-  };
+    return <button className={className}>{props.children}</button>
+  }
   ```
 
 - 36fdff89: Fix bug in generated js code for atomic slot recipe produce where `splitVariantProps` didn't work without
@@ -4165,14 +4102,7 @@ export default defineConfig({
   Example:
 
   ```tsx
-  <h1
-    className={cx(
-      css({ mx: "3", paddingTop: "4" }),
-      css({ mx: "10", pt: "6" }),
-    )}
-  >
-    Will result in "mx_10 pt_6"
-  </h1>
+  <h1 className={cx(css({ mx: '3', paddingTop: '4' }), css({ mx: '10', pt: '6' }))}>Will result in "mx_10 pt_6"</h1>
   ```
 
 - dfb3f85f: Add missing svg props types
@@ -4217,12 +4147,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -4230,33 +4160,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -4321,26 +4251,26 @@ export default defineConfig({
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -4438,17 +4368,9 @@ export default defineConfig({
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -4532,7 +4454,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -4542,7 +4464,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -4580,8 +4502,8 @@ export default defineConfig({
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -4613,12 +4535,12 @@ export default defineConfig({
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -4741,20 +4663,20 @@ Will now allow you to use the following syntax for token path:
   export default defaultConfig({
     conditions: {
       extend: {
-        supportHover: ["@media (hover: hover) and (pointer: fine)", "&:hover"],
+        supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
       },
     },
-  });
+  })
   ```
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     _supportHover: {
-      color: "red",
+      color: 'red',
     },
-  });
+  })
   ```
 
   will generate the following CSS:
@@ -4825,10 +4747,10 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -4938,24 +4860,24 @@ Will now allow you to use the following syntax for token path:
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -4997,54 +4919,39 @@ Will now allow you to use the following syntax for token path:
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -5192,18 +5099,18 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
   ```
 
   now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will not throw there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will not throw there is no config token for 'abc'
   ```
 
   Instead, if you want the v.19.0 behavior, you can use the new `config.strictPropertyValues` option. You can combine it
@@ -5214,79 +5121,79 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   type StrictableProps =
-    | "alignContent"
-    | "alignItems"
-    | "alignSelf"
-    | "all"
-    | "animationComposition"
-    | "animationDirection"
-    | "animationFillMode"
-    | "appearance"
-    | "backfaceVisibility"
-    | "backgroundAttachment"
-    | "backgroundClip"
-    | "borderCollapse"
-    | "border"
-    | "borderBlock"
-    | "borderBlockEnd"
-    | "borderBlockStart"
-    | "borderBottom"
-    | "borderInline"
-    | "borderInlineEnd"
-    | "borderInlineStart"
-    | "borderLeft"
-    | "borderRight"
-    | "borderTop"
-    | "borderBlockEndStyle"
-    | "borderBlockStartStyle"
-    | "borderBlockStyle"
-    | "borderBottomStyle"
-    | "borderInlineEndStyle"
-    | "borderInlineStartStyle"
-    | "borderInlineStyle"
-    | "borderLeftStyle"
-    | "borderRightStyle"
-    | "borderTopStyle"
-    | "boxDecorationBreak"
-    | "boxSizing"
-    | "breakAfter"
-    | "breakBefore"
-    | "breakInside"
-    | "captionSide"
-    | "clear"
-    | "columnFill"
-    | "columnRuleStyle"
-    | "contentVisibility"
-    | "direction"
-    | "display"
-    | "emptyCells"
-    | "flexDirection"
-    | "flexWrap"
-    | "float"
-    | "fontKerning"
-    | "forcedColorAdjust"
-    | "isolation"
-    | "lineBreak"
-    | "mixBlendMode"
-    | "objectFit"
-    | "outlineStyle"
-    | "overflow"
-    | "overflowX"
-    | "overflowY"
-    | "overflowBlock"
-    | "overflowInline"
-    | "overflowWrap"
-    | "pointerEvents"
-    | "position"
-    | "resize"
-    | "scrollBehavior"
-    | "touchAction"
-    | "transformBox"
-    | "transformStyle"
-    | "userSelect"
-    | "visibility"
-    | "wordBreak"
-    | "writingMode";
+    | 'alignContent'
+    | 'alignItems'
+    | 'alignSelf'
+    | 'all'
+    | 'animationComposition'
+    | 'animationDirection'
+    | 'animationFillMode'
+    | 'appearance'
+    | 'backfaceVisibility'
+    | 'backgroundAttachment'
+    | 'backgroundClip'
+    | 'borderCollapse'
+    | 'border'
+    | 'borderBlock'
+    | 'borderBlockEnd'
+    | 'borderBlockStart'
+    | 'borderBottom'
+    | 'borderInline'
+    | 'borderInlineEnd'
+    | 'borderInlineStart'
+    | 'borderLeft'
+    | 'borderRight'
+    | 'borderTop'
+    | 'borderBlockEndStyle'
+    | 'borderBlockStartStyle'
+    | 'borderBlockStyle'
+    | 'borderBottomStyle'
+    | 'borderInlineEndStyle'
+    | 'borderInlineStartStyle'
+    | 'borderInlineStyle'
+    | 'borderLeftStyle'
+    | 'borderRightStyle'
+    | 'borderTopStyle'
+    | 'boxDecorationBreak'
+    | 'boxSizing'
+    | 'breakAfter'
+    | 'breakBefore'
+    | 'breakInside'
+    | 'captionSide'
+    | 'clear'
+    | 'columnFill'
+    | 'columnRuleStyle'
+    | 'contentVisibility'
+    | 'direction'
+    | 'display'
+    | 'emptyCells'
+    | 'flexDirection'
+    | 'flexWrap'
+    | 'float'
+    | 'fontKerning'
+    | 'forcedColorAdjust'
+    | 'isolation'
+    | 'lineBreak'
+    | 'mixBlendMode'
+    | 'objectFit'
+    | 'outlineStyle'
+    | 'overflow'
+    | 'overflowX'
+    | 'overflowY'
+    | 'overflowBlock'
+    | 'overflowInline'
+    | 'overflowWrap'
+    | 'pointerEvents'
+    | 'position'
+    | 'resize'
+    | 'scrollBehavior'
+    | 'touchAction'
+    | 'transformBox'
+    | 'transformStyle'
+    | 'userSelect'
+    | 'visibility'
+    | 'wordBreak'
+    | 'writingMode'
   ```
 
 - Updated dependencies [657ca5da]
@@ -5357,38 +5264,38 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -5535,17 +5442,17 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   css({
-    bg: "[#3B00B9]", // ✅ was okay
+    bg: '[#3B00B9]', // ✅ was okay
     _dark: {
       // ✅ was okay
-      color: "[#3B00B9]",
+      color: '[#3B00B9]',
     },
 
     // ❌ Not okay, will be fixed in this patch
     color: {
-      _dark: "[#3B00B9]",
+      _dark: '[#3B00B9]',
     },
-  });
+  })
   ```
 
 - 647f05c9: Fix a CSS generation issue with `config.strictTokens` when using the `[xxx]` escape-hatch syntax with `!` or
@@ -5553,9 +5460,9 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -5596,18 +5503,18 @@ Will now allow you to use the following syntax for token path:
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -5641,49 +5548,49 @@ Will now allow you to use the following syntax for token path:
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - 052283c2: Fix vue `styled` factory internal class merging, for example:
 
   ```vue
   <script setup>
-  import { styled } from "../styled-system/jsx";
+  import { styled } from '../styled-system/jsx'
 
-  const StyledButton = styled("button", {
+  const StyledButton = styled('button', {
     base: {
-      bgColor: "red.300",
+      bgColor: 'red.300',
     },
-  });
+  })
   </script>
   <template>
     <StyledButton id="test" class="test">
@@ -5752,18 +5659,18 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ didn't throw even though 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ didn't throw even though 'abc' is not a valid value for 'display'
   ```
 
   Now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will throw since 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will throw since 'abc' is not a valid value for 'display'
   ```
 
 - Updated dependencies [61831040]
@@ -5822,28 +5729,22 @@ Will now allow you to use the following syntax for token path:
 - b7cb2073: Add a `splitCssProps` utility exported from the {outdir}/jsx entrypoint
 
   ```tsx
-  import { splitCssProps, styled } from "../styled-system/jsx";
-  import type { HTMLStyledProps } from "../styled-system/types";
+  import { splitCssProps, styled } from '../styled-system/jsx'
+  import type { HTMLStyledProps } from '../styled-system/types'
 
-  function SplitComponent({ children, ...props }: HTMLStyledProps<"div">) {
-    const [cssProps, restProps] = splitCssProps(props);
+  function SplitComponent({ children, ...props }: HTMLStyledProps<'div'>) {
+    const [cssProps, restProps] = splitCssProps(props)
     return (
-      <styled.div
-        {...restProps}
-        className={css(
-          { display: "flex", height: "20", width: "20" },
-          cssProps,
-        )}
-      >
+      <styled.div {...restProps} className={css({ display: 'flex', height: '20', width: '20' }, cssProps)}>
         {children}
       </styled.div>
-    );
+    )
   }
 
   // Usage
 
   function App() {
-    return <SplitComponent margin="2">Click me</SplitComponent>;
+    return <SplitComponent margin="2">Click me</SplitComponent>
   }
   ```
 
@@ -5936,16 +5837,16 @@ Will now allow you to use the following syntax for token path:
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -5958,32 +5859,32 @@ Will now allow you to use the following syntax for token path:
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 - fbf062c6: Added a new type to extract variants out of styled components
 
   ```tsx
-  import { StyledVariantProps } from "../styled-system/jsx";
+  import { StyledVariantProps } from '../styled-system/jsx'
 
-  const Button = styled("button", {
-    base: { color: "black" },
+  const Button = styled('button', {
+    base: { color: 'black' },
     variants: {
       state: {
-        error: { color: "red" },
-        success: { color: "green" },
+        error: { color: 'red' },
+        success: { color: 'green' },
       },
     },
-  });
+  })
 
-  type ButtonVariantProps = StyledVariantProps<typeof Button>;
+  type ButtonVariantProps = StyledVariantProps<typeof Button>
   //   ^ { state?: 'error' | 'success' | undefined }
   ```
 
@@ -6085,9 +5986,9 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -6095,16 +5996,16 @@ Will now allow you to use the following syntax for token path:
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -6112,17 +6013,17 @@ Will now allow you to use the following syntax for token path:
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -6130,20 +6031,19 @@ Will now allow you to use the following syntax for token path:
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
   - @pandacss/types@0.15.4
@@ -6166,42 +6066,42 @@ Will now allow you to use the following syntax for token path:
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - 1eb31118: Automatically allow overriding config recipe compoundVariants styles within the `styled` JSX factory,
@@ -6211,22 +6111,22 @@ Will now allow you to use the following syntax for token path:
 
   ```ts file="panda.config.ts"
   const button = defineRecipe({
-    className: "btn",
-    base: { color: "green", fontSize: "16px" },
+    className: 'btn',
+    base: { color: 'green', fontSize: '16px' },
     variants: {
-      size: { small: { fontSize: "14px" } },
+      size: { small: { fontSize: '14px' } },
     },
-    compoundVariants: [{ size: "small", css: { color: "blue" } }],
-  });
+    compoundVariants: [{ size: 'small', css: { color: 'blue' } }],
+  })
   ```
 
   This would previously not merge the `color` property overrides, but now it does:
 
   ```tsx file="example.tsx"
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button);
+  const Button = styled('button', button)
 
   function App() {
     return (
@@ -6235,7 +6135,7 @@ Will now allow you to use the following syntax for token path:
           Click me
         </Button>
       </>
-    );
+    )
   }
   ```
 
@@ -6414,8 +6314,8 @@ Will now allow you to use the following syntax for token path:
     passed in. This is to allow the `css` function to merge the styles correctly.
 
   ```tsx
-  import { css } from "../styled-system/css";
-  css({ mx: "3", paddingTop: "4" }, { mx: "10", pt: "6" }); // => mx_10 pt_6
+  import { css } from '../styled-system/css'
+  css({ mx: '3', paddingTop: '4' }, { mx: '10', pt: '6' }) // => mx_10 pt_6
   ```
 
   > ⚠️ This approach should be preferred for merging styles over the current `cx` function, which will be reverted to
@@ -6440,29 +6340,26 @@ Will now allow you to use the following syntax for token path:
   be merged correctly.
 
   ```tsx title="src/components/Button.tsx"
-  import { css } from "../../styled-system/css";
+  import { css } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
-    const className = css(
-      { display: "flex", alignItem: "center", color: "black" },
-      cssProp,
-    );
-    return <button className={className}>{children}</button>;
-  };
+    const className = css({ display: 'flex', alignItem: 'center', color: 'black' }, cssProp)
+    return <button className={className}>{children}</button>
+  }
   ```
 
   Then you can use the `Button` component like this:
 
   ```tsx title="src/app/page.tsx"
-  import { css } from "../../styled-system/css";
-  import { Button, Thingy } from "./Button";
+  import { css } from '../../styled-system/css'
+  import { Button, Thingy } from './Button'
 
   export default function Page() {
     return (
-      <Button css={{ color: "pink", _hover: { color: "red" } }}>
+      <Button css={{ color: 'pink', _hover: { color: 'red' } }}>
         will result in `class="d_flex items_center text_pink hover:text_red"`
       </Button>
-    );
+    )
   }
   ```
 
@@ -6474,51 +6371,51 @@ Will now allow you to use the following syntax for token path:
   **Pattern Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { hstack } from "../../styled-system/patterns";
-  import { css, cva } from "../../styled-system/css";
+  import { hstack } from '../../styled-system/patterns'
+  import { css, cva } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
     // using the flex pattern
     const hstackProps = hstack.raw({
-      border: "1px solid",
-      _hover: { color: "blue.400" },
-    });
+      border: '1px solid',
+      _hover: { color: 'blue.400' },
+    })
 
     // merging the styles
-    const className = css(hstackProps, cssProp);
+    const className = css(hstackProps, cssProp)
 
-    return <button className={className}>{children}</button>;
-  };
+    return <button className={className}>{children}</button>
+  }
   ```
 
   **CVA Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { css, cva } from "../../styled-system/css";
+  import { css, cva } from '../../styled-system/css'
 
   const buttonRecipe = cva({
-    base: { display: "flex", fontSize: "lg" },
+    base: { display: 'flex', fontSize: 'lg' },
     variants: {
       variant: {
-        primary: { color: "white", backgroundColor: "blue.500" },
+        primary: { color: 'white', backgroundColor: 'blue.500' },
       },
     },
-  });
+  })
 
   export const Button = ({ css: cssProp = {}, children }) => {
     const className = css(
       // using the button recipe
-      buttonRecipe.raw({ variant: "primary" }),
+      buttonRecipe.raw({ variant: 'primary' }),
 
       // adding style overrides (internal)
-      { _hover: { color: "blue.400" } },
+      { _hover: { color: 'blue.400' } },
 
       // adding style overrides (external)
       cssProp,
-    );
+    )
 
-    return <button className={className}>{props.children}</button>;
-  };
+    return <button className={className}>{props.children}</button>
+  }
   ```
 
 - 36fdff89: Fix bug in generated js code for atomic slot recipe produce where `splitVariantProps` didn't work without
@@ -6565,14 +6462,7 @@ Will now allow you to use the following syntax for token path:
   Example:
 
   ```tsx
-  <h1
-    className={cx(
-      css({ mx: "3", paddingTop: "4" }),
-      css({ mx: "10", pt: "6" }),
-    )}
-  >
-    Will result in "mx_10 pt_6"
-  </h1>
+  <h1 className={cx(css({ mx: '3', paddingTop: '4' }), css({ mx: '10', pt: '6' }))}>Will result in "mx_10 pt_6"</h1>
   ```
 
 - dfb3f85f: Add missing svg props types
@@ -6617,12 +6507,12 @@ Will now allow you to use the following syntax for token path:
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -6630,33 +6520,33 @@ Will now allow you to use the following syntax for token path:
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -6721,26 +6611,26 @@ Will now allow you to use the following syntax for token path:
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -6838,17 +6728,9 @@ Will now allow you to use the following syntax for token path:
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -6932,7 +6814,7 @@ Will now allow you to use the following syntax for token path:
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -6942,7 +6824,7 @@ Will now allow you to use the following syntax for token path:
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -6980,8 +6862,8 @@ Will now allow you to use the following syntax for token path:
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -7013,12 +6895,12 @@ Will now allow you to use the following syntax for token path:
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -7138,11 +7020,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - 49c760cd: Fix issue where responsive array in css and cva doesn't generate the correct classname
@@ -7160,11 +7042,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -7203,24 +7085,24 @@ export default defineConfig({
     patterns: {
       hstack: {
         properties: {
-          justify: { type: "property", value: "justifyContent" },
-          gap: { type: "property", value: "gap" },
+          justify: { type: 'property', value: 'justifyContent' },
+          gap: { type: 'property', value: 'gap' },
         },
         // you can also use a token like '10'
-        defaultValues: { gap: "40px" },
+        defaultValues: { gap: '40px' },
         transform(props) {
-          const { justify, gap, ...rest } = props;
+          const { justify, gap, ...rest } = props
           return {
-            display: "flex",
-            alignItems: "center",
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: justify,
             gap,
             ...rest,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -7262,54 +7144,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -7457,18 +7324,18 @@ export default defineConfig({
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ would throw since 'abc' is not part of predefined values of 'display' even thought there is no config token for 'abc'
   ```
 
   now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will not throw there is no config token for 'abc'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will not throw there is no config token for 'abc'
   ```
 
   Instead, if you want the v.19.0 behavior, you can use the new `config.strictPropertyValues` option. You can combine it
@@ -7479,79 +7346,79 @@ export default defineConfig({
 
   ```ts
   type StrictableProps =
-    | "alignContent"
-    | "alignItems"
-    | "alignSelf"
-    | "all"
-    | "animationComposition"
-    | "animationDirection"
-    | "animationFillMode"
-    | "appearance"
-    | "backfaceVisibility"
-    | "backgroundAttachment"
-    | "backgroundClip"
-    | "borderCollapse"
-    | "border"
-    | "borderBlock"
-    | "borderBlockEnd"
-    | "borderBlockStart"
-    | "borderBottom"
-    | "borderInline"
-    | "borderInlineEnd"
-    | "borderInlineStart"
-    | "borderLeft"
-    | "borderRight"
-    | "borderTop"
-    | "borderBlockEndStyle"
-    | "borderBlockStartStyle"
-    | "borderBlockStyle"
-    | "borderBottomStyle"
-    | "borderInlineEndStyle"
-    | "borderInlineStartStyle"
-    | "borderInlineStyle"
-    | "borderLeftStyle"
-    | "borderRightStyle"
-    | "borderTopStyle"
-    | "boxDecorationBreak"
-    | "boxSizing"
-    | "breakAfter"
-    | "breakBefore"
-    | "breakInside"
-    | "captionSide"
-    | "clear"
-    | "columnFill"
-    | "columnRuleStyle"
-    | "contentVisibility"
-    | "direction"
-    | "display"
-    | "emptyCells"
-    | "flexDirection"
-    | "flexWrap"
-    | "float"
-    | "fontKerning"
-    | "forcedColorAdjust"
-    | "isolation"
-    | "lineBreak"
-    | "mixBlendMode"
-    | "objectFit"
-    | "outlineStyle"
-    | "overflow"
-    | "overflowX"
-    | "overflowY"
-    | "overflowBlock"
-    | "overflowInline"
-    | "overflowWrap"
-    | "pointerEvents"
-    | "position"
-    | "resize"
-    | "scrollBehavior"
-    | "touchAction"
-    | "transformBox"
-    | "transformStyle"
-    | "userSelect"
-    | "visibility"
-    | "wordBreak"
-    | "writingMode";
+    | 'alignContent'
+    | 'alignItems'
+    | 'alignSelf'
+    | 'all'
+    | 'animationComposition'
+    | 'animationDirection'
+    | 'animationFillMode'
+    | 'appearance'
+    | 'backfaceVisibility'
+    | 'backgroundAttachment'
+    | 'backgroundClip'
+    | 'borderCollapse'
+    | 'border'
+    | 'borderBlock'
+    | 'borderBlockEnd'
+    | 'borderBlockStart'
+    | 'borderBottom'
+    | 'borderInline'
+    | 'borderInlineEnd'
+    | 'borderInlineStart'
+    | 'borderLeft'
+    | 'borderRight'
+    | 'borderTop'
+    | 'borderBlockEndStyle'
+    | 'borderBlockStartStyle'
+    | 'borderBlockStyle'
+    | 'borderBottomStyle'
+    | 'borderInlineEndStyle'
+    | 'borderInlineStartStyle'
+    | 'borderInlineStyle'
+    | 'borderLeftStyle'
+    | 'borderRightStyle'
+    | 'borderTopStyle'
+    | 'boxDecorationBreak'
+    | 'boxSizing'
+    | 'breakAfter'
+    | 'breakBefore'
+    | 'breakInside'
+    | 'captionSide'
+    | 'clear'
+    | 'columnFill'
+    | 'columnRuleStyle'
+    | 'contentVisibility'
+    | 'direction'
+    | 'display'
+    | 'emptyCells'
+    | 'flexDirection'
+    | 'flexWrap'
+    | 'float'
+    | 'fontKerning'
+    | 'forcedColorAdjust'
+    | 'isolation'
+    | 'lineBreak'
+    | 'mixBlendMode'
+    | 'objectFit'
+    | 'outlineStyle'
+    | 'overflow'
+    | 'overflowX'
+    | 'overflowY'
+    | 'overflowBlock'
+    | 'overflowInline'
+    | 'overflowWrap'
+    | 'pointerEvents'
+    | 'position'
+    | 'resize'
+    | 'scrollBehavior'
+    | 'touchAction'
+    | 'transformBox'
+    | 'transformStyle'
+    | 'userSelect'
+    | 'visibility'
+    | 'wordBreak'
+    | 'writingMode'
   ```
 
 - Updated dependencies [657ca5da]
@@ -7622,38 +7489,38 @@ export default defineConfig({
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -7800,17 +7667,17 @@ export default defineConfig({
 
   ```ts
   css({
-    bg: "[#3B00B9]", // ✅ was okay
+    bg: '[#3B00B9]', // ✅ was okay
     _dark: {
       // ✅ was okay
-      color: "[#3B00B9]",
+      color: '[#3B00B9]',
     },
 
     // ❌ Not okay, will be fixed in this patch
     color: {
-      _dark: "[#3B00B9]",
+      _dark: '[#3B00B9]',
     },
-  });
+  })
   ```
 
 - 647f05c9: Fix a CSS generation issue with `config.strictTokens` when using the `[xxx]` escape-hatch syntax with `!` or
@@ -7818,9 +7685,9 @@ export default defineConfig({
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -7861,18 +7728,18 @@ export default defineConfig({
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ### Patch Changes
@@ -7906,49 +7773,49 @@ export default defineConfig({
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 - 052283c2: Fix vue `styled` factory internal class merging, for example:
 
   ```vue
   <script setup>
-  import { styled } from "../styled-system/jsx";
+  import { styled } from '../styled-system/jsx'
 
-  const StyledButton = styled("button", {
+  const StyledButton = styled('button', {
     base: {
-      bgColor: "red.300",
+      bgColor: 'red.300',
     },
-  });
+  })
   </script>
   <template>
     <StyledButton id="test" class="test">
@@ -8017,18 +7884,18 @@ export default defineConfig({
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ❌ didn't throw even though 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ❌ didn't throw even though 'abc' is not a valid value for 'display'
   ```
 
   Now:
 
   ```ts
   // config.strictTokens = true
-  css({ display: "flex" }); // OK, didn't throw
-  css({ display: "block" }); // OK, didn't throw
-  css({ display: "abc" }); // ✅ will throw since 'abc' is not a valid value for 'display'
+  css({ display: 'flex' }) // OK, didn't throw
+  css({ display: 'block' }) // OK, didn't throw
+  css({ display: 'abc' }) // ✅ will throw since 'abc' is not a valid value for 'display'
   ```
 
 - Updated dependencies [61831040]
@@ -8087,28 +7954,22 @@ export default defineConfig({
 - b7cb2073: Add a `splitCssProps` utility exported from the {outdir}/jsx entrypoint
 
   ```tsx
-  import { splitCssProps, styled } from "../styled-system/jsx";
-  import type { HTMLStyledProps } from "../styled-system/types";
+  import { splitCssProps, styled } from '../styled-system/jsx'
+  import type { HTMLStyledProps } from '../styled-system/types'
 
-  function SplitComponent({ children, ...props }: HTMLStyledProps<"div">) {
-    const [cssProps, restProps] = splitCssProps(props);
+  function SplitComponent({ children, ...props }: HTMLStyledProps<'div'>) {
+    const [cssProps, restProps] = splitCssProps(props)
     return (
-      <styled.div
-        {...restProps}
-        className={css(
-          { display: "flex", height: "20", width: "20" },
-          cssProps,
-        )}
-      >
+      <styled.div {...restProps} className={css({ display: 'flex', height: '20', width: '20' }, cssProps)}>
         {children}
       </styled.div>
-    );
+    )
   }
 
   // Usage
 
   function App() {
-    return <SplitComponent margin="2">Click me</SplitComponent>;
+    return <SplitComponent margin="2">Click me</SplitComponent>
   }
   ```
 
@@ -8201,16 +8062,16 @@ export default defineConfig({
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -8223,32 +8084,32 @@ export default defineConfig({
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 - fbf062c6: Added a new type to extract variants out of styled components
 
   ```tsx
-  import { StyledVariantProps } from "../styled-system/jsx";
+  import { StyledVariantProps } from '../styled-system/jsx'
 
-  const Button = styled("button", {
-    base: { color: "black" },
+  const Button = styled('button', {
+    base: { color: 'black' },
     variants: {
       state: {
-        error: { color: "red" },
-        success: { color: "green" },
+        error: { color: 'red' },
+        success: { color: 'green' },
       },
     },
-  });
+  })
 
-  type ButtonVariantProps = StyledVariantProps<typeof Button>;
+  type ButtonVariantProps = StyledVariantProps<typeof Button>
   //   ^ { state?: 'error' | 'success' | undefined }
   ```
 
@@ -8350,9 +8211,9 @@ export default defineConfig({
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -8360,16 +8221,16 @@ export default defineConfig({
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -8377,17 +8238,17 @@ export default defineConfig({
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -8395,20 +8256,19 @@ export default defineConfig({
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
   - @pandacss/types@0.15.4
@@ -8431,42 +8291,42 @@ export default defineConfig({
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - 1eb31118: Automatically allow overriding config recipe compoundVariants styles within the `styled` JSX factory,
@@ -8476,22 +8336,22 @@ export default defineConfig({
 
   ```ts file="panda.config.ts"
   const button = defineRecipe({
-    className: "btn",
-    base: { color: "green", fontSize: "16px" },
+    className: 'btn',
+    base: { color: 'green', fontSize: '16px' },
     variants: {
-      size: { small: { fontSize: "14px" } },
+      size: { small: { fontSize: '14px' } },
     },
-    compoundVariants: [{ size: "small", css: { color: "blue" } }],
-  });
+    compoundVariants: [{ size: 'small', css: { color: 'blue' } }],
+  })
   ```
 
   This would previously not merge the `color` property overrides, but now it does:
 
   ```tsx file="example.tsx"
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button);
+  const Button = styled('button', button)
 
   function App() {
     return (
@@ -8500,7 +8360,7 @@ export default defineConfig({
           Click me
         </Button>
       </>
-    );
+    )
   }
   ```
 
@@ -8679,8 +8539,8 @@ export default defineConfig({
     passed in. This is to allow the `css` function to merge the styles correctly.
 
   ```tsx
-  import { css } from "../styled-system/css";
-  css({ mx: "3", paddingTop: "4" }, { mx: "10", pt: "6" }); // => mx_10 pt_6
+  import { css } from '../styled-system/css'
+  css({ mx: '3', paddingTop: '4' }, { mx: '10', pt: '6' }) // => mx_10 pt_6
   ```
 
   > ⚠️ This approach should be preferred for merging styles over the current `cx` function, which will be reverted to
@@ -8705,29 +8565,26 @@ export default defineConfig({
   be merged correctly.
 
   ```tsx title="src/components/Button.tsx"
-  import { css } from "../../styled-system/css";
+  import { css } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
-    const className = css(
-      { display: "flex", alignItem: "center", color: "black" },
-      cssProp,
-    );
-    return <button className={className}>{children}</button>;
-  };
+    const className = css({ display: 'flex', alignItem: 'center', color: 'black' }, cssProp)
+    return <button className={className}>{children}</button>
+  }
   ```
 
   Then you can use the `Button` component like this:
 
   ```tsx title="src/app/page.tsx"
-  import { css } from "../../styled-system/css";
-  import { Button, Thingy } from "./Button";
+  import { css } from '../../styled-system/css'
+  import { Button, Thingy } from './Button'
 
   export default function Page() {
     return (
-      <Button css={{ color: "pink", _hover: { color: "red" } }}>
+      <Button css={{ color: 'pink', _hover: { color: 'red' } }}>
         will result in `class="d_flex items_center text_pink hover:text_red"`
       </Button>
-    );
+    )
   }
   ```
 
@@ -8739,51 +8596,51 @@ export default defineConfig({
   **Pattern Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { hstack } from "../../styled-system/patterns";
-  import { css, cva } from "../../styled-system/css";
+  import { hstack } from '../../styled-system/patterns'
+  import { css, cva } from '../../styled-system/css'
 
   export const Button = ({ css: cssProp = {}, children }) => {
     // using the flex pattern
     const hstackProps = hstack.raw({
-      border: "1px solid",
-      _hover: { color: "blue.400" },
-    });
+      border: '1px solid',
+      _hover: { color: 'blue.400' },
+    })
 
     // merging the styles
-    const className = css(hstackProps, cssProp);
+    const className = css(hstackProps, cssProp)
 
-    return <button className={className}>{children}</button>;
-  };
+    return <button className={className}>{children}</button>
+  }
   ```
 
   **CVA Example:**
 
   ```tsx title="src/components/Button.tsx"
-  import { css, cva } from "../../styled-system/css";
+  import { css, cva } from '../../styled-system/css'
 
   const buttonRecipe = cva({
-    base: { display: "flex", fontSize: "lg" },
+    base: { display: 'flex', fontSize: 'lg' },
     variants: {
       variant: {
-        primary: { color: "white", backgroundColor: "blue.500" },
+        primary: { color: 'white', backgroundColor: 'blue.500' },
       },
     },
-  });
+  })
 
   export const Button = ({ css: cssProp = {}, children }) => {
     const className = css(
       // using the button recipe
-      buttonRecipe.raw({ variant: "primary" }),
+      buttonRecipe.raw({ variant: 'primary' }),
 
       // adding style overrides (internal)
-      { _hover: { color: "blue.400" } },
+      { _hover: { color: 'blue.400' } },
 
       // adding style overrides (external)
       cssProp,
-    );
+    )
 
-    return <button className={className}>{props.children}</button>;
-  };
+    return <button className={className}>{props.children}</button>
+  }
   ```
 
 - 36fdff89: Fix bug in generated js code for atomic slot recipe produce where `splitVariantProps` didn't work without
@@ -8830,14 +8687,7 @@ export default defineConfig({
   Example:
 
   ```tsx
-  <h1
-    className={cx(
-      css({ mx: "3", paddingTop: "4" }),
-      css({ mx: "10", pt: "6" }),
-    )}
-  >
-    Will result in "mx_10 pt_6"
-  </h1>
+  <h1 className={cx(css({ mx: '3', paddingTop: '4' }), css({ mx: '10', pt: '6' }))}>Will result in "mx_10 pt_6"</h1>
   ```
 
 - dfb3f85f: Add missing svg props types
@@ -8882,12 +8732,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -8895,33 +8745,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -8986,26 +8836,26 @@ export default defineConfig({
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -9103,17 +8953,9 @@ export default defineConfig({
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -9197,7 +9039,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -9207,7 +9049,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -9245,8 +9087,8 @@ export default defineConfig({
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -9278,12 +9120,12 @@ export default defineConfig({
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -833,4 +833,62 @@ describe('generator', () => {
       }"
     `)
   })
+
+  test('color-mix in semanticTokens conditions', () => {
+    const css = tokenCss(<any>{
+      dependencies: [],
+      config: {
+        cwd: '',
+        include: [],
+        conditions: {
+          light: '.light &',
+          dark: '.dark &',
+        },
+        theme: {
+          tokens: {
+            colors: {
+              blue: { 500: { value: 'blue' } },
+              green: { 500: { value: 'green' } },
+            },
+            opacity: {
+              half: { value: 0.5 },
+            },
+          },
+          semanticTokens: {
+            colors: {
+              secondary: {
+                value: {
+                  base: 'red',
+                  _light: '{colors.blue.500/32}',
+                  _dark: '{colors.green.500/half}',
+                },
+              },
+            },
+          },
+        },
+        outdir: '',
+      },
+      path: '',
+      hooks: {},
+    })
+
+    expect(css).toMatchInlineSnapshot(`
+      "@layer tokens {
+        :where(:root, :host) {
+          --colors-blue-500: blue;
+          --colors-green-500: green;
+          --opacity-half: 0.5;
+          --colors-secondary: red;
+      }
+
+        .light {
+          --colors-secondary: color-mix(in srgb, var(--colors-blue-500) 32%, transparent)
+      }
+
+        .dark {
+          --colors-secondary: color-mix(in srgb, var(--colors-green-500) 50%, transparent)
+      }
+      }"
+    `)
+  })
 })

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -71,11 +71,11 @@
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -104,10 +104,10 @@
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -235,8 +235,8 @@
   ```ts
   export default defineConfig({
     // ...
-    dependencies: ["path/to/files/**.ts"],
-  });
+    dependencies: ['path/to/files/**.ts'],
+  })
   ```
 
   - Invoke `config:change` hook in more situations (when the `--watch` flag is passed to `panda codegen`,
@@ -288,54 +288,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -953,16 +938,16 @@
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -975,14 +960,14 @@
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 ### Patch Changes
@@ -1786,11 +1771,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -1807,11 +1792,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [0dd45b6a]
@@ -1861,8 +1846,8 @@ export default defineConfig({
   ```ts
   export default defineConfig({
     // ...
-    dependencies: ["path/to/files/**.ts"],
-  });
+    dependencies: ['path/to/files/**.ts'],
+  })
   ```
 
   - Invoke `config:change` hook in more situations (when the `--watch` flag is passed to `panda codegen`,
@@ -1914,54 +1899,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -2579,16 +2549,16 @@ export default defineConfig({
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -2601,14 +2571,14 @@ export default defineConfig({
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 ### Patch Changes

--- a/packages/parser/CHANGELOG.md
+++ b/packages/parser/CHANGELOG.md
@@ -39,25 +39,25 @@
 - 31071ba: Fix an issue for token names starting with '0'
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     theme: {
       tokens: {
         spacing: {
-          "025": {
-            value: "0.125rem",
+          '025': {
+            value: '0.125rem',
           },
         },
       },
     },
-  });
+  })
   ```
 
   and then using it like
 
   ```ts
-  css({ margin: "025" });
+  css({ margin: '025' })
   ```
 
   This would not generate the expected CSS because the parser would try to parse `025` as a number (`25`) instead of
@@ -68,7 +68,7 @@
   Given this config:
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
@@ -79,13 +79,13 @@
             bg: {
               primary: {
                 DEFAULT: {
-                  value: "{colors.red.500}",
+                  value: '{colors.red.500}',
                 },
                 base: {
-                  value: "{colors.green.500}",
+                  value: '{colors.green.500}',
                 },
                 hover: {
-                  value: "{colors.yellow.300}",
+                  value: '{colors.yellow.300}',
                 },
               },
             },
@@ -93,17 +93,17 @@
         },
       },
     },
-  });
+  })
   ```
 
   And this style usage:
 
   ```ts
-  import { css } from "styled-system/css";
+  import { css } from 'styled-system/css'
 
   css({
-    colorPalette: "bg.primary",
-  });
+    colorPalette: 'bg.primary',
+  })
   ```
 
   This is the difference in the generated css
@@ -134,11 +134,11 @@
   - Allow using multiple aliases for the same identifier for the `/css` entrypoints just like `/patterns` and `/recipes`
 
   ```ts
-  import { css } from "../styled-system/css";
-  import { css as css2 } from "../styled-system/css";
+  import { css } from '../styled-system/css'
+  import { css as css2 } from '../styled-system/css'
 
-  css({ display: "flex" });
-  css2({ flexDirection: "column" }); // this wasn't working before, now it does
+  css({ display: 'flex' })
+  css2({ flexDirection: 'column' }) // this wasn't working before, now it does
   ```
 
 - Updated dependencies [a032375]
@@ -186,10 +186,10 @@
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -249,17 +249,16 @@
   export default defineConfig({
     // ...
     hooks: {
-      "parser:before": ({ configure }) => {
+      'parser:before': ({ configure }) => {
         configure({
           // ignore the Select.Content entirely
-          matchTag: (tag) => tag !== "Select.Content",
+          matchTag: (tag) => tag !== 'Select.Content',
           // ...or specifically ignore the `position` property
-          matchTagProp: (tag, prop) =>
-            tag === "Select.Content" && prop !== "position",
-        });
+          matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
+        })
       },
     },
-  });
+  })
   ```
 
 - Updated dependencies [6b829cab]
@@ -300,11 +299,11 @@
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [0dd45b6a]
@@ -343,10 +342,10 @@
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -388,54 +387,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -574,8 +558,8 @@
   ```jsx
   css({
     // This didn't work, but now it does
-    base: { color: "blue" },
-  });
+    base: { color: 'blue' },
+  })
   ```
 
 - Updated dependencies [59fd291c]
@@ -619,38 +603,38 @@
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -774,30 +758,30 @@
   another file, such as when using `Ark-UI` like `import { comboboxAnatomy } from '@ark-ui/anatomy'`
 
   ```ts
-  import { sva } from "../styled-system/css";
-  import { slots } from "./slots";
+  import { sva } from '../styled-system/css'
+  import { slots } from './slots'
 
   const card = sva({
     slots, // ❌ did NOT work -> ✅ will now work as expected
     base: {
       root: {
-        p: "6",
-        m: "4",
-        w: "md",
-        boxShadow: "md",
-        borderRadius: "md",
-        _dark: { bg: "#262626", color: "white" },
+        p: '6',
+        m: '4',
+        w: 'md',
+        boxShadow: 'md',
+        borderRadius: 'md',
+        _dark: { bg: '#262626', color: 'white' },
       },
       content: {
-        textStyle: "lg",
+        textStyle: 'lg',
       },
       title: {
-        textStyle: "xl",
-        fontWeight: "semibold",
-        pb: "2",
+        textStyle: 'xl',
+        fontWeight: 'semibold',
+        pb: '2',
       },
     },
-  });
+  })
   ```
 
 - b01eb049: Fix a parser issue where we didn't handle import aliases when using a {xxx}.raw() function.
@@ -806,15 +790,15 @@
 
   ```ts
   // button.stories.ts
-  import { button as buttonRecipe } from "@ui/styled-system/recipes";
+  import { button as buttonRecipe } from '@ui/styled-system/recipes'
 
   export const Primary: Story = {
     // ❌ this wouldn't be parsed as a recipe because of the alias + .raw()
     //  -> ✅ it's now fixed
     args: buttonRecipe.raw({
-      color: "primary",
+      color: 'primary',
     }),
-  };
+  }
   ```
 
 - a3b6ed5f: Fix & perf improvement: skip JSX parsing when not using `config.jsxFramework` / skip tagged template literal
@@ -836,9 +820,9 @@
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -1066,9 +1050,9 @@
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -1076,16 +1060,16 @@
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -1093,17 +1077,17 @@
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -1111,20 +1095,19 @@
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
 - 3a04a927: Fix static extraction of the
@@ -1224,42 +1207,42 @@
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - Updated dependencies [95b06bb1]
@@ -1294,20 +1277,20 @@
   so this will now work:
 
   ```ts
-  import { css } from "styled-system/css";
+  import { css } from 'styled-system/css'
 
   const paragraphSpacingStyle = css.raw({
-    "&:not(:first-child)": { marginBlockEnd: "1em" },
-  });
+    '&:not(:first-child)': { marginBlockEnd: '1em' },
+  })
 
   export const proseCss = css.raw({
-    maxWidth: "800px",
-    "& p": {
-      "&:not(:first-child)": { marginBlockStart: "1em" },
+    maxWidth: '800px',
+    '& p': {
+      '&:not(:first-child)': { marginBlockStart: '1em' },
     },
-    "& h1": paragraphSpacingStyle,
-    "& h2": paragraphSpacingStyle,
-  });
+    '& h1': paragraphSpacingStyle,
+    '& h2': paragraphSpacingStyle,
+  })
   ```
 
   & use ECMA preset for ts-evaluator: This means that no other globals than those that are defined in the ECMAScript
@@ -1315,35 +1298,35 @@
   this:
 
   ```ts
-  import { cva } from ".panda/css";
+  import { cva } from '.panda/css'
 
   const variants = () => {
     const spacingTokens = Object.entries({
-      s: "token(spacing.1)",
-      m: "token(spacing.2)",
-      l: "token(spacing.3)",
-    });
+      s: 'token(spacing.1)',
+      m: 'token(spacing.2)',
+      l: 'token(spacing.3)',
+    })
 
     const spacingProps = {
-      px: "paddingX",
-      py: "paddingY",
-    };
+      px: 'paddingX',
+      py: 'paddingY',
+    }
 
     // Generate variants programmatically
     return Object.entries(spacingProps)
       .map(([name, styleProp]) => {
         const variants = spacingTokens
           .map(([variant, token]) => ({ [variant]: { [styleProp]: token } }))
-          .reduce((_agg, kv) => ({ ..._agg, ...kv }));
+          .reduce((_agg, kv) => ({ ..._agg, ...kv }))
 
-        return { [name]: variants };
+        return { [name]: variants }
       })
-      .reduce((_agg, kv) => ({ ..._agg, ...kv }));
-  };
+      .reduce((_agg, kv) => ({ ..._agg, ...kv }))
+  }
 
   const baseStyle = cva({
     variants: variants(),
-  });
+  })
   ```
 
 - Updated dependencies [c40ae1b9]
@@ -1490,12 +1473,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -1503,33 +1486,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -1578,26 +1561,26 @@
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -1697,17 +1680,9 @@
   ```tsx
   const ComponentWithMultipleRecipes = ({ variant }) => {
     return (
-      <button
-        className={cx(
-          pinkRecipe({ variant }),
-          greenRecipe({ variant }),
-          blueRecipe({ variant }),
-        )}
-      >
-        Hello
-      </button>
-    );
-  };
+      <button className={cx(pinkRecipe({ variant }), greenRecipe({ variant }), blueRecipe({ variant }))}>Hello</button>
+    )
+  }
   ```
 
   Given a `panda.config.ts` with recipes each including a common `jsx` tag name, such as:
@@ -1815,8 +1790,8 @@
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -1837,10 +1812,10 @@
   ```ts
   const Input = styled.input({
     base: {
-      color: "blue.100",
-      bg: "blue.900",
+      color: 'blue.100',
+      bg: 'blue.900',
     },
-  });
+  })
   ```
 
 - Updated dependencies [60df9bd1]

--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -66,11 +66,11 @@
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [05686b9d]
@@ -507,11 +507,11 @@
   ```js
   module.exports = {
     plugins: [
-      require("@pandacss/postcss")({
-        configPath: "./path/to/panda.config.js",
+      require('@pandacss/postcss')({
+        configPath: './path/to/panda.config.js',
       }),
     ],
-  };
+  }
   ```
 
   - @pandacss/node@0.3.2

--- a/packages/preset-base/CHANGELOG.md
+++ b/packages/preset-base/CHANGELOG.md
@@ -40,9 +40,9 @@
 
   ```ts
   css({
-    textShadow: "1px 1px 1px var(--text-shadow-color)",
-    textShadowColor: "black",
-  });
+    textShadow: '1px 1px 1px var(--text-shadow-color)',
+    textShadowColor: 'black',
+  })
   ```
 
 ### Patch Changes
@@ -94,9 +94,9 @@
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -104,11 +104,7 @@
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -132,21 +128,21 @@
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -155,21 +151,21 @@
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -197,34 +193,34 @@
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -308,11 +304,11 @@
     patterns: {
       extend: {
         stack: {
-          defaultValues: { gap: "20px" },
+          defaultValues: { gap: '20px' },
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -383,13 +379,13 @@
         // add aspect ratio tokens
         tokens: {
           aspectRatios: {
-            "1:1": "1",
-            "16:9": "16/9",
+            '1:1': '1',
+            '16:9': '16/9',
           },
         },
       },
     },
-  });
+  })
   ```
 
   Here's what the default aspect ratio tokens in the base preset looks like:
@@ -717,15 +713,15 @@
   `block` bleed to a child element, setting its value to match the parent's padding.
 
   ```tsx
-  import { css } from "../styled-system/css";
-  import { bleed } from "../styled-system/patterns";
+  import { css } from '../styled-system/css'
+  import { bleed } from '../styled-system/patterns'
 
   export function Page() {
     return (
-      <div class={css({ px: "6" })}>
-        <div class={bleed({ inline: "6" })}>Welcome</div>
+      <div class={css({ px: '6' })}>
+        <div class={bleed({ inline: '6' })}>Welcome</div>
       </div>
-    );
+    )
   }
   ```
 
@@ -734,8 +730,8 @@
   Visually hidden is a layout pattern used to hide content visually, but still make it available to screen readers.
 
   ```tsx
-  import { css } from "../styled-system/css";
-  import { visuallyHidden } from "../styled-system/patterns";
+  import { css } from '../styled-system/css'
+  import { visuallyHidden } from '../styled-system/patterns'
 
   export function Checkbox() {
     return (
@@ -745,7 +741,7 @@
         </input>
         <span>Checkbox</span>
       </label>
-    );
+    )
   }
   ```
 
@@ -797,26 +793,26 @@
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -840,7 +836,7 @@
   transition property, timing function and duration. This allows you to add transitions with a single property.
 
   ```jsx
-  <div className={css({ transition: "background" })}>Content</div>
+  <div className={css({ transition: 'background' })}>Content</div>
   ```
 
   This will generate the following css:

--- a/packages/preset-panda/CHANGELOG.md
+++ b/packages/preset-panda/CHANGELOG.md
@@ -138,13 +138,13 @@
         // add aspect ratio tokens
         tokens: {
           aspectRatios: {
-            "1:1": "1",
-            "16:9": "16/9",
+            '1:1': '1',
+            '16:9': '16/9',
           },
         },
       },
     },
-  });
+  })
   ```
 
   Here's what the default aspect ratio tokens in the base preset looks like:

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -25,10 +25,10 @@
 
   ```ts
   css({
-    padding: "1px",
-    paddingTop: "3px",
-    paddingBottom: "4px",
-  });
+    padding: '1px',
+    paddingTop: '3px',
+    paddingBottom: '4px',
+  })
   ```
 
   Will now always generate the following css:
@@ -156,9 +156,9 @@
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 ## 0.22.0
@@ -175,18 +175,18 @@
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ## 0.20.1
@@ -229,16 +229,16 @@
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -251,14 +251,14 @@
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 ## 0.16.0
@@ -312,14 +312,7 @@
   Example:
 
   ```tsx
-  <h1
-    className={cx(
-      css({ mx: "3", paddingTop: "4" }),
-      css({ mx: "10", pt: "6" }),
-    )}
-  >
-    Will result in "mx_10 pt_6"
-  </h1>
+  <h1 className={cx(css({ mx: '3', paddingTop: '4' }), css({ mx: '10', pt: '6' }))}>Will result in "mx_10 pt_6"</h1>
   ```
 
 ## 0.11.0
@@ -338,12 +331,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -351,33 +344,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -425,19 +418,19 @@
 
   ```ts
   const shorthands = {
-    flexDir: "flexDirection",
-  };
+    flexDir: 'flexDirection',
+  }
 
   const obj = {
-    flexDir: "row",
+    flexDir: 'row',
     flexDirection: undefined,
-  };
+  }
 
   const result = walkObject(obj, (value) => value, {
     getKey(prop) {
-      return shorthands[prop] ?? prop;
+      return shorthands[prop] ?? prop
     },
-  });
+  })
   ```
 
   This would set the `flexDirection` to `row` (using `getKey`) and then set the `flexDirection` property again, this
@@ -458,8 +451,8 @@
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -536,11 +529,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - 49c760cd: Fix issue where responsive array in css and cva doesn't generate the correct classname
@@ -626,9 +619,9 @@ export default defineConfig({
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 ## 0.22.0
@@ -645,18 +638,18 @@ export default defineConfig({
   and suffixing with `]`, e.g. writing `[123px]` as a value will bypass the token validation.
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     // @ts-expect-error TS will throw when using from strictTokens: true
-    color: "#fff",
+    color: '#fff',
     // @ts-expect-error TS will throw when using from strictTokens: true
-    width: "100px",
+    width: '100px',
 
     // ✅ but this is now allowed:
-    bgColor: "[rgb(51 155 240)]",
-    fontSize: "[12px]",
-  });
+    bgColor: '[rgb(51 155 240)]',
+    fontSize: '[12px]',
+  })
   ```
 
 ## 0.20.1
@@ -699,16 +692,16 @@ export default defineConfig({
   together and the styles will be merged correctly.
 
   ```jsx
-  const Box = styled("div", {
+  const Box = styled('div', {
     base: {
-      background: "red.light",
-      color: "white",
+      background: 'red.light',
+      color: 'white',
     },
-  });
+  })
 
   const ExtendedBox = styled(Box, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
 
   // <ExtendedBox> will have a background of `red.dark` and a color of `white`
   ```
@@ -721,14 +714,14 @@ export default defineConfig({
   - CVA or Inline CVA + Config Recipe = ❌
 
   ```jsx
-  import { button } from "../styled-system/recipes";
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("div", button);
+  const Button = styled('div', button)
 
   // ❌ This will throw an error
   const ExtendedButton = styled(Button, {
-    base: { background: "red.dark" },
-  });
+    base: { background: 'red.dark' },
+  })
   ```
 
 ## 0.16.0
@@ -782,14 +775,7 @@ export default defineConfig({
   Example:
 
   ```tsx
-  <h1
-    className={cx(
-      css({ mx: "3", paddingTop: "4" }),
-      css({ mx: "10", pt: "6" }),
-    )}
-  >
-    Will result in "mx_10 pt_6"
-  </h1>
+  <h1 className={cx(css({ mx: '3', paddingTop: '4' }), css({ mx: '10', pt: '6' }))}>Will result in "mx_10 pt_6"</h1>
   ```
 
 ## 0.11.0
@@ -808,12 +794,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -821,33 +807,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -895,19 +881,19 @@ export default defineConfig({
 
   ```ts
   const shorthands = {
-    flexDir: "flexDirection",
-  };
+    flexDir: 'flexDirection',
+  }
 
   const obj = {
-    flexDir: "row",
+    flexDir: 'row',
     flexDirection: undefined,
-  };
+  }
 
   const result = walkObject(obj, (value) => value, {
     getKey(prop) {
-      return shorthands[prop] ?? prop;
+      return shorthands[prop] ?? prop
     },
-  });
+  })
   ```
 
   This would set the `flexDirection` to `row` (using `getKey`) and then set the `flexDirection` property again, this
@@ -928,8 +914,8 @@ export default defineConfig({
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`

--- a/packages/studio/CHANGELOG.md
+++ b/packages/studio/CHANGELOG.md
@@ -345,9 +345,9 @@
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -625,9 +625,9 @@
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -635,16 +635,16 @@
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -652,17 +652,17 @@
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -670,20 +670,19 @@
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
 - Updated dependencies [abd7c47a]
@@ -705,22 +704,22 @@
 
   ```ts file="panda.config.ts"
   const button = defineRecipe({
-    className: "btn",
-    base: { color: "green", fontSize: "16px" },
+    className: 'btn',
+    base: { color: 'green', fontSize: '16px' },
     variants: {
-      size: { small: { fontSize: "14px" } },
+      size: { small: { fontSize: '14px' } },
     },
-    compoundVariants: [{ size: "small", css: { color: "blue" } }],
-  });
+    compoundVariants: [{ size: 'small', css: { color: 'blue' } }],
+  })
   ```
 
   This would previously not merge the `color` property overrides, but now it does:
 
   ```tsx file="example.tsx"
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button);
+  const Button = styled('button', button)
 
   function App() {
     return (
@@ -729,7 +728,7 @@
           Click me
         </Button>
       </>
-    );
+    )
   }
   ```
 
@@ -912,11 +911,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -933,11 +932,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [0dd45b6a]
@@ -1173,9 +1172,9 @@ export default defineConfig({
 
   ```ts
   css({
-    borderWidth: "[2px!]",
-    width: "[2px !important]",
-  });
+    borderWidth: '[2px!]',
+    width: '[2px !important]',
+  })
   ```
 
 - Updated dependencies [8f4ce97c]
@@ -1453,9 +1452,9 @@ export default defineConfig({
 
   ```ts
   interface FactoryOptions<TProps extends Dict> {
-    dataAttr?: boolean;
-    defaultProps?: TProps;
-    shouldForwardProp?(prop: string, variantKeys: string[]): boolean;
+    dataAttr?: boolean
+    defaultProps?: TProps
+    shouldForwardProp?(prop: string, variantKeys: string[]): boolean
   }
   ```
 
@@ -1463,16 +1462,16 @@ export default defineConfig({
     This is useful for testing and debugging.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, { dataAttr: true });
+  const Button = styled('button', button, { dataAttr: true })
 
   const App = () => (
     <Button variant="secondary" mt="10px">
       Button
     </Button>
-  );
+  )
   // Will render something like <button data-recipe="button" class="btn btn--variant_purple mt_10px">Button</button>
   ```
 
@@ -1480,17 +1479,17 @@ export default defineConfig({
     override the default variants or base styles of a recipe.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button, {
+  const Button = styled('button', button, {
     defaultProps: {
-      variant: "secondary",
-      px: "10px",
+      variant: 'secondary',
+      px: '10px',
     },
-  });
+  })
 
-  const App = () => <Button>Button</Button>;
+  const App = () => <Button>Button</Button>
   // Will render something like <button class="btn btn--variant_secondary px_10px">Button</button>
   ```
 
@@ -1498,20 +1497,19 @@ export default defineConfig({
     props except recipe variants and style props are forwarded.
 
   ```jsx
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
-  import { isCssProperty } from "../styled-system/jsx";
-  import { motion, isValidMotionProp } from "framer-motion";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
+  import { isCssProperty } from '../styled-system/jsx'
+  import { motion, isValidMotionProp } from 'framer-motion'
 
   const StyledMotion = styled(
     motion.div,
     {},
     {
       shouldForwardProp: (prop, variantKeys) =>
-        isValidMotionProp(prop) ||
-        (!variantKeys.includes(prop) && !isCssProperty(prop)),
+        isValidMotionProp(prop) || (!variantKeys.includes(prop) && !isCssProperty(prop)),
     },
-  );
+  )
   ```
 
 - Updated dependencies [abd7c47a]
@@ -1533,22 +1531,22 @@ export default defineConfig({
 
   ```ts file="panda.config.ts"
   const button = defineRecipe({
-    className: "btn",
-    base: { color: "green", fontSize: "16px" },
+    className: 'btn',
+    base: { color: 'green', fontSize: '16px' },
     variants: {
-      size: { small: { fontSize: "14px" } },
+      size: { small: { fontSize: '14px' } },
     },
-    compoundVariants: [{ size: "small", css: { color: "blue" } }],
-  });
+    compoundVariants: [{ size: 'small', css: { color: 'blue' } }],
+  })
   ```
 
   This would previously not merge the `color` property overrides, but now it does:
 
   ```tsx file="example.tsx"
-  import { styled } from "../styled-system/jsx";
-  import { button } from "../styled-system/recipes";
+  import { styled } from '../styled-system/jsx'
+  import { button } from '../styled-system/recipes'
 
-  const Button = styled("button", button);
+  const Button = styled('button', button)
 
   function App() {
     return (
@@ -1557,7 +1555,7 @@ export default defineConfig({
           Click me
         </Button>
       </>
-    );
+    )
   }
   ```
 

--- a/packages/token-dictionary/CHANGELOG.md
+++ b/packages/token-dictionary/CHANGELOG.md
@@ -14,16 +14,16 @@
   ```ts
   // runtime usage
 
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
-  css({ bg: "{colors.blue.300/70}" });
+  css({ bg: '{colors.blue.300/70}' })
   // => @layer utilities {
   //    .bg_token\(colors\.blue\.300\/70\) {
   //      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
   //    }
   //  }
 
-  css({ bg: "token(colors.blue.300/70)" });
+  css({ bg: 'token(colors.blue.300/70)' })
   // => @layer utilities {
   //    .bg_token\(colors\.blue\.300\/70\) {
   //      background: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
@@ -33,37 +33,33 @@
 
   ```ts
   // build-time usage
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     theme: {
       tokens: {
         colors: {
           blue: {
-            300: { value: "#00f" },
+            300: { value: '#00f' },
           },
         },
       },
       semanticTokens: {
         colors: {
           primary: {
-            value: "{colors.blue.300/70}",
+            value: '{colors.blue.300/70}',
           },
         },
       },
     },
-  });
+  })
   ```
 
   ```css
   @layer tokens {
     :where(:root, :host) {
       --colors-blue-300: #00f;
-      --colors-primary: color-mix(
-        in srgb,
-        var(--colors-blue-300) 70%,
-        transparent
-      );
+      --colors-primary: color-mix(in srgb, var(--colors-blue-300) 70%, transparent);
     }
   }
   ```
@@ -100,7 +96,7 @@
   Given this config:
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
@@ -111,13 +107,13 @@
             bg: {
               primary: {
                 DEFAULT: {
-                  value: "{colors.red.500}",
+                  value: '{colors.red.500}',
                 },
                 base: {
-                  value: "{colors.green.500}",
+                  value: '{colors.green.500}',
                 },
                 hover: {
-                  value: "{colors.yellow.300}",
+                  value: '{colors.yellow.300}',
                 },
               },
             },
@@ -125,17 +121,17 @@
         },
       },
     },
-  });
+  })
   ```
 
   And this style usage:
 
   ```ts
-  import { css } from "styled-system/css";
+  import { css } from 'styled-system/css'
 
   css({
-    colorPalette: "bg.primary",
-  });
+    colorPalette: 'bg.primary',
+  })
   ```
 
   This is the difference in the generated css
@@ -249,10 +245,10 @@
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -331,13 +327,13 @@
         // add aspect ratio tokens
         tokens: {
           aspectRatios: {
-            "1:1": "1",
-            "16:9": "16/9",
+            '1:1': '1',
+            '16:9': '16/9',
           },
         },
       },
     },
-  });
+  })
   ```
 
   Here's what the default aspect ratio tokens in the base preset looks like:
@@ -398,11 +394,11 @@
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -422,18 +418,18 @@
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -681,18 +677,18 @@
         colors: {
           button: {
             dark: {
-              value: "navy",
+              value: 'navy',
             },
             light: {
               DEFAULT: {
-                value: "skyblue",
+                value: 'skyblue',
               },
               accent: {
                 DEFAULT: {
-                  value: "cyan",
+                  value: 'cyan',
                 },
                 secondary: {
-                  value: "blue",
+                  value: 'blue',
                 },
               },
             },
@@ -700,50 +696,50 @@
         },
       },
     },
-  };
+  }
   ```
 
   You can now use the root `button` color palette and its values directly:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button",
-          color: "colorPalette.light",
-          backgroundColor: "colorPalette.dark",
+          colorPalette: 'button',
+          color: 'colorPalette.light',
+          backgroundColor: 'colorPalette.dark',
           _hover: {
-            color: "colorPalette.light.accent",
-            background: "colorPalette.light.accent.secondary",
+            color: 'colorPalette.light.accent',
+            background: 'colorPalette.light.accent.secondary',
           },
         })}
       >
         Root color palette
       </button>
-    );
-  };
+    )
+  }
   ```
 
   Or you can use any deeply nested property (e.g. `button.light.accent`) as a root color palette:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button.light.accent",
-          color: "colorPalette.secondary",
+          colorPalette: 'button.light.accent',
+          color: 'colorPalette.secondary',
         })}
       >
         Nested color palette leaf
       </button>
-    );
-  };
+    )
+  }
   ```
 
 ### Patch Changes
@@ -958,11 +954,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -979,11 +975,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -1013,10 +1009,10 @@ export default defineConfig({
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -1095,13 +1091,13 @@ export default defineConfig({
         // add aspect ratio tokens
         tokens: {
           aspectRatios: {
-            "1:1": "1",
-            "16:9": "16/9",
+            '1:1': '1',
+            '16:9': '16/9',
           },
         },
       },
     },
-  });
+  })
   ```
 
   Here's what the default aspect ratio tokens in the base preset looks like:
@@ -1162,11 +1158,11 @@ export default defineConfig({
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -1186,18 +1182,18 @@ export default defineConfig({
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -1445,18 +1441,18 @@ export default defineConfig({
         colors: {
           button: {
             dark: {
-              value: "navy",
+              value: 'navy',
             },
             light: {
               DEFAULT: {
-                value: "skyblue",
+                value: 'skyblue',
               },
               accent: {
                 DEFAULT: {
-                  value: "cyan",
+                  value: 'cyan',
                 },
                 secondary: {
-                  value: "blue",
+                  value: 'blue',
                 },
               },
             },
@@ -1464,50 +1460,50 @@ export default defineConfig({
         },
       },
     },
-  };
+  }
   ```
 
   You can now use the root `button` color palette and its values directly:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button",
-          color: "colorPalette.light",
-          backgroundColor: "colorPalette.dark",
+          colorPalette: 'button',
+          color: 'colorPalette.light',
+          backgroundColor: 'colorPalette.dark',
           _hover: {
-            color: "colorPalette.light.accent",
-            background: "colorPalette.light.accent.secondary",
+            color: 'colorPalette.light.accent',
+            background: 'colorPalette.light.accent.secondary',
           },
         })}
       >
         Root color palette
       </button>
-    );
-  };
+    )
+  }
   ```
 
   Or you can use any deeply nested property (e.g. `button.light.accent`) as a root color palette:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button.light.accent",
-          color: "colorPalette.secondary",
+          colorPalette: 'button.light.accent',
+          color: 'colorPalette.secondary',
         })}
       >
         Nested color palette leaf
       </button>
-    );
-  };
+    )
+  }
   ```
 
 ### Patch Changes
@@ -1717,7 +1713,7 @@ Will now allow you to use the following syntax for token path:
   Given this config:
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
@@ -1728,13 +1724,13 @@ Will now allow you to use the following syntax for token path:
             bg: {
               primary: {
                 DEFAULT: {
-                  value: "{colors.red.500}",
+                  value: '{colors.red.500}',
                 },
                 base: {
-                  value: "{colors.green.500}",
+                  value: '{colors.green.500}',
                 },
                 hover: {
-                  value: "{colors.yellow.300}",
+                  value: '{colors.yellow.300}',
                 },
               },
             },
@@ -1742,17 +1738,17 @@ Will now allow you to use the following syntax for token path:
         },
       },
     },
-  });
+  })
   ```
 
   And this style usage:
 
   ```ts
-  import { css } from "styled-system/css";
+  import { css } from 'styled-system/css'
 
   css({
-    colorPalette: "bg.primary",
-  });
+    colorPalette: 'bg.primary',
+  })
   ```
 
   This is the difference in the generated css
@@ -1866,10 +1862,10 @@ Will now allow you to use the following syntax for token path:
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -1948,13 +1944,13 @@ Will now allow you to use the following syntax for token path:
         // add aspect ratio tokens
         tokens: {
           aspectRatios: {
-            "1:1": "1",
-            "16:9": "16/9",
+            '1:1': '1',
+            '16:9': '16/9',
           },
         },
       },
     },
-  });
+  })
   ```
 
   Here's what the default aspect ratio tokens in the base preset looks like:
@@ -2015,11 +2011,11 @@ Will now allow you to use the following syntax for token path:
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -2039,18 +2035,18 @@ Will now allow you to use the following syntax for token path:
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -2298,18 +2294,18 @@ Will now allow you to use the following syntax for token path:
         colors: {
           button: {
             dark: {
-              value: "navy",
+              value: 'navy',
             },
             light: {
               DEFAULT: {
-                value: "skyblue",
+                value: 'skyblue',
               },
               accent: {
                 DEFAULT: {
-                  value: "cyan",
+                  value: 'cyan',
                 },
                 secondary: {
-                  value: "blue",
+                  value: 'blue',
                 },
               },
             },
@@ -2317,50 +2313,50 @@ Will now allow you to use the following syntax for token path:
         },
       },
     },
-  };
+  }
   ```
 
   You can now use the root `button` color palette and its values directly:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button",
-          color: "colorPalette.light",
-          backgroundColor: "colorPalette.dark",
+          colorPalette: 'button',
+          color: 'colorPalette.light',
+          backgroundColor: 'colorPalette.dark',
           _hover: {
-            color: "colorPalette.light.accent",
-            background: "colorPalette.light.accent.secondary",
+            color: 'colorPalette.light.accent',
+            background: 'colorPalette.light.accent.secondary',
           },
         })}
       >
         Root color palette
       </button>
-    );
-  };
+    )
+  }
   ```
 
   Or you can use any deeply nested property (e.g. `button.light.accent`) as a root color palette:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button.light.accent",
-          color: "colorPalette.secondary",
+          colorPalette: 'button.light.accent',
+          color: 'colorPalette.secondary',
         })}
       >
         Nested color palette leaf
       </button>
-    );
-  };
+    )
+  }
   ```
 
 ### Patch Changes
@@ -2575,11 +2571,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -2596,11 +2592,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 - Updated dependencies [74485ef1]
@@ -2630,10 +2626,10 @@ export default defineConfig({
   css({
     // ✅ this is fine now, will resolve to something like
     // `@container (min-width: 56em)`
-    "@container (min-width: {sizes.4xl})": {
-      color: "green",
+    '@container (min-width: {sizes.4xl})': {
+      color: 'green',
     },
-  });
+  })
   ```
 
   Fix an issue where the curly token references would not be escaped if the token path was not found.
@@ -2712,13 +2708,13 @@ export default defineConfig({
         // add aspect ratio tokens
         tokens: {
           aspectRatios: {
-            "1:1": "1",
-            "16:9": "16/9",
+            '1:1': '1',
+            '16:9': '16/9',
           },
         },
       },
     },
-  });
+  })
   ```
 
   Here's what the default aspect ratio tokens in the base preset looks like:
@@ -2779,11 +2775,11 @@ export default defineConfig({
 - de282f60: Support token reference syntax when authoring styles object, text styles and layer styles.
 
   ```jsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   const styles = css({
-    border: "2px solid {colors.primary}",
-  });
+    border: '2px solid {colors.primary}',
+  })
   ```
 
   This will resolve the token reference and convert it to css variables.
@@ -2803,18 +2799,18 @@ export default defineConfig({
   ```jsx
   const styles = css({
     // token reference syntax
-    border: "2px solid {colors.primary}",
+    border: '2px solid {colors.primary}',
     // token function syntax
-    border: "2px solid token(colors.primary)",
-  });
+    border: '2px solid token(colors.primary)',
+  })
   ```
 
   However, The `token(...)` syntax allows you to set a fallback value.
 
   ```jsx
   const styles = css({
-    border: "2px solid token(colors.primary, red)",
-  });
+    border: '2px solid token(colors.primary, red)',
+  })
   ```
 
 ### Patch Changes
@@ -3062,18 +3058,18 @@ export default defineConfig({
         colors: {
           button: {
             dark: {
-              value: "navy",
+              value: 'navy',
             },
             light: {
               DEFAULT: {
-                value: "skyblue",
+                value: 'skyblue',
               },
               accent: {
                 DEFAULT: {
-                  value: "cyan",
+                  value: 'cyan',
                 },
                 secondary: {
-                  value: "blue",
+                  value: 'blue',
                 },
               },
             },
@@ -3081,50 +3077,50 @@ export default defineConfig({
         },
       },
     },
-  };
+  }
   ```
 
   You can now use the root `button` color palette and its values directly:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button",
-          color: "colorPalette.light",
-          backgroundColor: "colorPalette.dark",
+          colorPalette: 'button',
+          color: 'colorPalette.light',
+          backgroundColor: 'colorPalette.dark',
           _hover: {
-            color: "colorPalette.light.accent",
-            background: "colorPalette.light.accent.secondary",
+            color: 'colorPalette.light.accent',
+            background: 'colorPalette.light.accent.secondary',
           },
         })}
       >
         Root color palette
       </button>
-    );
-  };
+    )
+  }
   ```
 
   Or you can use any deeply nested property (e.g. `button.light.accent`) as a root color palette:
 
   ```tsx
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   export const App = () => {
     return (
       <button
         className={css({
-          colorPalette: "button.light.accent",
-          color: "colorPalette.secondary",
+          colorPalette: 'button.light.accent',
+          color: 'colorPalette.secondary',
         })}
       >
         Nested color palette leaf
       </button>
-    );
-  };
+    )
+  }
   ```
 
 ### Patch Changes

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -18,8 +18,8 @@
   ## As alternatives, you can use:
 
   - relative paths instead of absolute paths (e.g. `../styled-system/css` instead of `styled-system/css`)
-  - use [package.json #imports](https://nodejs.org/api/packages.html#subpath-imports) and/or tsconfig path aliases (prefer
-    package.json#imports when possible, TS 5.4 supports them by default) like `#styled-system/css` instead of
+  - use [package.json #imports](https://nodejs.org/api/packages.html#subpath-imports) and/or tsconfig path aliases
+    (prefer package.json#imports when possible, TS 5.4 supports them by default) like `#styled-system/css` instead of
     `styled-system/css`
   - for a [component library](https://panda-css.com/docs/guides/component-library), use a dedicated workspace package
     (e.g. `@acme/styled-system`) and use `importMap: "@acme/styled-system"` so that Panda knows which entrypoint to
@@ -36,15 +36,15 @@
   class assigned.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     preflight: {
-      scope: ".my-scope",
-      level: "element", // 'element' | 'parent (default)'
+      scope: '.my-scope',
+      level: 'element', // 'element' | 'parent (default)'
     },
     // ...
-  });
+  })
   ```
 
   This will generate CSS that looks like:
@@ -74,20 +74,20 @@
   export default defaultConfig({
     conditions: {
       extend: {
-        supportHover: ["@media (hover: hover) and (pointer: fine)", "&:hover"],
+        supportHover: ['@media (hover: hover) and (pointer: fine)', '&:hover'],
       },
     },
-  });
+  })
   ```
 
   ```ts
-  import { css } from "../styled-system/css";
+  import { css } from '../styled-system/css'
 
   css({
     _supportHover: {
-      color: "red",
+      color: 'red',
     },
-  });
+  })
   ```
 
   will generate the following CSS:
@@ -164,17 +164,16 @@
   export default defineConfig({
     // ...
     hooks: {
-      "parser:before": ({ configure }) => {
+      'parser:before': ({ configure }) => {
         configure({
           // ignore the Select.Content entirely
-          matchTag: (tag) => tag !== "Select.Content",
+          matchTag: (tag) => tag !== 'Select.Content',
           // ...or specifically ignore the `position` property
-          matchTagProp: (tag, prop) =>
-            tag === "Select.Content" && prop !== "position",
-        });
+          matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position',
+        })
       },
     },
-  });
+  })
   ```
 
 ## 0.30.1
@@ -190,16 +189,16 @@
   keeping the rest. Let's say we want to remove the `stack` pattern from the built-in `@pandacss/preset-base`:
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     hooks: {
-      "config:resolved": ({ config, utils }) => {
-        return utils.omit(config, ["patterns.stack"]);
+      'config:resolved': ({ config, utils }) => {
+        return utils.omit(config, ['patterns.stack'])
       },
     },
-  });
+  })
   ```
 
 - ab32d1d7: Introduce 3 new hooks:
@@ -236,9 +235,9 @@
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -246,11 +245,7 @@
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -274,21 +269,21 @@
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -297,21 +292,21 @@
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -339,34 +334,34 @@
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -451,8 +446,8 @@
   ```ts
   export default defineConfig({
     // ...
-    dependencies: ["path/to/files/**.ts"],
-  });
+    dependencies: ['path/to/files/**.ts'],
+  })
   ```
 
   - Invoke `config:change` hook in more situations (when the `--watch` flag is passed to `panda codegen`,
@@ -485,54 +480,39 @@
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -612,38 +592,38 @@
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -795,36 +775,36 @@
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 ## 0.20.1
@@ -842,10 +822,10 @@
     staticCss: {
       recipes: {
         // generate all button styles and variants
-        button: ["*"],
+        button: ['*'],
       },
     },
-  });
+  })
 
   export default defineConfig({
     presets: [presetWithStaticCss],
@@ -853,11 +833,11 @@
       extend: {
         recipes: {
           // extend and pre-generate all sizes for card
-          card: [{ size: ["small", "medium", "large"] }],
+          card: [{ size: ['small', 'medium', 'large'] }],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -927,42 +907,42 @@
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - 58743bc4: - Fix `ExtendableUtilityConfig` typings after a regression in 0.15.2 (due to
@@ -1036,12 +1016,12 @@
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -1049,33 +1029,33 @@
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -1126,26 +1106,26 @@
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ## 0.8.0
@@ -1174,7 +1154,7 @@
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -1184,7 +1164,7 @@
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -1208,8 +1188,8 @@
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -1230,12 +1210,12 @@
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes
@@ -1308,11 +1288,11 @@ This hook is called right before writing the codegen files to disk. You can use 
 export default defineConfig({
   // ...
   hooks: {
-    "codegen:prepare": ({ artifacts, changed }) => {
+    'codegen:prepare': ({ artifacts, changed }) => {
       // do something with the emitted js/d.ts files
     },
   },
-});
+})
 ```
 
 - d5977c24: - Add a `--logfile` flag to the `panda`, `panda codegen`, `panda cssgen` and `panda debug` commands.
@@ -1329,11 +1309,11 @@ export default defineConfig({
   ```js
   module.exports = {
     plugins: {
-      "@pandacss/dev/postcss": {
-        logfile: "./logs/panda.log",
+      '@pandacss/dev/postcss': {
+        logfile: './logs/panda.log',
       },
     },
-  };
+  }
   ```
 
 ## 0.29.1
@@ -1352,9 +1332,9 @@ export default defineConfig({
 
   ```ts
   css({
-    bg: "red.300/40",
-    color: "white",
-  });
+    bg: 'red.300/40',
+    color: 'white',
+  })
   ```
 
   This will generate:
@@ -1362,11 +1342,7 @@ export default defineConfig({
   ```css
   @layer utilities {
     .bg_red\.300\/40 {
-      --mix-background: color-mix(
-        in srgb,
-        var(--colors-red-300) 40%,
-        transparent
-      );
+      --mix-background: color-mix(in srgb, var(--colors-red-300) 40%, transparent);
       background: var(--mix-background, var(--colors-red-300));
     }
 
@@ -1390,21 +1366,21 @@ export default defineConfig({
   export default defineConfig({
     utilities: {
       background: {
-        shorthand: "bg",
-        className: "bg",
-        values: "colors",
+        shorthand: 'bg',
+        className: 'bg',
+        values: 'colors',
         transform(value, args) {
-          const mix = args.utils.colorMix(value);
+          const mix = args.utils.colorMix(value)
           // This can happen if the value format is invalid (e.g. `bg: red.300/invalid` or `bg: red.300//10`)
-          if (mix.invalid) return { background: value };
+          if (mix.invalid) return { background: value }
 
           return {
             background: mix.value,
-          };
+          }
         },
       },
     },
-  });
+  })
   ```
 
   ***
@@ -1413,21 +1389,21 @@ export default defineConfig({
   property:
 
   ```ts
-  import type { PropertyTransform } from "@pandacss/types";
+  import type { PropertyTransform } from '@pandacss/types'
 
   export const createColorMixTransform =
     (prop: string): PropertyTransform =>
     (value, args) => {
-      const mix = args.utils.colorMix(value);
-      if (mix.invalid) return { [prop]: value };
+      const mix = args.utils.colorMix(value)
+      if (mix.invalid) return { [prop]: value }
 
-      const cssVar = "--mix-" + prop;
+      const cssVar = '--mix-' + prop
 
       return {
         [cssVar]: mix.value,
         [prop]: `var(${cssVar}, ${mix.color})`,
-      };
-    };
+      }
+    }
   ```
 
   then the same utility transform as above can be written like this:
@@ -1455,34 +1431,34 @@ export default defineConfig({
     // ...
     theme: {
       extend: {
-        containerNames: ["sidebar", "content"],
+        containerNames: ['sidebar', 'content'],
         containerSizes: {
-          xs: "40em",
-          sm: "60em",
-          md: "80em",
+          xs: '40em',
+          sm: '60em',
+          md: '80em',
         },
       },
     },
-  });
+  })
   ```
 
   The default container sizes in the `@pandacss/preset-panda` preset are shown below:
 
   ```ts
   export const containerSizes = {
-    xs: "320px",
-    sm: "384px",
-    md: "448px",
-    lg: "512px",
-    xl: "576px",
-    "2xl": "672px",
-    "3xl": "768px",
-    "4xl": "896px",
-    "5xl": "1024px",
-    "6xl": "1152px",
-    "7xl": "1280px",
-    "8xl": "1440px",
-  };
+    xs: '320px',
+    sm: '384px',
+    md: '448px',
+    lg: '512px',
+    xl: '576px',
+    '2xl': '672px',
+    '3xl': '768px',
+    '4xl': '896px',
+    '5xl': '1024px',
+    '6xl': '1152px',
+    '7xl': '1280px',
+    '8xl': '1440px',
+  }
   ```
 
   Then use them in your styles by referencing using `@<container-name>/<container-size>` syntax:
@@ -1567,8 +1543,8 @@ export default defineConfig({
   ```ts
   export default defineConfig({
     // ...
-    dependencies: ["path/to/files/**.ts"],
-  });
+    dependencies: ['path/to/files/**.ts'],
+  })
   ```
 
   - Invoke `config:change` hook in more situations (when the `--watch` flag is passed to `panda codegen`,
@@ -1601,54 +1577,39 @@ export default defineConfig({
      * Called when the config is resolved, after all the presets are loaded and merged.
      * This is the first hook called, you can use it to tweak the config before the context is created.
      */
-    "config:resolved": (args: { conf: LoadConfigResult }) => MaybeAsyncReturn;
+    'config:resolved': (args: { conf: LoadConfigResult }) => MaybeAsyncReturn
     /**
      * Called when the Panda context has been created and the API is ready to be used.
      */
-    "context:created": (args: {
-      ctx: ApiInterface;
-      logger: LoggerInterface;
-    }) => void;
+    'context:created': (args: { ctx: ApiInterface; logger: LoggerInterface }) => void
     /**
      * Called when the config file or one of its dependencies (imports) has changed.
      */
-    "config:change": (args: { config: UserConfig }) => MaybeAsyncReturn;
+    'config:change': (args: { config: UserConfig }) => MaybeAsyncReturn
     /**
      * Called after reading the file content but before parsing it.
      * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
      * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
      */
-    "parser:before": (args: {
-      filePath: string;
-      content: string;
-    }) => string | void;
+    'parser:before': (args: { filePath: string; content: string }) => string | void
     /**
      * Called after the file styles are extracted and processed into the resulting ParserResult object.
      * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
      */
-    "parser:after": (args: {
-      filePath: string;
-      result: ParserResultInterface | undefined;
-    }) => void;
+    'parser:after': (args: { filePath: string; result: ParserResultInterface | undefined }) => void
     /**
      * Called after the codegen is completed
      */
-    "codegen:done": () => MaybeAsyncReturn;
+    'codegen:done': () => MaybeAsyncReturn
     /**
      * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
      * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
      * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
      */
-    "cssgen:done": (args: {
-      artifact:
-        | "global"
-        | "static"
-        | "reset"
-        | "tokens"
-        | "keyframes"
-        | "styles.css";
-      content: string;
-    }) => string | void;
+    'cssgen:done': (args: {
+      artifact: 'global' | 'static' | 'reset' | 'tokens' | 'keyframes' | 'styles.css'
+      content: string
+    }) => string | void
   }
   ```
 
@@ -1728,38 +1689,38 @@ export default defineConfig({
 
   ```ts
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
       visual: {
-        primary: { backgroundColor: "blue" },
-        secondary: { backgroundColor: "gray" },
+        primary: { backgroundColor: 'blue' },
+        secondary: { backgroundColor: 'gray' },
       },
     },
-  });
+  })
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
-        card: ["*"], // this
+        card: ['*'], // this
 
         // was equivalent to:
         card: [
           // notice how `responsive: true` was implicitly added
-          { size: ["*"], responsive: true },
-          { visual: ["*"], responsive: true },
+          { size: ['*'], responsive: true },
+          { visual: ['*'], responsive: true },
         ],
 
         //   will now correctly be equivalent to:
-        card: [{ size: ["*"] }, { visual: ["*"] }],
+        card: [{ size: ['*'] }, { visual: ['*'] }],
       },
     },
-  });
+  })
   ```
 
   Here's the diff in the generated CSS:
@@ -1911,36 +1872,36 @@ export default defineConfig({
 - 105f74ce: Add a way to specify a recipe's `staticCss` options from inside a recipe config, e.g.:
 
   ```js
-  import { defineRecipe } from "@pandacss/dev";
+  import { defineRecipe } from '@pandacss/dev'
 
   const card = defineRecipe({
-    className: "card",
-    base: { color: "white" },
+    className: 'card',
+    base: { color: 'white' },
     variants: {
       size: {
-        small: { fontSize: "14px" },
-        large: { fontSize: "18px" },
+        small: { fontSize: '14px' },
+        large: { fontSize: '18px' },
       },
     },
-    staticCss: [{ size: ["*"] }],
-  });
+    staticCss: [{ size: ['*'] }],
+  })
   ```
 
   would be the equivalent of defining it inside the main config:
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     staticCss: {
       recipes: {
         card: {
-          size: ["*"],
+          size: ['*'],
         },
       },
     },
-  });
+  })
   ```
 
 ## 0.20.1
@@ -1958,10 +1919,10 @@ export default defineConfig({
     staticCss: {
       recipes: {
         // generate all button styles and variants
-        button: ["*"],
+        button: ['*'],
       },
     },
-  });
+  })
 
   export default defineConfig({
     presets: [presetWithStaticCss],
@@ -1969,11 +1930,11 @@ export default defineConfig({
       extend: {
         recipes: {
           // extend and pre-generate all sizes for card
-          card: [{ size: ["small", "medium", "large"] }],
+          card: [{ size: ['small', 'medium', 'large'] }],
         },
       },
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -2043,42 +2004,42 @@ export default defineConfig({
 
   ```ts
   export default defineConfig({
-    outdir: "./outdir",
+    outdir: './outdir',
     importMap: {
-      css: "#panda/styled-system/css",
-      recipes: "#panda/styled-system/recipes",
-      patterns: "#panda/styled-system/patterns",
-      jsx: "#panda/styled-system/jsx",
+      css: '#panda/styled-system/css',
+      recipes: '#panda/styled-system/recipes',
+      patterns: '#panda/styled-system/patterns',
+      jsx: '#panda/styled-system/jsx',
     },
-  });
+  })
   ```
 
   Or you could also make your outdir an actual package from your monorepo:
 
   ```ts
   export default defineConfig({
-    outdir: "../packages/styled-system",
+    outdir: '../packages/styled-system',
     importMap: {
-      css: "@monorepo/styled-system",
-      recipes: "@monorepo/styled-system",
-      patterns: "@monorepo/styled-system",
-      jsx: "@monorepo/styled-system",
+      css: '@monorepo/styled-system',
+      recipes: '@monorepo/styled-system',
+      patterns: '@monorepo/styled-system',
+      jsx: '@monorepo/styled-system',
     },
-  });
+  })
   ```
 
   Working with tsconfig paths aliases is easy:
 
   ```ts
   export default defineConfig({
-    outdir: "styled-system",
+    outdir: 'styled-system',
     importMap: {
-      css: "styled-system/css",
-      recipes: "styled-system/recipes",
-      patterns: "styled-system/patterns",
-      jsx: "styled-system/jsx",
+      css: 'styled-system/css',
+      recipes: 'styled-system/recipes',
+      patterns: 'styled-system/patterns',
+      jsx: 'styled-system/jsx',
     },
-  });
+  })
   ```
 
 - 58743bc4: - Fix `ExtendableUtilityConfig` typings after a regression in 0.15.2 (due to
@@ -2152,12 +2113,12 @@ export default defineConfig({
   **Definition**
 
   ```jsx
-  import { sva } from "styled-system/css";
+  import { sva } from 'styled-system/css'
 
   const button = sva({
-    slots: ["label", "icon"],
+    slots: ['label', 'icon'],
     base: {
-      label: { color: "red", textDecoration: "underline" },
+      label: { color: 'red', textDecoration: 'underline' },
     },
     variants: {
       rounded: {
@@ -2165,33 +2126,33 @@ export default defineConfig({
       },
       size: {
         sm: {
-          label: { fontSize: "sm" },
-          icon: { fontSize: "sm" },
+          label: { fontSize: 'sm' },
+          icon: { fontSize: 'sm' },
         },
         lg: {
-          label: { fontSize: "lg" },
-          icon: { fontSize: "lg", color: "pink" },
+          label: { fontSize: 'lg' },
+          icon: { fontSize: 'lg', color: 'pink' },
         },
       },
     },
     defaultVariants: {
-      size: "sm",
+      size: 'sm',
     },
-  });
+  })
   ```
 
   **Usage**
 
   ```jsx
   export function App() {
-    const btnClass = button({ size: "lg", rounded: true });
+    const btnClass = button({ size: 'lg', rounded: true })
 
     return (
       <button>
         <p class={btnClass.label}> Label</p>
         <p class={btnClass.icon}> Icon</p>
       </button>
-    );
+    )
   }
   ```
 
@@ -2242,26 +2203,26 @@ export default defineConfig({
   Update the `jsx` property to be used for advanced tracking of custom pattern components.
 
   ```jsx
-  import { Circle } from "styled-system/jsx";
+  import { Circle } from 'styled-system/jsx'
   const CustomCircle = ({ children, ...props }) => {
-    return <Circle {...props}>{children}</Circle>;
-  };
+    return <Circle {...props}>{children}</Circle>
+  }
   ```
 
   To track the `CustomCircle` component, you can now use the `jsx` property.
 
   ```js
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     patterns: {
       extend: {
         circle: {
-          jsx: ["CustomCircle"],
+          jsx: ['CustomCircle'],
         },
       },
     },
-  });
+  })
   ```
 
 ## 0.8.0
@@ -2290,7 +2251,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: [{ size: ["*"], shape: ["*"] }];
+      button: [{ size: ['*'], shape: ['*'] }]
     }
   }
   ```
@@ -2300,7 +2261,7 @@ export default defineConfig({
   ```ts
   staticCss: {
     recipes: {
-      button: ["*"];
+      button: ['*']
     }
   }
   ```
@@ -2324,8 +2285,8 @@ export default defineConfig({
   // panda.config.ts
   export default defineConfig({
     //...
-    syntax: "template-literal",
-  });
+    syntax: 'template-literal',
+  })
   ```
 
   > For existing projects, you might need to run the `panda codegen --clean`
@@ -2346,12 +2307,12 @@ export default defineConfig({
 - 5b344b9c: Add support for disabling shorthand props
 
   ```ts
-  import { defineConfig } from "@pandacss/dev";
+  import { defineConfig } from '@pandacss/dev'
 
   export default defineConfig({
     // ...
     shorthands: false,
-  });
+  })
   ```
 
 ### Patch Changes


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/2318

## 📝 Description

Fix the color opacity modifier syntax for `semanticTokens` inside of conditions

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  conditions: {
    light: '.light &',
    dark: '.dark &',
  },
  theme: {
    tokens: {
      colors: {
        blue: { 500: { value: 'blue' } },
        green: { 500: { value: 'green' } },
      },
      opacity: {
        half: { value: 0.5 },
      },
    },
    semanticTokens: {
      colors: {
        secondary: {
          value: {
            base: 'red',
            _light: '{colors.blue.500/32}', // <-- wasn't working as expected
            _dark: '{colors.green.500/half}',
          },
        },
      },
    },
  },
})
```

will now correctly generate the following CSS:

```css
@layer tokens {
  :where(:root, :host) {
    --colors-blue-500: blue;
    --colors-green-500: green;
    --opacity-half: 0.5;
    --colors-secondary: red;
  }

  .light {
    --colors-secondary: color-mix(in srgb, var(--colors-blue-500) 32%, transparent);
  }

  .dark {
    --colors-secondary: color-mix(in srgb, var(--colors-green-500) 50%, transparent);
  }
}
```

## 💣 Is this a breaking change (Yes/No):

no
