### PR TITLE
fix: JSX matching with recipes after introducing namespace imports

### DIFF
--- a/.changeset/blue-wolves-sniff.md
+++ b/.changeset/blue-wolves-sniff.md
@@ -1,0 +1,50 @@
+---
+'@pandacss/parser': patch
+---
+
+Fix JSX matching with recipes after introducing namespace imports
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  // ...
+  theme: {
+    extend: {
+      slotRecipes: {
+        tabs: {
+          className: 'tabs',
+          slots: ['root', 'list', 'trigger', 'content', 'indicator'],
+          base: {
+            root: {
+              display: 'flex',
+              // ...
+            },
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+```tsx
+const App = () => {
+  return (
+    // ❌ this was not matched to the `tabs` slot recipe
+    // ✅ fixed with this PR
+    <Tabs.Root defaultValue="button">
+      <Tabs.List>
+        <Tabs.Trigger value="button">Button</Tabs.Trigger>
+        <Tabs.Trigger value="radio">Radio Group</Tabs.Trigger>
+        <Tabs.Trigger value="slider">Slider</Tabs.Trigger>
+        <Tabs.Indicator />
+      </Tabs.List>
+    </Tabs.Root>
+  )
+}
+```
+
+We introduced a bug in [v0.34.2](https://github.com/chakra-ui/panda/blob/main/CHANGELOG.md#0342---2024-03-08) where the
+`Tabs.Trigger` component was not being matched to the `tabs` slot recipe, due to the
+[new namespace import feature](https://github.com/chakra-ui/panda/pull/2371).

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -4041,7 +4041,7 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
-  test.only('JSX matching with dot component that are not from a namespace', () => {
+  test('JSX recipes matching with dot component that are not from a namespace', () => {
     const code = `
     const App = () => {
       return (
@@ -4078,47 +4078,55 @@ describe('extract to css output pipeline', () => {
           "data": [
             {},
           ],
-          "name": "Root",
-          "type": "jsx",
+          "name": "Tabs.Root",
+          "type": "jsx-recipe",
         },
         {
           "data": [
             {},
           ],
-          "name": "List",
-          "type": "jsx",
+          "name": "Tabs.List",
+          "type": "jsx-recipe",
         },
         {
           "data": [
             {},
           ],
-          "name": "Trigger",
-          "type": "jsx",
+          "name": "Tabs.Trigger",
+          "type": "jsx-recipe",
         },
         {
           "data": [
             {},
           ],
-          "name": "Trigger",
-          "type": "jsx",
+          "name": "Tabs.Trigger",
+          "type": "jsx-recipe",
         },
         {
           "data": [
             {},
           ],
-          "name": "Trigger",
-          "type": "jsx",
+          "name": "Tabs.Trigger",
+          "type": "jsx-recipe",
         },
         {
           "data": [
             {},
           ],
-          "name": "Indicator",
-          "type": "jsx",
+          "name": "Tabs.Indicator",
+          "type": "jsx-recipe",
         },
       ]
     `)
 
-    expect(result.css).toMatchInlineSnapshot(`""`)
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes.slots {
+        @layer _base {
+          .tabs__root {
+            display: flex;
+      }
+          }
+      }"
+    `)
   })
 })

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -4040,4 +4040,85 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test.only('JSX matching with dot component that are not from a namespace', () => {
+    const code = `
+    const App = () => {
+      return (
+        <Tabs.Root defaultValue="button">
+          <Tabs.List>
+            <Tabs.Trigger value="button">Button</Tabs.Trigger>
+            <Tabs.Trigger value="radio">Radio Group</Tabs.Trigger>
+            <Tabs.Trigger value="slider">Slider</Tabs.Trigger>
+            <Tabs.Indicator />
+          </Tabs.List>
+      </Tabs.Root>)
+    }
+     `
+    const result = parseAndExtract(code, {
+      theme: {
+        extend: {
+          slotRecipes: {
+            tabs: {
+              className: 'tabs',
+              slots: ['root', 'list', 'trigger', 'content', 'indicator'],
+              base: {
+                root: {
+                  display: 'flex',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "Root",
+          "type": "jsx",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "List",
+          "type": "jsx",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "Trigger",
+          "type": "jsx",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "Trigger",
+          "type": "jsx",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "Trigger",
+          "type": "jsx",
+        },
+        {
+          "data": [
+            {},
+          ],
+          "name": "Indicator",
+          "type": "jsx",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`""`)
+  })
 })

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -269,18 +269,27 @@ export function createParser(context: ParserOptions) {
           const data = combineResult(unbox(query.box))
 
           switch (true) {
-            case file.isJsxFactory(name): {
+            case file.isJsxFactory(name) || file.isJsxFactory(alias): {
               parserResult.setJsx({ type: 'jsx-factory', name: name, box: query.box, data })
               break
             }
-            case jsx.isJsxTagPattern(name): {
+            case jsx.isJsxTagPattern(name) || jsx.isJsxTagPattern(alias): {
               parserResult.setPattern(name, { type: 'jsx-pattern', name: name, box: query.box, data })
               break
             }
+            // name: Trigger
             case jsx.isJsxTagRecipe(name): {
               const matchingRecipes = recipes.filter(name)
               matchingRecipes.map((recipe) => {
                 parserResult.setRecipe(recipe.baseName, { type: 'jsx-recipe', name: name, box: query.box, data })
+              })
+              break
+            }
+            // alias: Tabs.Trigger
+            case jsx.isJsxTagRecipe(alias): {
+              const matchingRecipes = recipes.filter(alias)
+              matchingRecipes.map((recipe) => {
+                parserResult.setRecipe(recipe.baseName, { type: 'jsx-recipe', name: alias, box: query.box, data })
               })
               break
             }


### PR DESCRIPTION
Closes https://github.com/cschroeter/park-ui/issues/264

## 📝 Description

Fix JSX matching with recipes after introducing namespace imports

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  // ...
  theme: {
    extend: {
      slotRecipes: {
        tabs: {
          className: 'tabs',
          slots: ['root', 'list', 'trigger', 'content', 'indicator'],
          base: {
            root: {
              display: 'flex',
              // ...
            },
          },
        },
      },
    },
  },
})
```

```tsx
const App = () => {
  return (
    // ❌ this was not matched to the `tabs` slot recipe
    // ✅ fixed with this PR
    <Tabs.Root defaultValue="button">
      <Tabs.List>
        <Tabs.Trigger value="button">Button</Tabs.Trigger>
        <Tabs.Trigger value="radio">Radio Group</Tabs.Trigger>
        <Tabs.Trigger value="slider">Slider</Tabs.Trigger>
        <Tabs.Indicator />
      </Tabs.List>
    </Tabs.Root>
  )
}
```

We introduced a bug in [v0.34.2](https://github.com/chakra-ui/panda/blob/main/CHANGELOG.md#0342---2024-03-08) where the
`Tabs.Trigger` component was not being matched to the `tabs` slot recipe, due to the
[new namespace import feature](https://github.com/chakra-ui/panda/pull/2371).