### PR TITLE
perf(shared): do not check if value is important before checking if it is null

### DIFF
--- a/packages/shared/src/classname.ts
+++ b/packages/shared/src/classname.ts
@@ -61,9 +61,9 @@ export function createCss(context: CreateCssContext) {
     const classNames = new Set<string>()
 
     walkObject(normalizedObject, (value, paths) => {
-      const important = isImportant(value)
-
       if (value == null) return
+
+      const important = isImportant(value)
 
       const [prop, ...allConditions] = conds.shift(paths)
       const conditions = filterBaseConditions(allConditions)


### PR DESCRIPTION
## 📝 Description

Just a quick early return that probably won't occur too often

## ⛳️ Current behavior (updates)

Css checks if value is important before checking if it is null

## 🚀 New behavior

Css checks if value is important after checking for null

## 💣 Is this a breaking change (Yes/No):

No

