### PR TITLE
fix: panda analyze --json file

### DIFF
--- a/.changeset/wild-schools-camp.md
+++ b/.changeset/wild-schools-camp.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/node": patch
+---
+
+Fix `panda analyze` JSON output serialization

--- a/packages/node/src/analyze-tokens.ts
+++ b/packages/node/src/analyze-tokens.ts
@@ -101,7 +101,6 @@ export const writeAnalyzeJSON = (filePath: string, result: ReturnType<typeof ana
         utilities: ctx.config.utilities,
         conditions: ctx.config.conditions,
         shorthands: ctx.utility.shorthands,
-        parserOptions: ctx.parserOptions,
       }),
       analyzeResultSerializer,
       2,


### PR DESCRIPTION
## 📝 Description

Fix ` error [cli] TypeError: Converting circular structure to JSON` when running `panda analyze --json output.json`

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
