### PR TITLE
fix: merging flat and nested object on same key

### DIFF
--- a/.changeset/clever-coats-check.md
+++ b/.changeset/clever-coats-check.md
@@ -1,0 +1,74 @@
+---
+'@pandacss/config': patch
+---
+
+Fix merging issue when using a preset that has a token with a conflicting value with another (or the user's config)
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+const userConfig = defineConfig({
+  presets: [
+    {
+      theme: {
+        extend: {
+          tokens: {
+            colors: {
+              black: { value: 'black' },
+            },
+          },
+        },
+      },
+    },
+  ],
+  theme: {
+    tokens: {
+      colors: {
+        black: {
+          0: { value: 'black' },
+          10: { value: 'black/10' },
+          20: { value: 'black/20' },
+          30: { value: 'black/30' },
+        },
+      },
+    },
+  },
+})
+```
+
+When merged with the preset, the config would create nested tokens (`black.10`, `black.20`, `black.30`) inside of the
+initially flat `black` token.
+
+This would cause issues as the token engine stops diving deeper after encountering an object with a `value` property.
+
+To fix this, we now automatically replace the flat `black` token using the `DEFAULT` keyword when resolving the config
+so that the token engine can continue to dive deeper into the object:
+
+```diff
+{
+  "theme": {
+    "tokens": {
+      "colors": {
+        "black": {
+          "0": {
+            "value": "black",
+          },
+          "10": {
+            "value": "black/10",
+          },
+          "20": {
+            "value": "black/20",
+          },
+          "30": {
+            "value": "black/30",
+          },
+-          "value": "black",
++          "DEFAULT": {
++            "value": "black",
++          },
+        },
+      },
+    },
+  },
+}
+```

--- a/.changeset/clever-coats-check.md
+++ b/.changeset/clever-coats-check.md
@@ -23,12 +23,14 @@ const userConfig = defineConfig({
   ],
   theme: {
     tokens: {
-      colors: {
-        black: {
-          0: { value: 'black' },
-          10: { value: 'black/10' },
-          20: { value: 'black/20' },
-          30: { value: 'black/30' },
+      extend: {
+        colors: {
+          black: {
+            0: { value: 'black' },
+            10: { value: 'black/10' },
+            20: { value: 'black/20' },
+            30: { value: 'black/30' },
+          },
         },
       },
     },

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -486,7 +486,9 @@ describe('mergeConfigs / theme', () => {
                 "30": {
                   "value": "black/30",
                 },
-                "value": "black",
+                "DEFAULT": {
+                  "value": "black",
+                },
               },
             },
           },

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import { mergeConfigs } from '../src/merge-config'
 import { getResolvedConfig } from '../src/get-resolved-config'
-import type { Config } from '@pandacss/types'
+import type { Config, Preset } from '@pandacss/types'
 
 const defineConfig = <T extends Config>(config: T) => config
+const definePreset = <T extends Preset>(preset: T) => preset
 
 describe('mergeConfigs / theme', () => {
   test('should merge configs', () => {
@@ -436,6 +437,63 @@ describe('mergeConfigs / theme', () => {
       }
     `)
   })
