### PR TITLE
fix(website): prevent li within non-permitted parent elements

### DIFF
--- a/website/src/components/feature-marquee.tsx
+++ b/website/src/components/feature-marquee.tsx
@@ -28,12 +28,12 @@ export const FeatureMarquee = () => {
         autoFill
       >
         {features.map((feature, index) => (
-          <panda.li key={index} mx="2">
+          <panda.div key={index} mx="2">
             <HStack gap="4">
               <panda.span letterSpacing="tight">{feature}</panda.span>
               <span>•</span>
             </HStack>
-          </panda.li>
+          </panda.div>
         ))}
       </Marquee>
     </panda.div>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Hi everyone, I noticed that the `li` elements in `feature-marquee.tsx` were not placed within permitted parent elements, so I replaced them with `div` elements.

Feel free to close this if I missed somthing.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

```html
<div class="rfm-child">
  <li class="mx_2"> <!-- here -->
    <div class="d_flex ai_center gap_4 flex-d_row">
      <span class="ls_tight">Design Tokens</span>
      <span>•</span>
    </div>
  </li>
</div>
```

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

```html
<div class="rfm-child">
  <div class="mx_2"> <!-- here -->
    <div class="d_flex ai_center gap_4 flex-d_row">
      <span class="ls_tight">Design Tokens</span>
      <span>•</span>
    </div>
  </div>
</div>
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No

## 📝 Additional Information

N/A