### PR TITLE
fix(postcss): set postcss as peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "postcss": "^8.4.x"
+  },
   "dependencies": {
     "@csstools/postcss-cascade-layers": "4.0.4",
     "@pandacss/is-valid-prop": "workspace:^",
@@ -48,7 +51,6 @@
     "lightningcss": "1.23.0",
     "lodash.merge": "4.6.2",
     "outdent": "0.8.0",
-    "postcss": "8.4.35",
     "postcss-discard-duplicates": "6.0.1",
     "postcss-discard-empty": "6.0.1",
     "postcss-merge-rules": "6.0.3",
@@ -59,6 +61,7 @@
     "ts-pattern": "5.0.8"
   },
   "devDependencies": {
-    "@types/lodash.merge": "4.6.9"
+    "@types/lodash.merge": "4.6.9",
+    "postcss": "8.4.35"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -36,6 +36,9 @@
   "files": [
     "dist"
   ],
+  "peerDependencies": {
+    "postcss": "^8.4.x"
+  },
   "dependencies": {
     "@pandacss/core": "workspace:*",
     "@pandacss/is-valid-prop": "workspace:^",
@@ -46,10 +49,10 @@
     "javascript-stringify": "2.1.0",
     "outdent": " ^0.8.0",
     "pluralize": "8.0.0",
-    "postcss": "8.4.35",
     "ts-pattern": "5.0.8"
   },
   "devDependencies": {
-    "@types/pluralize": "0.0.33"
+    "@types/pluralize": "0.0.33",
+    "postcss": "8.4.35"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,6 +36,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "postcss": "^8.4.x"
+  },
   "dependencies": {
     "@pandacss/config": "workspace:*",
     "@pandacss/core": "workspace:*",
@@ -60,7 +63,6 @@
     "perfect-debounce": "1.0.0",
     "pkg-types": "1.0.3",
     "pluralize": "8.0.0",
-    "postcss": "8.4.35",
     "preferred-pm": "3.1.2",
     "prettier": "3.2.5",
     "ts-morph": "21.0.1",
@@ -74,6 +76,7 @@
     "@types/lodash.merge": "4.6.9",
     "@types/pluralize": "0.0.33",
     "boxen": "7.1.1",
-    "p-limit": "5.0.0"
+    "p-limit": "5.0.0",
+    "postcss": "8.4.35"
   }
 }

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -36,11 +36,14 @@
   "files": [
     "dist"
   ],
+  "peerDependencies": {
+    "postcss": "^8.4.x"
+  },
   "dependencies": {
-    "@pandacss/node": "workspace:*",
-    "postcss": "8.4.35"
+    "@pandacss/node": "workspace:*"
   },
   "devDependencies": {
-    "@pandacss/logger": "workspace:*"
+    "@pandacss/logger": "workspace:*",
+    "postcss": "8.4.35"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -283,9 +283,6 @@ importers:
       outdent:
         specifier: 0.8.0
         version: 0.8.0
-      postcss:
-        specifier: 8.4.35
-        version: 8.4.35
       postcss-discard-duplicates:
         specifier: 6.0.1
         version: 6.0.1(postcss@8.4.35)
@@ -314,6 +311,9 @@ importers:
       '@types/lodash.merge':
         specifier: 4.6.9
         version: 4.6.9
+      postcss:
+        specifier: 8.4.35
+        version: 8.4.35
 
   packages/extractor:
     dependencies:
@@ -389,9 +389,6 @@ importers:
       pluralize:
         specifier: 8.0.0
         version: 8.0.0
-      postcss:
-        specifier: 8.4.35
-        version: 8.4.35
       ts-pattern:
         specifier: 5.0.8
         version: 5.0.8
@@ -399,6 +396,9 @@ importers:
       '@types/pluralize':
         specifier: 0.0.33
         version: 0.0.33
+      postcss:
+        specifier: 8.4.35
+        version: 8.4.35
 
   packages/is-valid-prop:
     devDependencies:
@@ -490,9 +490,6 @@ importers:
       pluralize:
         specifier: 8.0.0
         version: 8.0.0
-      postcss:
-        specifier: 8.4.35
-        version: 8.4.35
       preferred-pm:
         specifier: 3.1.2
         version: 3.1.2
@@ -530,6 +527,9 @@ importers:
       p-limit:
         specifier: 5.0.0
         version: 5.0.0
+      postcss:
+        specifier: 8.4.35
+        version: 8.4.35
 
   packages/parser:
     dependencies:
@@ -576,13 +576,13 @@ importers:
       '@pandacss/node':
         specifier: workspace:*
         version: link:../node
-      postcss:
-        specifier: 8.4.35
-        version: 8.4.35
     devDependencies:
       '@pandacss/logger':
         specifier: workspace:*
         version: link:../logger
+      postcss:
+        specifier: 8.4.35
+        version: 8.4.35
 
   packages/preset-atlaskit:
     dependencies:
@@ -14900,7 +14900,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     dev: true
 
   /css-tree@2.3.1:
@@ -14908,7 +14908,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     dev: true
 
   /css-what@5.1.0:
@@ -21020,7 +21020,7 @@ packages:
     dependencies:
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     dev: true
 
   /make-dir@2.1.0:
@@ -24685,7 +24685,7 @@ packages:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.0
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
     dev: false
 
   /postcss@8.4.35:
@@ -24694,7 +24694,7 @@ packages:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.0
-      source-map-js: 1.0.2
+      source-map-js: 1.2.0
 
   /postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}


### PR DESCRIPTION
Closes #2520 

## 📝 Description

This PR turns the `postcss` dependency into a peer dependency.

## ⛳️ Current behavior (updates)

`postcss` is being installed as a dependency with a fixed version.

## 🚀 New behavior

`postcss` will be a peer dependency. End users will be the ones providing an appropriate postcss version.

## 💣 Is this a breaking change (Yes/No):

Potentially, if users were using a postcss version lower than 8.4.x. However, if they were doing that it's possible they were also experiencing some weird behaviour.

## 📝 Additional Information

This is my first contribution to the repository so I'm probably missing some context. I'd appreciate a thorough review from a more experienced contributor!

I hope this helps 😄 