### PR TITLE
docs: add example for bgGradient based on tokens

### DIFF
--- a/website/pages/docs/utilities/background.md
+++ b/website/pages/docs/utilities/background.md
@@ -34,6 +34,40 @@ Properties to create a background gradient based on color stops.
 />
 ```
 
+You can provide also a string value to `bgGradient` or `textGradient` to use a gradient token. 
+```ts
+const theme = {
+  tokens: {
+    gradients: { 
+      // string value
+      simple: { value: 'linear-gradient(to right, red, blue)' },
+      // composite value
+      primary: {
+        value: {
+          type: 'linear',
+          placement: 'to right',
+          stops: ['red', 'blue']
+        }
+      }
+    }
+  }
+}
+```    
+
+```jsx
+<div
+  className={css({
+    bgGradient: "token(gradients.simple)",
+  })}
+/>
+
+<div
+  className={css({
+    bgGradient: "token(gradients.primary)",
+  })}
+/>
+```
+
 | Prop           | CSS Property       | Token Category |
 | -------------- | ------------------ | -------------- |
 | `bgGradient`   | `background-image` | `gradients`    |

--- a/website/pages/docs/utilities/background.md
+++ b/website/pages/docs/utilities/background.md
@@ -34,7 +34,7 @@ Properties to create a background gradient based on color stops.
 />
 ```
 
-Background and text gradients can be connected to a design tokens. Here's how to define a gradient token in your theme.
+Background and text gradients can be connected to design tokens. Here's how to define a gradient token in your theme.
 
 ```ts
 const theme = {
@@ -55,7 +55,7 @@ const theme = {
 }
 ```
 
-To use a gradient token, provide a string value to `bgGradient` or `textGradient`.
+These tokens can be used in the `bgGradient` or `textGradient` properties.
 
 ```jsx
 <div

--- a/website/pages/docs/utilities/background.md
+++ b/website/pages/docs/utilities/background.md
@@ -34,11 +34,12 @@ Properties to create a background gradient based on color stops.
 />
 ```
 
-You can provide also a string value to `bgGradient` or `textGradient` to use a gradient token. 
+Background and text gradients can be connected to a design tokens. Here's how to define a gradient token in your theme.
+
 ```ts
 const theme = {
   tokens: {
-    gradients: { 
+    gradients: {
       // string value
       simple: { value: 'linear-gradient(to right, red, blue)' },
       // composite value
@@ -52,18 +53,20 @@ const theme = {
     }
   }
 }
-```    
+```
+
+To use a gradient token, provide a string value to `bgGradient` or `textGradient`.
 
 ```jsx
 <div
   className={css({
-    bgGradient: "token(gradients.simple)",
+    bgGradient: "simple",
   })}
 />
 
 <div
   className={css({
-    bgGradient: "token(gradients.primary)",
+    bgGradient: "primary",
   })}
 />
 ```


### PR DESCRIPTION

Related to: https://github.com/chakra-ui/panda/discussions/1656

## 📝 Description
Improved documentation for using bgGradient.

## ⛳️ Current behavior (updates)

Usage of gradients is not intuitive since it doesn't work with `backgroundImage`. Better documentation needed.

## 🚀 New behavior

Added documentation examples for using `bgGradient` based on tokens.

## 💣 Is this a breaking change (Yes/No):

No

