### PR TITLE
fix: negative semanticTokens CSS vars generation

### DIFF
--- a/.changeset/chilly-moose-provide.md
+++ b/.changeset/chilly-moose-provide.md
@@ -1,0 +1,30 @@
+---
+'@pandacss/token-dictionary': patch
+---
+
+Fix negative `semanticTokens` generation
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  tokens: {
+    spacing: {
+      1: { value: '1rem' },
+    },
+  },
+  semanticTokens: {
+    spacing: {
+      lg: { value: '{spacing.1}' },
+    },
+  },
+})
+```
+
+Will now correctly generate the negative value:
+
+```diff
+"spacing.-1" => "calc(var(--spacing-1) * -1)",
+- "spacing.-lg" => "{spacing.1}",
++ "spacing.-lg" => "calc(var(--spacing-lg) * -1)",
+```

--- a/packages/token-dictionary/__tests__/middleware.test.ts
+++ b/packages/token-dictionary/__tests__/middleware.test.ts
@@ -59,6 +59,118 @@ test('middleware / add negative', () => {
   `)
 })
 
+test('negative tokens', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      spacing: {
+        1: { value: '1rem' },
+      },
+    },
+    semanticTokens: {
+      spacing: {
+        lg: { value: '{spacing.1}' },
+      },
+    },
+  })
+
+  dictionary.registerTokens()
+  dictionary.registerMiddleware(addNegativeTokens)
+  dictionary.build()
+
+  expect(dictionary.allTokens).toMatchInlineSnapshot(`
+    [
+      Token {
+        "description": undefined,
+        "extensions": {
+          "category": "spacing",
+          "condition": "base",
+          "prop": "1",
+        },
+        "name": "spacing.1",
+        "originalValue": "1rem",
+        "path": [
+          "spacing",
+          "1",
+        ],
+        "type": "dimension",
+        "value": "1rem",
+      },
+      Token {
+        "description": undefined,
+        "extensions": {
+          "category": "spacing",
+          "condition": "base",
+          "conditions": {
+            "base": "{spacing.1}",
+          },
+          "prop": "lg",
+        },
+        "name": "spacing.lg",
+        "originalValue": "{spacing.1}",
+        "path": [
+          "spacing",
+          "lg",
+        ],
+        "type": "dimension",
+        "value": "1rem",
+      },
+      Token {
+        "description": undefined,
+        "extensions": {
+          "category": "spacing",
+          "condition": "base",
+          "isNegative": true,
+          "originalPath": [
+            "spacing",
+            "1",
+          ],
+          "prop": "-1",
+        },
+        "name": "spacing.-1",
+        "originalValue": "1rem",
+        "path": [
+          "spacing",
+          "-1",
+        ],
+        "type": "dimension",
+        "value": "calc(var(--spacing-1) * -1)",
+      },
+      Token {
+        "description": undefined,
+        "extensions": {
+          "category": "spacing",
+          "condition": "base",
+          "conditions": {
+            "base": "{spacing.1}",
+          },
+          "isNegative": true,
+          "originalPath": [
+            "spacing",
+            "lg",
+          ],
+          "prop": "-lg",
+        },
+        "name": "spacing.-lg",
+        "originalValue": "{spacing.1}",
+        "path": [
+          "spacing",
+          "-lg",
+        ],
+        "type": "dimension",
+        "value": "calc(var(--spacing-lg) * -1)",
+      },
+    ]
+  `)
+  expect(dictionary.view.values).toMatchInlineSnapshot(`
+    Map {
+      "spacing.1" => undefined,
+      "spacing.lg" => undefined,
+      "spacing.-1" => "calc(var(--spacing-1) * -1)",
+      "spacing.-lg" => "{spacing.1}",
+    }
+  `)
+})
+
 test('middleware / formatTokenName', () => {
   const dictionary = new TokenDictionary({
     tokens: {

--- a/packages/token-dictionary/__tests__/middleware.test.ts
+++ b/packages/token-dictionary/__tests__/middleware.test.ts
@@ -166,7 +166,7 @@ test('negative tokens', () => {
       "spacing.1" => undefined,
       "spacing.lg" => undefined,
       "spacing.-1" => "calc(var(--spacing-1) * -1)",
-      "spacing.-lg" => "{spacing.1}",
+      "spacing.-lg" => "calc(var(--spacing-lg) * -1)",
     }
   `)
 })

--- a/packages/token-dictionary/src/dictionary.ts
+++ b/packages/token-dictionary/src/dictionary.ts
@@ -8,7 +8,7 @@ import {
   type CssVar,
   type CssVarOptions,
 } from '@pandacss/shared'
-import type { SemanticTokens, Tokens } from '@pandacss/types'
+import type { SemanticTokens, TokenCategory, Tokens } from '@pandacss/types'
 import { isMatching, match } from 'ts-pattern'
 import { isCompositeTokenValue } from './is-composite'
 import { middlewares } from './middleware'
@@ -392,18 +392,25 @@ export class TokenDictionary {
  * Computed token views
  * -----------------------------------------------------------------------------*/
 
+type ConditionName = string
+type TokenName = string
+type VarName = string
+type VarRef = string
+type TokenValue = string
+type ColorPalette = string
+
 export class TokenDictionaryView {
   constructor(private dictionary: TokenDictionary) {
     this.dictionary = dictionary
   }
 
   getTokensView() {
-    const conditionMap = new Map<string, Set<Token>>()
-    const categoryMap = new Map<string, Map<string, Token>>()
-    const colorPalettes = new Map<string, Map<string, string>>()
-    const valuesByCategory = new Map<string, Map<string, string>>()
-    const flatValues = new Map<string, string>()
-    const vars = new Map<string, Map<string, string>>()
+    const conditionMap = new Map<ConditionName, Set<Token>>()
+    const categoryMap = new Map<TokenCategory, Map<TokenName, Token>>()
+    const colorPalettes = new Map<ColorPalette, Map<VarName, VarRef>>()
+    const valuesByCategory = new Map<TokenCategory, Map<VarName, TokenValue>>()
+    const flatValues = new Map<TokenName, VarRef>()
+    const vars = new Map<ConditionName, Map<VarName, TokenValue>>()
 
     this.dictionary.allTokens.forEach((token) => {
       this.processCondition(token, conditionMap)
@@ -495,7 +502,7 @@ export class TokenDictionaryView {
     if (!category) return
 
     if (!byCategory.has(category)) byCategory.set(category, new Map())
-    const value = isNegative ? (token.isConditional ? token.originalValue : token.value) : varRef
+    const value = isNegative ? (token.extensions.condition !== 'base' ? token.originalValue : token.value) : varRef
     byCategory.get(category)!.set(prop, value)
     flat.set(token.name, value)
   }


### PR DESCRIPTION
## 📝 Description

Fix negative `semanticTokens` generation

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  tokens: {
    spacing: {
      1: { value: '1rem' },
    },
  },
  semanticTokens: {
    spacing: {
      lg: { value: '{spacing.1}' },
    },
  },
})
```

Will now correctly generate the negative value:

```diff
"spacing.-1" => "calc(var(--spacing-1) * -1)",
- "spacing.-lg" => "{spacing.1}",
+ "spacing.-lg" => "calc(var(--spacing-lg) * -1)",
```


## 💣 Is this a breaking change (Yes/No):

no