### PR TITLE
chore(docs): remove duplicate tags

### DIFF
--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -8,7 +8,6 @@ import {
   FileTree,
   Tab,
   Tabs,
-  useConfig
 } from './src'
 import { Steps } from './src/mdx/steps'
 import { css } from './styled-system/css'
@@ -70,9 +69,6 @@ const config: DocsThemeConfig = {
     )
   },
   head: () => {
-    const { frontMatter: meta } = useConfig()
-    const { title } = meta
-
     return (
       <>
         {seoConfig.icons.map((icon, index) => (

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -79,20 +79,6 @@ const config: DocsThemeConfig = {
           <link key={index} rel={icon.rel} href={icon.url} />
         ))}
         <meta httpEquiv="Content-Language" content="en" />
-        <meta
-          name="description"
-          content={meta['description'] || seoConfig.description}
-        />
-        <meta
-          name="og:title"
-          content={title ? title + ' – Panda' : seoConfig.title.default}
-        />
-        <meta
-          name="og:description"
-          content={meta['description'] || seoConfig.description}
-        />
-        <meta name="og:image" content={seoConfig.openGraph.images} />
-        <meta name="og:url" content={seoConfig.openGraph.url} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content={seoConfig.twitter.site} />
         <meta name="twitter:creator" content={seoConfig.twitter.creator} />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->



## 📝 Description

`description`, `og:title`, `og:description`, `og:image` and `og:url` are duplicated in web page. These tags are provided by [metadata](https://github.com/chakra-ui/panda/blob/bc09d893a63ab2b40f6fe026ab3b7bd62dad289d/website/app/layout.tsx#L15) and theme. This removed the tags  provided by the theme.

## ⛳️ Current behavior (updates)



## 🚀 New behavior



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
