### PR TITLE
feat: multiple importMap

### DIFF
--- a/.changeset/yellow-pens-poke.md
+++ b/.changeset/yellow-pens-poke.md
@@ -1,0 +1,24 @@
+---
+'@pandacss/types': minor
+'@pandacss/core': minor
+---
+
+Allow multiple `importMap` (or multiple single import entrypoints if using the object format).
+
+It can be useful to use a component library's `styled-system` while also using your own `styled-system` in your app.
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  importMap: ['@acme/styled-system', '@ui-lib/styled-system', 'styled-system'],
+})
+```
+
+Now you can use any of the `@acme/styled-system`, `@ui-lib/styled-system` and `styled-system` import sources:
+
+```ts
+import { css } from '@acme/css'
+import { css as uiCss } from '@ui-lib/styled-system/css'
+import { css as appCss } from '@ui-lib/styled-system/css'
+```

--- a/packages/core/__tests__/file-matcher.test.ts
+++ b/packages/core/__tests__/file-matcher.test.ts
@@ -27,6 +27,29 @@ describe('file matcher', () => {
     expect(file.getName('xcss')).toMatchInlineSnapshot('"css"')
   })
 
+  test('imports - multiple sources', () => {
+    const ctx = createContext({ importMap: ['styled-system', '@acme/org'] })
+
+    const file = ctx.imports.file([
+      { mod: 'styled-system/css', name: 'cva', alias: 'cva' },
+      { mod: 'styled-system/patterns', name: 'stack', alias: 'stack' },
+      { mod: '@acme/org/css', name: 'cva', alias: 'cvaAcme' },
+      { mod: '@acme/org/patterns', name: 'stack', alias: 'stackAcme' },
+
+      { mod: '@wrong/org/css', name: 'cva', alias: 'cvaWrong' },
+      { mod: '@wrong/org/patterns', name: 'stack', alias: 'stackWrong' },
+    ])
+
+    expect(file.matchFn('cva')).toMatchInlineSnapshot('true')
+    expect(file.matchFn('cvaAcme')).toMatchInlineSnapshot('true')
+    expect(file.isValidPattern('stack')).toMatchInlineSnapshot('true')
+    expect(file.isValidPattern('stackAcme')).toMatchInlineSnapshot('true')
+
+    expect(file.isValidPattern('randxxx')).toMatchInlineSnapshot('false')
+    expect(file.matchFn('cvaWrong')).toMatchInlineSnapshot(`false`)
+    expect(file.matchFn('stackWrong')).toMatchInlineSnapshot(`false`)
+  })
+
   test('isPandaComponent', () => {
     const ctx = createContext()
 

--- a/packages/core/__tests__/import-map.test.ts
+++ b/packages/core/__tests__/import-map.test.ts
@@ -7,10 +7,18 @@ describe('import map', () => {
     const ctx = createContext()
     expect(ctx.imports.value).toMatchInlineSnapshot(`
       {
-        "css": "styled-system/css",
-        "jsx": "styled-system/jsx",
-        "pattern": "styled-system/patterns",
-        "recipe": "styled-system/recipes",
+        "css": [
+          "styled-system/css",
+        ],
+        "jsx": [
+          "styled-system/jsx",
+        ],
+        "pattern": [
+          "styled-system/patterns",
+        ],
+        "recipe": [
+          "styled-system/recipes",
+        ],
       }
     `)
   })
@@ -19,10 +27,74 @@ describe('import map', () => {
     const ctx = createContext({ importMap: '@acme/org' })
     expect(ctx.imports.value).toMatchInlineSnapshot(`
       {
-        "css": "@acme/org/css",
-        "jsx": "@acme/org/jsx",
-        "pattern": "@acme/org/patterns",
-        "recipe": "@acme/org/recipes",
+        "css": [
+          "@acme/org/css",
+        ],
+        "jsx": [
+          "@acme/org/jsx",
+        ],
+        "pattern": [
+          "@acme/org/patterns",
+        ],
+        "recipe": [
+          "@acme/org/recipes",
+        ],
+      }
+    `)
+  })
+
+  test('normalize - array', () => {
+    const ctx = createContext({ importMap: ['@acme/org', '@foo/org', '@bar/org'] })
+    expect(ctx.imports.value).toMatchInlineSnapshot(`
+      {
+        "css": [
+          "@acme/org/css",
+          "@foo/org/css",
+          "@bar/org/css",
+        ],
+        "jsx": [
+          "@acme/org/jsx",
+          "@foo/org/jsx",
+          "@bar/org/jsx",
+        ],
+        "pattern": [
+          "@acme/org/patterns",
+          "@foo/org/patterns",
+          "@bar/org/patterns",
+        ],
+        "recipe": [
+          "@acme/org/recipes",
+          "@foo/org/recipes",
+          "@bar/org/recipes",
+        ],
+      }
+    `)
+  })
+
+  test('normalize - object input with array and without jsx', () => {
+    const ctx = createContext({
+      importMap: {
+        css: ['@acme/org/css', '@foo/org/css', '@bar/org/css'],
+        recipes: '@acme/org/recipes',
+        patterns: '@acme/org/patterns',
+      },
+    })
+    expect(ctx.imports.value).toMatchInlineSnapshot(`
+      {
+        "css": [
+          "@acme/org/css",
+          "@foo/org/css",
+          "@bar/org/css",
+        ],
+        "jsx": [
+          "styled-system/jsx",
+        ],
+        "pattern": [
+          "@acme/org/patterns",
+        ],
+        "recipe": [
+          "@acme/org/recipes",
+        ],
       }
     `)
   })
@@ -41,6 +113,91 @@ describe('import map', () => {
         if (mod === 'anydir/css') return `${ctx.config.cwd}/styled-system/css`
       }),
     ).toBeTruthy()
+  })
+
+  test('match - multiple sources', () => {
+    const ctx = createContext({
+      importMap: {
+        css: ['@acme/org/css', '@foo/org/css', 'styled-system/css'],
+        recipes: '@acme/org/recipes',
+        patterns: '@acme/org/patterns',
+      },
+    })
+
+    expect(ctx.imports.match({ mod: '@acme/org/css', alias: 'css', name: 'css' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: '@foo/org/css', alias: 'css', name: 'css' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: 'styled-system/css', alias: 'css', name: 'css' })).toBeTruthy()
+
+    expect(ctx.imports.match({ mod: '@acme/org/recipes', alias: 'cardStyle', name: 'cardStyle' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: '@acme/org/patterns', alias: 'box', name: 'box' })).toBeTruthy()
+
+    // incorrect module should not match
+    expect(ctx.imports.match({ mod: '@wrong/org/css', alias: 'css', name: 'css' })).toBeFalsy()
+
+    expect(ctx.imports.match({ mod: 'styled-system/recipes', alias: 'cardStyle', name: 'cardStyle' })).toBeFalsy()
+    expect(ctx.imports.match({ mod: 'styled-system/patterns', alias: 'stack', name: 'stack' })).toBeFalsy()
+
+    expect(ctx.imports.match({ mod: '@foo/org/recipes', alias: 'cardStyle', name: 'cardStyle' })).toBeFalsy()
+    expect(ctx.imports.match({ mod: '@foo/org/patterns', alias: 'stack', name: 'stack' })).toBeFalsy()
+
+    // ts paths
+    expect(
+      ctx.imports.match({ mod: 'anydir/css', alias: 'css', name: 'css' }, function resolveTsPath(mod) {
+        if (mod === 'anydir/css') return `@acme/org/css`
+      }),
+    ).toBeTruthy()
+
+    expect(
+      ctx.imports.match({ mod: 'anydir/css', alias: 'css', name: 'css' }, function resolveTsPath(mod) {
+        if (mod === 'anydir/css') return `${ctx.config.cwd}/styled-system/css`
+      }),
+    ).toBeTruthy()
+
+    expect(
+      ctx.imports.match({ mod: 'anydir/css', alias: 'css', name: 'css' }, function resolveTsPath(mod) {
+        if (mod === 'anydir/css') return `@wrong/org/css`
+      }),
+    ).toBeFalsy()
+  })
+
+  test('match - multiple importMap', () => {
+    const ctx = createContext({
+      importMap: ['@acme/org', '@foo/org', 'styled-system'],
+    })
+
+    expect(ctx.imports.match({ mod: '@foo/org/css', alias: 'css', name: 'css' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: '@foo/org/recipes', alias: 'cardStyle', name: 'cardStyle' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: '@foo/org/patterns', alias: 'stack', name: 'stack' })).toBeTruthy()
+
+    expect(ctx.imports.match({ mod: 'styled-system/css', alias: 'css', name: 'css' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: 'styled-system/recipes', alias: 'cardStyle', name: 'cardStyle' })).toBeTruthy()
+    expect(ctx.imports.match({ mod: 'styled-system/patterns', alias: 'stack', name: 'stack' })).toBeTruthy()
+
+    expect(ctx.imports.match({ mod: '@wrong/org/css', alias: 'css', name: 'css' })).toBeFalsy()
+    expect(ctx.imports.match({ mod: '@wrong/org/recipes', alias: 'cardStyle', name: 'cardStyle' })).toBeFalsy()
+    expect(ctx.imports.match({ mod: '@wrong/org/patterns', alias: 'box', name: 'box' })).toBeFalsy()
+
+    // incorrect module should not match
+    expect(ctx.imports.match({ mod: '@wrong/org/css', alias: 'css', name: 'css' })).toBeFalsy()
+
+    // ts paths
+    expect(
+      ctx.imports.match({ mod: 'anydir/css', alias: 'css', name: 'css' }, function resolveTsPath(mod) {
+        if (mod === 'anydir/css') return `@acme/org/css`
+      }),
+    ).toBeTruthy()
+
+    expect(
+      ctx.imports.match({ mod: 'anydir/css', alias: 'css', name: 'css' }, function resolveTsPath(mod) {
+        if (mod === 'anydir/css') return `${ctx.config.cwd}/styled-system/css`
+      }),
+    ).toBeTruthy()
+
+    expect(
+      ctx.imports.match({ mod: 'anydir/css', alias: 'css', name: 'css' }, function resolveTsPath(mod) {
+        if (mod === 'anydir/css') return `@wrong/org/css`
+      }),
+    ).toBeFalsy()
   })
 
   test('import file / valid', () => {

--- a/packages/core/__tests__/import-map.test.ts
+++ b/packages/core/__tests__/import-map.test.ts
@@ -23,6 +23,31 @@ describe('import map', () => {
     `)
   })
 
