### PR TITLE
docs: fix background shorthand in defineLayerStyles

### DIFF
--- a/website/pages/docs/customization/config-functions.md
+++ b/website/pages/docs/customization/config-functions.md
@@ -261,7 +261,7 @@ const layerStyles = defineLayerStyles({
   container: {
     description: 'container styles',
     value: {
-      bg: 'gray.50',
+      background: 'gray.50',
       border: '2px solid',
       borderColor: 'gray.500'
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I found that the example for `defineLayerStyles` from the [docs](https://panda-css.com/docs/theming/layer-styles#defining-layer-styles) throws type errors.


## ⛳️ Current behavior (updates)
### Using `bg` inside `value`.
<img width="1344" alt="image" src="https://github.com/chakra-ui/panda/assets/6158959/87cfd4a8-202d-4e05-857c-50938fb7565e">

## 🚀 New behavior
### Using `background` inside `value`.
<img width="419" alt="image" src="https://github.com/chakra-ui/panda/assets/6158959/bb6819d5-7304-4167-9256-c1d07e425b9f">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A
