### PR TITLE
fix(shared): create a new object in deepSet, avoid re-using the same reference

### DIFF
--- a/.changeset/heavy-badgers-try.md
+++ b/.changeset/heavy-badgers-try.md
@@ -1,0 +1,11 @@
+---
+'@pandacss/parser': patch
+'@pandacss/shared': patch
+---
+
+Fix a bug where some styles would be grouped together in the same rule, even if they were not related to each other.
+
+## Internal details
+
+This was caused by an object reference being re-used while setting a property deeply in the hashes decoding process,
+leading to the mutation of a previous style object with additional properties.

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -4129,4 +4129,148 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test.only('slot recipes with textStyles', () => {
+    const code = `
+    import { cta } from 'styled-system/recipes';
+    import { css } from 'styled-system/css';
+
+    const Cta = ({ level, text, title }) => {
+      const cn = cta({ level });
+
+      return (
+        <div className={cn.wrapper}>
+          <p className={cn.heading}>{title}</p>
+          <p className={cn.text}>{text}</p>
+        </div>
+      );
+    };
+
+    const App = () => {
+      return (
+        <>
+        <div className="case">
+          <p>
+            The following paragraph should not have any bottom margin nor color
+            applied as it uses the <code>heading-1</code> <code>textStyle</code>:
+          </p>
+          <p
+            className={css({ textStyle: 'heading-1' })}
+          >
+            P with textStyle
+          </p>
+          <p>Text</p>
+        </div>
+        <div className="case">
+          <p>
+            The following paragraph should have a bottom margin and color applied
+            as it uses the <code>cta</code> recipe:
+          </p>
+          <Cta text="Text" title="P in recipe heading" level="1" />
+        </div>
+        </>)
+    }
+     `
+    const result = parseAndExtract(code, {
+      theme: {
+        extend: {
+          slotRecipes: {
+            cta: {
+              className: 'cta',
+              slots: ['heading', 'text', 'wrapper'],
+              base: {},
+              variants: {
+                level: {
+                  1: {
+                    heading: {
+                      textStyle: 'heading-1',
+                      color: { base: 'green.500', sm: 'red.500' },
+                      marginBottom: { base: '20px', sm: '40px' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          textStyles: {
+            'heading-1': {
+              description: 'Heading 1',
+              value: {
+                fontWeight: 'bold',
+                fontSize: { base: '2xl', sm: '4xl' },
+                textTransform: 'uppercase',
+              },
+            },
+          },
+        },
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "cta",
+          "type": "recipe",
+        },
+        {
+          "data": [
+            {
+              "textStyle": "heading-1",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+        {
+          "data": [
+            {
+              "level": "1",
+            },
+          ],
+          "name": "Cta",
+          "type": "jsx-recipe",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer recipes.slots {
+        .cta__heading--level_1 {
+          text-transform: uppercase;
+          font-weight: var(--font-weights-bold);
+          font-size: var(--font-sizes-2xl);
+          color: var(--colors-green-500);
+          margin-bottom: 20px;
+      }
+
+        @media screen and (min-width: 40rem) {
+          .cta__heading--level_1 {
+            font-size: var(--font-sizes-4xl);
+            color: var(--colors-red-500);
+            margin-bottom: 40px;
+      }
+      }
+      }
+
+      @layer utilities {
+        @layer compositions {
+          .textStyle_heading-1 {
+            text-transform: uppercase;
+            font-weight: var(--font-weights-bold);
+            font-size: var(--font-sizes-2xl);
+      }
+
+          @media screen and (min-width: 40rem) {
+            .textStyle_heading-1 {
+              font-size: var(--font-sizes-4xl);
+              color: var(--colors-red-500);
+              margin-bottom: 40px;
+      }
+      }
+      }
+      }"
+    `)
+  })
 })

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -4172,34 +4172,34 @@ describe('extract to css output pipeline', () => {
     }
      `
     const result = parseAndExtract(code, {
+      eject: true,
       theme: {
-        extend: {
-          slotRecipes: {
-            cta: {
-              className: 'cta',
-              slots: ['heading', 'text', 'wrapper'],
-              base: {},
-              variants: {
-                level: {
-                  1: {
-                    heading: {
-                      textStyle: 'heading-1',
-                      color: { base: 'green.500', sm: 'red.500' },
-                      marginBottom: { base: '20px', sm: '40px' },
-                    },
+        breakpoints: { sm: '480px' },
+        slotRecipes: {
+          cta: {
+            className: 'cta',
+            slots: ['heading', 'text', 'wrapper'],
+            base: {},
+            variants: {
+              level: {
+                1: {
+                  heading: {
+                    textStyle: 'heading-1',
+                    color: { base: 'green', sm: 'red' },
+                    marginBottom: { base: '20px', sm: '40px' },
                   },
                 },
               },
             },
           },
-          textStyles: {
-            'heading-1': {
-              description: 'Heading 1',
-              value: {
-                fontWeight: 'bold',
-                fontSize: { base: '2xl', sm: '4xl' },
-                textTransform: 'uppercase',
-              },
+        },
+        textStyles: {
+          'heading-1': {
+            description: 'Heading 1',
+            value: {
+              fontWeight: 'bold',
+              fontSize: { base: '2px', sm: '40px' },
+              textTransform: 'uppercase',
             },
           },
         },
@@ -4239,16 +4239,16 @@ describe('extract to css output pipeline', () => {
       "@layer recipes.slots {
         .cta__heading--level_1 {
           text-transform: uppercase;
-          font-weight: var(--font-weights-bold);
-          font-size: var(--font-sizes-2xl);
-          color: var(--colors-green-500);
+          font-weight: bold;
+          font-size: 2px;
+          color: green;
           margin-bottom: 20px;
       }
 
-        @media screen and (min-width: 40rem) {
+        @media screen and (min-width: 30rem) {
           .cta__heading--level_1 {
-            font-size: var(--font-sizes-4xl);
-            color: var(--colors-red-500);
+            font-size: 40px;
+            color: red;
             margin-bottom: 40px;
       }
       }
@@ -4258,14 +4258,14 @@ describe('extract to css output pipeline', () => {
         @layer compositions {
           .textStyle_heading-1 {
             text-transform: uppercase;
-            font-weight: var(--font-weights-bold);
-            font-size: var(--font-sizes-2xl);
+            font-weight: bold;
+            font-size: 2px;
       }
 
-          @media screen and (min-width: 40rem) {
+          @media screen and (min-width: 30rem) {
             .textStyle_heading-1 {
-              font-size: var(--font-sizes-4xl);
-              color: var(--colors-red-500);
+              font-size: 40px;
+              color: red;
               margin-bottom: 40px;
       }
       }

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -4130,7 +4130,7 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
-  test.only('slot recipes with textStyles', () => {
+  test('slot recipes with textStyles', () => {
     const code = `
     import { cta } from 'styled-system/recipes';
     import { css } from 'styled-system/css';
@@ -4265,8 +4265,6 @@ describe('extract to css output pipeline', () => {
           @media screen and (min-width: 30rem) {
             .textStyle_heading-1 {
               font-size: 40px;
-              color: red;
-              margin-bottom: 40px;
       }
       }
       }

--- a/packages/shared/src/deep-set.ts
+++ b/packages/shared/src/deep-set.ts
@@ -20,7 +20,7 @@ export const deepSet = <T extends Dict>(target: T, path: string[], value: Dict |
 
     if (i === path.length - 1) {
       if (isValueObject && isObject(current[key])) {
-        Object.assign(current[key], value)
+        current[key] = Object.assign({ ...current[key] }, value)
       } else {
         current[key] = value
       }


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/2439

## 📝 Description

Fix a bug where some styles would be grouped together in the same rule, even if they were not related to each other.

## Internal details

This was caused by an object reference being re-used while setting a property deeply in the hashes decoding process,
leading to the mutation of a previous style object with additional properties.

