### PR TITLE
fix: invalid import in generated source

### DIFF
--- a/.changeset/lovely-islands-applaud.md
+++ b/.changeset/lovely-islands-applaud.md
@@ -1,0 +1,6 @@
+---
+"@pandacss/generator": patch
+"@pandacss/studio": patch
+---
+
+Fix type import

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -5,7 +5,7 @@ import { generatePropTypes } from '../src/artifacts/types/prop-types'
 describe('generate property types', () => {
   test('should ', () => {
     expect(generatePropTypes(createContext())).toMatchInlineSnapshot(`
-      "import type { Conditional } from './conditions';
+      "import type { ConditionalValue } from './conditions';
       import type { CssProperties } from './system-types';
       import type { Tokens } from '../tokens/index';
 
@@ -268,7 +268,7 @@ describe('generate property types', () => {
         }),
       ),
     ).toMatchInlineSnapshot(`
-      "import type { Conditional } from './conditions';
+      "import type { ConditionalValue } from './conditions';
       import type { CssProperties } from './system-types';
       import type { Tokens } from '../tokens/index';
 

--- a/packages/generator/src/artifacts/types/prop-types.ts
+++ b/packages/generator/src/artifacts/types/prop-types.ts
@@ -6,7 +6,7 @@ export function generatePropTypes(ctx: Context) {
 
   const result = [
     outdent`
-    ${ctx.file.importType('Conditional', './conditions')}
+    ${ctx.file.importType('ConditionalValue', './conditions')}
     ${ctx.file.importType('CssProperties', './system-types')}
     ${ctx.file.importType('Tokens', '../tokens/index')}
 

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { Conditional } from './conditions';
+import type { ConditionalValue } from './conditions';
 import type { CssProperties } from './system-types';
 import type { Tokens } from '../tokens/index';
 

--- a/sandbox/codegen/cli.ts
+++ b/sandbox/codegen/cli.ts
@@ -31,7 +31,6 @@ const runCommand = (command: string, envVars = {}) => {
     const [cmd, ...args] = command.split(' ')
     const proc = spawn(cmd, args, {
       env: { ...process.env, ...envVars },
-      shell: true,
       stdio: 'inherit',
     })
 

--- a/sandbox/codegen/cli.ts
+++ b/sandbox/codegen/cli.ts
@@ -30,8 +30,9 @@ const runCommand = (command: string, envVars = {}) => {
   return new Promise((resolve, reject) => {
     const [cmd, ...args] = command.split(' ')
     const proc = spawn(cmd, args, {
-      stdio: 'inherit',
       env: { ...process.env, ...envVars },
+      shell: true,
+      stdio: 'inherit',
     })
 
     proc.on('close', (code) => {


### PR DESCRIPTION
## 📝 Description

Closes  #2526. I tried deno check with panda, and found the following error.

```
error: TS2724 [ERROR]: '"file:///D:/Repos/project/styled-system/types/conditions.d.mts"' has no exported member named 'Conditional'. Did you mean 'Condition'?
import type { Conditional } from './conditions.d.mts';
              ~~~~~~~~~~~
    at file:///D:/Repos/project/styled-system/types/prop-type.d.mts:2:15

TS2339 [ERROR]: Property 'initialLetterAlign' does not exist on type 'CssProperties'.
 initialLetterAlign?: ConditionalValue<CssProperties["initialLetterAlign"] | AnyString>
                                                     ~~~~~~~~~~~~~~~~~~~~
    at file:///D:/Repos/project/styled-system/types/style-props.d.mts:3041:54
```

## ⛳️ Current behavior (updates)

Generated prop-type.d.mts imports `Conditional ` that does not exist.

## 🚀 New behavior

Generated prop-type.d.mts imports `ConditionalValue` that exist.

## 💣 Is this a breaking change (Yes/No):

I don't think it's a breaking change.

## 📝 Additional Information

The second error(TS2339) seems tricky to fix, because I think root cause is that csstype missed `initial-letter-align` property.

Any advice for this would be appreciated.