### PR TITLE
docs: fix example value more realistic

### DIFF
--- a/website/pages/docs/theming/text-styles.md
+++ b/website/pages/docs/theming/text-styles.md
@@ -31,7 +31,7 @@ export const textStyles = defineTextStyles({
       fontFamily: 'Inter',
       fontWeight: '500',
       fontSize: '16px',
-      lineHeight: '24',
+      lineHeight: '24px',
       letterSpacing: '0',
       textDecoration: 'None',
       textTransform: 'None'


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Changed the lineHeight value from '24' to '24px' in the body text style to make the examples more realistic.

## ⛳️ Current behavior (updates)

The `lineHeight` is set to a unitless value of `24`, which may not accurately reflect real-world usage.

## 🚀 New behavior

Although I’m not sure if this was the value originally intended by the author, I have changed it based on my assumption. It may be appropriate to adjust it to a more suitable value later.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
