### PR TITLE
fix(parser): JSX styled namespace imports

### DIFF
--- a/.changeset/rude-ravens-listen.md
+++ b/.changeset/rude-ravens-listen.md
@@ -1,0 +1,14 @@
+---
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Fix extraction of JSX `styled` factory when using namespace imports
+
+```tsx
+import * as pandaJsx from '../styled-system/jsx'
+
+// ✅ this will work now
+pandaJsx.styled('div', { base: { color: 'red' } })
+const App = () => <pandaJsx.styled.span color="blue">Hello</pandaJsx.styled.span>
+```

--- a/packages/core/src/file-matcher.ts
+++ b/packages/core/src/file-matcher.ts
@@ -229,6 +229,12 @@ export class FileMatcher {
     for (const alias of this.jsxFactoryAliases) {
       if (tagName.startsWith(alias)) return true
     }
+
+    const [namespace, identifier] = tagName.split('.')
+    const ns = this.namespaces.get(namespace)
+    if (ns && ns.mod.includes(this.importMap.jsx) && identifier === this.context.jsx.factoryName) {
+      return true
+    }
   })
 
   isPandaComponent = memo((tagName: string) => {

--- a/packages/core/src/jsx.ts
+++ b/packages/core/src/jsx.ts
@@ -93,7 +93,13 @@ export class JsxEngine {
   }
 
   isJsxFactory = (name: string) => {
-    return name === this.factoryName
+    // `styled` -> true
+    const isFactory = name === this.factoryName
+    if (isFactory) return true
+
+    // `pandaJsx.styled` -> true
+    const [_namespace, identifier] = name.split('.')
+    return identifier === this.factoryName
   }
 
   isJsxTagRecipe = memo((tagName: string) => {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3840,8 +3840,8 @@ describe('extract to css output pipeline', () => {
               "color": "red",
             },
           ],
-          "name": "styled",
-          "type": "jsx",
+          "name": "JSX.styled.div",
+          "type": "jsx-factory",
         },
         {
           "data": [
@@ -3909,5 +3909,51 @@ describe('extract to css output pipeline', () => {
     expect(result.json).toMatchInlineSnapshot(`[]`)
 
     expect(result.css).toMatchInlineSnapshot(`""`)
+  })
+
+  test('TS namespaces - JSX factory', () => {
+    const code = `
+    import * as pandaJsx from '../styled-system/jsx';
+
+    pandaJsx.styled('div', { base: { color: 'red' } })
+    const App = () => <pandaJsx.styled.span color="blue">Hello</pandaJsx.styled.span>
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "base": {
+                "color": "red",
+              },
+            },
+          ],
+          "name": "pandaJsx.styled",
+          "type": "cva",
+        },
+        {
+          "data": [
+            {
+              "color": "blue",
+            },
+          ],
+          "name": "pandaJsx.styled.span",
+          "type": "jsx-factory",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_red {
+          color: red;
+      }
+
+        .text_blue {
+          color: blue;
+      }
+      }"
+    `)
   })
 })


### PR DESCRIPTION
## 📝 Description

Fix extraction of JSX `styled` factory when using namespace imports

```tsx
import * as pandaJsx from '../styled-system/jsx'

// ✅ this will work now
pandaJsx.styled('div', { base: { color: 'red' } })
const App = () => <pandaJsx.styled.span color="blue">Hello</pandaJsx.styled.span>
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

follow-up to https://github.com/chakra-ui/panda/pull/2327