### PR TITLE
refactor: improve token reference validation

### DIFF
--- a/.changeset/lazy-falcons-rest.md
+++ b/.changeset/lazy-falcons-rest.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/config': patch
+---
+
+Improve token validation logic to parse references in `tokens` and compositve values like `borders` and `shadows` which
+could be objects.

--- a/packages/config/__tests__/validate-config.test.ts
+++ b/packages/config/__tests__/validate-config.test.ts
@@ -239,14 +239,14 @@ describe('validateConfig', () => {
         "[tokens] Token must contain 'value': \`theme.tokens.colors.secondary\`",
         "[tokens] Token must contain 'value': \`theme.tokens.colors.group.with.invalid\`",
         "[tokens] Token must contain 'value': \`theme.semanticTokens.colors.another.group.invalid\`",
-        "[tokens] Missing token: \`colors.doesntexist\` used in \`config.semanticTokens.colors.another.group.stillok\`",
+        "[tokens] Missing token: \`colors.doesntexist\` used in \`theme.semanticTokens.colors.another.group.stillok\`",
         "[tokens] Circular token reference: \`colors.another.group.recursive\` -> \`colors.another.circular\` -> ... -> \`colors.another.group.recursive\`",
-        "[tokens] Missing token: \`colors.missing\` used in \`config.semanticTokens.colors.another.group.missing\`",
+        "[tokens] Missing token: \`colors.missing\` used in \`theme.semanticTokens.colors.another.group.missing\`",
         "[tokens] Self token reference: \`colors.another.self\`",
         "[tokens] Circular token reference: \`colors.another.self\` -> \`colors.another.self\` -> ... -> \`colors.another.self\`",
         "[tokens] Circular token reference: \`colors.another.circular\` -> \`colors.another.group.recursive\` -> ... -> \`colors.another.circular\`",
-        "[tokens] Missing token: \`fontSizes.md2\` used in \`config.semanticTokens.fontSizes.main\`",
-        "[recipes] This recipe name is already used in \`config.patterns\`: btn-primary",
+        "[tokens] Missing token: \`fontSizes.md2\` used in \`theme.semanticTokens.fontSizes.main\`",
+        "[recipes] This recipe name is already used in \`patterns\`: btn-primary",
       }
     `)
   })
@@ -351,7 +351,7 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: ⚠️ Invalid config:
-      - [tokens] Missing token: \`colors.doesntexist\` used in \`config.semanticTokens.colors.another.group.stillok\`
+      - [tokens] Missing token: \`colors.doesntexist\` used in \`theme.semanticTokens.colors.another.group.stillok\`
       ]
     `,
     )
@@ -431,7 +431,7 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: ⚠️ Invalid config:
-      - [tokens] Missing token: \`colors.bg\` used in \`config.semanticTokens.colors.primary\`
+      - [tokens] Missing token: \`colors.bg\` used in \`theme.semanticTokens.colors.primary\`
       ]
     `,
     )
@@ -454,7 +454,7 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).toThrowErrorMatchingInlineSnapshot(
       `
       [Error: ⚠️ Invalid config:
-      - [recipes] This recipe name is already used in \`config.patterns\`: \`stack\`
+      - [recipes] This recipe name is already used in \`patterns\`: \`stack\`
       ]
     `,
     )
