### PR TITLE
feat: extract namespace imports

### DIFF
--- a/.changeset/orange-bikes-collect.md
+++ b/.changeset/orange-bikes-collect.md
@@ -1,0 +1,22 @@
+---
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Allow using namespaced imports
+
+```ts
+import * as p from 'styled-system/patterns'
+import * as recipes from 'styled-system/recipes'
+import * as panda from 'styled-system/css'
+
+// this will now be extracted
+p.stack({ mt: '40px' })
+
+recipes.cardStyle({ rounded: true })
+
+panda.css({ color: 'red' })
+panda.cva({ base: { color: 'blue' } })
+panda.sva({ base: { root: { color: 'green' } } })
+```

--- a/packages/core/src/file-matcher.ts
+++ b/packages/core/src/file-matcher.ts
@@ -13,6 +13,7 @@ export interface ImportResult {
    */
   mod: string
   importMapValue?: string
+  kind?: 'named' | 'namespace'
 }
 
 interface FileMatcherOptions {
@@ -20,8 +21,11 @@ interface FileMatcherOptions {
   value: ImportResult[]
 }
 
+const cssEntrypointFns = new Set(['css', 'cva', 'sva'])
+
 export class FileMatcher {
   imports: ImportResult[]
+  namespaces: Map<string, ImportResult> = new Map()
   private importMap: ImportMapOutput<string>
 
   private cssAliases = new Set<string>()
@@ -44,6 +48,11 @@ export class FileMatcher {
 
     this.importMap = importMap
     this.imports = value
+    this.imports.forEach((result) => {
+      if (result.kind === 'namespace') {
+        this.namespaces.set(result.name, result)
+      }
+    })
 
     this.assignAliases()
     this.assignProperties()
@@ -73,6 +82,24 @@ export class FileMatcher {
 
       if (result.name === this.context.jsx.factoryName) {
         this.jsxFactoryAliases.add(result.alias)
+      }
+
+      if (result.kind === 'namespace') {
+        // Add all patterns when using a namespace import
+        // e.g. import * as p from '../styled-system/patterns'
+        if (result.mod.includes(this.importMap.pattern)) {
+          this.context.patterns.keys.forEach((pattern) => {
+            this.patternAliases.add(pattern)
+          })
+        }
+
+        // Add all recipes when using a namespace import
+        // e.g. import * as r from '../styled-system/recipes'
+        if (result.mod.includes(this.importMap.recipe)) {
+          this.context.recipes.keys.forEach((recipe) => {
+            this.recipeAliases.add(recipe)
+          })
+        }
       }
     })
   }
@@ -104,11 +131,20 @@ export class FileMatcher {
   private createMatch = (mod: string, keys: string[]) => {
     const mods = this.imports.filter((o) => {
       const isFromMod = o.mod.includes(mod) || o.importMapValue?.includes(mod)
-      const isOneOfKeys = keys.includes(o.name)
+      const isOneOfKeys = o.kind === 'namespace' ? true : keys.includes(o.name)
       return isFromMod && isOneOfKeys
     })
 
-    return memo((id: string) => !!mods.find((mod) => mod.alias === id || mod.name === id))
+    return memo((id: string) => {
+      return !!mods.find((mod) => {
+        // Match patterns/recipes when using a namespace import
+        if (mod.kind === 'namespace') {
+          return keys.includes(id)
+        }
+
+        return mod.alias === id || mod.name === id
+      })
+    })
   }
 
   match = (id: string) => {
@@ -123,13 +159,17 @@ export class FileMatcher {
     return this.imports.filter((o) => o.name === id).map((o) => o.alias || id)
   }
 
+  private _patternsMatcher: ReturnType<typeof this.createMatch> | undefined
   isValidPattern = (id: string) => {
-    const match = this.createMatch(this.importMap.pattern, this.context.patterns.keys)
+    if (!this._patternsMatcher)
+      this._patternsMatcher = this.createMatch(this.importMap.pattern, this.context.patterns.keys)
+    const match = this._patternsMatcher
     return match(id)
   }
-
+  private _recipesMatcher: ReturnType<typeof this.createMatch> | undefined
   isValidRecipe = (id: string) => {
-    const match = this.createMatch(this.importMap.recipe, this.context.recipes.keys)
+    if (!this._recipesMatcher) this._recipesMatcher = this.createMatch(this.importMap.recipe, this.context.recipes.keys)
+    const match = this._recipesMatcher
     return match(id)
   }
 
@@ -139,7 +179,20 @@ export class FileMatcher {
   }
 
   normalizeFnName = (fnName: string) => {
-    return this.isRawFn(fnName) ? fnName.replace('.raw', '') : fnName
+    if (this.isRawFn(fnName)) return fnName.replace('.raw', '')
+
+    // ASSUMPTION: the only way to have a `.` in the fnName is
+    // - when using `{fn}.raw` (handled above)
+    // - when using a jsx factory (e.g. `<styled.div />`) (skipped in the condition below)
+
+    // or when using a namespace import, which is the case handled in the condition below
+    // import * as p from '../styled-system/patterns'
+    // 'p.stack' => 'stack'
+    if (!this.isJsxFactory(fnName) && fnName.includes('.')) {
+      return fnName.split('.')[1]
+    }
+
+    return fnName
   }
 
   isAliasFnName = memo((fnName: string) => {
@@ -154,7 +207,19 @@ export class FileMatcher {
   matchFn = memo((fnName: string) => {
     if (this.recipeAliases.has(fnName) || this.patternAliases.has(fnName)) return true
     if (this.isAliasFnName(fnName) || this.isRawFn(fnName)) return true
-    return this.functions.has(fnName)
+    if (this.functions.has(fnName)) return true
+
+    const [namespace, identifier] = fnName.split('.')
+    const ns = this.namespaces.get(namespace)
+    if (ns) {
+      if (ns.mod.includes(this.importMap.css) && cssEntrypointFns.has(identifier)) return true
+      if (ns.mod.includes(this.importMap.recipe) && this.recipeAliases.has(identifier)) return true
+      if (ns.mod.includes(this.importMap.pattern) && this.patternAliases.has(identifier)) return true
+
+      return this.functions.has(identifier)
+    }
+
+    return false
   })
 
   isJsxFactory = memo((tagName: string) => {

--- a/packages/core/src/import-map.ts
+++ b/packages/core/src/import-map.ts
@@ -77,7 +77,7 @@ export class ImportMap {
 
     for (const { regex, mod } of Object.values(this.matchers)) {
       // if none of the imported values match the regex, skip
-      if (!regex.test(result.name)) continue
+      if (result.kind !== 'namespace' && !regex.test(result.name)) continue
 
       // this checks that `yyy` contains {outdir}/{folder} in `import xxx from yyy`
       if (result.mod.includes(mod)) {

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -6018,3 +6018,37 @@ it('handles TS enum', () => {
     }
   `)
 })
+
+it('can handle TS namespaces', () => {
+  const code = `
+import * as p from "styled-system/patterns"
+
+p.stack({ mt: "40px" })`
+
+  expect(
+    extractFromCode(code, {
+      functions: {
+        matchFn: ({ fnName }) => {
+          const identifier = fnName.split('.')[1]
+          return identifier === 'stack'
+        },
+        matchProp: () => true,
+        matchArg: () => true,
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "p.stack": [
+        {
+          "conditions": [],
+          "raw": [
+            {
+              "mt": "40px",
+            },
+          ],
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/parser/__tests__/import.test.ts
+++ b/packages/parser/__tests__/import.test.ts
@@ -13,6 +13,7 @@ describe('extract imports', () => {
       [
         {
           "alias": "nCss",
+          "kind": "named",
           "mod": "@panda/css",
           "name": "css",
         },

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3679,4 +3679,235 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('TS namespaces - patterns', () => {
+    const code = `
+    import * as p from "styled-system/patterns"
+
+    p.stack({ mt: "40px" })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "mt": "40px",
+            },
+          ],
+          "name": "stack",
+          "type": "pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .d_flex {
+          display: flex;
+      }
+
+        .gap_10px {
+          gap: 10px;
+      }
+
+        .flex_column {
+          flex-direction: column;
+      }
+
+        .mt_40px {
+          margin-top: 40px;
+      }
+      }"
+    `)
+  })
+
+  test('TS namespaces - recipes', () => {
+    const code = `
+    import * as recipes from "styled-system/recipes"
+
+    recipes.cardStyle({ rounded: true })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "rounded": true,
+            },
+          ],
+          "name": "cardStyle",
+          "type": "recipe",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes {
+        .card--rounded_true {
+          border-radius: 0.375rem;
+      }
+      }"
+    `)
+  })
+
+  test('TS namespaces - css', () => {
+    const code = `
+    import * as panda from "styled-system/css"
+
+    panda.css({ color: "red" })
+    panda.cva({ base: { color: "blue" } })
+    panda.sva({ base: { root: { color: "green" } } })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "color": "red",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+        {
+          "data": [
+            {
+              "base": {
+                "color": "blue",
+              },
+            },
+          ],
+          "name": "cva",
+          "type": "cva",
+        },
+        {
+          "data": [
+            {
+              "base": {
+                "root": {
+                  "color": "green",
+                },
+              },
+              "slots": [
+                "root",
+              ],
+            },
+          ],
+          "name": "sva",
+          "type": "sva",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_red {
+          color: red;
+      }
+
+        .text_blue {
+          color: blue;
+      }
+
+        .text_green {
+          color: green;
+      }
+      }"
+    `)
+  })
+
+  test('TS namespaces - jsx', () => {
+    const code = `
+    import * as JSX from "styled-system/jsx"
+
+    const App = () => {
+      return <>
+      <JSX.styled.div color="red" />
+      <JSX.Stack color="blue" />
+      <JSX.Grid color="green" />
+      </>
+    }
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "color": "red",
+            },
+          ],
+          "name": "styled",
+          "type": "jsx",
+        },
+        {
+          "data": [
+            {
+              "color": "blue",
+            },
+          ],
+          "name": "Stack",
+          "type": "jsx-pattern",
+        },
+        {
+          "data": [
+            {
+              "color": "green",
+            },
+          ],
+          "name": "Grid",
+          "type": "jsx-pattern",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_red {
+          color: red;
+      }
+
+        .d_flex {
+          display: flex;
+      }
+
+        .gap_10px {
+          gap: 10px;
+      }
+
+        .text_blue {
+          color: blue;
+      }
+
+        .d_grid {
+          display: grid;
+      }
+
+        .text_green {
+          color: green;
+      }
+
+        .flex_column {
+          flex-direction: column;
+      }
+      }"
+    `)
+  })
+
+  test('TS namespaces - ignore not from panda', () => {
+    const code = `
+    import * as panda from "not-panda"
+
+    panda.css({ color: "red" })
+    panda.cva({ base: { color: "blue" } })
+    panda.sva({ base: { root: { color: "green" } } })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`[]`)
+
+    expect(result.css).toMatchInlineSnapshot(`""`)
+  })
 })

