### PR TITLE
feat: allow ! or !important with strictTokens

### DIFF
--- a/.changeset/many-tomatoes-sneeze.md
+++ b/.changeset/many-tomatoes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/generator": patch
+---
+
+Allow using `!` or `!important` when using `strictTokens: true` (without TS throwing an error)

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -390,7 +390,13 @@ describe('generate property types', () => {
         | 'writingMode'
 
       type WithColorOpacityModifier<T> = T extends string ? \`\${T}/\${string}\` : T
-      type WithEscapeHatch<T> = T | \`[\${string}]\` | \`\${T}/{string}\` | WithColorOpacityModifier<T>
+
+      type ImportantMark = "!" | "!important"
+      type WhitespaceImportant = \` \${ImportantMark}\`
+      type Important = ImportantMark | WhitespaceImportant
+      type WithImportant<T> = T extends string ? \`\${T}\${Important}\${string}\` : T
+
+      type WithEscapeHatch<T> = T | \`[\${string}]\` | (T extends string ? WithColorOpacityModifier<string> | WithImportant<T> : T)
 
       type FilterVagueString<Key, Value> = Value extends boolean
         ? Value
@@ -798,7 +804,13 @@ describe('generate property types', () => {
         | 'writingMode'
 
       type WithColorOpacityModifier<T> = T extends string ? \`\${T}/\${string}\` : T
-      type WithEscapeHatch<T> = T | \`[\${string}]\` | \`\${T}/{string}\` | WithColorOpacityModifier<T>
+
+      type ImportantMark = "!" | "!important"
+      type WhitespaceImportant = \` \${ImportantMark}\`
+      type Important = ImportantMark | WhitespaceImportant
+      type WithImportant<T> = T extends string ? \`\${T}\${Important}\${string}\` : T
+
+      type WithEscapeHatch<T> = T | \`[\${string}]\` | (T extends string ? WithColorOpacityModifier<string> | WithImportant<T> : T)
 
       type FilterVagueString<Key, Value> = Value extends boolean
         ? Value

--- a/packages/generator/src/artifacts/types/prop-types.ts
+++ b/packages/generator/src/artifacts/types/prop-types.ts
@@ -109,7 +109,13 @@ export function generatePropTypes(ctx: Context) {
     | 'writingMode'
 
   type WithColorOpacityModifier<T> = T extends string ? \`$\{T}/\${string}\` : T
-  type WithEscapeHatch<T> = T | \`[\${string}]\` | \`\${T}/{string}\` | WithColorOpacityModifier<T>
+
+  type ImportantMark = "!" | "!important"
+  type WhitespaceImportant = \` \${ImportantMark}\`
+  type Important = ImportantMark | WhitespaceImportant
+  type WithImportant<T> = T extends string ? \`\${T}\${Important}\${string}\` : T
+
+  type WithEscapeHatch<T> = T | \`[\${string}]\` | (T extends string ? WithColorOpacityModifier<string> | WithImportant<T> : T)
 
   type FilterVagueString<Key, Value> = Value extends boolean
     ? Value

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -377,7 +377,13 @@ type StrictableProps =
   | 'writingMode'
 
 type WithColorOpacityModifier<T> = T extends string ? `${T}/${string}` : T
-type WithEscapeHatch<T> = T | `[${string}]` | `${T}/{string}` | WithColorOpacityModifier<T>
+
+type ImportantMark = "!" | "!important"
+type WhitespaceImportant = ` ${ImportantMark}`
+type Important = ImportantMark | WhitespaceImportant
+type WithImportant<T> = T extends string ? `${T}${Important}${string}` : T
+
+type WithEscapeHatch<T> = T | `[${string}]` | (T extends string ? WithColorOpacityModifier<string> | WithImportant<T> : T)
 
 type FilterVagueString<Key, Value> = Value extends boolean
   ? Value

--- a/sandbox/codegen/__tests__/scenarios/strict-tokens.test.ts
+++ b/sandbox/codegen/__tests__/scenarios/strict-tokens.test.ts
@@ -10,8 +10,10 @@ describe('css', () => {
     assertType(css({ willChange: 'abc' }))
 
     assertType(css({ pos: 'absolute' }))
-    // @ts-expect-error always expected
+    // @ts-expect-error expected from strictTokens: true
     assertType(css({ pos: 'absolute123' }))
+    // @ts-expect-error expected from strictTokens: true
+    assertType(css({ position: 'absolute123' }))
     // @ts-expect-error expected from strictTokens: true
     assertType(css({ flex: '0 1' }))
   })
@@ -114,9 +116,7 @@ describe('css', () => {
   test('important', () => {
     assertType(
       css({
-        // @ts-expect-error expected from strictTokens: true
         fontSize: '2xl!',
-        // @ts-expect-error expected from strictTokens: true
         p: '4 !important',
         // @ts-expect-error expected from strictTokens: true
         bgColor: '#fff!',
@@ -126,7 +126,6 @@ describe('css', () => {
         borderColor: '#fff !important',
         _hover: {
           fontSize: '3xl',
-          // @ts-expect-error expected from strictTokens: true
           p: '4 !important',
           // @ts-expect-error expected from strictTokens: true
 

--- a/sandbox/codegen/__tests__/scenarios/strict.test.ts
+++ b/sandbox/codegen/__tests__/scenarios/strict.test.ts
@@ -12,7 +12,9 @@ describe('css', () => {
 
     assertType(css({ pos: 'absolute' }))
 
-    // @ts-expect-error always expected
+    // @ts-expect-error expected from strictPropertyValues: true
+    assertType(css({ position: 'absolute123' }))
+    // @ts-expect-error expected from strictPropertyValues: true
     assertType(css({ pos: 'absolute123' }))
     // @ts-expect-error expected from strictTokens: true
     assertType(css({ flex: '0 1' }))
@@ -109,18 +111,14 @@ describe('css', () => {
   test('important', () => {
     assertType(
       css({
-        // @ts-expect-error expected from strictTokens: true
-        fontSize: '2xl!',
-        // @ts-expect-error expected from strictTokens: true
+        fontSize: '2xl !important',
         p: '4 !important',
         // @ts-expect-error expected from strictTokens: true
         bgColor: '#fff!',
         // @ts-expect-error expected from strictTokens: true
         borderColor: '#fff !important',
         _hover: {
-          // @ts-expect-error expected from strictTokens: true
-          fontSize: '2xl!',
-          // @ts-expect-error expected from strictTokens: true
+          fontSize: '2xl !important',
           p: '4 !important',
           // @ts-expect-error expected from strictTokens: true
 


### PR DESCRIPTION
## 📝 Description

Allow using `!` or `!important` when using `strictTokens: true` (without TS throwing an error)

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

I found a way to get this working without losing type-safety and without polluting the suggestions with duplicates so we can get the best of both worlds !