### PR TITLE
fix(patterns): rewrite codegen for `jsxStyleProps=none`

### DIFF
--- a/.changeset/kind-kiwis-arrive.md
+++ b/.changeset/kind-kiwis-arrive.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/generator': patch
+'@pandacss/core': patch
+---
+
+Fix issue where using `jsxStyleProps: none` with the generated jsx patterns, lead to unoptimized code that causes the
+component to be recreated on every render.

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -71,4 +71,12 @@ export class FileEngine {
     comments.push(' */')
     return comments.join('\n')
   }
+
+  /**
+   * convert import type { CompositionStyleObject } from './system-types'
+   * to import type { CompositionStyleObject } from './system-types.d.ts'
+   */
+  rewriteTypeImport(code: string) {
+    return code.replace(/import\s+type\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/g, this.importType('$1', '$2'))
+  }
 }

--- a/packages/generator/src/artifacts/js/is-valid-prop.ts
+++ b/packages/generator/src/artifacts/js/is-valid-prop.ts
@@ -16,7 +16,7 @@ export function generateIsValidProp(ctx: Context) {
     `var userGeneratedStr = "${match(ctx.jsx.styleProps)
       .with('all', () => Array.from(ctx.properties).join(','))
       .with('minimal', () => 'css')
-      .with('none', () => '')
+      .with('none', () => 'css')
       .exhaustive()}"`,
   )
 

