### PR TITLE
fix: add missing ParserResultInterface typings

### DIFF
--- a/.changeset/slimy-bugs-double.md
+++ b/.changeset/slimy-bugs-double.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/types": patch
+---
+
+Add missing methods for ParserResultInterface (which can be used in the `parser:after` hook to dynamically add extraction results from your own logic, like using a custom parser)

--- a/packages/types/src/parser.ts
+++ b/packages/types/src/parser.ts
@@ -18,6 +18,13 @@ export interface ParserResultInterface {
   filePath: string | undefined
   isEmpty: () => boolean
   toArray: () => Array<ResultItem>
+  set: (name: 'cva' | 'css' | 'sva', result: ResultItem) => void
+  setCss: (result: ResultItem) => void
+  setCva: (result: ResultItem) => void
+  setSva: (result: ResultItem) => void
+  setJsx: (result: ResultItem) => void
+  setPattern: (name: string, result: ResultItem) => void
+  setRecipe: (name: string, result: ResultItem) => void
 }
 
 export interface EncoderJson {


### PR DESCRIPTION
## 📝 Description

Add missing methods for ParserResultInterface (which can be used in the `parser:after` hook to dynamically add extraction results from your own logic, like using a custom parser)

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

(these are just types fixing, it was already ok at runtime)