### PR TITLE
docs: Make homepage installation instructions match docs

### DIFF
--- a/website/src/components/sections/try-panda.tsx
+++ b/website/src/components/sections/try-panda.tsx
@@ -11,7 +11,7 @@ const installSteps = [
   },
   {
     title: 'Run the initialize command',
-    command: 'npm run panda init -p'
+    command: 'npx panda init --postcss'
   },
   {
     title: 'Start using Panda in your project',


### PR DESCRIPTION
## 📝 Description

[This comment](https://github.com/chakra-ui/panda/issues/2592#issuecomment-2109070488) made me realize there's a discrepancy between the homepage installation instructions and the docs installation instructions.

The /docs/installation pages contain this command:

```
npx panda init --postcss
```

But try-panda.tsx, rendered on the homepage, instructs:

```
npm run panda init -p
```

This change makes the homepage match the docs pages.

## 💣 Is this a breaking change: No, website change

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information

I've tried to follow the contributing guidelines but I may have messed up somehow, apologies in advance if so.

Also, I wasn't able to actually run the website locally, but the string change should be correct. Possibly I should run a build command or something before merging? Thanks in advance. Happy to make additional changes, thanks so much for everything this team does.