+  test('partial value - has fallbacks', () => {
+    const ctx = createContext({
+      importMap: {
+        jsx: ['styled-system/jsx', 'custom-entrypoint'],
+      },
+    })
+    expect(ctx.imports.value).toMatchInlineSnapshot(`
+      {
+        "css": [
+          "styled-system/css",
+        ],
+        "jsx": [
+          "styled-system/jsx",
+          "custom-entrypoint",
+        ],
+        "pattern": [
+          "styled-system/patterns",
+        ],
+        "recipe": [
+          "styled-system/recipes",
+        ],
+      }
+    `)
+  })
+
   test('normalize', () => {
     const ctx = createContext({ importMap: '@acme/org' })
     expect(ctx.imports.value).toMatchInlineSnapshot(`

--- a/packages/core/src/file-matcher.ts
+++ b/packages/core/src/file-matcher.ts
@@ -236,7 +236,7 @@ export class FileMatcher {
 
     const [namespace, identifier] = tagName.split('.')
     const ns = this.namespaces.get(namespace)
-    if (ns && ns.mod.includes(this.importMap.jsx) && identifier === this.context.jsx.factoryName) {
+    if (ns && this.importMap.jsx.some((m) => ns.mod.includes(m)) && identifier === this.context.jsx.factoryName) {
       return true
     }
   })

--- a/packages/core/src/import-map.ts
+++ b/packages/core/src/import-map.ts
@@ -1,10 +1,10 @@
-import { isString, mapEntries } from '@pandacss/shared'
-import type { ImportMapInput, ImportMapOutput } from '@pandacss/types'
+import { isString } from '@pandacss/shared'
+import type { ImportMapInput, ImportMapOutput, UserConfig } from '@pandacss/types'
 import type { Context } from './context'
 import { FileMatcher, type ImportResult } from './file-matcher'
 
 interface ImportMatcher {
-  mod: string
+  mods: string[]
   regex: RegExp
   match(value: string): boolean
 }
@@ -19,7 +19,7 @@ export class ImportMap {
 
     this.outdir = this.getOutdir()
 
-    const importMap = mapEntries(this.normalize(context.config.importMap), (key, paths) => [key, paths.join('/')])
+    const importMap = this.buildImportMap(context.config.importMap)
 
     this.matchers.css = this.createMatcher(importMap.css, ['css', 'cva', 'sva'])
     this.matchers.recipe = this.createMatcher(importMap.recipe)
@@ -32,22 +32,68 @@ export class ImportMap {
     this.value = importMap
   }
 
+  /**
+   * Normalize one/many import map inputs to a single import map output with absolute paths.
+   * @example
+   * ```ts
+   * importMap: '@acme/org'
+   * ```
+   *
+   * will be normalized to
+   * ```ts
+   * {
+   *   css: ['@acme/org/css'],
+   *   recipe: ['@acme/org/recipes'],
+   *   pattern: ['@acme/org/patterns'],
+   *   jsx: ['@acme/org/jsx'],
+   * }
+   * ```
+   *
+   * @exammple
+   * importMap: ['@acme/org', '@foo/org', '@bar/org']
+   * ```
+   *
+   * will be normalized to
+   * ```ts
+   * {
+   *   css: ['@acme/org/css', '@foo/org/css', '@bar/org/css'],
+   *   recipe: ['@acme/org/recipes', '@foo/org/recipes', '@bar/org/recipes'],
+   *   pattern: ['@acme/org/patterns', '@foo/org/patterns', '@bar/org/patterns'],
+   *   jsx: ['@acme/org/jsx', '@foo/org/jsx', '@bar/org/jsx'],
+   * }
+   * ```
+   */
+  buildImportMap = (option: UserConfig['importMap']): ImportMapOutput<string> => {
+    const output: ImportMapOutput<string> = { css: [], recipe: [], pattern: [], jsx: [] }
+    const inputs = asArray(option)
+
+    inputs.forEach((input) => {
+      const normalized = this.normalize(input)
+      output.css.push(...normalized.css)
+      output.recipe.push(...normalized.recipe)
+      output.pattern.push(...normalized.pattern)
+      if (normalized.jsx) output.jsx.push(...normalized.jsx)
+    })
+
+    return output
+  }
+
   private fromString = (map: string): ImportMapOutput => {
     return {
-      css: [map, 'css'],
-      recipe: [map, 'recipes'],
-      pattern: [map, 'patterns'],
-      jsx: [map, 'jsx'],
+      css: [[map, 'css'].join('/')],
+      recipe: [[map, 'recipes'].join('/')],
+      pattern: [[map, 'patterns'].join('/')],
+      jsx: [[map, 'jsx'].join('/')],
     }
   }
 
   private fromInput = (map: ImportMapInput | undefined): ImportMapOutput => {
     const { css, recipes, patterns, jsx } = map ?? {}
     return {
-      css: css ? [css] : [this.outdir, 'css'],
-      recipe: recipes ? [recipes] : [this.outdir, 'recipes'],
-      pattern: patterns ? [patterns] : [this.outdir, 'patterns'],
-      jsx: jsx ? [jsx] : [this.outdir, 'jsx'],
+      css: css ? asArray(css) : [[this.outdir, 'css'].join('/')],
+      recipe: recipes ? asArray(recipes) : [[this.outdir, 'recipes'].join('/')],
+      pattern: patterns ? asArray(patterns) : [[this.outdir, 'patterns'].join('/')],
+      jsx: jsx ? asArray(jsx) : [[this.outdir, 'jsx'].join('/')],
     }
   }
 
@@ -66,31 +112,34 @@ export class ImportMap {
     return this.fromInput(map)
   }
 
-  private createMatcher = (mod: string, values?: string[]): ImportMatcher => {
+  private createMatcher = (mods: string[], values?: string[]): ImportMatcher => {
     const regex = values ? new RegExp(`^(${values.join('|')})$`) : /.*/
     const match = (value: string) => regex.test(value)
-    return { mod, regex, match }
+    return { mods, regex, match }
   }
 
   match = (result: ImportResult | undefined, resolveTsPath?: (mod: string) => string | undefined): boolean => {
     if (!result) return false
 
-    for (const { regex, mod } of Object.values(this.matchers)) {
+    for (const { regex, mods } of Object.values(this.matchers)) {
       // if none of the imported values match the regex, skip
       if (result.kind !== 'namespace' && !regex.test(result.name)) continue
 
       // this checks that `yyy` contains {outdir}/{folder} in `import xxx from yyy`
-      if (result.mod.includes(mod)) {
+      if (mods.some((m) => result.mod.includes(m))) {
         return true
       }
 
       // that might be a TS path mapping, it could be completely different from the actual path
       const resolvedMod = resolveTsPath?.(result.mod)
-      const absMod = [this.context.config.cwd, mod].join('/')
 
-      if (resolvedMod?.includes(absMod)) {
-        result.importMapValue = resolvedMod
-        return true
+      for (const mod of mods) {
+        const absMod = [this.context.config.cwd, mod].join('/')
+
+        if (resolvedMod?.includes(absMod) || resolvedMod === mod) {
+          result.importMapValue = resolvedMod
+          return true
+        }
       }
     }
 
@@ -101,3 +150,5 @@ export class ImportMap {
     return new FileMatcher(this.context, { importMap: this.value, value: results })
   }
 }
+
+const asArray = <T>(value: T | T[]) => (Array.isArray(value) ? value : [value])

--- a/packages/parser/__tests__/import-map.test.ts
+++ b/packages/parser/__tests__/import-map.test.ts
@@ -165,4 +165,99 @@ describe('config.importMap', () => {
       }"
     `)
   })
+
+  test('multiple importMap', () => {
+    const code = `
+    import { cardStyle } from "@acme/org/recipes"
+    import { buttonStyle } from "@bar/org/recipes"
+    import { css } from "@foo/org/css"
+    import { tooltipStyle } from "styled-system/recipes"
+    import { flex } from "@bar/org/patterns"
+    cardStyle()
+    buttonStyle()
+    css({ color: "red" })
+    // won't be extracted
+    tooltipStyle()
+    flex()
+     `
+    const result = parseAndExtract(code, {
+      importMap: {
+        css: ['@acme/org/css', '@foo/org/css'],
+        recipes: ['@acme/org/recipes', '@bar/org/recipes'],
+        patterns: '@acme/org/patterns',
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "cardStyle",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "buttonStyle",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "color": "red",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes {
+        @layer _base {
+          .buttonStyle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+      }
+
+          .buttonStyle:is(:hover, [data-hover]) {
+            color: var(--colors-white);
+            background-color: var(--colors-red-200);
+            font-size: var(--font-sizes-3xl);
+      }
+      }
+
+        .buttonStyle--size_md {
+          height: 3rem;
+          min-width: 3rem;
+          padding: 0 0.75rem;
+      }
+
+        .buttonStyle--variant_solid {
+          color: var(--colors-white);
+          background-color: blue;
+      }
+
+        .buttonStyle--variant_solid[data-disabled] {
+          color: var(--colors-black);
+          background-color: gray;
+          font-size: var(--font-sizes-2xl);
+      }
+
+        .buttonStyle--variant_solid:is(:hover, [data-hover]) {
+          background-color: darkblue;
+      }
+      }
+
+      @layer utilities {
+        .text_red {
+          color: red;
+      }
+      }"
+    `)
+  })
 })

--- a/packages/parser/src/project.ts
+++ b/packages/parser/src/project.ts
@@ -1,5 +1,11 @@
 import type { ParserOptions } from '@pandacss/core'
-import type { ConfigTsOptions, PandaHooks, ParserResultConfigureOptions, Runtime } from '@pandacss/types'
+import type {
+  ConfigTsOptions,
+  PandaHooks,
+  ParserResultConfigureOptions,
+  Runtime,
+  JsxFactoryResultTransform,
+} from '@pandacss/types'
 import {
   FileSystemRefreshResult,
   ScriptKind,
@@ -127,7 +133,7 @@ export class Project {
 
     const original = sourceFile.getText()
 
-    const options: ParserResultConfigureOptions = {}
+    const options: ParserResultConfigureOptions & Partial<JsxFactoryResultTransform> = {}
     const custom = hooks['parser:before']?.({
       filePath,
       content: original,
@@ -147,6 +153,10 @@ export class Project {
     // or if the hook returned a different content
     if (original !== transformed) {
       sourceFile.replaceWithText(transformed)
+    }
+
+    if (hooks['parser:preprocess']) {
+      options.transform = hooks['parser:preprocess']
     }
 
     const result = this.parser(sourceFile, encoder, options)?.setFilePath(filePath)

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -173,18 +173,20 @@ export interface ExtendableOptions {
 }
 
 export interface ImportMapInput {
-  css: string
-  recipes: string
-  patterns: string
-  jsx?: string
+  css: string | string[]
+  recipes: string | string[]
+  patterns: string | string[]
+  jsx?: string | string[]
 }
 
-export interface ImportMapOutput<T = string[]> {
-  css: T
-  recipe: T
-  pattern: T
-  jsx: T
+export interface ImportMapOutput<T = string> {
+  css: T[]
+  recipe: T[]
+  pattern: T[]
+  jsx: T[]
 }
+
+type ImportMapOption = string | ImportMapInput
 
 interface FileSystemOptions {
   /**
@@ -209,7 +211,7 @@ interface FileSystemOptions {
    * }
    * ```
    */
-  importMap?: string | ImportMapInput
+  importMap?: ImportMapOption | Array<ImportMapOption>
   /**
    * List of files glob to watch for changes.
    * @default []

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -173,9 +173,9 @@ export interface ExtendableOptions {
 }
 
 export interface ImportMapInput {
-  css: string | string[]
-  recipes: string | string[]
-  patterns: string | string[]
+  css?: string | string[]
+  recipes?: string | string[]
+  patterns?: string | string[]
   jsx?: string | string[]
 }
 

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -2,7 +2,7 @@ import type { Artifact, ArtifactId, DiffConfigResult } from './artifact'
 import type { LoadConfigResult, UserConfig } from './config'
 import type { HooksApiInterface } from './hooks-api'
 import type { LoggerInterface } from './logger'
-import type { ParserResultInterface } from './parser'
+import type { ParserResultInterface, ResultItem } from './parser'
 
 export interface PandaHooks {
   /**
@@ -32,6 +32,10 @@ export interface PandaHooks {
    * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
    */
   'parser:before': (args: ParserResultBeforeHookArgs) => string | void
+  /**
+   * @private USE IT ONLY IF YOU KNOW WHAT YOU ARE DOING
+   */
+  'parser:preprocess': JsxFactoryResultTransform['transform']
   /**
    * Called after the file styles are extracted and processed into the resulting ParserResult object.
    * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
@@ -147,6 +151,10 @@ export interface ParserResultBeforeHookArgs {
   content: string
   configure: (opts: ParserResultConfigureOptions) => void
   original?: string
+}
+
+export interface JsxFactoryResultTransform {
+  transform: (result: { type: 'jsx-factory'; data: ResultItem['data'] }) => ResultItem['data']
 }
 
 export interface ParserResultAfterHookArgs {

--- a/sandbox/preact-ts/package.json
+++ b/sandbox/preact-ts/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "preact": "10.19.5"
   },
+  "imports": {
+    "#styles/*": "./styled-system/*"
+  },
   "devDependencies": {
     "@pandacss/dev": "workspace:*",
     "@preact/preset-vite": "2.8.2",

--- a/sandbox/preact-ts/panda.config.ts
+++ b/sandbox/preact-ts/panda.config.ts
@@ -22,6 +22,14 @@ export default defineConfig({
           aaa: { value: 'azaz23' },
         },
       },
+      recipes: {
+        btn: {
+          base: {
+            color: 'blue.500',
+          },
+        },
+      },
     },
   },
+  importMap: ['styled-system', '#styles'],
 })

--- a/sandbox/preact-ts/src/app.tsx
+++ b/sandbox/preact-ts/src/app.tsx
@@ -1,5 +1,7 @@
 import { css, sva } from '../styled-system/css'
 import { cq } from '../styled-system/patterns'
+// @ts-expect-error ts 5.4 will fix it
+import { btn } from '#styles/recipes'
 
 const button = sva({
   className: 'button',
@@ -36,6 +38,7 @@ export const App = () => {
       <div className={classes.root}>
         <div className={classes.text}>Click me</div>
       </div>
+      <div className={btn()}>aaaa Click me</div>
     </>
   )
 }


### PR DESCRIPTION
## 📝 Description

Allow multiple `importMap` (or multiple single import entrypoints if using the object format).

It can be useful to use a component library's `styled-system` while also using your own `styled-system` in your app.

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  importMap: ['@acme/styled-system', '@ui-lib/styled-system', 'styled-system'],
})
```

Now you can use any of the `@acme/styled-system`, `@ui-lib/styled-system` and `styled-system` import sources:

```ts
import { css } from '@acme/css'
import { css as uiCss } from '@ui-lib/styled-system/css'
import { css as appCss } from '@ui-lib/styled-system/css'
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
