### PR TITLE
fix: build correct path for debug files on windows

### DIFF
--- a/.changeset/fair-teachers-kiss.md
+++ b/.changeset/fair-teachers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/node": patch
+---
+
+fix: build correct path for debug files on windows

--- a/packages/node/src/debug.ts
+++ b/packages/node/src/debug.ts
@@ -54,15 +54,15 @@ export async function debug(ctx: PandaContext, options: DebugOptions) {
       const parsedPath = parse(file)
       const relative = path.relative(ctx.config.cwd, parsedPath.dir)
 
-      const astJsonPath = `${relative}/${parsedPath.name}.ast.json`.replaceAll(path.sep, '__')
-      const cssPath = `${relative}/${parsedPath.name}.css`.replaceAll(path.sep, '__')
+      const astJsonPath = `${relative}${path.sep}${parsedPath.name}.ast.json`.replaceAll(path.sep, '__')
+      const cssPath = `${relative}${path.sep}${parsedPath.name}.css`.replaceAll(path.sep, '__')
 
       logger.info('cli', `Writing ${colors.bold(`${outdir}/${astJsonPath}`)}`)
       logger.info('cli', `Writing ${colors.bold(`${outdir}/${cssPath}`)}`)
 
       return Promise.allSettled([
-        fs.writeFile(`${outdir}/${astJsonPath}`, JSON.stringify(result.toJSON(), null, 2)),
-        fs.writeFile(`${outdir}/${cssPath}`, css),
+        fs.writeFile(`${outdir}${path.sep}${astJsonPath}`, JSON.stringify(result.toJSON(), null, 2)),
+        fs.writeFile(`${outdir}${path.sep}${cssPath}`, css),
       ])
     }
   })


### PR DESCRIPTION
Using `/` as a separator makes the `replaceAll` not work on windows due to `path.sep` being `\`.

This change makes `panda debug` work on windows.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

`panda debug` fails if it tries to create debug files for files that are under a directory. This means that a file `src/foo/component.tsx` is renamed to `src\foo\component.css` instead of `src__foo__component.css`.

## 🚀 New behavior

`panda debug` renames the files correctly under windows.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
