### PR TITLE
feat(conditions): JIT merging

### DIFF
--- a/.changeset/new-numbers-sip.md
+++ b/.changeset/new-numbers-sip.md
@@ -1,0 +1,53 @@
+---
+'@pandacss/parser': patch
+'@pandacss/core': patch
+---
+
+Simple conditions can now be combined just-in-time, without having to create a new one in the config file.
+
+```tsx
+// panda.config.ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  conditions: {
+    hover: '&:is(:hover, [data-hover])',
+    disabled: '&:is(:disabled, [disabled], [data-disabled])',
+  },
+})
+
+// src/app.tsx
+import { css } from '../styled-system/css'
+
+export const App = () => {
+  return (
+    <div
+      className={css({
+        color: 'red.600',
+        '&_hover:not(_disabled)': {
+          color: 'yellow.500',
+        },
+      })}
+    >
+      JIT conditions are pretty cool
+    </div>
+  )
+}
+```
+
+This will generate a CSS file looking like this:
+
+```css
+@layer utilities {
+  .c_red\.600 {
+    color: var(--colors-red-600);
+  }
+
+  .\[\&_hover\:not\(_disabled\)\]\:c_yellow\.500.\[\&_hover\:not\(_disabled\)\]\:c_yellow\.500:is(
+      :hover,
+      [data-hover]
+    ):not(.\[\&_hover\:not\(_disabled\)\]\:c_yellow\.500:is(:disabled, [disabled], [data-disabled])) {
+    color: var(--colors-yellow-500);
+  }
+}
+```

--- a/packages/core/__tests__/conditions.test.ts
+++ b/packages/core/__tests__/conditions.test.ts
@@ -73,11 +73,19 @@ describe('Conditions', () => {
           ],
         }
       `)
+
+    expect(css.normalize('&:not(_disabled)')).toMatchInlineSnapshot(`
+      {
+        "raw": "&:not(&:is(:disabled, [disabled], [data-disabled]))",
+        "type": "self-nesting",
+        "value": "&:not(&:is(:disabled, [disabled], [data-disabled]))",
+      }
+    `)
   })
 
   test('conditions sorting', () => {
     const css = new Conditions({ conditions: fixturePreset.conditions!, breakpoints: fixturePreset.theme.breakpoints })
-    const conditions = ['sm', 'md', 'lg', '_hover', '_focus', '_focus-visible', '_focus-within', '_active']
+    const conditions = ['sm', 'md', 'lg', '_hover', '_focus', '_focusVisible', '_focusWithin', '_active']
     expect(css.sort(conditions).map((c) => c.raw)).toMatchInlineSnapshot(`
       [
         "@media screen and (min-width: 40rem)",
@@ -85,6 +93,8 @@ describe('Conditions', () => {
         "@media screen and (min-width: 64rem)",
         "&:is(:hover, [data-hover])",
         "&:is(:focus, [data-focus])",
+        "&:is(:focus-visible, [data-focus-visible])",
+        "&:focus-within",
         "&:is(:active, [data-active])",
       ]
     `)


### PR DESCRIPTION
## 📝 Description

Simple conditions can now be combined just-in-time, without having to create a new one in the config file.

```tsx
// panda.config.ts
import { defineConfig } from '@pandacss/dev'

export default defineConfig({
  conditions: {
    hover: '&:is(:hover, [data-hover])',
    disabled: '&:is(:disabled, [disabled], [data-disabled])',
  },
})

// src/app.tsx
import { css } from '../styled-system/css'

export const App = () => {
  return (
    <div
      className={css({
        color: 'red.600',
        '&_hover:not(_disabled)': {
          color: 'yellow.500',
        },
      })}
    >
      JIT conditions are pretty cool
    </div>
  )
}
```

This will generate a CSS file looking like this:

```css
@layer utilities {
  .c_red\.600 {
    color: var(--colors-red-600);
  }

  .\[\&_hover\:not\(_disabled\)\]\:c_yellow\.500.\[\&_hover\:not\(_disabled\)\]\:c_yellow\.500:is(
      :hover,
      [data-hover]
    ):not(.\[\&_hover\:not\(_disabled\)\]\:c_yellow\.500:is(:disabled, [disabled], [data-disabled])) {
    color: var(--colors-yellow-500);
  }
}
```


## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information

https://github.com/chakra-ui/panda/discussions/2709
https://github.com/chakra-ui/panda/discussions/2508#discussioncomment-9972535
https://github.com/chakra-ui/panda/discussions/1191