### PR TITLE
Docs: Remove duplicate Radii callout

### DIFF
--- a/website/pages/docs/theming/tokens.md
+++ b/website/pages/docs/theming/tokens.md
@@ -411,8 +411,6 @@ const theme = {
 }
 ```
 
-> Radii tokens are typically used in `border-radius` property.
-
 ### Shadows
 
 Shadow tokens represent the shadow of an element. Its value is defined as single or multiple values containing a


### PR DESCRIPTION
Closes #2533

The [Border Width](https://panda-css.com/docs/theming/tokens#border-widths) section contained a duplicate callout from the Radii section. This PR removes it.