### PR TITLE
docs: fix link to "CSS Cascade Layers" caniuse page

### DIFF
--- a/website/pages/docs/overview/browser-support.md
+++ b/website/pages/docs/overview/browser-support.md
@@ -9,8 +9,8 @@ Panda CSS is built with modern CSS features and uses [PostCSS](https://postcss.o
 
 Panda supports the latest, stable releases of major browsers that support the following features:
 
-- [CSS Variables](https://caniuse.com/#feat=css-variables)
-- [CSS Cascade Layers](https://caniuse.com/css-variables)
+- [CSS Variables](https://caniuse.com/css-variables)
+- [CSS Cascade Layers](https://caniuse.com/css-cascade-layers)
 - Modern selectors, such as [:where()](https://caniuse.com/mdn-css_selectors_where) and [:is()](https://caniuse.com/css-matches-pseudo)
 
 ## Browserlist


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This fixes url for link `CSS Cascade Layers` on https://panda-css.com/docs/overview/browser-support

## ⛳️ Current behavior (updates)

n/a

## 🚀 New behavior

n/a

## 💣 Is this a breaking change (Yes/No):

n/a

## 📝 Additional Information
