### PR TITLE
fix(postcss): race condition on builder instance for simultaneous plugin invocations

### DIFF
--- a/.changeset/fast-zebras-live.md
+++ b/.changeset/fast-zebras-live.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/postcss': patch
+---
+
+fix(postcss): race condition on builder instance for simultaneous plugin invocations


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes [#2916](https://github.com/chakra-ui/panda/discussions/2916)

## 📝 Description

Fixes postcss race condition because builder instance is singelton, and postcss plugin is async.

## ⛳️ Current behavior (updates)

Reported in bug report.

## 🚀 New behavior

Added `builderGuard` which allow only one plugin invocation to be run at a time, other invocations will wait. Tested on my instance.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
