### PR TITLE
docs: fix px and py CSS Property

### DIFF
--- a/website/pages/docs/utilities/spacing.md
+++ b/website/pages/docs/utilities/spacing.md
@@ -45,8 +45,8 @@ Use the `padding{X|Y}` properties to apply padding on the horizontal and vertica
 | `pr`, `paddingRight`  | `padding-right`  | `spacing`      |
 | `pt`, `paddingTop`    | `padding-top`    | `spacing`      |
 | `pb`, `paddingBottom` | `padding-bottom` | `spacing`      |
-| `px`, `paddingX`      | `padding-left`   | `spacing`      |
-| `py`, `paddingY`      | `padding-top`    | `spacing`      |
+| `px`, `paddingX`      | `padding-inline` | `spacing`      |
+| `py`, `paddingY`      | `padding-block`  | `spacing`      |
 
 ### Logical properties
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description
In the [documentation](https://panda-css.com/docs/utilities/spacing#horizontal-and-vertical-padding), CSS Property in `px`, `paddingX`, `py` and `paddingY` was written as `padding-left` or `padding-top`, but in the implementation it was `padding-inline` or `padding-block`. 

In [`@pandacss/preset-base`](https://github.com/chakra-ui/panda/blob/ca2998718f94990305299dc4d07c0869ff32cef7/packages/preset-base/src/utilities/spacing.ts).
```ts
  paddingBlock: {
    className: 'py',
    values: 'spacing',
    group: 'Padding',
    shorthand: ['py', 'paddingY'],
  },
// some lines
  paddingInline: {
    className: 'px',
    values: 'spacing',
    group: 'Padding',
    shorthand: ['paddingX', 'px'],
  },
```

## ⛳️ Current behavior (updates)
`px` and `paddingX` of CSS Property is `padding-left`.
`py` and `paddingY` of CSS Property is `padding-top`.

## 🚀 New behavior
`px` and `paddingX` of CSS Property is `padding-inline`.
`py` and `paddingY` of CSS Property is `padding-block`.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
