### PR TITLE
feat: allow custom TokenCategory in tokens/semanticTokens

### DIFF
--- a/.changeset/brown-ghosts-juggle.md
+++ b/.changeset/brown-ghosts-juggle.md
@@ -14,14 +14,16 @@ export default defineConfig({
   theme: {
     extend: {
       tokens: {
-        filters: { // ✅ this is now allowed !
+        filters: {
+          // ✅ this is now allowed !
           blurry: {
             value: 'blur(5px)',
           },
         },
       },
+    },
   },
-   utilities: {
+  utilities: {
     extend: {
       filter: {
         values: 'filters', // ✅ you can reference your own TokenCategory here

--- a/.changeset/brown-ghosts-juggle.md
+++ b/.changeset/brown-ghosts-juggle.md
@@ -1,0 +1,50 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/parser': patch
+'@pandacss/types': patch
+---
+
+Slightly change the typings so that you can use any string as a `TokenCategory` (colors, spacing, etc).
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  // ...
+  theme: {
+    extend: {
+      tokens: {
+        filters: { // ✅ this is now allowed !
+          blurry: {
+            value: 'blur(5px)',
+          },
+        },
+      },
+  },
+   utilities: {
+    extend: {
+      filter: {
+        values: 'filters', // ✅ you can reference your own TokenCategory here
+      },
+    },
+  },
+})
+```
+
+so that you can use it in your app like this:
+
+```tsx
+import { css } from '../styled-system/css'
+
+export const App = () => {
+  return (
+    <div
+      className={css({
+        filter: 'blurry', // ✅ this will be suggested by the autocomplete
+      })}
+    >
+      this text will be blurry
+    </div>
+  )
+}
+```

--- a/packages/parser/__tests__/output.test.ts
+++ b/packages/parser/__tests__/output.test.ts
@@ -3887,4 +3887,57 @@ describe('extract to css output pipeline', () => {
       }"
     `)
   })
+
+  test('unknown token type', () => {
+    const code = `
+    import { css } from 'styled-system/css'
+
+    export const App = () => {
+      return (
+          <div className={css({
+            filter: 'blurry'
+          })}>blurry</div>
+      )
+    }
+     `
+    const result = parseAndExtract(code, {
+      utilities: {
+        extend: {
+          filter: {
+            values: 'filters',
+          },
+        },
+      },
+      theme: {
+        tokens: {
+          filters: {
+            blurry: {
+              value: 'blur(5px)',
+            },
+          },
+        },
+      },
+    })
+    expect(result.json).toMatchInlineSnapshot(`
+      [
+        {
+          "data": [
+            {
+              "filter": "blurry",
+            },
+          ],
+          "name": "css",
+          "type": "css",
+        },
+      ]
+    `)
+
+    expect(result.css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .filter_blurry {
+          filter: var(--filters-blurry);
+      }
+      }"
+    `)
+  })
 })

--- a/packages/token-dictionary/__tests__/unknown-token-type.test.ts
+++ b/packages/token-dictionary/__tests__/unknown-token-type.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+import { TokenDictionary } from '../src/dictionary'
+
+test('unknown token type', () => {
+  const dictionary = new TokenDictionary({
+    tokens: {
+      filters: {
+        blurry: {
+          value: 'blur(5px)',
+        },
+      },
+    },
+  })
+
+  dictionary.init()
+
+  expect(dictionary.allTokens).toMatchInlineSnapshot(`
+    [
+      Token {
+        "deprecated": undefined,
+        "description": undefined,
+        "extensions": {
+          "category": "filters",
+          "condition": "base",
+          "prop": "blurry",
+          "var": "--filters-blurry",
+          "varRef": "var(--filters-blurry)",
+        },
+        "name": "filters.blurry",
+        "originalValue": "blur(5px)",
+        "path": [
+          "filters",
+          "blurry",
+        ],
+        "type": undefined,
+        "value": "blur(5px)",
+      },
+    ]
+  `)
+  expect(dictionary.view.values).toMatchInlineSnapshot(`
+    Map {
+      "filters.blurry" => "var(--filters-blurry)",
+    }
+  `)
+})

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -91,12 +91,19 @@ export interface TokenDataTypes {
   containerNames: string
 }
 
+export type DefaultTokenCategory = keyof TokenDataTypes
+export type TokenCategory = DefaultTokenCategory | (string & {})
+
+type UnknownTokenTypeValue = string | number | Record<string, any>
+
 export type Tokens = {
-  [key in keyof TokenDataTypes]?: Recursive<Token<TokenDataTypes[key]>>
+  [key in TokenCategory]?: Recursive<
+    Token<key extends DefaultTokenCategory ? TokenDataTypes[key] : UnknownTokenTypeValue>
+  >
 }
 
 export type SemanticTokens<ConditionKey extends string = string> = {
-  [key in keyof TokenDataTypes]?: Recursive<SemanticToken<TokenDataTypes[key], ConditionKey>>
+  [key in TokenCategory]?: Recursive<
+    SemanticToken<key extends DefaultTokenCategory ? TokenDataTypes[key] : UnknownTokenTypeValue, ConditionKey>
+  >
 }
-
-export type TokenCategory = keyof TokenDataTypes

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -94,7 +94,7 @@ export interface TokenDataTypes {
 export type DefaultTokenCategory = keyof TokenDataTypes
 export type TokenCategory = DefaultTokenCategory | (string & {})
 
-type UnknownTokenTypeValue = string | number | Record<string, any>
+type UnknownTokenTypeValue = string | number
 
 export type Tokens = {
   [key in TokenCategory]?: Recursive<

--- a/sandbox/preact-ts/panda.config.ts
+++ b/sandbox/preact-ts/panda.config.ts
@@ -15,11 +15,23 @@ export default defineConfig({
       },
     },
   },
+  utilities: {
+    extend: {
+      filter: {
+        values: 'filters',
+      },
+    },
+  },
   theme: {
     extend: {
       tokens: {
         colors: {
-          aaa: { value: 'azaz23' },
+          foreground: { value: '#ebdbb2' },
+        },
+        filters: {
+          blurry: {
+            value: 'blur(5px)',
+          },
         },
       },
       recipes: {

--- a/sandbox/preact-ts/src/app.tsx
+++ b/sandbox/preact-ts/src/app.tsx
@@ -1,6 +1,6 @@
-import { css } from 'styled-system/css'
-import { stack } from 'styled-system/patterns'
-import { btn } from 'styled-system/recipes'
+import { css } from '../styled-system/css'
+import { stack } from '../styled-system/patterns'
+import { btn } from '../styled-system/recipes'
 
 export const App = () => {
   return (
@@ -10,6 +10,7 @@ export const App = () => {
       </div>
       <div className={css({ color: 'yellow' })}></div>
       <div className={btn()}>aaaa Click me</div>
+      <div className={css({ filter: 'blurry' })}>blurry</div>
     </>
   )
 }


### PR DESCRIPTION
## 📝 Description

Slightly change the typings so that you can use any string as a `TokenCategory` (colors, spacing, etc).

```ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  // ...
  theme: {
    extend: {
      tokens: {
        filters: { // ✅ this is now allowed !
          blurry: {
            value: 'blur(5px)',
          },
        },
      },
  },
   utilities: {
    extend: {
      filter: {
        values: 'filters', // ✅ you can reference your own TokenCategory here
      },
    },
  },
})
```

so that you can use it in your app like this:

```tsx
import { css } from '../styled-system/css'

export const App = () => {
  return (
    <div
      className={css({
        filter: 'blurry', // ✅ this will be suggested by the autocomplete
      })}
    >
      this text will be blurry
    </div>
  )
}
```

## 💣 Is this a breaking change (Yes/No):

no