@@ -511,7 +511,7 @@ describe('validateConfig', () => {
       [Error: ⚠️ Invalid config:
       - [tokens] Token must contain 'value': \`theme.semanticTokens.colors.primary\`
       - [tokens] Unknown token reference: \`colors.primary\` used in \`{colors.bbb}\`
-      - [tokens] Missing token: \`colors.red\` used in \`config.semanticTokens.colors.group.nested.something\`
+      - [tokens] Missing token: \`colors.red\` used in \`theme.semanticTokens.colors.group.nested.something\`
       ]
     `,
     )
@@ -661,5 +661,101 @@ describe('validateConfig', () => {
     }
 
     expect(validateConfig(config)).toMatchInlineSnapshot(`undefined`)
+  })
+
+  test('should validate shadow tokens', () => {
+    const config: Partial<UserConfig> = {
+      validation: 'warn',
+      theme: {
+        tokens: {
+          shadows: {
+            strong: {
+              value: '2px 4px 16px 0px {colors.gray.934/16}, 0px 2px 4px 0px {colors.gray.34/8}',
+            },
+          },
+        },
+      },
+    }
+
+    expect(validateConfig(config)).toMatchInlineSnapshot(`
+      Set {
+        "[tokens] Missing token: \`colors.gray.34\` used in \`theme.tokens.shadows.strong\`",
+        "[tokens] Missing token: \`colors.gray.934\` used in \`theme.tokens.shadows.strong\`",
+      }
+    `)
+  })
+
+  test('should validate composite tokens', () => {
+    const config: Partial<UserConfig> = {
+      validation: 'warn',
+      theme: {
+        tokens: {
+          shadows: {
+            strong: {
+              value: {
+                offsetX: 2,
+                offsetY: 4,
+                blur: 16,
+                spread: 0,
+                color: '{colors.gray.100/16}',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    expect(validateConfig(config)).toMatchInlineSnapshot(`
+      Set {
+        "[tokens] Missing token: \`colors.gray.100\` used in \`theme.tokens.shadows.strong\`",
+      }
+    `)
+  })
+
+  test('should validate composite array tokens', () => {
+    const config: Partial<UserConfig> = {
+      validation: 'warn',
+      theme: {
+        tokens: {
+          borders: {
+            soft: {
+              value: {
+                width: 1,
+                style: 'solid',
+                color: '{colors.gray.100}',
+              },
+            },
+          },
+          shadows: {
+            strong: {
+              value: [
+                {
+                  offsetX: 2,
+                  offsetY: 4,
+                  blur: 16,
+                  spread: 0,
+                  color: '{colors.gray.100/16}',
+                },
+                {
+                  offsetX: 0,
+                  offsetY: 2,
+                  blur: 4,
+                  spread: 0,
+                  color: '{colors.gray.300/8}',
+                },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    expect(validateConfig(config)).toMatchInlineSnapshot(`
+      Set {
+        "[tokens] Missing token: \`colors.gray.100\` used in \`theme.tokens.borders.soft\`",
+        "[tokens] Missing token: \`colors.gray.300\` used in \`theme.tokens.shadows.strong\`",
+        "[tokens] Missing token: \`colors.gray.100\` used in \`theme.tokens.shadows.strong\`",
+      }
+    `)
   })
 })

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -14,6 +14,7 @@ export interface TokensData {
   semanticTokenNames: Set<string>
   valueAtPath: Map<string, any>
   refsByPath: Map<string, Set<string>>
+  typeByPath: Map<string, 'tokens' | 'semanticTokens'>
 }
 
 export interface ArtifactNames {

--- a/packages/config/src/validate-config.ts
+++ b/packages/config/src/validate-config.ts
@@ -43,6 +43,7 @@ export const validateConfig = (config: Partial<UserConfig>) => {
     semanticTokenNames: new Set(),
     valueAtPath: new Map(),
     refsByPath: new Map(),
+    typeByPath: new Map(),
   }
 
   if (config.theme) {

--- a/packages/config/src/validation/utils.ts
+++ b/packages/config/src/validation/utils.ts
@@ -1,5 +1,41 @@
+import { isObject, isString } from '@pandacss/shared'
+
+const REFERENCE_REGEX = /({([^}]*)})/g
+const curlyBracketRegex = /[{}]/g
+
 export const isValidToken = (token: unknown) => Object.hasOwnProperty.call(token, 'value')
-export const isTokenReference = (value: unknown) => typeof value === 'string' && value.startsWith('{')
+export const isTokenReference = (value: unknown) => typeof value === 'string' && REFERENCE_REGEX.test(value)
 
 export const formatPath = (path: string) => path
 export const SEP = '.'
+
+export function getReferences(value: string) {
+  if (typeof value !== 'string') return []
+
+  const matches = value.match(REFERENCE_REGEX)
+  if (!matches) return []
+
+  return matches
+    .map((match) => match.replace(curlyBracketRegex, ''))
+    .map((value) => {
+      return value.trim().split('/')[0]
+    })
+}
+
+export const serializeTokenValue = (value: any): string => {
+  if (isString(value)) {
+    return value
+  }
+
+  if (isObject(value)) {
+    return Object.values(value)
+      .map((v) => serializeTokenValue(v))
+      .join(' ')
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((v) => serializeTokenValue(v)).join(' ')
+  }
+
+  return value.toString()
+}

--- a/packages/config/src/validation/validate-artifact.ts
+++ b/packages/config/src/validation/validate-artifact.ts
@@ -3,17 +3,17 @@ import type { AddError, ArtifactNames } from '../types'
 export const validateArtifactNames = (names: ArtifactNames, addError: AddError) => {
   names.recipes.forEach((recipeName) => {
     if (names.slotRecipes.has(recipeName)) {
-      addError('recipes', `This recipe name is already used in \`config.theme.slotRecipes\`: ${recipeName}`)
+      addError('recipes', `This recipe name is already used in \`theme.slotRecipes\`: ${recipeName}`)
     }
 
     if (names.patterns.has(recipeName)) {
-      addError('recipes', `This recipe name is already used in \`config.patterns\`: \`${recipeName}\``)
+      addError('recipes', `This recipe name is already used in \`patterns\`: \`${recipeName}\``)
     }
   })
 
   names.slotRecipes.forEach((recipeName) => {
     if (names.patterns.has(recipeName)) {
-      addError('recipes', `This recipe name is already used in \`config.patterns\`: ${recipeName}`)
+      addError('recipes', `This recipe name is already used in \`patterns\`: ${recipeName}`)
     }
   })
 }

--- a/packages/config/src/validation/validate-token-references.ts
+++ b/packages/config/src/validation/validate-token-references.ts
@@ -1,11 +1,16 @@
 import type { AddError } from '../types'
 import { isTokenReference } from './utils'
 
-export const validateTokenReferences = (
-  valueAtPath: Map<string, any>,
-  refsByPath: Map<string, Set<string>>,
-  addError: AddError,
-) => {
+interface Props {
+  valueAtPath: Map<string, any>
+  refsByPath: Map<string, Set<string>>
+  typeByPath: Map<string, 'tokens' | 'semanticTokens'>
+  addError: AddError
+}
+
+export const validateTokenReferences = (props: Props) => {
+  const { valueAtPath, refsByPath, addError, typeByPath } = props
+
   refsByPath.forEach((refs, path) => {
     if (refs.has(path)) {
       addError('tokens', `Self token reference: \`${path}\``)
@@ -23,7 +28,8 @@ export const validateTokenReferences = (
       const value = valueAtPath.get(currentPath)
 
       if (!value) {
-        addError('tokens', `Missing token: \`${currentPath}\` used in \`config.semanticTokens.${path}\``)
+        const configKey = typeByPath.get(path)
+        addError('tokens', `Missing token: \`${currentPath}\` used in \`theme.${configKey}.${path}\``)
       }
 
       if (isTokenReference(value) && !refsByPath.has(value)) {


### PR DESCRIPTION
Closes #2392 

## 📝 Description

Expand validation logic to cover these scenarios:
- references in the `theme.tokens` config (esp shadows, and borders)
- references in composite tokens like gradients, shadows, and borders

## ⛳️ Current behavior (updates)

Previously, we only tracked references for semanticTokens

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
