### PR TITLE
Docs: Fix section alignment

### DIFF
--- a/website/src/components/sections/css-in-js.tsx
+++ b/website/src/components/sections/css-in-js.tsx
@@ -134,7 +134,7 @@ export const SectionCssInJS = () => {
 
             <Stack
               direction={{ base: 'column', lg: 'row' }}
-              align={{ base: 'center', lg: 'center' }}
+              align={{ base: 'center', lg: 'flex-start' }}
               justify="space-between"
               w="100%"
               gap="8"

--- a/website/src/components/sections/css-in-js.tsx
+++ b/website/src/components/sections/css-in-js.tsx
@@ -134,12 +134,11 @@ export const SectionCssInJS = () => {
 
             <Stack
               direction={{ base: 'column', lg: 'row' }}
-              align={{ base: 'center', lg: 'flex-start' }}
+              align={{ base: 'center', lg: 'center' }}
               justify="space-between"
               w="100%"
               gap="8"
             >
-              <panda.div style={{display:"flex", justifyContent:"space-between", width:'100%', alignItems:'center' }}>
               {features.map(({ title, description, icon }) => (
                   <Stack maxW="20ch" textStyle="xl" width="full" key={title}>
                     <HStack>
@@ -154,7 +153,6 @@ export const SectionCssInJS = () => {
                     </panda.span>
                   </Stack>
               ))}
-              </panda.div>
             </Stack>
           </VStack>
         </VStack>

--- a/website/src/components/sections/css-in-js.tsx
+++ b/website/src/components/sections/css-in-js.tsx
@@ -139,20 +139,22 @@ export const SectionCssInJS = () => {
               w="100%"
               gap="8"
             >
+              <panda.div style={{display:"flex", justifyContent:"space-between", width:'100%', alignItems:'center' }}>
               {features.map(({ title, description, icon }) => (
-                <Stack maxW="440px" textStyle="xl" width="full" key={title}>
-                  <HStack>
-                    <Icon
-                      icon={icon}
-                      className={css({ color: 'yellow.300' })}
-                    />
-                    <panda.span fontWeight="semibold">{title}</panda.span>
-                  </HStack>
-                  <panda.span color="gray.200" maxW={{ lg: '256px' }}>
-                    {description}
-                  </panda.span>
-                </Stack>
+                  <Stack maxW="20ch" textStyle="xl" width="full" key={title}>
+                    <HStack>
+                      <Icon
+                        icon={icon}
+                        className={css({ color: 'yellow.300' })}
+                        />
+                      <panda.span fontWeight="semibold">{title}</panda.span>
+                    </HStack>
+                    <panda.span color="gray.200" maxW={{ lg: '256px' }}>
+                      {description}
+                    </panda.span>
+                  </Stack>
               ))}
+              </panda.div>
             </Stack>
           </VStack>
         </VStack>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->


## 📝 Description

Small adjustment to the `maxW` prop of the mapped features in `css-in-js.tsx` to fix the off-center alignment.

## ⛳️ Current behavior (updates)

<img width="1629" alt="panda-broke" src="https://github.com/chakra-ui/panda/assets/72817096/ed773496-a3ae-4f72-99c3-8377290147da">

## 🚀 New behavior

<img width="1613" alt="panda-fix" src="https://github.com/chakra-ui/panda/assets/72817096/c3d17621-5276-4672-a4e3-d799116f83ef">

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information

I didn't generate a changeset as I didn't feel it was warranted for such a minor adjustment.