### PR TITLE
docs: fix title of effects page

### DIFF
--- a/website/pages/docs/utilities/effects.md
+++ b/website/pages/docs/utilities/effects.md
@@ -3,7 +3,7 @@ title: Effects
 description: Panda provides utilities or style properties for applying various visual effects to elements.
 ---
 
-# Background
+# Effects
 
 Panda offers a range of utilities or style properties for applying visual effects to elements. These effects include opacity, shadows, blending modes, filters, and more.
 


### PR DESCRIPTION
## 📝 Description

Fixed the utilities/effects page title from `Background` to `Effects`.

## ⛳️ Current behavior (updates)

No Change

## 🚀 New behavior

No Change

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://panda-css.com/docs/utilities/effects