### PR TITLE
feat: allow nesting string token ref / fix CSS var in string token ref fallback

### DIFF
--- a/.changeset/unlucky-humans-own.md
+++ b/.changeset/unlucky-humans-own.md
@@ -1,0 +1,7 @@
+---
+"@pandacss/token-dictionary": patch
+"@pandacss/parser": patch
+"@pandacss/core": patch
+---
+
+Allow nesting (string) token references in the fallback argument, fix an issue where using CSS var in the fallback argument would be mistakenly escaped

--- a/packages/core/__tests__/serialize.test.ts
+++ b/packages/core/__tests__/serialize.test.ts
@@ -202,22 +202,21 @@ describe('serialize - with token()', () => {
     `)
   })
 
-  // TODO: This is not supported yet
-  // test.skip('with nested fallback reference', () => {
-  //   const result = css({
-  //     html: {
-  //       color: 'red',
-  //       border: '2px solid token(colors.red.300, token(colors.blue.300, colors.green.300))',
-  //     },
-  //   })
+  test('with nested fallback reference', () => {
+    const result = css({
+      html: {
+        color: 'red',
+        border: '2px solid token(colors.red.300, token(colors.blue.300, colors.green.300))',
+      },
+    })
 
-  //   expect(result).toMatchInlineSnapshot(`
-  //     {
-  //       "html": {
-  //         "border": "2px solid var(--colors-red-300, var(--colors-blue-300, var(--colors-green-300)))",
-  //         "color": "red",
-  //       },
-  //     }
-  //   `)
-  // })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "html": {
+          "border": "2px solid var(--colors-red-300, var(--colors-blue-300, var(--colors-green-300)))",
+          "color": "red",
+        },
+      }
+    `)
+  })
 })

--- a/packages/core/__tests__/static-css.test.ts
+++ b/packages/core/__tests__/static-css.test.ts
@@ -890,11 +890,11 @@ describe('static-css', () => {
       }
 
         .\\--bleed-x_token\\(spacing\\.20\\,_20\\) {
-          --bleed-x: var(--spacing-20, \\320);
+          --bleed-x: var(--spacing-20, 20);
       }
 
         .\\--bleed-y_token\\(spacing\\.0\\,_0\\) {
-          --bleed-y: var(spacing\\.0, \\30);
+          --bleed-y: 0;
       }
 
         .mx_calc\\(var\\(--bleed-x\\,_0\\)_\\*_-1\\) {
@@ -906,27 +906,27 @@ describe('static-css', () => {
       }
 
         .\\--bleed-x_token\\(spacing\\.40\\,_40\\) {
-          --bleed-x: var(--spacing-40, \\340);
+          --bleed-x: var(--spacing-40, 40);
       }
 
         .\\--bleed-x_token\\(spacing\\.60\\,_60\\) {
-          --bleed-x: var(--spacing-60, \\360);
+          --bleed-x: var(--spacing-60, 60);
       }
 
         .\\--bleed-x_token\\(spacing\\.auto\\,_auto\\) {
-          --bleed-x: var(spacing\\.auto, auto);
+          --bleed-x: auto;
       }
 
         .\\--bleed-x_token\\(spacing\\.-20\\,_-20\\) {
-          --bleed-x: calc(var(--spacing-20) * -1, -\\320);
+          --bleed-x: calc(var(--spacing-20) * -1, -20);
       }
 
         .\\--bleed-x_token\\(spacing\\.-40\\,_-40\\) {
-          --bleed-x: calc(var(--spacing-40) * -1, -\\340);
+          --bleed-x: calc(var(--spacing-40) * -1, -40);
       }
 
         .\\--bleed-x_token\\(spacing\\.-60\\,_-60\\) {
-          --bleed-x: calc(var(--spacing-60) * -1, -\\360);
+          --bleed-x: calc(var(--spacing-60) * -1, -60);
       }
 
         .\\--thickness_1px {

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -2794,7 +2794,7 @@ describe('extract to css output pipeline', () => {
       }
 
         .grid-cols_repeat\\(auto-fit\\,_minmax\\(token\\(sizes\\.20\\,_20\\)\\,_1fr\\)\\) {
-          grid-template-columns: repeat(auto-fit, minmax(var(--sizes-20, \\320), 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(var(--sizes-20, 20), 1fr));
       }
       }"
     `)

