### PR TITLE
fix: color opacity modifier with semanticTokens

### DIFF
--- a/.changeset/five-phones-work.md
+++ b/.changeset/five-phones-work.md
@@ -1,0 +1,32 @@
+---
+'@pandacss/token-dictionary': patch
+---
+
+Fix an issue when using a semantic token with one (but not all) condition using the color opacity modifier
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  theme: {
+    extend: {
+      tokens: {
+        colors: {
+          black: { value: 'black' },
+          white: { value: 'white' },
+        },
+      },
+      semanticTokens: {
+        colors: {
+          fg: {
+            value: {
+              base: '{colors.black/87}',
+              _dark: '{colors.white}', // <- this was causing a weird issue
+            },
+          },
+        },
+      },
+    },
+  },
+})
+```

--- a/packages/token-dictionary/__tests__/color-mix.test.ts
+++ b/packages/token-dictionary/__tests__/color-mix.test.ts
@@ -26,4 +26,54 @@ test('color-mix', () => {
   expect(dictionary.expandReferenceInValue('{colors.border/half}')).toMatchInlineSnapshot(
     `"color-mix(in srgb, var(--colors-border) 50%, transparent)"`,
   )
+
+  expect(dictionary.view.vars).toMatchInlineSnapshot(`
+    Map {
+      "base" => Map {
+        "--colors-pink" => "#ff00ff",
+        "--colors-border" => "color-mix(in srgb, var(--colors-pink) 30%, transparent)",
+        "--colors-ref" => "color-mix(in srgb, var(--colors-border) 40%, transparent)",
+        "--opacity-half" => 0.5,
+      },
+    }
+  `)
+})
+
+test('color-mix with semanticTokens', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        black: { value: 'black' },
+        white: { value: 'white' },
+      },
+    },
+    semanticTokens: {
+      colors: {
+        fg: {
+          default: {
+            value: { base: '{colors.black/87}', _dark: '{colors.white}' },
+          },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('{colors.black/87}')).toMatchInlineSnapshot(
+    `"color-mix(in srgb, var(--colors-black) 87%, transparent)"`,
+  )
+
+  expect(dictionary.view.vars).toMatchInlineSnapshot(`
+    Map {
+      "base" => Map {
+        "--colors-black" => "black",
+        "--colors-white" => "white",
+        "--colors-fg-default" => "color-mix(in srgb, var(--colors-black) 87%, transparent)",
+      },
+      "_dark:value" => Map {
+        "--colors-fg-default" => "var(--colors-white)",
+      },
+    }
+  `)
 })

--- a/packages/token-dictionary/src/transform.ts
+++ b/packages/token-dictionary/src/transform.ts
@@ -138,6 +138,8 @@ export const transformColorMix: TokenTransformer = {
     return token.extensions.category === 'colors' && token.value.includes('/')
   },
   transform(token, dict) {
+    if (!token.value.includes('/')) return token
+
     return expandReferences(token.value, (path) => {
       const tokenFn = (tokenPath: string) => {
         const token = dict.getByName(tokenPath)

--- a/sandbox/solid-ts/panda.config.ts
+++ b/sandbox/solid-ts/panda.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         colors: {
           fg: {
             default: {
-              value: { base: '{colors.black}', _dark: '{colors.white}' },
+              value: { base: '{colors.black/87}', _dark: '{colors.white}' },
             },
           },
         },


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description

Fix an issue when using a semantic token with one (but not all) condition using the color opacity modifier

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  theme: {
    extend: {
      tokens: {
        colors: {
          black: { value: 'black' },
          white: { value: 'white' },
        },
      },
      semanticTokens: {
        colors: {
          fg: {
            value: {
              base: '{colors.black/87}',
              _dark: '{colors.white}', // <- this was causing a weird issue
            },
          },
        },
      },
    },
  },
})
```


## ⛳️ Current behavior (updates)

Panda throws

## 🚀 New behavior

now it doesn't 

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
