### PR TITLE
fix(website): adjust sticky-top of toc to prevent content being cut off

### DIFF
--- a/website/src/nextra/toc.tsx
+++ b/website/src/nextra/toc.tsx
@@ -68,7 +68,7 @@ export function TOC({ headings, filePath }: TOCProps) {
         css({
           ms: '4',
           position: 'sticky',
-          top: '16',
+          top: '20',
           overflowY: 'auto',
           pe: '4',
           pt: '8',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Hi everyone, I noticed that part of the table of contents gets cut off due to insufficient sticky top spacing, so I adjusted `top: 16` to `top: 20`. Feel free to close this if it's unnecessary.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

![image](https://github.com/user-attachments/assets/dc5b94a0-2e18-4966-9e47-a584e8da9e34)

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

![image](https://github.com/user-attachments/assets/dfc81524-29ea-4b47-a18e-34c6da001e99)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No

## 📝 Additional Information
