### PR TITLE
docs: remove unnecessary code block around table

### DIFF
--- a/website/pages/docs/utilities/layout.md
+++ b/website/pages/docs/utilities/layout.md
@@ -66,9 +66,6 @@ Use the `inset{Start|End}` utilities to set the position of an element based on 
 
 You can define container names and sizes in your theme configuration and use them in your styles. [Read more.](/docs/concepts/conditional-styles#container-queries)
 
-```jsx
-
 | Prop            | CSS Property    | Token Category   |
 | --------------- | --------------- | ---------------- |
 | `containerName` | `containerName` | `containerNames` |
-```


### PR DESCRIPTION
## 📝 Description

I fixed the layout issue in the Container Query section on the [layout utilities page](https://panda-css.com/docs/utilities/layout), where the table was incorrectly displayed inside a code block.

| before | after |
| :-- | :-- |
| ![before](https://github.com/user-attachments/assets/4e6c6c29-6abd-465f-a5b9-ce9bccb25e1e) | ![after](https://github.com/user-attachments/assets/ac784902-df8a-414b-95a8-b7cddf01fc3e) |

## ⛳️ Current behavior (updates)

No Change

## 🚀 New behavior

No Change

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

https://panda-css.com/docs/utilities/layout
