### PR TITLE
fix: allow passing in inherited float values

### DIFF
--- a/.changeset/fresh-eggs-kneel.md
+++ b/.changeset/fresh-eggs-kneel.md
@@ -1,0 +1,7 @@
+---
+"@pandacss/generator": patch
+"@pandacss/preset-base": patch
+"@pandacss/studio": patch
+---
+
+Fix issue where `float` property did not allow inherited values (auto, initial, none, etc.)

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -22,7 +22,7 @@ describe('generate property types', () => {
       	insetInlineStart: Tokens["spacing"];
       	right: Tokens["spacing"];
       	bottom: Tokens["spacing"];
-      	float: "left" | "right" | "start" | "end";
+      	float: "start" | "end" | CssProperties["float"];
       	hideFrom: Tokens["breakpoints"];
       	hideBelow: Tokens["breakpoints"];
       	flexBasis: Tokens["spacing"] | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "1/5" | "2/5" | "3/5" | "4/5" | "1/6" | "2/6" | "3/6" | "4/6" | "5/6" | "1/12" | "2/12" | "3/12" | "4/12" | "5/12" | "6/12" | "7/12" | "8/12" | "9/12" | "10/12" | "11/12" | "full";

--- a/packages/preset-base/src/utilities/layout.ts
+++ b/packages/preset-base/src/utilities/layout.ts
@@ -117,7 +117,8 @@ export const layout: UtilityConfig = {
   },
   float: {
     className: 'float',
-    values: ['left', 'right', 'start', 'end'],
+    values: ['start', 'end'],
+    property: 'float',
     group: 'Position',
     transform(value) {
       if (value === 'start') {

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -16,7 +16,7 @@ export interface UtilityValues {
 	insetInlineStart: Tokens["spacing"];
 	right: Tokens["spacing"];
 	bottom: Tokens["spacing"];
-	float: "left" | "right" | "start" | "end";
+	float: "start" | "end" | CssProperties["float"];
 	hideFrom: Tokens["breakpoints"];
 	hideBelow: Tokens["breakpoints"];
 	flexBasis: Tokens["spacing"] | "1/2" | "1/3" | "2/3" | "1/4" | "2/4" | "3/4" | "1/5" | "2/5" | "3/5" | "4/5" | "1/6" | "2/6" | "3/6" | "4/6" | "5/6" | "1/12" | "2/12" | "3/12" | "4/12" | "5/12" | "6/12" | "7/12" | "8/12" | "9/12" | "10/12" | "11/12" | "full";


### PR DESCRIPTION
## 📝 Description

Inherit all possible float values for the `float` utility, allowing values such as `none` to be passed in.

## ⛳️ Current behavior (updates)

Panda only allowed `start`, `end`, `left` and `right`. 

## 🚀 New behavior

More css values!

## 💣 Is this a breaking change (Yes/No):

No
