### PR TITLE
refactor: make codegen result compatible with older browsers.

### DIFF
--- a/packages/shared/src/classname.ts
+++ b/packages/shared/src/classname.ts
@@ -36,7 +36,7 @@ const fallbackCondition: NonNullable<CreateCssContext['conditions']> = {
   breakpoints: { keys: [] },
 }
 
-const sanitize = (value: any) => (typeof value === 'string' ? value.replaceAll(/[\n\s]+/g, ' ') : value)
+const sanitize = (value: any) => (typeof value === 'string' ? value.replace(/[\n\s]+/g, ' ') : value)
 
 export function createCss(context: CreateCssContext) {
   const { utility, hash, conditions: conds = fallbackCondition } = context

--- a/packages/shared/src/important.ts
+++ b/packages/shared/src/important.ts
@@ -9,7 +9,7 @@ export function withoutImportant<T extends string | number | boolean>(value: T) 
 }
 
 export function withoutSpace<T extends string | number | boolean>(str: T) {
-  return typeof str === 'string' ? str.replaceAll(' ', '_') : str
+  return typeof str === 'string' ? str.split(' ').join('_') : str
 }
 
 type Dict = Record<string, unknown>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The result of `codegen` is a file that has enough browser compatibility except it has some `replaceAll` methods in `helpers.mjs` which prevents the codegen results from great browser compatibility

> NOTE: with this minor improvements, the codegen result now is compatible with `iOS <= 12`

## ⛳️ Current behavior (updates)

It has some `replaceAll` methods in two different shared utility.

## 🚀 New behavior

I've replaced the two `replaceAll` methods with pure `replace`, `split`, and `join` methods.

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information
