### PR TITLE
feat: strictTokens: "extends" to allow for known values of CssPropert…

### DIFF
--- a/.changeset/sweet-cups-sit.md
+++ b/.changeset/sweet-cups-sit.md
@@ -11,6 +11,14 @@ your theme).
 Example:
 
 ```ts
+// panda.config.js
+import { defineConfig } from '@pandacss/dev'
+export default defineConfig({
+  //...
+  strictTokens: 'extends',
+})
+
+// app.tsx
 import { css } from './styled-system/css'
 
 css({ color: 'blue' }) // ✅ will work as `blue` is a native value for the CSS color property
@@ -27,4 +35,8 @@ css({ color: 'unset' }) // ✅
 // or another example with the width property
 css({ width: 'min-content' }) // ✅
 css({ width: 'max-content' }) // ✅
+
+// and anything else will still not be allowed
+css({ color: '#FFF' }) // ❌ will throw a type error
+css({ width: '123px' }) // ❌ will throw a type error
 ```

--- a/.changeset/sweet-cups-sit.md
+++ b/.changeset/sweet-cups-sit.md
@@ -1,0 +1,30 @@
+---
+'@pandacss/generator': patch
+'@pandacss/types': patch
+---
+
+Introduce a new `extends` value for `strictTokens`
+
+Setting this in your config will let you use the known values of a CSS property (in addition to the values defined in
+your theme).
+
+Example:
+
+```ts
+import { css } from './styled-system/css'
+
+css({ color: 'blue' }) // ✅ will work as `blue` is a native value for the CSS color property
+css({ color: 'blue.300' }) // ✅ will work as `blue.300` is defined in your theme by default through the built-in `@pandacss/preset-panda`
+
+// the global CSS values are also available
+css({ color: 'initial' }) // ✅
+css({ color: 'inherit' }) // ✅
+css({ color: 'currentcolor' }) // ✅
+css({ color: 'revert' }) // ✅
+css({ color: 'revert-layer' }) // ✅
+css({ color: 'unset' }) // ✅
+
+// or another example with the width property
+css({ width: 'min-content' }) // ✅
+css({ width: 'max-content' }) // ✅
+```

