### PR TITLE
fix: divide utility merging

### DIFF
--- a/.changeset/tender-parents-sin.md
+++ b/.changeset/tender-parents-sin.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/shared': patch
+'@pandacss/core': patch
+---
+
+Fix issue where `divideY` and `divideColor` utilities, used together in a recipe, doesn't generate the correct css.

--- a/packages/core/__tests__/serialize.test.ts
+++ b/packages/core/__tests__/serialize.test.ts
@@ -219,4 +219,25 @@ describe('serialize - with token()', () => {
       }
     `)
   })
+
+  test('serialize divide utility', () => {
+    const result = css({
+      html: {
+        divideY: '1px',
+        divideColor: 'red',
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "html": {
+          "& > :not([hidden]) ~ :not([hidden])": {
+            "borderBottomWidth": "0px",
+            "borderColor": "red",
+            "borderTopWidth": "1px",
+          },
+        },
+      }
+    `)
+  })
 })

--- a/packages/shared/src/deep-set.ts
+++ b/packages/shared/src/deep-set.ts
@@ -1,4 +1,5 @@
 import { isObject } from './assert'
+import { mergeProps } from './merge-props'
 
 type Dict = Record<string, any>
 
@@ -6,7 +7,7 @@ export const deepSet = <T extends Dict>(target: T, path: string[], value: Dict |
   const isValueObject = isObject(value)
 
   if (!path.length && isValueObject) {
-    return Object.assign(target, value) as T
+    return mergeProps(target, value) as T
   }
 
   let current = target as Dict
@@ -14,9 +15,7 @@ export const deepSet = <T extends Dict>(target: T, path: string[], value: Dict |
   for (let i = 0; i < path.length; i++) {
     const key = path[i]
 
-    if (!current[key]) {
-      current[key] = {}
-    }
+    current[key] ||= {}
 
     if (i === path.length - 1) {
       if (isValueObject && isObject(current[key])) {

--- a/packages/shared/src/deep-set.ts
+++ b/packages/shared/src/deep-set.ts
@@ -19,7 +19,7 @@ export const deepSet = <T extends Dict>(target: T, path: string[], value: Dict |
 
     if (i === path.length - 1) {
       if (isValueObject && isObject(current[key])) {
-        current[key] = Object.assign({ ...current[key] }, value)
+        current[key] = mergeProps(current[key], value)
       } else {
         current[key] = value
       }


### PR DESCRIPTION
Closes #2772

## 📝 Description

Fix issue where `divideY` and `divideColor` utilities, used together in a recipe, doesn't generate the correct css.

## ⛳️ Current behavior (updates)

Only the last one of `divideY` or `divideColor` works

## 🚀 New behavior

Works as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