--- a/packages/parser/__tests__/preset-patterns.test.ts
+++ b/packages/parser/__tests__/preset-patterns.test.ts
@@ -2069,11 +2069,11 @@ describe('staticCss', () => {
     expect(css).toMatchInlineSnapshot(`
       "@layer utilities {
         .\\--bleed-x_token\\(spacing\\.0\\,_0\\) {
-          --bleed-x: var(--spacing-0, \\30);
+          --bleed-x: var(--spacing-0, 0);
       }
 
         .\\--bleed-y_token\\(spacing\\.0\\,_0\\) {
-          --bleed-y: var(--spacing-0, \\30);
+          --bleed-y: var(--spacing-0, 0);
       }
 
         .mx_calc\\(var\\(--bleed-x\\,_0\\)_\\*_-1\\) {
@@ -2085,123 +2085,123 @@ describe('staticCss', () => {
       }
 
         .\\--bleed-x_token\\(spacing\\.1\\,_1\\) {
-          --bleed-x: var(--spacing-1, \\31);
+          --bleed-x: var(--spacing-1, 1);
       }
 
         .\\--bleed-x_token\\(spacing\\.2\\,_2\\) {
-          --bleed-x: var(--spacing-2, \\32);
+          --bleed-x: var(--spacing-2, 2);
       }
 
         .\\--bleed-x_token\\(spacing\\.3\\,_3\\) {
-          --bleed-x: var(--spacing-3, \\33);
+          --bleed-x: var(--spacing-3, 3);
       }
 
         .\\--bleed-x_token\\(spacing\\.4\\,_4\\) {
-          --bleed-x: var(--spacing-4, \\34);
+          --bleed-x: var(--spacing-4, 4);
       }
 
         .\\--bleed-x_token\\(spacing\\.5\\,_5\\) {
-          --bleed-x: var(--spacing-5, \\35);
+          --bleed-x: var(--spacing-5, 5);
       }
 
         .\\--bleed-x_token\\(spacing\\.6\\,_6\\) {
-          --bleed-x: var(--spacing-6, \\36);
+          --bleed-x: var(--spacing-6, 6);
       }
 
         .\\--bleed-x_token\\(spacing\\.7\\,_7\\) {
-          --bleed-x: var(--spacing-7, \\37);
+          --bleed-x: var(--spacing-7, 7);
       }
 
         .\\--bleed-x_token\\(spacing\\.8\\,_8\\) {
-          --bleed-x: var(--spacing-8, \\38);
+          --bleed-x: var(--spacing-8, 8);
       }
 
         .\\--bleed-x_token\\(spacing\\.9\\,_9\\) {
-          --bleed-x: var(--spacing-9, \\39);
+          --bleed-x: var(--spacing-9, 9);
       }
 
         .\\--bleed-x_token\\(spacing\\.10\\,_10\\) {
-          --bleed-x: var(--spacing-10, \\310);
+          --bleed-x: var(--spacing-10, 10);
       }
 
         .\\--bleed-x_token\\(spacing\\.11\\,_11\\) {
-          --bleed-x: var(--spacing-11, \\311);
+          --bleed-x: var(--spacing-11, 11);
       }
 
         .\\--bleed-x_token\\(spacing\\.12\\,_12\\) {
-          --bleed-x: var(--spacing-12, \\312);
+          --bleed-x: var(--spacing-12, 12);
       }
 
         .\\--bleed-x_token\\(spacing\\.14\\,_14\\) {
-          --bleed-x: var(--spacing-14, \\314);
+          --bleed-x: var(--spacing-14, 14);
       }
 
         .\\--bleed-x_token\\(spacing\\.16\\,_16\\) {
-          --bleed-x: var(--spacing-16, \\316);
+          --bleed-x: var(--spacing-16, 16);
       }
 
         .\\--bleed-x_token\\(spacing\\.20\\,_20\\) {
-          --bleed-x: var(--spacing-20, \\320);
+          --bleed-x: var(--spacing-20, 20);
       }
 
         .\\--bleed-x_token\\(spacing\\.24\\,_24\\) {
-          --bleed-x: var(--spacing-24, \\324);
+          --bleed-x: var(--spacing-24, 24);
       }
 
         .\\--bleed-x_token\\(spacing\\.28\\,_28\\) {
-          --bleed-x: var(--spacing-28, \\328);
+          --bleed-x: var(--spacing-28, 28);
       }
 
         .\\--bleed-x_token\\(spacing\\.32\\,_32\\) {
-          --bleed-x: var(--spacing-32, \\332);
+          --bleed-x: var(--spacing-32, 32);
       }
 
         .\\--bleed-x_token\\(spacing\\.36\\,_36\\) {
-          --bleed-x: var(--spacing-36, \\336);
+          --bleed-x: var(--spacing-36, 36);
       }
 
         .\\--bleed-x_token\\(spacing\\.40\\,_40\\) {
-          --bleed-x: var(--spacing-40, \\340);
+          --bleed-x: var(--spacing-40, 40);
       }
 
         .\\--bleed-x_token\\(spacing\\.44\\,_44\\) {
-          --bleed-x: var(--spacing-44, \\344);
+          --bleed-x: var(--spacing-44, 44);
       }
 
         .\\--bleed-x_token\\(spacing\\.48\\,_48\\) {
-          --bleed-x: var(--spacing-48, \\348);
+          --bleed-x: var(--spacing-48, 48);
       }
 
         .\\--bleed-x_token\\(spacing\\.52\\,_52\\) {
-          --bleed-x: var(--spacing-52, \\352);
+          --bleed-x: var(--spacing-52, 52);
       }
 
         .\\--bleed-x_token\\(spacing\\.56\\,_56\\) {
-          --bleed-x: var(--spacing-56, \\356);
+          --bleed-x: var(--spacing-56, 56);
       }
 
         .\\--bleed-x_token\\(spacing\\.60\\,_60\\) {
-          --bleed-x: var(--spacing-60, \\360);
+          --bleed-x: var(--spacing-60, 60);
       }
 
         .\\--bleed-x_token\\(spacing\\.64\\,_64\\) {
-          --bleed-x: var(--spacing-64, \\364);
+          --bleed-x: var(--spacing-64, 64);
       }
 
         .\\--bleed-x_token\\(spacing\\.72\\,_72\\) {
-          --bleed-x: var(--spacing-72, \\372);
+          --bleed-x: var(--spacing-72, 72);
       }
 
         .\\--bleed-x_token\\(spacing\\.80\\,_80\\) {
-          --bleed-x: var(--spacing-80, \\380);
+          --bleed-x: var(--spacing-80, 80);
       }
 
         .\\--bleed-x_token\\(spacing\\.96\\,_96\\) {
-          --bleed-x: var(--spacing-96, \\396);
+          --bleed-x: var(--spacing-96, 96);
       }
 
         .\\--bleed-x_token\\(spacing\\.auto\\,_auto\\) {
-          --bleed-x: var(spacing\\.auto, auto);
+          --bleed-x: auto;
       }
 
         .\\--bleed-x_token\\(spacing\\.0\\.5\\,_0\\.5\\) {
@@ -2225,119 +2225,119 @@ describe('staticCss', () => {
       }
 
         .\\--bleed-x_token\\(spacing\\.-1\\,_-1\\) {
-          --bleed-x: calc(var(--spacing-1) * -1, -\\31);
+          --bleed-x: calc(var(--spacing-1) * -1, -1);
       }
 
         .\\--bleed-x_token\\(spacing\\.-2\\,_-2\\) {
-          --bleed-x: calc(var(--spacing-2) * -1, -\\32);
+          --bleed-x: calc(var(--spacing-2) * -1, -2);
       }
 
         .\\--bleed-x_token\\(spacing\\.-3\\,_-3\\) {
-          --bleed-x: calc(var(--spacing-3) * -1, -\\33);
+          --bleed-x: calc(var(--spacing-3) * -1, -3);
       }
 
         .\\--bleed-x_token\\(spacing\\.-4\\,_-4\\) {
-          --bleed-x: calc(var(--spacing-4) * -1, -\\34);
+          --bleed-x: calc(var(--spacing-4) * -1, -4);
       }
 
         .\\--bleed-x_token\\(spacing\\.-5\\,_-5\\) {
-          --bleed-x: calc(var(--spacing-5) * -1, -\\35);
+          --bleed-x: calc(var(--spacing-5) * -1, -5);
       }
 
         .\\--bleed-x_token\\(spacing\\.-6\\,_-6\\) {
-          --bleed-x: calc(var(--spacing-6) * -1, -\\36);
+          --bleed-x: calc(var(--spacing-6) * -1, -6);
       }
 
         .\\--bleed-x_token\\(spacing\\.-7\\,_-7\\) {
-          --bleed-x: calc(var(--spacing-7) * -1, -\\37);
+          --bleed-x: calc(var(--spacing-7) * -1, -7);
       }
 
         .\\--bleed-x_token\\(spacing\\.-8\\,_-8\\) {
-          --bleed-x: calc(var(--spacing-8) * -1, -\\38);
+          --bleed-x: calc(var(--spacing-8) * -1, -8);
       }
 
         .\\--bleed-x_token\\(spacing\\.-9\\,_-9\\) {
-          --bleed-x: calc(var(--spacing-9) * -1, -\\39);
+          --bleed-x: calc(var(--spacing-9) * -1, -9);
       }
 
         .\\--bleed-x_token\\(spacing\\.-10\\,_-10\\) {
-          --bleed-x: calc(var(--spacing-10) * -1, -\\310);
+          --bleed-x: calc(var(--spacing-10) * -1, -10);
       }
 
         .\\--bleed-x_token\\(spacing\\.-11\\,_-11\\) {
-          --bleed-x: calc(var(--spacing-11) * -1, -\\311);
+          --bleed-x: calc(var(--spacing-11) * -1, -11);
       }
 
         .\\--bleed-x_token\\(spacing\\.-12\\,_-12\\) {
-          --bleed-x: calc(var(--spacing-12) * -1, -\\312);
+          --bleed-x: calc(var(--spacing-12) * -1, -12);
       }
 
         .\\--bleed-x_token\\(spacing\\.-14\\,_-14\\) {
-          --bleed-x: calc(var(--spacing-14) * -1, -\\314);
+          --bleed-x: calc(var(--spacing-14) * -1, -14);
       }
 
         .\\--bleed-x_token\\(spacing\\.-16\\,_-16\\) {
-          --bleed-x: calc(var(--spacing-16) * -1, -\\316);
+          --bleed-x: calc(var(--spacing-16) * -1, -16);
       }
 
         .\\--bleed-x_token\\(spacing\\.-20\\,_-20\\) {
-          --bleed-x: calc(var(--spacing-20) * -1, -\\320);
+          --bleed-x: calc(var(--spacing-20) * -1, -20);
       }
 
         .\\--bleed-x_token\\(spacing\\.-24\\,_-24\\) {
-          --bleed-x: calc(var(--spacing-24) * -1, -\\324);
+          --bleed-x: calc(var(--spacing-24) * -1, -24);
       }
 
         .\\--bleed-x_token\\(spacing\\.-28\\,_-28\\) {
-          --bleed-x: calc(var(--spacing-28) * -1, -\\328);
+          --bleed-x: calc(var(--spacing-28) * -1, -28);
       }
 
         .\\--bleed-x_token\\(spacing\\.-32\\,_-32\\) {
-          --bleed-x: calc(var(--spacing-32) * -1, -\\332);
+          --bleed-x: calc(var(--spacing-32) * -1, -32);
       }
 
         .\\--bleed-x_token\\(spacing\\.-36\\,_-36\\) {
-          --bleed-x: calc(var(--spacing-36) * -1, -\\336);
+          --bleed-x: calc(var(--spacing-36) * -1, -36);
       }
 
         .\\--bleed-x_token\\(spacing\\.-40\\,_-40\\) {
-          --bleed-x: calc(var(--spacing-40) * -1, -\\340);
+          --bleed-x: calc(var(--spacing-40) * -1, -40);
       }
 
         .\\--bleed-x_token\\(spacing\\.-44\\,_-44\\) {
-          --bleed-x: calc(var(--spacing-44) * -1, -\\344);
+          --bleed-x: calc(var(--spacing-44) * -1, -44);
       }
 
         .\\--bleed-x_token\\(spacing\\.-48\\,_-48\\) {
-          --bleed-x: calc(var(--spacing-48) * -1, -\\348);
+          --bleed-x: calc(var(--spacing-48) * -1, -48);
       }
 
         .\\--bleed-x_token\\(spacing\\.-52\\,_-52\\) {
-          --bleed-x: calc(var(--spacing-52) * -1, -\\352);
+          --bleed-x: calc(var(--spacing-52) * -1, -52);
       }
 
         .\\--bleed-x_token\\(spacing\\.-56\\,_-56\\) {
-          --bleed-x: calc(var(--spacing-56) * -1, -\\356);
+          --bleed-x: calc(var(--spacing-56) * -1, -56);
       }
 
         .\\--bleed-x_token\\(spacing\\.-60\\,_-60\\) {
-          --bleed-x: calc(var(--spacing-60) * -1, -\\360);
+          --bleed-x: calc(var(--spacing-60) * -1, -60);
       }
 
         .\\--bleed-x_token\\(spacing\\.-64\\,_-64\\) {
-          --bleed-x: calc(var(--spacing-64) * -1, -\\364);
+          --bleed-x: calc(var(--spacing-64) * -1, -64);
       }
 
         .\\--bleed-x_token\\(spacing\\.-72\\,_-72\\) {
-          --bleed-x: calc(var(--spacing-72) * -1, -\\372);
+          --bleed-x: calc(var(--spacing-72) * -1, -72);
       }
 
         .\\--bleed-x_token\\(spacing\\.-80\\,_-80\\) {
-          --bleed-x: calc(var(--spacing-80) * -1, -\\380);
+          --bleed-x: calc(var(--spacing-80) * -1, -80);
       }
 
         .\\--bleed-x_token\\(spacing\\.-96\\,_-96\\) {
-          --bleed-x: calc(var(--spacing-96) * -1, -\\396);
+          --bleed-x: calc(var(--spacing-96) * -1, -96);
       }
 
         .\\--bleed-x_token\\(spacing\\.-0\\.5\\,_-0\\.5\\) {
@@ -2357,7 +2357,7 @@ describe('staticCss', () => {
       }
 
         .\\--bleed-x_token\\(spacing\\.-gutter\\,_-gutter\\) {
-          --bleed-x: calc(var(--spacing-gutter) * -1, \\-gutter);
+          --bleed-x: calc(var(--spacing-gutter) * -1, -gutter);
       }
       }"
     `)

--- a/packages/token-dictionary/__tests__/expand-references.test.ts
+++ b/packages/token-dictionary/__tests__/expand-references.test.ts
@@ -1,0 +1,218 @@
+import { expect, test } from 'vitest'
+import { TokenDictionary } from '../src/dictionary'
+
+test('expand references in value - curly ref', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('{colors.red.300}')).toMatchInlineSnapshot(`"var(--colors-red-300)"`)
+})
+
+test('expand references in value - token fn', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(colors.red.300)')).toMatchInlineSnapshot(`"var(--colors-red-300)"`)
+})
+
+test('expand references in value - token fn with fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(colors.red.300, blue)')).toMatchInlineSnapshot(
+    `"var(--colors-red-300, blue)"`,
+  )
+})
+
+test('expand references in value - token fn with var fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(colors.red.300, var(--some-var))')).toMatchInlineSnapshot(
+    `"var(--colors-red-300, var\\(--some-var))"`,
+  )
+})
+
+test('expand references in value - token fn with var fallback that also has a fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(colors.red.300, var(--some-var, purple))')).toMatchInlineSnapshot(
+    `"var(--colors-red-300, var\\(--some-var))"`,
+  )
+})
+
+test('expand references in value - token fn with var fallback that also has a var fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(
+    dictionary.expandReferenceInValue('token(colors.red.300, var(--some-var, var(--another-var, purple)))'),
+  ).toMatchInlineSnapshot(`"var(--colors-red-300, var\\(--some-var)))"`)
+})
+
+test('expand references in value - token fn with ref fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(colors.red.300, colors.blue.500)')).toMatchInlineSnapshot(
+    `"var(--colors-red-300, var(--colors-blue-500))"`,
+  )
+})
+
+test('expand references in value - token fn with nested ref fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(
+    dictionary.expandReferenceInValue('token(colors.red.300, token(colors.blue.500, yellow))'),
+  ).toMatchInlineSnapshot(`"var(--colors-red-300, token\\(colors\\.blue\\.500))"`)
+})
+
+test('expand references in value - token fn with deeply nested ref fallback', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(
+    dictionary.expandReferenceInValue(
+      'token(colors.red.300, token(colors.blue.500, token(colors.primary, token(colors.blue.700, colors.red.500))))',
+    ),
+  ).toMatchInlineSnapshot(
+    `"var(--colors-red-300, token\\(colors\\.blue\\.500))))"`,
+  )
+})

