### PR TITLE
fix: allow css files in node_modules/.embroider

### DIFF
--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -71,6 +71,8 @@ pandacss.postcss = true
 export default pandacss
 
 const nodeModulesRegex = /node_modules/
+// Embroider virtualizes files inside of `/node_modules/.embroider/rewritten-app`
+const nodeModulesEmbroiderRegex = /node_modules\/.embroider/
 
 function isValidCss(file: string) {
   const [filePath] = file.split('?')
@@ -80,5 +82,5 @@ function isValidCss(file: string) {
 const shouldSkip = (fileName: string | undefined) => {
   if (!fileName) return true
   if (!isValidCss(fileName)) return true
-  return nodeModulesRegex.test(fileName)
+  return nodeModulesRegex.test(fileName) && !nodeModulesEmbroiderRegex.test(fileName)
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes the PostCSS plugin to be compatible with [Embroider](https://github.com/embroider-build/embroider).

Embroider virtualizes app import files in `/node_modules/.embroider/`. Currently this gets skipped as it's inside `/node_modules/`.

See also: https://github.com/IgnaceMaes/ember-pandacss-demo

## ⛳️ Current behavior (updates)

CSS files inside of `/node_modules/` are skipped.

## 🚀 New behavior

CSS files inside of `/node_modules/` are skipped, except if it's inside of `/node_modules/.embroider/`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

❤️ 