### PR TITLE
fix(hooks): add missing reducers to properly return results for confi…

### DIFF
--- a/.changeset/ninety-months-run.md
+++ b/.changeset/ninety-months-run.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/config': patch
+'@pandacss/parser': patch
+'@pandacss/types': patch
+---
+
+Add missing reducers to properly return the results of hooks for `config:resolved` and `parser:before`

--- a/packages/config/__tests__/merge-hooks.test.ts
+++ b/packages/config/__tests__/merge-hooks.test.ts
@@ -152,7 +152,7 @@ describe('mergeConfigs / theme', () => {
       },
     ])
 
-    const result = hooks['codegen:prepare']?.({
+    const result = await hooks['codegen:prepare']?.({
       changed: [],
       artifacts: [
         { id: 'recipes.1', files: [{ code: 'aaa aaa aaa', file: 'aaa.js' }] },

--- a/packages/config/src/merge-hooks.ts
+++ b/packages/config/src/merge-hooks.ts
@@ -22,12 +22,9 @@ export const mergeHooks = (plugins: PandaPlugin[]) => {
 
       // Those special hooks use their callback return to update the internal state
       // Each fn is called sequentially and the result of the previous hook is passed to the next hook
-      if (key === 'cssgen:done') {
-        return [key, reducers['cssgen:done'](fns)]
-      }
-
-      if (key === 'codegen:prepare') {
-        return [key, reducers['codegen:prepare'](fns)]
+      const reducer = key in reducers ? reducers[key as keyof typeof reducers] : undefined
+      if (reducer) {
+        return [key, reducer(fns)]
       }
 
       return [key, syncHooks.includes(key) ? callAll(...fns) : callAllAsync(...fns)]
@@ -37,35 +34,70 @@ export const mergeHooks = (plugins: PandaPlugin[]) => {
   return mergedHooks
 }
 
+type Reducer<T extends keyof PandaHooks> = (fns: Array<PandaHooks[T]>) => PandaHooks[T]
+
+const createReducer = <T extends keyof PandaHooks>(reducer: Reducer<T>) => reducer
+
 const reducers = {
-  'cssgen:done':
-    (fns: AnyFunction[]): PandaHooks['cssgen:done'] =>
-    (args) => {
-      let content = args.content
-      for (const hookFn of fns) {
-        const result = hookFn({ ...args, content, original: args.content })
-        if (result !== undefined) {
-          content = result
-        }
+  'config:resolved': createReducer<'config:resolved'>((fns) => async (_args) => {
+    // this allows mutating the args object to pass information to the next hook
+    // without mutating the original args object
+    const args = Object.assign({}, _args)
+    const original = _args.config
+    let config = args.config
+
+    for (const hookFn of fns) {
+      const result = await hookFn(Object.assign(args, { config, original }))
+      if (result !== undefined) {
+        config = result
       }
-      return content
-    },
-  'codegen:prepare':
-    (fns: AnyFunction[]): PandaHooks['codegen:prepare'] =>
-    (args) => {
-      let artifacts = args.artifacts
+    }
 
-      for (const hookFn of fns) {
-        const result = hookFn({ ...args, artifacts, original: args.artifacts })
+    return config
+  }),
+  'parser:before': createReducer<'parser:before'>((fns) => (_args) => {
+    const args = Object.assign({}, _args)
+    const original = _args.content
+    let content = args.content
 
-        // it's fine to not return anything, it will just be ignored
-        if (result) {
-          artifacts = result
-        }
+    for (const hookFn of fns) {
+      const result = hookFn(Object.assign(args, { content, original }))
+      if (result !== undefined) {
+        content = result
       }
+    }
 
-      return artifacts
-    },
+    return content
+  }),
+  'cssgen:done': createReducer<'cssgen:done'>((fns) => (_args) => {
+    const args = Object.assign({}, _args)
+    const original = _args.content
+    let content = args.content
+
+    for (const hookFn of fns) {
+      const result = hookFn(Object.assign(args, { content, original }))
+      if (result !== undefined) {
+        content = result
+      }
+    }
+    return content
+  }),
+  'codegen:prepare': createReducer<'codegen:prepare'>((fns): PandaHooks['codegen:prepare'] => async (_args) => {
+    const args = Object.assign({}, _args)
+    const original = _args.artifacts
+    let artifacts = args.artifacts
+
+    for (const hookFn of fns) {
+      const result = await hookFn(Object.assign(args, { artifacts, original }))
+
+      // it's fine to not return anything, it will just be ignored
+      if (result) {
+        artifacts = result
+      }
+    }
+
+    return artifacts
+  }),
 }
 
 const syncHooks = ['context:created', 'parser:before', 'parser:after', 'cssgen:done']

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -325,17 +325,6 @@ type StrictableProps =
   | 'backgroundAttachment'
   | 'backgroundClip'
   | 'borderCollapse'
-  | 'border'
-  | 'borderBlock'
-  | 'borderBlockEnd'
-  | 'borderBlockStart'
-  | 'borderBottom'
-  | 'borderInline'
-  | 'borderInlineEnd'
-  | 'borderInlineStart'
-  | 'borderLeft'
-  | 'borderRight'
-  | 'borderTop'
   | 'borderBlockEndStyle'
   | 'borderBlockStartStyle'
   | 'borderBlockStyle'
@@ -387,7 +376,8 @@ type StrictableProps =
   | 'wordBreak'
   | 'writingMode'
 
-type WithEscapeHatch<T> = T | `[${string}]`
+type WithColorOpacityModifier<T> = T extends string ? `${T}/${string}` : T
+type WithEscapeHatch<T> = T | `[${string}]` | `${T}/{string}` | WithColorOpacityModifier<T>
 
 type FilterVagueString<Key, Value> = Value extends boolean
   ? Value

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -125,6 +125,7 @@ export interface ConfigResolvedHookArgs {
   path: string
   dependencies: string[]
   utils: ConfigResolvedHookUtils
+  original?: LoadConfigResult['config']
 }
 
 export interface ConfigChangeHookArgs {
@@ -145,6 +146,7 @@ export interface ParserResultBeforeHookArgs {
   filePath: string
   content: string
   configure: (opts: ParserResultConfigureOptions) => void
+  original?: string
 }
 
 export interface ParserResultAfterHookArgs {


### PR DESCRIPTION
…g:resolved and parser:before

## 📝 Description

Add missing reducers to properly return the results of hooks for `config:resolved` and `parser:before`