--- a/packages/generator/src/artifacts/preact-jsx/pattern.ts
+++ b/packages/generator/src/artifacts/preact-jsx/pattern.ts
@@ -30,9 +30,9 @@ export function generatePreactJsxPattern(ctx: Context, filters?: ArtifactFilters
           const [patternProps, restProps] = splitProps(props, ${JSON.stringify(props)})
           
           const styleProps = ${styleFnName}(patternProps)
-          const Comp = ${factoryName}("${jsxElement}", { base: styleProps })
+          const mergedProps = { ref, ...restProps, css: styleProps }
           
-          return h(Comp, { ref, ...restProps })
+          return h(${factoryName}.${jsxElement}, mergedProps)
           `,
           )
           .with(

--- a/packages/generator/src/artifacts/qwik-jsx/pattern.ts
+++ b/packages/generator/src/artifacts/qwik-jsx/pattern.ts
@@ -29,9 +29,9 @@ export function generateQwikJsxPattern(ctx: Context, filters?: ArtifactFilters) 
           const [patternProps, restProps] = splitProps(props, ${JSON.stringify(props)})
           
           const styleProps = ${styleFnName}(patternProps)
-          const Comp = ${factoryName}("${jsxElement}", { base: styleProps })
+          const mergedProps = { ref, ...restProps, css: styleProps }
           
-          return h(Comp, restProps)
+          return h(${factoryName}.${jsxElement}, mergedProps)
           `,
           )
           .with(

--- a/packages/generator/src/artifacts/react-jsx/pattern.ts
+++ b/packages/generator/src/artifacts/react-jsx/pattern.ts
@@ -29,9 +29,9 @@ export function generateReactJsxPattern(ctx: Context, filters?: ArtifactFilters)
           const [patternProps, restProps] = splitProps(props, ${JSON.stringify(props)})
           
           const styleProps = ${styleFnName}(patternProps)
-          const Comp = ${factoryName}("${jsxElement}", { base: styleProps })
+          const mergedProps = { ref, ...restProps, css: styleProps }
           
-          return createElement(Comp, { ref, ...restProps })
+          return createElement(${factoryName}.${jsxElement}, mergedProps)
           `,
           )
           .with(

--- a/packages/generator/src/artifacts/solid-jsx/pattern.ts
+++ b/packages/generator/src/artifacts/solid-jsx/pattern.ts
@@ -28,10 +28,14 @@ export function generateSolidJsxPattern(ctx: Context, filters?: ArtifactFilters)
           () => outdent`
         const [patternProps, restProps] = splitProps(props, ${JSON.stringify(props)})
         
-        const styleProps = ${styleFnName}(patternProps)
-        const Comp = ${factoryName}("${jsxElement}", { base: styleProps })
+        const cssProps = createMemo(() => {
+          const styleProps = ${styleFnName}(patternProps)
+          return { css: styleProps }
+        })
         
-        return createComponent(Comp, restProps)
+        const mergedProps = mergeProps(restProps, cssProps)
+
+        return createComponent(${factoryName}.${jsxElement}, mergedProps)
         `,
         )
         .with(
@@ -43,6 +47,7 @@ export function generateSolidJsxPattern(ctx: Context, filters?: ArtifactFilters)
           const styleProps = ${styleFnName}(patternProps)
           return { css: mergeCss(styleProps, props.css) }
         })
+
         const mergedProps = mergeProps(restProps, cssProps)
 
         return createComponent(${factoryName}.${jsxElement}, mergedProps)

--- a/packages/generator/src/artifacts/types/generated.ts
+++ b/packages/generator/src/artifacts/types/generated.ts
@@ -10,35 +10,22 @@ import staticCss from '../generated/static-css.d.ts.json' assert { type: 'json' 
 import system from '../generated/system-types.d.ts.json' assert { type: 'json' }
 
 export function getGeneratedTypes(ctx: Context) {
-  /**
-   * convert import type { CompositionStyleObject } from './system-types'
-   * to import type { CompositionStyleObject } from './system-types.d.ts'
-   */
-  const rewriteImports = (code: string) =>
-    code.replace(/import\s+type\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/g, ctx.file.importType('$1', '$2'))
-
   return {
     cssType: csstype.content,
     static: staticCss.content,
-    recipe: rewriteImports(recipe.content),
-    pattern: rewriteImports(pattern.content.replace('../tokens', '../tokens/index')),
-    parts: rewriteImports(parts.content),
-    composition: rewriteImports(composition.content),
-    selectors: rewriteImports(selectors.content),
+    recipe: ctx.file.rewriteTypeImport(recipe.content),
+    pattern: ctx.file.rewriteTypeImport(pattern.content.replace('../tokens', '../tokens/index')),
+    parts: ctx.file.rewriteTypeImport(parts.content),
+    composition: ctx.file.rewriteTypeImport(composition.content),
+    selectors: ctx.file.rewriteTypeImport(selectors.content),
   }
 }
 
-const jsxStyleProps = 'export type JsxStyleProps = StyleProps & WithCss'
-export function getGeneratedSystemTypes(ctx: Context) {
-  /**
-   * convert import type { CompositionStyleObject } from './system-types'
-   * to import type { CompositionStyleObject } from './system-types.d.ts'
-   */
-  const rewriteImports = (code: string) =>
-    code.replace(/import\s+type\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/g, ctx.file.importType('$1', '$2'))
+const jsxStyleProps = 'export type JsxStyleProps = SystemStyleObject & WithCss'
 
+export function getGeneratedSystemTypes(ctx: Context) {
   return {
-    system: rewriteImports(
+    system: ctx.file.rewriteTypeImport(
       match(ctx.jsx.styleProps)
         .with('all', () => system.content)
         .with('minimal', () =>

--- a/packages/generator/src/artifacts/vue-jsx/pattern.ts
+++ b/packages/generator/src/artifacts/vue-jsx/pattern.ts
@@ -29,13 +29,14 @@ export function generateVueJsxPattern(ctx: Context, filters?: ArtifactFilters) {
             .with(
               'none',
               () => outdent`
-            const Comp = computed(() => {
+            const cssProps = computed(() => {
               const styleProps = ${styleFnName}(props)
-              return ${factoryName}("${jsxElement}", { base: styleProps })
+              return { css: styleProps }
             })
             
             return () => {
-              return h(Comp.value, attrs, slots)
+              const mergedProps = { ...attrs, ...cssProps.value }
+              return h(${factoryName}.${jsxElement}, mergedProps, slots)
             }
             `,
             )

--- a/sandbox/codegen/__tests__/scenarios/jsx-minimal.test.tsx
+++ b/sandbox/codegen/__tests__/scenarios/jsx-minimal.test.tsx
@@ -83,6 +83,7 @@ describe('styled factory - cva', () => {
 
   test('style prop', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" mx="2">
         Click me
       </Button>,
@@ -100,6 +101,7 @@ describe('styled factory - cva', () => {
 
   test('style prop with variant', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" size="sm" mx="2">
         Click me
       </Button>,
@@ -149,6 +151,7 @@ describe('styled factory - cva', () => {
 
   test('all together', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" css={{ color: 'red.200', fontSize: 'xl' }} size="lg" mx="2">
         Click me
       </Button>,
@@ -210,6 +213,7 @@ describe('styled factory - button recipe', () => {
 
   test('style prop', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" mx="2">
         Click me
       </Button>,
@@ -227,6 +231,7 @@ describe('styled factory - button recipe', () => {
 
   test('style prop with variant', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" size="sm" mx="2">
         Click me
       </Button>,
@@ -276,6 +281,7 @@ describe('styled factory - button recipe', () => {
 
   test('all together', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" css={{ color: 'red.200', fontSize: 'xl' }} size="md" visual="outline" mx="2">
         Click me
       </Button>,

--- a/sandbox/codegen/__tests__/scenarios/jsx-none.test.tsx
+++ b/sandbox/codegen/__tests__/scenarios/jsx-none.test.tsx
@@ -83,6 +83,7 @@ describe('styled factory - cva', () => {
 
   test('style prop', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" mx="2">
         Click me
       </Button>,
@@ -100,6 +101,7 @@ describe('styled factory - cva', () => {
 
   test('style prop with variant', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" size="sm" mx="2">
         Click me
       </Button>,
@@ -149,6 +151,7 @@ describe('styled factory - cva', () => {
 
   test('all together', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" css={{ color: 'red.200', fontSize: 'xl' }} size="lg" mx="2">
         Click me
       </Button>,
@@ -210,6 +213,7 @@ describe('styled factory - button recipe', () => {
 
   test('style prop', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" mx="2">
         Click me
       </Button>,
@@ -227,6 +231,7 @@ describe('styled factory - button recipe', () => {
 
   test('style prop with variant', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" size="sm" mx="2">
         Click me
       </Button>,
@@ -276,6 +281,7 @@ describe('styled factory - button recipe', () => {
 
   test('all together', () => {
     const { container } = render(
+      // @ts-expect-error
       <Button className="custom-btn" css={{ color: 'red.200', fontSize: 'xl' }} size="md" visual="outline" mx="2">
         Click me
       </Button>,


### PR DESCRIPTION
Closes #2632

## 📝 Description

This PR optimizes the code generated for JSX patterns when `jsxStyleProps=none.` We used to create a component in the render function; now, we only create one component, avoiding re-renders.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I had to reuse the `css` prop pattern to achieve this but I believe it's fine since there's no way to override this prop from the consuming side.