### PR TITLE
fix: imports detection leading to missing CSS when using tsconfig baseUrl with prefixed outdir

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["sandbox-*", "playground", "website"]
+  "ignore": ["sandbox-*", "playground", "website", "@pandacss/fixture"]
 }

--- a/.changeset/loud-tips-heal.md
+++ b/.changeset/loud-tips-heal.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Fix Panda imports detection when using `tsconfig`.`baseUrl` with an outdir that starts with `./`.

--- a/packages/core/__tests__/import-map.test.ts
+++ b/packages/core/__tests__/import-map.test.ts
@@ -265,3 +265,122 @@ describe('import map', () => {
     expect(file.find('sx')).toBeFalsy()
   })
 })
+
+describe('import map - outdir', () => {
+  test('default', () => {
+    const ctx = createContext()
+    expect(ctx.imports.outdir).toMatchInlineSnapshot('"styled-system"')
+  })
+
+  test('relative outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: './styled-system',
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: 'styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: '.',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - relative outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: '../styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: '.',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - parent outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: '../styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: '.',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - nested parent outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: '../../../styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: '.',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - ./src', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: 'styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: './src',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - ./src - relative outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: '../styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: './src',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - ./src - parent outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: '../styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: './src',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+
+  test('with baseUrl - ./src - nested parent outdir', () => {
+    const ctx = createContext({
+      cwd: '/Users/astahmer/dev/open-source/panda-app',
+      outdir: '../../../styled-system',
+      tsconfig: {
+        compilerOptions: {
+          baseUrl: './src',
+        },
+      },
+    })
+    expect(ctx.imports.outdir).toMatchInlineSnapshot(`"styled-system"`)
+  })
+})

--- a/packages/core/src/import-map.ts
+++ b/packages/core/src/import-map.ts
@@ -98,13 +98,10 @@ export class ImportMap {
   }
 
   private getOutdir = () => {
-    const { cwd, outdir } = this.context.config
+    const { outdir } = this.context.config
 
-    const compilerOptions = this.context.conf.tsconfig?.compilerOptions ?? {}
-    const baseUrl = compilerOptions.baseUrl ?? ''
-
-    const relativeBaseUrl = baseUrl !== cwd ? baseUrl.replace(cwd, '').slice(1) : cwd
-    return outdir.replace(relativeBaseUrl, '').replace('./', '')
+    const split = outdir.split('/')
+    return split[split.length - 1]
   }
 
   normalize = (map: string | ImportMapInput | undefined): ImportMapOutput => {

--- a/packages/core/src/import-map.ts
+++ b/packages/core/src/import-map.ts
@@ -104,7 +104,7 @@ export class ImportMap {
     const baseUrl = compilerOptions.baseUrl ?? ''
 
     const relativeBaseUrl = baseUrl !== cwd ? baseUrl.replace(cwd, '').slice(1) : cwd
-    return outdir.replace(relativeBaseUrl, '')
+    return outdir.replace(relativeBaseUrl, '').replace('./', '')
   }
 
   normalize = (map: string | ImportMapInput | undefined): ImportMapOutput => {

--- a/packages/fixture/src/create-context.ts
+++ b/packages/fixture/src/create-context.ts
@@ -67,6 +67,7 @@ export const createContext = (userConfig?: Config) => {
     config: Object.assign({}, defaults, resolvedConfig),
     tsconfig: {
       // @ts-expect-error
+      ...userConfig?.tsconfig,
       useInMemoryFileSystem: true,
     },
   })

--- a/packages/fixture/src/create-context.ts
+++ b/packages/fixture/src/create-context.ts
@@ -39,7 +39,7 @@ export const createGeneratorContext = (userConfig?: Config) => {
   return new Generator({ ...fixtureDefaults, config: resolvedConfig })
 }
 
-export const createContext = (userConfig?: Config) => {
+export const createContext = (userConfig?: Config & Pick<Partial<LoadConfigResult>, 'tsconfig'>) => {
   let resolvedConfig = (
     userConfig ? mergeConfigs([userConfig, userConfig.eject ? {} : fixtureDefaults.config]) : fixtureDefaults.config
   ) as UserConfig
@@ -66,8 +66,8 @@ export const createContext = (userConfig?: Config) => {
     hooks: userConfig?.hooks ?? {},
     config: Object.assign({}, defaults, resolvedConfig),
     tsconfig: {
-      // @ts-expect-error
       ...userConfig?.tsconfig,
+      // @ts-expect-error
       useInMemoryFileSystem: true,
     },
   })

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3650,7 +3650,7 @@ describe('extract to css output pipeline', () => {
     `)
   })
 
-  test.only('config.outdir detection', () => {
+  test('config.outdir detection with baseUrl', () => {
     const code = `
     import { styled } from "styled-system/jsx";
 
@@ -3701,13 +3701,75 @@ describe('extract to css output pipeline', () => {
           "name": "ReactMarkdown",
           "type": "jsx",
         },
+        {
+          "data": [
+            {
+              "borderLeftColor": "border.default",
+              "borderLeftStyle": "solid",
+              "borderLeftWidth": "4px",
+              "padding": 4,
+            },
+          ],
+          "name": "styled.blockquote",
+          "type": "jsx-factory",
+        },
+        {
+          "data": [
+            {
+              "listStyleType": "disc",
+              "pl": "4",
+            },
+          ],
+          "name": "styled.ul",
+          "type": "jsx-factory",
+        },
+        {
+          "data": [
+            {
+              "listStyleType": "decimal",
+              "pl": "4",
+            },
+          ],
+          "name": "styled.ol",
+          "type": "jsx-factory",
+        },
       ]
     `)
 
-    expect(result.css).toMatchInlineSnapshot(`""`)
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .p_4 {
+          padding: var(--spacing-4);
+      }
+
+        .border-lw_4px {
+          border-left-width: 4px;
+      }
+
+        .border-left-style_solid {
+          border-left-style: solid;
+      }
+
+        .border-l_border\\.default {
+          border-left-color: border.default;
+      }
+
+        .pl_4 {
+          padding-left: var(--spacing-4);
+      }
+
+        .list-type_disc {
+          list-style-type: disc;
+      }
+
+        .list-type_decimal {
+          list-style-type: decimal;
+      }
+      }"
+    `)
   })
 
-  test.only('config.outdir detection nested', () => {
+  test('config.outdir detection in nested folder with baseUrl', () => {
     const code = `
     import { styled } from "styled-system/jsx";
 
@@ -3758,9 +3820,71 @@ describe('extract to css output pipeline', () => {
           "name": "ReactMarkdown",
           "type": "jsx",
         },
+        {
+          "data": [
+            {
+              "borderLeftColor": "border.default",
+              "borderLeftStyle": "solid",
+              "borderLeftWidth": "4px",
+              "padding": 4,
+            },
+          ],
+          "name": "styled.blockquote",
+          "type": "jsx-factory",
+        },
+        {
+          "data": [
+            {
+              "listStyleType": "disc",
+              "pl": "4",
+            },
+          ],
+          "name": "styled.ul",
+          "type": "jsx-factory",
+        },
+        {
+          "data": [
+            {
+              "listStyleType": "decimal",
+              "pl": "4",
+            },
+          ],
+          "name": "styled.ol",
+          "type": "jsx-factory",
+        },
       ]
     `)
 
-    expect(result.css).toMatchInlineSnapshot(`""`)
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .p_4 {
+          padding: var(--spacing-4);
+      }
+
+        .border-lw_4px {
+          border-left-width: 4px;
+      }
+
+        .border-left-style_solid {
+          border-left-style: solid;
+      }
+
+        .border-l_border\\.default {
+          border-left-color: border.default;
+      }
+
+        .pl_4 {
+          padding-left: var(--spacing-4);
+      }
+
+        .list-type_disc {
+          list-style-type: disc;
+      }
+
+        .list-type_decimal {
+          list-style-type: decimal;
+      }
+      }"
+    `)
   })
 })

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3649,4 +3649,118 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test.only('config.outdir detection', () => {
+    const code = `
+    import { styled } from "styled-system/jsx";
+
+    export const Markdown = () => {
+      return (
+        <ReactMarkdown
+          components={{
+            blockquote: ({ ref, node, ...props }) => (
+              <styled.blockquote
+                borderLeftWidth="4px"
+                borderLeftStyle="solid"
+                borderLeftColor="border.default"
+                padding={4}
+                {...props}
+              />
+            ),
+            ul: ({ ref, node, ...props }) => (
+              <styled.ul pl="4" listStyleType="disc" {...props} />
+            ),
+            ol: ({ ref, node, ...props }) => (
+              <styled.ol pl="4" listStyleType="decimal" {...props} />
+            ),
+          }}
+        >
+          {content}
+        </ReactMarkdown>
+      );
+    };
+
+     `
+    const result = parseAndExtract(
+      code,
+      {
+        outdir: './styled-system',
+      },
+      {
+        compilerOptions: {
+          baseUrl: '.',
+        },
+      },
+    )
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "ReactMarkdown",
+          "type": "jsx",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`""`)
+  })
+
+  test.only('config.outdir detection nested', () => {
+    const code = `
+    import { styled } from "styled-system/jsx";
+
+    export const Markdown = () => {
+      return (
+        <ReactMarkdown
+          components={{
+            blockquote: ({ ref, node, ...props }) => (
+              <styled.blockquote
+                borderLeftWidth="4px"
+                borderLeftStyle="solid"
+                borderLeftColor="border.default"
+                padding={4}
+                {...props}
+              />
+            ),
+            ul: ({ ref, node, ...props }) => (
+              <styled.ul pl="4" listStyleType="disc" {...props} />
+            ),
+            ol: ({ ref, node, ...props }) => (
+              <styled.ol pl="4" listStyleType="decimal" {...props} />
+            ),
+          }}
+        >
+          {content}
+        </ReactMarkdown>
+      );
+    };
+
+     `
+    const result = parseAndExtract(
+      code,
+      {
+        outdir: './src/styled-system',
+      },
+      {
+        compilerOptions: {
+          baseUrl: './src',
+        },
+      },
+    )
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {},
+          ],
+          "name": "ReactMarkdown",
+          "type": "jsx",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`""`)
+  })
 })

--- a/website/pages/docs/guides/debugging.mdx
+++ b/website/pages/docs/guides/debugging.mdx
@@ -186,9 +186,9 @@ import { css } from "#styled-system/css"
 ```js
 // panda.config.js
 
-module.exports = {
+export default defineConfig({
   importMap: '~/styled-system'
-}
+})
 ```
 
 This will ensure that the paths are resolved correctly, and HMR works as expected.

--- a/website/pages/docs/guides/debugging.mdx
+++ b/website/pages/docs/guides/debugging.mdx
@@ -153,6 +153,46 @@ pnpm panda --cpu-prof
 
 Check that the [`@layer` rules](/docs/concepts/cascade-layers#layer-css) are set and the corresponding `.css` file is included. [If you're not using `postcss`](/docs/installation/cli), ensure that `styled-system/styles.css` is imported and that the `panda` command has been run (or is running with `--watch`).
 
+
+### Some CSS is missing when using absolute imports
+
+This can happen when `tsconfig` (with `paths` or `baseUrl`) or with package.json [`#imports`](https://nodejs.org/api/packages.html#subpath-imports).
+Panda tries to automatically infer and read the custom paths defined in `tsconfig.json` file. However, there might be scenarios that won't work.
+
+
+To fix this add the `importMap` option to your `panda.config.js` file, setting it's value to match the way you import the `outdir` modules.
+
+```app.tsx
+// app.tsx
+
+import { css } from "~/styled-system/css"
+// tsconfig.json paths
+// -> importMap: "~/styled-system"
+
+import { css } from "styled-system/css"
+// tsconfig.json baseUrl
+// -> importMap: "styled-system"
+
+import { css } from "@my-monorepo/ui-kit/css"
+// monorepo workspace package
+// -> importMap: "@my-monorepo/ui-kit"
+
+import { css } from "#styled-system/css"
+// package.json#imports
+// -> importMap: "#styled-system
+
+```
+
+```js
+// panda.config.js
+
+module.exports = {
+  importMap: '~/styled-system'
+}
+```
+
+This will ensure that the paths are resolved correctly, and HMR works as expected.
+
 ---
 
 ### How can I debug the styles?


### PR DESCRIPTION
## 📝 Description

Fix Panda imports detection when using `tsconfig`.`baseUrl` with an outdir that starts with `./`.

## ⛳️ Current behavior (updates)

Styles were missing due to absolute imports not seen as valid Panda imports when using an outdir that started with `./`

```ts
// app.tsx
import { styled } from "styled-system/jsx";

// tsconfig.json
{
  compilerOptions: {
    baseUrl: '.',
  },
},

// panda.config.ts
{
  outdir: './styled-system',
}
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

If some part of your CSS is still missing when using absolute imports:

This can happen when `tsconfig` (with `paths` or `baseUrl`) or with package.json [`#imports`](https://nodejs.org/api/packages.html#subpath-imports).
Panda tries to automatically infer and read the custom paths defined in `tsconfig.json` file. However, there might be scenarios that won't work.


To fix this add the `importMap` option to your `panda.config.js` file, setting it's value to match the way you import the `outdir` modules.

```app.tsx
// app.tsx

import { css } from "~/styled-system/css"
// tsconfig.json paths
// -> importMap: "~/styled-system"

import { css } from "styled-system/css"
// tsconfig.json baseUrl
// -> importMap: "styled-system"

import { css } from "@my-monorepo/ui-kit/css"
// monorepo workspace package
// -> importMap: "@my-monorepo/ui-kit"

import { css } from "#styled-system/css"
// package.json#imports
// -> importMap: "#styled-system

```

```js
// panda.config.js

module.exports = {
  importMap: '~/styled-system'
}
```

This will ensure that the paths are resolved correctly, and HMR works as expected.

