### PR TITLE
fix(sva): spreading in slots would prevent CSS from being generated

### DIFF
--- a/.changeset/sharp-emus-crash.md
+++ b/.changeset/sharp-emus-crash.md
@@ -1,0 +1,21 @@
+---
+'@pandacss/extractor': patch
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Fix an issue where spreading an identifier in a sva `slots` array would prevent expected CSS from being generated
+
+```ts
+import { sva } from 'styled-system/css'
+const parts = ['positioner', 'content']
+
+const card = sva({
+  slots: [...parts], // <- spreading here was causing the below CSS not to be generated, it's now fixed ✅
+  base: {
+    root: {
+      p: '6',
+    },
+  },
+})
+```

--- a/packages/core/src/style-encoder.ts
+++ b/packages/core/src/style-encoder.ts
@@ -268,7 +268,7 @@ export class StyleEncoder {
   }
 
   processAtomicSlotRecipe = (recipe: PartialBy<SlotRecipeDefinition, 'slots'>) => {
-    recipe.slots ||= Recipes.inferSlots(recipe)
+    if (!recipe.slots?.filter(Boolean).length) recipe.slots = Recipes.inferSlots(recipe)
     const slots = getSlotRecipes(recipe)
 
     for (const slotRecipe of Object.values(slots)) {

--- a/packages/extractor/__tests__/extract.test.ts
+++ b/packages/extractor/__tests__/extract.test.ts
@@ -6052,3 +6052,40 @@ p.stack({ mt: "40px" })`
     }
   `)
 })
+
+// TODO ? not useful as of now
+it.skip('extracts slots when spread', () => {
+  const code = `import { sva } from 'styled-system/css';
+
+  const parts = ['positioner', 'content']
+
+  const useStyles = sva({
+    slots: [...parts],
+    base: {
+      root: { bgColor: 'red' }
+    },
+  });`
+
+  expect(extractFromCode(code, { functionNameList: ['sva'] })).toMatchInlineSnapshot(`
+    {
+      "sva": [
+        {
+          "conditions": [],
+          "raw": [
+            {
+              "base": {
+                "root": {
+                  "bgColor": "red",
+                },
+              },
+              "slots": [
+                undefined,
+              ],
+            },
+          ],
+          "spreadConditions": [],
+        },
+      ],
+    }
+  `)
+})

--- a/packages/parser/__tests__/sva.test.ts
+++ b/packages/parser/__tests__/sva.test.ts
@@ -222,4 +222,43 @@ describe('ast parser / sva', () => {
       }"
     `)
   })
+
+  test.only('unresolvable slots - spread', () => {
+    const code = `
+    import { sva } from 'styled-system/css'
+    const parts = ['positioner', 'content']
+
+    const card = sva({
+      slots: [...parts],
+      base: {
+        root: {
+          p: '6',
+        },
+      },
+    })
+     `
+    const result = parseAndExtract(code)
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "base": {
+                "root": {
+                  "p": "6",
+                },
+              },
+              "slots": [
+                undefined,
+              ],
+            },
+          ],
+          "name": "sva",
+          "type": "sva",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`""`)
+  })
 })

--- a/packages/parser/__tests__/sva.test.ts
+++ b/packages/parser/__tests__/sva.test.ts
@@ -223,7 +223,7 @@ describe('ast parser / sva', () => {
     `)
   })
 
-  test.only('unresolvable slots - spread', () => {
+  test('unresolvable slots - spread', () => {
     const code = `
     import { sva } from 'styled-system/css'
     const parts = ['positioner', 'content']
@@ -249,7 +249,7 @@ describe('ast parser / sva', () => {
                 },
               },
               "slots": [
-                undefined,
+                "root",
               ],
             },
           ],
@@ -259,6 +259,12 @@ describe('ast parser / sva', () => {
       ]
     `)
 
-    expect(result.css).toMatchInlineSnapshot(`""`)
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .p_6 {
+          padding: var(--spacing-6);
+      }
+      }"
+    `)
   })
 })


### PR DESCRIPTION
Closes https://github.com/chakra-ui/panda/issues/2671

## 📝 Description

Fix an issue where spreading an identifier in a sva `slots` array would prevent expected CSS from being generated

```ts
import { sva } from 'styled-system/css'
const parts = ['positioner', 'content']

const card = sva({
  slots: [...parts], // <- spreading here was causing the below CSS not to be generated, it's now fixed ✅
  base: {
    root: {
      p: '6',
    },
  },
})
```


## 💣 Is this a breaking change (Yes/No):

no