--- a/packages/parser/src/get-import-declarations.ts
+++ b/packages/parser/src/get-import-declarations.ts
@@ -12,11 +12,12 @@ export function getImportDeclarations(context: ParserOptions, sourceFile: Source
     const mod = getModuleSpecifierValue(node)
     if (!mod) return
 
+    // import { flex, stack } from "styled-system/patterns"
     node.getNamedImports().forEach((specifier) => {
       const name = specifier.getNameNode().getText()
       const alias = specifier.getAliasNode()?.getText() || name
 
-      const result = { name, alias, mod }
+      const result: ImportResult = { name, alias, mod, kind: 'named' }
 
       const found = imports.match(result, (mod) => {
         if (!tsOptions?.pathMappings) return
@@ -27,6 +28,22 @@ export function getImportDeclarations(context: ParserOptions, sourceFile: Source
 
       importDeclarations.push(result)
     })
+
+    // import * as p from "styled-system/patterns
+    const namespace = node.getNamespaceImport()
+    if (namespace) {
+      const name = namespace.getText()
+      const result: ImportResult = { name, alias: name, mod, kind: 'namespace' }
+
+      const found = imports.match(result, (mod) => {
+        if (!tsOptions?.pathMappings) return
+        return resolveTsPathPattern(tsOptions.pathMappings, mod)
+      })
+
+      if (!found) return
+
+      importDeclarations.push(result)
+    }
   })
 
   return importDeclarations


### PR DESCRIPTION
## 📝 Description

Allow using namespaced imports

```ts
import * as p from 'styled-system/patterns'
import * as recipes from 'styled-system/recipes'
import * as panda from 'styled-system/css'

// this will now be extracted
p.stack({ mt: '40px' })

recipes.cardStyle({ rounded: true })

panda.css({ color: 'red' })
panda.cva({ base: { color: 'blue' } })
panda.sva({ base: { root: { color: 'green' } } })
```

## 💣 Is this a breaking change (Yes/No):

no
