### PR TITLE
fix(website): adjust the mobile menu button appear breakpoint

### DIFF
--- a/website/theme/recipes/navbar.recipe.ts
+++ b/website/theme/recipes/navbar.recipe.ts
@@ -97,7 +97,7 @@ export const navbarRecipe = defineRecipe({
       rounded: 'sm',
       p: '2',
       _active: { bg: 'rgb(156 163 175 / 0.2)' },
-      md: { display: 'none' },
+      sm: { display: 'none' },
       '& svg': {
         '& g': {
           transformOrigin: 'center',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Hi everyone, I noticed that the doc website's mobile menu button appears at the wrong breakpoint.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

https://github.com/user-attachments/assets/2ffe15da-fa27-4f0d-9da9-d182a61dae22

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

https://github.com/user-attachments/assets/15ae0296-e2e0-4d72-93e7-4a1f5c944591

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No

## 📝 Additional Information
