### PR TITLE
Attempting to fix alignment in the css-in-js.tsx

### DIFF
--- a/website/src/components/sections/css-in-js.tsx
+++ b/website/src/components/sections/css-in-js.tsx
@@ -139,20 +139,22 @@ export const SectionCssInJS = () => {
               w="100%"
               gap="8"
             >
+              <panda.div style={{display:"flex", justifyContent:"space-between", width:'100%', alignItems:'center' }}>
               {features.map(({ title, description, icon }) => (
-                <Stack maxW="440px" textStyle="xl" width="full" key={title}>
-                  <HStack>
-                    <Icon
-                      icon={icon}
-                      className={css({ color: 'yellow.300' })}
-                    />
-                    <panda.span fontWeight="semibold">{title}</panda.span>
-                  </HStack>
-                  <panda.span color="gray.200" maxW={{ lg: '256px' }}>
-                    {description}
-                  </panda.span>
-                </Stack>
+                  <Stack maxW="20ch" textStyle="xl" width="full" key={title}>
+                    <HStack>
+                      <Icon
+                        icon={icon}
+                        className={css({ color: 'yellow.300' })}
+                        />
+                      <panda.span fontWeight="semibold">{title}</panda.span>
+                    </HStack>
+                    <panda.span color="gray.200" maxW={{ lg: '256px' }}>
+                      {description}
+                    </panda.span>
+                  </Stack>
               ))}
+              </panda.div>
             </Stack>
           </VStack>
         </VStack>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

I am attempting to fix the weird off-center alignment of the features portion of `css-in-js.tsx`, however I don't use panda (just love the website) so I was only able to achieve it by wrapping the `map` in a `div` and using inline styling

If there is an appropriate "Panda" way to do it I'm happy to make adjustments 👍 

## ⛳️ Current behavior (updates)

<img width="1629" alt="panda-broke" src="https://github.com/chakra-ui/panda/assets/72817096/712e1906-9536-4946-92b3-24b09e6fc214">

## 🚀 New behavior

<img width="1613" alt="panda-fix" src="https://github.com/chakra-ui/panda/assets/72817096/4a110f28-9b21-49e9-a7fd-250aba82605c">

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information

I apologize my commit message does not meet the conventions, I was originally intending to only drop this info in the discord rather than make an actual PR >.<