### PR TITLE
docs: add `globalFontface` to preset

### DIFF
--- a/website/pages/docs/customization/presets.md
+++ b/website/pages/docs/customization/presets.md
@@ -60,6 +60,7 @@ The available keys for a preset are:
 
 - [`conditions`](/docs/concepts/conditional-styles)
 - [`globalCss`](/docs/concepts/writing-styles#global-styles)
+- [`globalFontface`](/docs/guides/fonts#global-font-face)
 - [`patterns`](/docs/concepts/patterns)
 - [`staticCss`](/docs/guides/static)
 - [`theme`](/docs/customization/theme)


### PR DESCRIPTION
## 📝 Description

Preset has supported `globalFontface`.
This PR add that to document.

## ⛳️ Current behavior (updates)

No Change

## 🚀 New behavior

No Change

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

`globalFontface` is introduced in https://github.com/chakra-ui/panda/pull/2738
It appears to be already supported at that point.