### PR TITLE
refactor: make `WithEscapeHatch<T>` much more performant

### DIFF
--- a/.changeset/fresh-dodos-return.md
+++ b/.changeset/fresh-dodos-return.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/generator': patch
+'@pandacss/studio': patch
+---
+
+make `WithEscapeHatch<T>` much more performant
+
+This pull request is a follow-up pull request to #2466.
+
+Make `WithEscapeHatch<T>` much more performant and typescript happy by updating the type signature of `WithImportant<T>`
+and `WithColorOpacityModifier<T>` to use _branded type_ and _non-distributive conditional types_, while keeping such
+tokens valid and also not appearing in autocompletions to prevent them from polluting autocompletion result (which is
+the current behavior).

--- a/packages/generator/__tests__/generate-prop-types.test.ts
+++ b/packages/generator/__tests__/generate-prop-types.test.ts
@@ -211,12 +211,12 @@ describe('generate property types', () => {
 
 
 
-      type WithColorOpacityModifier<T> = T extends string ? \`\${T}/\${string}\` : T
+      type WithColorOpacityModifier<T> = [T] extends [string] ? \`\${T}/\${string}\` & { __colorOpacityModifier?: true } : never
 
       type ImportantMark = "!" | "!important"
       type WhitespaceImportant = \` \${ImportantMark}\`
       type Important = ImportantMark | WhitespaceImportant
-      type WithImportant<T> = T extends string ? \`\${T}\${Important}\` & { __important?: true } : T;
+      type WithImportant<T> = [T] extends [string] ? \`\${T}\${Important}\` & { __important?: true } : never
 
       /**
        * Only relevant when using \`strictTokens\` or \`strictPropertyValues\` in your config.
@@ -283,12 +283,12 @@ describe('generate property types', () => {
 
 
 
-      type WithColorOpacityModifier<T> = T extends string ? \`\${T}/\${string}\` : T
+      type WithColorOpacityModifier<T> = [T] extends [string] ? \`\${T}/\${string}\` & { __colorOpacityModifier?: true } : never
 
       type ImportantMark = "!" | "!important"
       type WhitespaceImportant = \` \${ImportantMark}\`
       type Important = ImportantMark | WhitespaceImportant
-      type WithImportant<T> = T extends string ? \`\${T}\${Important}\` & { __important?: true } : T;
+      type WithImportant<T> = [T] extends [string] ? \`\${T}\${Important}\` & { __important?: true } : never
 
       /**
        * Only relevant when using \`strictTokens\` or \`strictPropertyValues\` in your config.

--- a/packages/generator/src/artifacts/types/prop-types.ts
+++ b/packages/generator/src/artifacts/types/prop-types.ts
@@ -24,12 +24,12 @@ export function generatePropTypes(ctx: Context) {
   return outdent`
   ${result.join('\n')}
 
-  type WithColorOpacityModifier<T> = T extends string ? \`$\{T}/\${string}\` : T
+  type WithColorOpacityModifier<T> = [T] extends [string] ? \`$\{T}/\${string}\` & { __colorOpacityModifier?: true } : never
 
   type ImportantMark = "!" | "!important"
   type WhitespaceImportant = \` \${ImportantMark}\`
   type Important = ImportantMark | WhitespaceImportant
-  type WithImportant<T> = T extends string ? \`\${T}\${Important}\` & { __important?: true } : T;
+  type WithImportant<T> = [T] extends [string] ? \`\${T}\${Important}\` & { __important?: true } : never
 
   /**
    * Only relevant when using \`strictTokens\` or \`strictPropertyValues\` in your config.

--- a/packages/studio/styled-system/types/prop-type.d.ts
+++ b/packages/studio/styled-system/types/prop-type.d.ts
@@ -207,12 +207,12 @@ export interface UtilityValues {
 
 
 
-type WithColorOpacityModifier<T> = T extends string ? `${T}/${string}` : T
+type WithColorOpacityModifier<T> = [T] extends [string] ? `${T}/${string}` & { __colorOpacityModifier?: true } : never
 
 type ImportantMark = "!" | "!important"
 type WhitespaceImportant = ` ${ImportantMark}`
 type Important = ImportantMark | WhitespaceImportant
-type WithImportant<T> = T extends string ? `${T}${Important}` & { __important?: true } : T;
+type WithImportant<T> = [T] extends [string] ? `${T}${Important}` & { __important?: true } : never
 
 /**
  * Only relevant when using `strictTokens` or `strictPropertyValues` in your config.


### PR DESCRIPTION
This pull request is a follow-up pull request to #2466.

## 📝 Description

Make `WithEscapeHatch<T>` much more performant and typescript happy by updating the type signature of `WithImportant<T>` and `WithColorOpacityModifier<T>` to use *branded type* and *non-distributive conditional types*, while keeping such tokens valid and also not appearing in autocompletions to prevent them from polluting autocompletion result (which is the current behavior).

## ⛳️ Current behavior (updates)

Current type signaure of `WithImportant<T>` and `WithColorOpacityModifier<T>` somehow makes typescript compiler unhappy and slows down both code autocompletion and linting.

## 🚀 New behavior

New type signaure of `WithImportant<T>` and `WithColorOpacityModifier<T>` is much more performant. On using `svelte-check` in large codebase was taking over 3 minutes but now it takes under 4 seconds. VSCode autocompletion is also nearly instant, instead of taking ~5 seconds to show.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
