### PR TITLE
Fix bun command to install NextJS

### DIFF
--- a/website/pages/docs/installation/nextjs.mdx
+++ b/website/pages/docs/installation/nextjs.mdx
@@ -43,7 +43,7 @@ If you don't have Next.js app installed, you can follow the [Create a Next.js ap
     </Tab>
     <Tab>
       ```bash
-      bunx create-next-app@latest --use-bun
+      bunx create next-app@latest --use-bun
       ```
     </Tab>
   </Tabs>


### PR DESCRIPTION
## 📝 Description

> The previous command gave an error and I fix it

## ⛳️ Current behavior (updates)

> An error message is displayed when using the current command.

## 🚀 New behavior

> With this command, other users won't have any problem when installing nextjs with bun.

## 💣 Is this a breaking change (Yes/No):

Yes

## 📝 Additional Information
Source: [https://bun.sh/guides/ecosystem/nextjs](https://bun.sh/guides/ecosystem/nextjs)