+
+  test.only('flat and nested object on same key', () => {
+    const userConfig = defineConfig({
+      theme: {
+        extend: {
+          tokens: {
+            colors: {
+              black: {
+                0: { value: 'black' },
+                10: { value: 'black/10' },
+                20: { value: 'black/20' },
+                30: { value: 'black/30' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const preset = definePreset({
+      theme: {
+        tokens: {
+          colors: {
+            black: { value: 'black' },
+          },
+        },
+      },
+    })
+
+    const result = mergeConfigs([userConfig, preset])
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "theme": {
+          "tokens": {
+            "colors": {
+              "black": {
+                "0": {
+                  "value": "black",
+                },
+                "10": {
+                  "value": "black/10",
+                },
+                "20": {
+                  "value": "black/20",
+                },
+                "30": {
+                  "value": "black/30",
+                },
+                "value": "black",
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
 })
 
 describe('mergeConfigs / utilities', () => {
@@ -528,7 +586,7 @@ describe('mergeConfigs / recipes', () => {
 
     const result = mergeConfigs([userConfig, defaultConfig])
 
-    expect(result.theme.recipes).toMatchInlineSnapshot(`
+    expect(result.theme?.recipes).toMatchInlineSnapshot(`
       {
         "button": {
           "className": "button",

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -438,8 +438,8 @@ describe('mergeConfigs / theme', () => {
     `)
   })
 
-  test.only('flat and nested object on same key', () => {
-    const userConfig = defineConfig({
+  test('flat and nested object on same key', () => {
+    const preset = definePreset({
       theme: {
         extend: {
           tokens: {
@@ -456,7 +456,7 @@ describe('mergeConfigs / theme', () => {
       },
     })
 
-    const preset = definePreset({
+    const userConfig = defineConfig({
       theme: {
         tokens: {
           colors: {
@@ -488,6 +488,124 @@ describe('mergeConfigs / theme', () => {
                 },
                 "DEFAULT": {
                   "value": "black",
+                },
+              },
+            },
+          },
+        },
+      }
+    `)
+
+    // opposite order
+    expect(mergeConfigs([preset, userConfig])).toMatchInlineSnapshot(`
+      {
+        "theme": {
+          "tokens": {
+            "colors": {
+              "black": {
+                "0": {
+                  "value": "black",
+                },
+                "10": {
+                  "value": "black/10",
+                },
+                "20": {
+                  "value": "black/20",
+                },
+                "30": {
+                  "value": "black/30",
+                },
+                "DEFAULT": {
+                  "value": "black",
+                },
+              },
+            },
+          },
+        },
+      }
+    `)
+  })
+
+  test('flat and nested object with existing DEFAULT', () => {
+    const preset = definePreset({
+      theme: {
+        extend: {
+          tokens: {
+            colors: {
+              black: {
+                DEFAULT: { value: 'white' },
+                0: { value: 'black' },
+                10: { value: 'black/10' },
+                20: { value: 'black/20' },
+                30: { value: 'black/30' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const userConfig = defineConfig({
+      theme: {
+        tokens: {
+          colors: {
+            black: { value: 'black' },
+          },
+        },
+      },
+    })
+
+    const result = mergeConfigs([userConfig, preset])
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "theme": {
+          "tokens": {
+            "colors": {
+              "black": {
+                "0": {
+                  "value": "black",
+                },
+                "10": {
+                  "value": "black/10",
+                },
+                "20": {
+                  "value": "black/20",
+                },
+                "30": {
+                  "value": "black/30",
+                },
+                "DEFAULT": {
+                  "value": "white",
+                },
+              },
+            },
+          },
+        },
+      }
+    `)
+
+    // opposite order
+    expect(mergeConfigs([preset, userConfig])).toMatchInlineSnapshot(`
+      {
+        "theme": {
+          "tokens": {
+            "colors": {
+              "black": {
+                "0": {
+                  "value": "black",
+                },
+                "10": {
+                  "value": "black/10",
+                },
+                "20": {
+                  "value": "black/20",
+                },
+                "30": {
+                  "value": "black/30",
+                },
+                "DEFAULT": {
+                  "value": "white",
                 },
               },
             },

--- a/packages/config/__tests__/merge-config.test.ts
+++ b/packages/config/__tests__/merge-config.test.ts
@@ -444,12 +444,7 @@ describe('mergeConfigs / theme', () => {
         extend: {
           tokens: {
             colors: {
-              black: {
-                0: { value: 'black' },
-                10: { value: 'black/10' },
-                20: { value: 'black/20' },
-                30: { value: 'black/30' },
-              },
+              black: { value: 'black' },
             },
           },
         },
@@ -460,7 +455,12 @@ describe('mergeConfigs / theme', () => {
       theme: {
         tokens: {
           colors: {
-            black: { value: 'black' },
+            black: {
+              0: { value: 'black' },
+              10: { value: 'black/10' },
+              20: { value: 'black/20' },
+              30: { value: 'black/30' },
+            },
           },
         },
       },
@@ -532,13 +532,7 @@ describe('mergeConfigs / theme', () => {
         extend: {
           tokens: {
             colors: {
-              black: {
-                DEFAULT: { value: 'white' },
-                0: { value: 'black' },
-                10: { value: 'black/10' },
-                20: { value: 'black/20' },
-                30: { value: 'black/30' },
-              },
+              black: { value: 'black' },
             },
           },
         },
@@ -549,7 +543,13 @@ describe('mergeConfigs / theme', () => {
       theme: {
         tokens: {
           colors: {
-            black: { value: 'black' },
+            black: {
+              DEFAULT: { value: 'white' },
+              0: { value: 'black' },
+              10: { value: 'black/10' },
+              20: { value: 'black/20' },
+              30: { value: 'black/30' },
+            },
           },
         },
       },

--- a/packages/config/src/get-resolved-config.ts
+++ b/packages/config/src/get-resolved-config.ts
@@ -25,5 +25,5 @@ export async function getResolvedConfig(config: ExtendableConfig, cwd: string) {
   }
 
   configs.unshift(config)
-  return mergeConfigs(configs) as Config
+  return mergeConfigs(configs)
 }

--- a/packages/config/src/merge-config.ts
+++ b/packages/config/src/merge-config.ts
@@ -120,7 +120,7 @@ export function mergeConfigs(configs: ExtendableConfig[]): UserConfig {
    * // color: "black.20"
    * ```
    */
-  if (false && withoutEmpty.theme?.tokens) {
+  if (withoutEmpty.theme?.tokens) {
     traverse(withoutEmpty.theme.tokens, (args) => args, {
       stop(args) {
         if (isObject(args.value) && 'value' in args.value) {

--- a/packages/config/src/merge-config.ts
+++ b/packages/config/src/merge-config.ts
@@ -126,8 +126,8 @@ export function mergeConfigs(configs: ExtendableConfig[]): UserConfig {
         if (isObject(args.value) && 'value' in args.value) {
           const keys = Object.keys(args.value)
           if (keys.filter((k) => !tokenKeys.includes(k)).length) {
-            const { type: _type, description: _description, extensions: _extensions, value } = args.value
-            args.value.DEFAULT = { value }
+            const { type: _type, description: _description, extensions: _extensions, value, DEFAULT } = args.value
+            args.value.DEFAULT = { value: DEFAULT?.value ?? value }
             delete args.value.value
           }
 

--- a/packages/config/src/merge-config.ts
+++ b/packages/config/src/merge-config.ts
@@ -120,7 +120,7 @@ export function mergeConfigs(configs: ExtendableConfig[]): UserConfig {
    * // color: "black.20"
    * ```
    */
-  if (withoutEmpty.theme?.tokens) {
+  if (false && withoutEmpty.theme?.tokens) {
     traverse(withoutEmpty.theme.tokens, (args) => args, {
       stop(args) {
         if (isObject(args.value) && 'value' in args.value) {

--- a/packages/config/src/merge-config.ts
+++ b/packages/config/src/merge-config.ts
@@ -1,5 +1,5 @@
-import { assign, mergeWith } from '@pandacss/shared'
-import type { Config } from '@pandacss/types'
+import { assign, isObject, mergeWith, traverse } from '@pandacss/shared'
+import type { Config, UserConfig } from '@pandacss/types'
 import { mergeAndConcat } from 'merge-anything'
 import { mergeHooks } from './merge-hooks'
 
@@ -66,10 +66,12 @@ const compact = (obj: any) => {
   }, {} as any)
 }
 
+const tokenKeys = ['description', 'extensions', 'type', 'value']
+
 /**
  * Merge all configs into a single config
  */
-export function mergeConfigs(configs: ExtendableConfig[]) {
+export function mergeConfigs(configs: ExtendableConfig[]): UserConfig {
   const [userConfig] = configs
   const pluginHooks = userConfig.plugins ?? []
   if (userConfig.hooks) {
@@ -90,5 +92,52 @@ export function mergeConfigs(configs: ExtendableConfig[]) {
     ...configs,
   )
 
-  return compact(mergedResult)
+  const withoutEmpty = compact(mergedResult)
+
+  /**
+   * Properly merge tokens between flat/nested forms by setting the flat form as the default
+   * preset:
+   * ```
+   * tokens: {
+   *   black: {
+   *     value: "black"
+   *   }
+   * }
+   * // color: "black"
+   * ```
+   *
+   * config:
+   * ```
+   * tokens: {
+   *   black: {
+   *     0: { value: "black" },
+   *     10: { value: "black/10" },
+   *     20: { value: "black/20" },
+   *     // ...
+   *   }
+   * }
+   *
+   * // color: "black.20"
+   * ```
+   */
+  if (withoutEmpty.theme?.tokens) {
+    traverse(withoutEmpty.theme.tokens, (args) => args, {
+      stop(args) {
+        if (isObject(args.value) && 'value' in args.value) {
+          const keys = Object.keys(args.value)
+          if (keys.filter((k) => !tokenKeys.includes(k)).length) {
+            const { type: _type, description: _description, extensions: _extensions, value } = args.value
+            args.value.DEFAULT = { value }
+            delete args.value.value
+          }
+
+          return true
+        }
+
+        return false
+      },
+    })
+  }
+
+  return withoutEmpty
 }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3971,7 +3971,7 @@ describe('extract to css output pipeline', () => {
     expect(result.css).toMatchInlineSnapshot(`""`)
   })
 
-  test.only('flat and nested object on same key', () => {
+  test('flat and nested object on same key', () => {
     const code = `
     const className = css({
       color: "black",
@@ -4031,11 +4031,11 @@ describe('extract to css output pipeline', () => {
       }
 
         .bg_black\\.10 {
-          background-color: black.10;
+          background-color: var(--colors-black-10);
       }
 
         .border_black\\.20 {
-          border-color: black.20;
+          border-color: var(--colors-black-20);
       }
       }"
     `)

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3956,4 +3956,88 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('TS namespaces - ignore not from panda', () => {
+    const code = `
+    import * as panda from "not-panda"
+
+    panda.css({ color: "red" })
+    panda.cva({ base: { color: "blue" } })
+    panda.sva({ base: { root: { color: "green" } } })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`[]`)
+
+    expect(result.css).toMatchInlineSnapshot(`""`)
+  })
+
+  test.only('flat and nested object on same key', () => {
+    const code = `
+    const className = css({
+      color: "black",
+      backgroundColor: "black.10",
+      borderColor: "black.20"
+    })
+     `
+    const result = parseAndExtract(code, {
+      presets: [
+        {
+          theme: {
+            extend: {
+              tokens: {
+                colors: {
+                  black: { value: 'black' },
+                },
+              },
+            },
+          },
+        },
+      ],
+      theme: {
+        extend: {
+          tokens: {
+            colors: {
+              black: {
+                0: { value: 'black' },
+                10: { value: 'black/10' },
+                20: { value: 'black/20' },
+                30: { value: 'black/30' },
+              },
+            },
+          },
+        },
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "backgroundColor": "black.10",
+              "borderColor": "black.20",
+              "color": "black",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .text_black {
+          color: var(--colors-black);
+      }
+
+        .bg_black\\.10 {
+          background-color: black.10;
+      }
+
+        .border_black\\.20 {
+          border-color: black.20;
+      }
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
## 📝 Description

Fix merging issue when using a preset that has a token with a conflicting value with another (or the user's config)

```ts
import { defineConfig } from '@pandacss/dev'

const userConfig = defineConfig({
  presets: [
    {
      theme: {
        extend: {
          tokens: {
            colors: {
              black: { value: 'black' },
            },
          },
        },
      },
    },
  ],
  theme: {
    tokens: {
      extend: {
        colors: {
          black: {
            0: { value: 'black' },
            10: { value: 'black/10' },
            20: { value: 'black/20' },
            30: { value: 'black/30' },
          },
        },
      },
    },
  },
})
```

When merged with the preset, the config would create nested tokens (`black.10`, `black.20`, `black.30`) inside of the
initially flat `black` token.

This would cause issues as the token engine stops diving deeper after encountering an object with a `value` property.

To fix this, we now automatically replace the flat `black` token using the `DEFAULT` keyword when resolving the config
so that the token engine can continue to dive deeper into the object:

```diff
{
  "theme": {
    "tokens": {
      "colors": {
        "black": {
          "0": {
            "value": "black",
          },
          "10": {
            "value": "black/10",
          },
          "20": {
            "value": "black/20",
          },
          "30": {
            "value": "black/30",
          },
-          "value": "black",
+          "DEFAULT": {
+            "value": "black",
+          },
        },
      },
    },
  },
}
```


## ⛳️ Current behavior (updates)

some tokens (nesteds) are completely ignored when a flat one (primitive `value`) is merged in the same object as nested ones

## 🚀 New behavior

tokens are now merged correctly !

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
