### PR TITLE
docs: Adds information about Grid's minChildWidth property

### DIFF
--- a/website/pages/docs/concepts/patterns.mdx
+++ b/website/pages/docs/concepts/patterns.mdx
@@ -514,7 +514,7 @@ The `grid` function accepts the following properties:
 - `gap`: The gap between the elements in the stack.
 - `columnGap`: The gap between the elements in the stack horizontally.
 - `rowGap`: The gap between the elements in the stack vertically.
-- `minChildWidth`: The minimum width of the child elements before wrapping.
+- `minChildWidth`: The minimum width of the child elements before wrapping (must not be used with `columns`).
 
 <Tabs items={['Function', 'JSX']}>
 <Tab>


### PR DESCRIPTION
## 📝 Description

It took me a while to figure out that Grid's `minChildWidth` parameter doesn't work if `columns` are defined. I figure it might help other people.

## ⛳️ Current behavior (updates)

No information on the fact that the two are not compatible
![image](https://github.com/user-attachments/assets/539f68a7-850f-4cd0-a30a-5e8431752e10)

## 🚀 New behavior

Adds information about the fact that it doesn't work if columns are defined.
"(must not be used with `columns`)"

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A