--- a/packages/core/src/utility.ts
+++ b/packages/core/src/utility.ts
@@ -12,6 +12,7 @@ import {
 import type { TokenDictionary } from '@pandacss/token-dictionary'
 import type {
   AnyFunction,
+  Config,
   Dict,
   PropertyConfig,
   PropertyTransform,
@@ -21,13 +22,13 @@ import type {
 import type { TransformResult } from './types'
 import { colorMix } from './color-mix'
 
-export interface UtilityOptions {
+export interface UtilityOptions extends Pick<Config, 'shorthands' | 'strictTokens'> {
   config?: UtilityConfig
   tokens: TokenDictionary
   separator?: string
   prefix?: string
   shorthands?: boolean
-  strictTokens?: boolean
+  strictTokens?: Config['strictTokens']
 }
 
 export class Utility {
@@ -90,7 +91,7 @@ export class Utility {
 
   prefix = ''
 
-  strictTokens = false
+  strictTokens: Config['strictTokens'] = false
 
   constructor(options: UtilityOptions) {
     const { tokens, config = {}, separator, prefix, shorthands, strictTokens } = options

--- a/packages/generator/src/artifacts/types/style-props.ts
+++ b/packages/generator/src/artifacts/types/style-props.ts
@@ -46,7 +46,17 @@ export function generateStyleProps(ctx: Context) {
               union.push([utilityValue, 'CssVars'].join(' | '))
             } else {
               union.push(
-                [utilityValue, 'CssVars', ctx.config.strictTokens ? '' : cssFallback].filter(Boolean).join(' | '),
+                [
+                  utilityValue,
+                  'CssVars',
+                  ctx.config.strictTokens === 'extends'
+                    ? `OnlyKnown<"${prop}", ${cssFallback}>`
+                    : ctx.config.strictTokens
+                      ? ''
+                      : cssFallback,
+                ]
+                  .filter(Boolean)
+                  .join(' | '),
               )
             }
           } else {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -385,7 +385,7 @@ interface CodegenOptions {
   /**
    * Change generated typescript definitions to be more strict for property having a token or utility.
    */
-  strictTokens?: boolean
+  strictTokens?: boolean | 'extends'
   /**
    * Change generated typescript definitions to be more strict for built-in CSS properties to only allow valid CSS values.
    */

--- a/sandbox/codegen/__tests__/scenarios/strict-tokens-extends.test.ts
+++ b/sandbox/codegen/__tests__/scenarios/strict-tokens-extends.test.ts
@@ -1,0 +1,185 @@
+import { assertType, describe, test } from 'vitest'
+import { css } from '../../styled-system-strict-tokens-extends/css'
+
+describe('css', () => {
+  test('native CSS prop and value', () => {
+    assertType(css({ display: 'flex' }))
+
+    assertType(css({ display: 'abc' }))
+    assertType(css({ content: 'abc' }))
+    assertType(css({ willChange: 'abc' }))
+
+    assertType(css({ pos: 'absolute' }))
+    // @ts-expect-error expected from strictTokens: extends
+    assertType(css({ pos: 'absolute123' }))
+    // @ts-expect-error expected from strictTokens: extends
+    assertType(css({ position: 'absolute123' }))
+    // @ts-expect-error expected from strictTokens: extends
+    assertType(css({ flex: '0 1' }))
+  })
+
+  test('token value', () => {
+    assertType(css({ color: 'blue.300' }))
+  })
+
+  test('color opacity modifier', () => {
+    assertType(css({ color: 'blue.300/40' }))
+
+    // TODO shouldnt be allowed
+    assertType(css({ fontSize: '2xl/2' }))
+  })
+
+  test('utility prop', () => {
+    assertType(
+      css({
+        srOnly: true,
+      }),
+    )
+  })
+
+  test('shorthand prop', () => {
+    assertType(
+      css({
+        backgroundColor: 'teal',
+        bg: 'red',
+      }),
+    )
+  })
+
+  test('object condition prop', () => {
+    assertType(css({ bg: { _hover: 'yellow.100' } }))
+  })
+
+  test('condition prop', () => {
+    assertType(css({ _hover: { bg: 'yellow.200' } }))
+  })
+
+  test('nested condition prop', () => {
+    assertType(
+      css({
+        _hover: {
+          _dark: {
+            bg: 'pink',
+          },
+        },
+      }),
+    )
+  })
+
+  test('arbitrary value', () => {
+    assertType(
+      css({
+        // @ts-expect-error expected from strictTokens: extends
+        color: '#fff',
+      }),
+    )
+  })
+
+  test('arbitrary value escape hatch', () => {
+    assertType(
+      css({
+        color: '[#fff]',
+        fontSize: '[123px]',
+      }),
+    )
+  })
+
+  test('arbitrary value escape hatch with conditionals', () => {
+    assertType(
+      css({
+        color: '[#fff]',
+        fontSize: '[123px]',
+        bgColor: '[#fff!]',
+        borderColor: '[#fff !important]',
+        _hover: {
+          color: '[#fff]',
+          fontSize: '[123px]',
+          bgColor: '[#fff!]',
+          borderColor: '[#fff !important]',
+        },
+        backgroundColor: {
+          _dark: '[#3B00B9]',
+          _hover: '[#3B00B9!]',
+          _focus: '[#3B00B9 !important]',
+        },
+      }),
+    )
+  })
+
+  test('arbitrary selector', () => {
+    assertType(css({ ['&:data-panda']: { display: 'flex' } }))
+  })
+
+  test('important', () => {
+    assertType(
+      css({
+        fontSize: '2xl!',
+        p: '4 !important',
+        // @ts-expect-error expected from strictTokens: extends
+        bgColor: '#fff!',
+        // @ts-expect-error expected from strictTokens: extends
+        bg: '#fff!',
+        // @ts-expect-error expected from strictTokens: extends
+        borderColor: '#fff !important',
+        _hover: {
+          fontSize: '3xl',
+          p: '4 !important',
+          // @ts-expect-error expected from strictTokens: extends
+
+          bgColor: '#fff!',
+          // @ts-expect-error expected from strictTokens: extends
+          borderColor: '#fff !important',
+        },
+        // @ts-expect-error expected from strictTokens: extends
+        backgroundColor: {
+          _disabled: '2xl!',
+          _active: '4 !important',
+          _hover: '#3B00B9!',
+          _focus: '#3B00B9 !important',
+        },
+      }),
+    )
+  })
+
+  test('responsive condition', () => {
+    assertType(
+      css({
+        sm: {
+          bg: 'purple',
+        },
+      }),
+    )
+  })
+
+  test('responsive array syntax prop', () => {
+    assertType(
+      css({
+        bg: [
+          'cyan.100',
+          'cyan.200',
+          null,
+          // @ts-expect-error expected from strictTokens: extends
+          undefined,
+          'cyan.300',
+        ],
+      }),
+    )
+  })
+
+  test('using inline token helper - in value', () => {
+    assertType(
+      css({
+        // @ts-expect-error expected from strictTokens: extends
+        border: '1px solid token(colors.blue.400)',
+      }),
+    )
+  })
+
+  test('using inline token helper - in condition', () => {
+    assertType(css({ '@media screen and (min-width: token(sizes.4xl))': { bg: 'blue.500' } }))
+  })
+
+  test('nested condition prop with array syntax', () => {
+    assertType(css({ _hover: { _dark: { bg: ['pink.100', 'pink.200'] } } }))
+  })
+})

--- a/sandbox/codegen/cli.ts
+++ b/sandbox/codegen/cli.ts
@@ -11,6 +11,7 @@ const scenarioList = [
   'solid',
   'vue',
   'strict-tokens',
+  'strict-tokens-extends',
   'strict-property-values',
   'strict',
   'jsx-minimal',

--- a/sandbox/codegen/panda.strict-tokens-extends.config.ts
+++ b/sandbox/codegen/panda.strict-tokens-extends.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@pandacss/dev'
+import codegenPreset from './preset'
+
+export default defineConfig({
+  presets: ['@pandacss/dev/presets', codegenPreset],
+  // Whether to use css reset
+  preflight: true,
+
+  // Where to look for your css declarations
+  include: ['./src/**/*.{js,jsx,ts,tsx}', './pages/**/*.{js,jsx,ts,tsx}'],
+
+  // Files to exclude
+  exclude: [],
+
+  // The output directory for your css system
+  outdir: 'styled-system-strict-tokens-extends',
+
+  // The JSX framework to use
+  jsxFramework: 'react',
+  strictTokens: 'extends',
+})

--- a/sandbox/codegen/vitest.config.ts
+++ b/sandbox/codegen/vitest.config.ts
@@ -34,6 +34,12 @@ const options: TestUserConfig = {
       typecheck: { enabled: true, include: ['**/__tests__/scenarios/strict-tokens.{test,spec}.{j,t}s?(x)'] },
     },
   },
+  'strict-tokens-extends': {
+    test: {
+      include: ['**/__tests__/scenarios/strict-tokens-extends.{test,spec}.{j,t}s?(x)'],
+      typecheck: { enabled: true, include: ['**/__tests__/scenarios/strict-tokens-extends.{test,spec}.{j,t}s?(x)'] },
+    },
+  },
   'strict-property-values': {
     test: {
       include: ['**/__tests__/scenarios/strict-property-values.{test,spec}.{j,t}s?(x)'],


### PR DESCRIPTION
…ies in addition to tokens values

Closes # <!-- Github issue # here -->

## 📝 Description

Introduce a new `extends` value for `strictTokens`

Setting this in your config will let you use the known values of a CSS property (in addition to the values defined in
your theme).

Example:

```ts
// panda.config.js
import { defineConfig } from '@pandacss/dev'
export default defineConfig({
  //...
  strictTokens: 'extends',
})

// app.tsx
import { css } from './styled-system/css'

css({ color: 'blue' }) // ✅ will work as `blue` is a native value for the CSS color property
css({ color: 'blue.300' }) // ✅ will work as `blue.300` is defined in your theme by default through the built-in `@pandacss/preset-panda`

// the global CSS values are also available
css({ color: 'initial' }) // ✅
css({ color: 'inherit' }) // ✅
css({ color: 'currentcolor' }) // ✅
css({ color: 'revert' }) // ✅
css({ color: 'revert-layer' }) // ✅
css({ color: 'unset' }) // ✅

// or another example with the width property
css({ width: 'min-content' }) // ✅
css({ width: 'max-content' }) // ✅

// and anything else will still not be allowed
css({ color: '#FFF' }) // ❌ will throw a type error
css({ width: '123px' }) // ❌ will throw a type error
```

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

https://github.com/chakra-ui/panda/discussions/2159#discussioncomment-9096306