### PR TITLE
perf(shared): return early if obj is falsy, avoiding an additional traversal

### DIFF
--- a/packages/shared/src/merge-props.ts
+++ b/packages/shared/src/merge-props.ts
@@ -1,8 +1,8 @@
 import { isObject } from './assert'
 
 export function mergeProps<T extends Record<string, unknown>>(...sources: T[]): T {
-  const objects = sources.filter(Boolean)
-  return objects.reduce((prev: any, obj) => {
+  return sources.reduce((prev: any, obj) => {
+    if (!obj) return prev
     Object.keys(obj).forEach((key) => {
       const prevValue = prev[key]
       const value = obj[key]


### PR DESCRIPTION
## 📝 Description

There's no reason to filter through all objects before reducing. We can just return early if the value is falsy.

## 💣 Is this a breaking change (Yes/No):

No
