### PR TITLE
fix: token reference expansion

### DIFF
--- a/.changeset/ninety-cheetahs-count.md
+++ b/.changeset/ninety-cheetahs-count.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/token-dictionary': patch
+---
+
+Fix issue where shadow token with color opacity modifier produces incorrect css value

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -10,6 +10,33 @@ const tokenCss = (config?: Config) => {
 }
 
 describe('generator', () => {
+  test('shadow tokens', () => {
+    const css = tokenCss({
+      eject: true,
+      theme: {
+        tokens: {
+          colors: {
+            primary: { value: '#f9a4d6' },
+            secondary: { value: '{colors.primary/20}' },
+          },
+          shadows: {
+            test: { value: '0 4px 20px 0 {colors.primary/30}' },
+          },
+        },
+      },
+    })
+
+    expect(css).toMatchInlineSnapshot(`
+      "@layer tokens {
+        :where(html) {
+          --colors-primary: #f9a4d6;
+          --colors-secondary: color-mix(in srgb, var(--colors-primary) 20%, transparent);
+          --shadows-test: 0 4px 20px 0 color-mix(in srgb, var(--colors-primary) 30%, transparent);
+      }
+      }"
+    `)
+  })
+
   test('[css] should generate css', () => {
     expect(tokenCss()).toMatchInlineSnapshot(`
       "@layer tokens {

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -21,6 +21,11 @@ describe('generator', () => {
           },
           shadows: {
             test: { value: '0 4px 20px 0 {colors.primary/30}' },
+            test2: { value: { blur: 2, spread: 2, color: '{colors.primary/20}', offsetX: 0, offsetY: 0 } },
+          },
+          borders: {
+            test: { value: '2px solid {colors.primary/40}' },
+            test2: { value: { width: '1px', style: 'solid', color: '{colors.primary/40}' } },
           },
         },
       },
@@ -32,6 +37,9 @@ describe('generator', () => {
           --colors-primary: #f9a4d6;
           --colors-secondary: color-mix(in srgb, var(--colors-primary) 20%, transparent);
           --shadows-test: 0 4px 20px 0 color-mix(in srgb, var(--colors-primary) 30%, transparent);
+          --shadows-test2: 0px 0px 2px 2px color-mix(in srgb, var(--colors-primary) 20%, transparent);
+          --borders-test: 2px solid color-mix(in srgb, var(--colors-primary) 40%, transparent);
+          --borders-test2: 1px solid color-mix(in srgb, var(--colors-primary) 40%, transparent);
       }
       }"
     `)


### PR DESCRIPTION
Closes #2782

## 📝 Description

Fix issue where shadow token with color opacity modifier produces incorrect css value

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
