### PR TITLE
perf(artifacts): do not construct the condition regex within `isCondition` function body

### DIFF
--- a/packages/generator/src/artifacts/js/conditions.ts
+++ b/packages/generator/src/artifacts/js/conditions.ts
@@ -10,8 +10,10 @@ export function generateConditions(ctx: Context) {
     const conditionsStr = "${keys.join(',')}"
     const conditions = new Set(conditionsStr.split(','))
 
+    const conditionRegex = /^@|&|&$/
+
     export function isCondition(value){
-      return conditions.has(value) || /^@|&|&$/.test(value)
+      return conditions.has(value) || conditionRegex.test(value)
     }
 
     const underscoreRegex = /^_/

--- a/packages/studio/styled-system/css/conditions.mjs
+++ b/packages/studio/styled-system/css/conditions.mjs
@@ -3,8 +3,10 @@ import { withoutSpace } from '../helpers.mjs';
 const conditionsStr = "_hover,_focus,_focusWithin,_focusVisible,_disabled,_active,_visited,_target,_readOnly,_readWrite,_empty,_checked,_enabled,_expanded,_highlighted,_before,_after,_firstLetter,_firstLine,_marker,_selection,_file,_backdrop,_first,_last,_only,_even,_odd,_firstOfType,_lastOfType,_onlyOfType,_peerFocus,_peerHover,_peerActive,_peerFocusWithin,_peerFocusVisible,_peerDisabled,_peerChecked,_peerInvalid,_peerExpanded,_peerPlaceholderShown,_groupFocus,_groupHover,_groupActive,_groupFocusWithin,_groupFocusVisible,_groupDisabled,_groupChecked,_groupExpanded,_groupInvalid,_indeterminate,_required,_valid,_invalid,_autofill,_inRange,_outOfRange,_placeholder,_placeholderShown,_pressed,_selected,_default,_optional,_open,_closed,_fullscreen,_loading,_currentPage,_currentStep,_motionReduce,_motionSafe,_print,_landscape,_portrait,_dark,_light,_osDark,_osLight,_highContrast,_lessContrast,_moreContrast,_ltr,_rtl,_scrollbar,_scrollbarThumb,_scrollbarTrack,_horizontal,_vertical,_starting,sm,smOnly,smDown,md,mdOnly,mdDown,lg,lgOnly,lgDown,xl,xlOnly,xlDown,2xl,2xlOnly,2xlDown,smToMd,smToLg,smToXl,smTo2xl,mdToLg,mdToXl,mdTo2xl,lgToXl,lgTo2xl,xlTo2xl,@/xs,@/sm,@/md,@/lg,@/xl,@/2xl,@/3xl,@/4xl,@/5xl,@/6xl,@/7xl,@/8xl,base"
 const conditions = new Set(conditionsStr.split(','))
 
+const conditionRegex = /^@|&|&$/
+
 export function isCondition(value){
-  return conditions.has(value) || /^@|&|&$/.test(value)
+  return conditions.has(value) || conditionRegex.test(value)
 }
 
 const underscoreRegex = /^_/

--- a/packages/studio/styled-system/helpers.mjs
+++ b/packages/studio/styled-system/helpers.mjs
@@ -64,8 +64,9 @@ var memo = (fn) => {
 
 // src/merge-props.ts
 function mergeProps(...sources) {
-  const objects = sources.filter(Boolean);
-  return objects.reduce((prev, obj) => {
+  return sources.reduce((prev, obj) => {
+    if (!obj)
+      return prev;
     Object.keys(obj).forEach((key) => {
       const prevValue = prev[key];
       const value = obj[key];
@@ -165,9 +166,9 @@ function createCss(context) {
     const normalizedObject = normalizeStyleObject(styleObject, context);
     const classNames = /* @__PURE__ */ new Set();
     walkObject(normalizedObject, (value, paths) => {
-      const important = isImportant(value);
       if (value == null)
         return;
+      const important = isImportant(value);
       const [prop, ...allConditions] = conds.shift(paths);
       const conditions = filterBaseConditions(allConditions);
       const transformed = utility.transform(prop, withoutImportant(sanitize(value)));


### PR DESCRIPTION
## 📝 Description

More low-hanging fruit. Just moving the regex creation out of the function body.

## 💣 Is this a breaking change (Yes/No):

No