--- a/packages/token-dictionary/__tests__/expand-references.test.ts
+++ b/packages/token-dictionary/__tests__/expand-references.test.ts
@@ -45,6 +45,30 @@ test('expand references in value - token fn', () => {
   expect(dictionary.expandReferenceInValue('token(colors.red.300)')).toMatchInlineSnapshot(`"var(--colors-red-300)"`)
 })
 
+test('expand references in value - multiple token fn', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        primary: { value: '#000' },
+        red: {
+          300: { value: '#red300' },
+          500: { value: '#red500' },
+        },
+        blue: {
+          500: { value: '#blue500' },
+          700: { value: '#blue700' },
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(colors.red.300) token(colors.blue.500)')).toMatchInlineSnapshot(
+    `"var(--colors-red-300) var(--colors-blue-500)"`,
+  )
+})
+
 test('expand references in value - token fn with fallback', () => {
   const dictionary = new TokenDictionary({
     tokens: {
@@ -69,6 +93,24 @@ test('expand references in value - token fn with fallback', () => {
   )
 })
 
+test('expand references in value - token fn with non existing token and fallback', () => {
+  const dictionary = new TokenDictionary({})
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('token(spacing.auto, auto)')).toMatchInlineSnapshot(`"auto"`)
+})
+
+test('expand references in value - token fn with non existing token and fallback in composite value', () => {
+  const dictionary = new TokenDictionary({})
+
+  dictionary.init()
+
+  expect(dictionary.expandReferenceInValue('1px solid token(sizes.123, auto)')).toMatchInlineSnapshot(
+    `"1px solid auto"`,
+  )
+})
+
 test('expand references in value - token fn with var fallback', () => {
   const dictionary = new TokenDictionary({
     tokens: {
@@ -89,7 +131,7 @@ test('expand references in value - token fn with var fallback', () => {
   dictionary.init()
 
   expect(dictionary.expandReferenceInValue('token(colors.red.300, var(--some-var))')).toMatchInlineSnapshot(
-    `"var(--colors-red-300, var\\(--some-var))"`,
+    `"var(--colors-red-300, var(--some-var))"`,
   )
 })
 
@@ -113,7 +155,7 @@ test('expand references in value - token fn with var fallback that also has a fa
   dictionary.init()
 
   expect(dictionary.expandReferenceInValue('token(colors.red.300, var(--some-var, purple))')).toMatchInlineSnapshot(
-    `"var(--colors-red-300, var\\(--some-var))"`,
+    `"var(--colors-red-300, var(--some-var, purple))"`,
   )
 })
 
@@ -138,7 +180,7 @@ test('expand references in value - token fn with var fallback that also has a va
 
   expect(
     dictionary.expandReferenceInValue('token(colors.red.300, var(--some-var, var(--another-var, purple)))'),
-  ).toMatchInlineSnapshot(`"var(--colors-red-300, var\\(--some-var)))"`)
+  ).toMatchInlineSnapshot(`"var(--colors-red-300, var(--some-var, var(--another-var, purple)))"`)
 })
 
 test('expand references in value - token fn with ref fallback', () => {
@@ -186,7 +228,7 @@ test('expand references in value - token fn with nested ref fallback', () => {
 
   expect(
     dictionary.expandReferenceInValue('token(colors.red.300, token(colors.blue.500, yellow))'),
-  ).toMatchInlineSnapshot(`"var(--colors-red-300, token\\(colors\\.blue\\.500))"`)
+  ).toMatchInlineSnapshot(`"var(--colors-red-300, var(--colors-blue-500, yellow))"`)
 })
 
 test('expand references in value - token fn with deeply nested ref fallback', () => {
@@ -213,6 +255,6 @@ test('expand references in value - token fn with deeply nested ref fallback', ()
       'token(colors.red.300, token(colors.blue.500, token(colors.primary, token(colors.blue.700, colors.red.500))))',
     ),
   ).toMatchInlineSnapshot(
-    `"var(--colors-red-300, token\\(colors\\.blue\\.500))))"`,
+    `"var(--colors-red-300, var(--colors-blue-500, var(--colors-primary, var(--colors-blue-700, var(--colors-red-500)))))"`,
   )
 })

--- a/packages/token-dictionary/src/expand-token-references.ts
+++ b/packages/token-dictionary/src/expand-token-references.ts
@@ -1,0 +1,209 @@
+import { esc } from '@pandacss/shared'
+
+/**
+ * Recursively parse a string to extract Panda token references (curly or with the `token` function syntax)
+ * Allows nested token references, e.g. `token(colors.xxx.yyy, token(colors.aaa.bbb, blue))`
+ * Properly ignore CSS vars in fallback syntax, e.g. `token(colors.xxx.yyy, var(--some-var, var(--can-be-nested, blue)))`
+ */
+export const expandTokenReferences = (str: string, resolve: (path: string) => string | undefined) => {
+  let expanded = ''
+  let index = 0
+
+  type State = 'char' | 'token' | 'fallback'
+  let state = 'char' as State
+  let tokenPath = ''
+  let fallback = ''
+  const currentStates = [] as State[]
+
+  while (index < str.length) {
+    const char = str[index]
+
+    // Starting a curly bracket token reference
+    // `{colors.xxx.yyy}`
+    if (char === '{') {
+      const endIndex = str.indexOf('}', index)
+      // Invalid string, a curly bracket was not closed
+      if (endIndex === -1) {
+        break
+      }
+
+      // Jump to the end of the curly bracket
+      // Add the resolved token (CSS var) to the expanded string
+      const path = str.slice(index + 1, endIndex)
+      const resolved = resolve(path)
+      expanded += resolved ?? path
+      index = endIndex + 1
+      continue
+    }
+
+    if (state === 'token') {
+      // Found a token ref fallback
+      // `token(xxx, yyy)`
+      if (char === ',') {
+        if (str[index] === '') {
+          index++
+        }
+
+        state = 'fallback'
+        currentStates.push(state)
+        // `token(colors.xxx.yyy, colors.aaa.bbb)`
+        // `token(colors.xxx.yyy, blue)`
+        const resolved = resolve(tokenPath)
+        if (resolved?.endsWith(')')) {
+          // we need to get rid of this parenthesis for the fallback syntax
+          // var(--colors-xxx-yyy), var(--colors-aaa-bbb)
+          //                     ^
+          expanded += resolved.slice(0, -1)
+        }
+
+        tokenPath = ''
+        fallback = ''
+        continue
+      }
+    }
+
+    // `token(colors.xxx.yyy, colors.aaa.bbb)`
+    //                      ^^^^^^^^^^^^^^^^^
+    // `token(colors.xxx.yyy, blue)`
+    //                      ^^^^^^^
+    if (state === 'fallback') {
+      const nextFallback = fallback + char
+
+      // `token(colors.xxx.yyy, var(--some-var, var(--can-be-nested, blue)))`
+      //                      ^^^^^^
+      if (nextFallback === ', var(') {
+        // Compute the end index of the (fallback) CSS var
+        const innerEndIndex = cssVarParser(str.slice(index + 1))
+        const endIndex = innerEndIndex + index + 1
+
+        // That's the last parenthesis of the CSS var
+        // `token(colors.xxx.yyy, var(--some-var, var(--can-be-nested, blue)))`
+        //                                                                  ^
+
+        // Now we can extract the inner (fallback) CSS var content
+        // `token(colors.xxx.yyy, var(--some-var, var(--can-be-nested, blue)))`
+        //                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        const cssVar = str.slice(index + 1, endIndex)
+        if (endIndex === -1) {
+          break
+        }
+
+        // Add it to the expanded string and go back to the previous state
+        expanded += ', var(' + cssVar + ')'
+        index = endIndex + 1
+        state = currentStates.pop() ?? state
+        fallback = ''
+        continue
+      }
+    }
+
+    // Already inside a token fn reference
+    if (state === 'token' || state === 'fallback') {
+      index++
+
+      // Closing a token fn reference
+      // `token(colors.xxx.yyy)`
+      //                      ^
+      // `token(colors.xxx.yyy, blue)`
+      //                            ^
+      // `token(colors.xxx.yyy, var(--some-var, var(--can-be-nested, blue)))`
+      //                                                                   ^
+      if (char === ')') {
+        state = currentStates.pop() ?? state ?? 'char'
+        fallback += char
+
+        // Try to resolve the token path, which is the left part of the token fn
+        // `token(tokenPath, fallback))`
+        //        ^^^^^^^^^
+        const resolved = tokenPath ? resolve(tokenPath) ?? esc(tokenPath) : tokenPath
+
+        if (fallback) {
+          // `, colors.xxx.yyy` -> `colors.xxx.yyy`
+          fallback = fallback.slice(1).trim()
+
+          if (!fallback.startsWith('token(') && fallback.endsWith(')')) {
+            fallback = fallback.slice(0, -1)
+          }
+
+          if (fallback.includes('token(')) {
+            const parsed = expandTokenReferences(fallback, resolve)
+            if (parsed) {
+              fallback = parsed.slice(0, -1)
+            }
+          } else if (fallback) {
+            const resolvedFallback = resolve(fallback)
+            if (resolvedFallback) {
+              fallback = resolvedFallback
+            }
+          }
+        }
+
+        const lastChar = expanded.at(-1)
+        if (fallback) {
+          if (lastChar?.trim()) {
+            expanded += resolved.slice(0, -1) + (', ' + fallback + ')')
+          } else {
+            expanded += fallback
+          }
+        } else {
+          expanded += resolved || ')'
+        }
+
+        tokenPath = ''
+        fallback = ''
+        state = 'char'
+        continue
+      }
+
+      if (state === 'token') {
+        tokenPath += char
+      }
+      if (state === 'fallback') {
+        fallback += char
+      }
+
+      continue
+    }
+
+    const tokenIndex = str.indexOf('token(', index)
+    // Starting a token fn reference, jump to the first character inside it
+    // `token(colors.xxx.yyy)`
+    if (tokenIndex !== -1) {
+      const innerTokenIndex = tokenIndex + 'token('.length
+      expanded += str.slice(index, tokenIndex)
+      index = innerTokenIndex
+      state = 'token'
+      currentStates.push(state)
+      continue
+    }
+
+    expanded += char
+    index++
+  }
+
+  return expanded
+}
+
+/**
+ * Finds the closing parenthesis index in a string starting from the start of a CSS var
+ * @example cssVarParser('--colors-red-100, var(--colors-blue-200, var(--fallback)))')
+ */
+const cssVarParser = (str: string) => {
+  let index = 0
+  const openedParenthesises = ['(']
+
+  while (index < str.length) {
+    const char = str[index]
+    if (char === '(') {
+      openedParenthesises.push(char)
+    } else if (char === ')') {
+      openedParenthesises.pop()
+      if (openedParenthesises.length === 0) {
+        return index
+      }
+    }
+    index++
+  }
+
+  return index
+}


### PR DESCRIPTION
## 📝 Description

Allow nesting (string) token references in the fallback argument, fix an issue where using CSS var in the fallback argument would be mistakenly escaped

## ⛳️ Current behavior (updates)

```ts
css({ color: "token(colors.red.300, token(colors.blue.500, yellow))" )}
// ❌ -> "var(--colors-red-300, token\\(colors\\.blue\\.500))"

css({ color: "token(colors.red.300, var(--some-var, var(--another-var, purple)))" )}
// ❌ -> "var(--colors-red-300, var\\(--some-var)))"
```

## 🚀 New behavior


```ts
css({ color: "token(colors.red.300, token(colors.blue.500, yellow))" )}
// ✅ -> "var(--colors-red-300, var(--colors-blue-500, yellow))"

css({ color: "token(colors.red.300, var(--some-var, var(--another-var, purple)))" )}
// ✅ -> "var(--colors-red-300, var(--some-var, var(--another-var, purple)))"
```

## 💣 Is this a breaking change (Yes/No):

no