### PR TITLE
feat: add drop shadow token

### DIFF
--- a/.changeset/lemon-beds-ring.md
+++ b/.changeset/lemon-beds-ring.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/generator': patch
+'@pandacss/types': patch
+---
+
+Support dropShadows as Tokens

--- a/packages/generator/__tests__/generate-token-dts.test.ts
+++ b/packages/generator/__tests__/generate-token-dts.test.ts
@@ -62,7 +62,7 @@ test('[dts] should generate package', () => {
     		breakpoints: BreakpointToken
     } & { [token: string]: never }
 
-    export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "gradients" | "breakpoints" | "assets""
+    export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "dropShadows" | "gradients" | "breakpoints" | "assets""
   `)
 })
 
@@ -138,6 +138,6 @@ test('[dts] should generate package - custom formatTokenName', () => {
     		breakpoints: BreakpointToken
     } & { [token: string]: never }
 
-    export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "gradients" | "breakpoints" | "assets""
+    export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "dropShadows" | "gradients" | "breakpoints" | "assets""
   `)
 })

--- a/packages/generator/src/artifacts/types/token-types.ts
+++ b/packages/generator/src/artifacts/types/token-types.ts
@@ -23,6 +23,7 @@ const categories = [
   'easings',
   'animations',
   'blurs',
+  'dropShadows',
   'gradients',
   'breakpoints',
   'assets',

--- a/packages/studio/styled-system/tokens/tokens.d.ts
+++ b/packages/studio/styled-system/tokens/tokens.d.ts
@@ -60,4 +60,4 @@ export type Tokens = {
 		breakpoints: BreakpointToken
 } & { [token: string]: never }
 
-export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "gradients" | "breakpoints" | "assets"
+export type TokenCategory = "aspectRatios" | "zIndex" | "opacity" | "colors" | "fonts" | "fontSizes" | "fontWeights" | "lineHeights" | "letterSpacings" | "sizes" | "shadows" | "spacing" | "radii" | "borders" | "borderWidths" | "durations" | "easings" | "animations" | "blurs" | "dropShadows" | "gradients" | "breakpoints" | "assets"

--- a/packages/token-dictionary/__tests__/transform-drop-shadow.test.ts
+++ b/packages/token-dictionary/__tests__/transform-drop-shadow.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'vitest'
+import { TokenDictionary } from '../src/dictionary'
+import { transformDropShadow } from '../src/transform'
+
+test('transform / shadow', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      colors: {
+        red: { value: '#ff0000' },
+      },
+      dropShadows: {
+        sm: { value: { offsetX: 4, offsetY: 10, blur: 4, color: '{colors.red}' } },
+        md: { value: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' },
+      },
+    },
+  })
+
+  dictionary.registerTokens()
+  dictionary.registerTransform(transformDropShadow)
+
+  dictionary.build()
+
+  expect(dictionary.allTokens).toMatchInlineSnapshot(`
+    [
+      Token {
+        "deprecated": undefined,
+        "description": undefined,
+        "extensions": {
+          "category": "colors",
+          "condition": "base",
+          "prop": "red",
+        },
+        "name": "colors.red",
+        "originalValue": "#ff0000",
+        "path": [
+          "colors",
+          "red",
+        ],
+        "type": "color",
+        "value": "#ff0000",
+      },
+      Token {
+        "deprecated": undefined,
+        "description": undefined,
+        "extensions": {
+          "category": "dropShadows",
+          "condition": "base",
+          "prop": "sm",
+        },
+        "name": "dropShadows.sm",
+        "originalValue": {
+          "blur": 4,
+          "color": "{colors.red}",
+          "offsetX": 4,
+          "offsetY": 10,
+        },
+        "path": [
+          "dropShadows",
+          "sm",
+        ],
+        "type": "dropShadow",
+        "value": "4px 10px 4px #ff0000",
+      },
+      Token {
+        "deprecated": undefined,
+        "description": undefined,
+        "extensions": {
+          "category": "dropShadows",
+          "condition": "base",
+          "prop": "md",
+        },
+        "name": "dropShadows.md",
+        "originalValue": "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+        "path": [
+          "dropShadows",
+          "md",
+        ],
+        "type": "dropShadow",
+        "value": "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+      },
+    ]
+  `)
+})

--- a/packages/token-dictionary/__tests__/transform-drop-shadow.test.ts
+++ b/packages/token-dictionary/__tests__/transform-drop-shadow.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { TokenDictionary } from '../src/dictionary'
 import { transformDropShadow } from '../src/transform'
 
-test('transform / shadow', () => {
+test('transform / dropShadow', () => {
   const dictionary = new TokenDictionary({
     tokens: {
       colors: {

--- a/packages/token-dictionary/__tests__/transform-drop-shadow.test.ts
+++ b/packages/token-dictionary/__tests__/transform-drop-shadow.test.ts
@@ -59,7 +59,7 @@ test('transform / shadow', () => {
           "sm",
         ],
         "type": "dropShadow",
-        "value": "4px 10px 4px #ff0000",
+        "value": "drop-shadow(4px 10px 4px #ff0000)",
       },
       Token {
         "deprecated": undefined,

--- a/packages/token-dictionary/src/is-composite.ts
+++ b/packages/token-dictionary/src/is-composite.ts
@@ -32,6 +32,13 @@ export const isCompositeAsset = isMatching({
   value: P.string,
 })
 
+export const isCompositeDropShadow = isMatching({
+  offsetX: P.number,
+  offsetY: P.number,
+  blur: P.number,
+  color: P.string,
+})
+
 export const isCompositeTokenValue = (value: any) => {
   return (
     isCompositeGradient(value) ||

--- a/packages/token-dictionary/src/token.ts
+++ b/packages/token-dictionary/src/token.ts
@@ -240,4 +240,5 @@ const TOKEN_TYPES = {
   components: 'cti',
   assets: 'asset',
   aspectRatios: 'aspectRatio',
+  dropShadows: 'dropShadow',
 }

--- a/packages/token-dictionary/src/transform.ts
+++ b/packages/token-dictionary/src/transform.ts
@@ -146,7 +146,7 @@ export const transformDropShadow: TokenTransformer = {
 
     if (isCompositeDropShadow(token.value)) {
       const { offsetX, offsetY, blur, color } = token.value
-      return `${offsetX}px ${offsetY}px ${blur}px ${color}`
+      return `drop-shadow(${offsetX}px ${offsetY}px ${blur}px ${color})`
     }
 
     return token.value

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -66,6 +66,13 @@ export interface Asset {
   value: string
 }
 
+export interface DropShadow {
+  offsetX: number
+  offsetY: number
+  blur: number
+  color: string
+}
+
 export interface TokenDataTypes {
   zIndex: string | number
   opacity: string | number
@@ -84,6 +91,7 @@ export interface TokenDataTypes {
   easings: string | number[]
   animations: string
   blurs: string
+  dropShadows: DropShadow | DropShadow[] | string | string[]
   gradients: string | Gradient
   assets: string | Asset
   borderWidths: string


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description
`dropShadow` could not be granted as Tokens, so it can now be granted.

discussed by https://github.com/chakra-ui/panda/discussions/2677

<img width="1466" alt="スクリーンショット 2024-06-19 18 16 07" src="https://github.com/chakra-ui/panda/assets/61353435/224776a4-f5c8-42e9-b12b-2b39cfc55761">


## ⛳️ Current behavior (updates)
Type error when trying to add `dropShadows` to Tokens

## 🚀 New behavior
- Allow dropShadows to be added to Tokens
- Array and Object are now received and transform into appropriate strings.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/drop-shadow
