### PR TITLE
docs: fix wrong config emitTokensOnly link at cli emitTokensOnly

### DIFF
--- a/website/pages/docs/references/cli.md
+++ b/website/pages/docs/references/cli.md
@@ -187,7 +187,7 @@ Related: [`config.polyfill`](/docs/references/config#polyfill)
 
 Whether to only emit the `tokens` directory
 
-Related: [`config.emitTokensOnly`](/docs/references/config#emitTokensOnly)
+Related: [`config.emitTokensOnly`](/docs/references/config#emittokensonly)
 
 #### `--cpu-prof`
 


### PR DESCRIPTION
Closes # 

## 📝 Description

> Add a brief description

I found wrong link at cli emitTokensOnly and fixed it.
( I'm really enjoying this library, thanks for maintaining. )


## ⛳️ Current behavior (updates)

The shortcut for config emitTokensOnly doesn't work correctly.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The shortcut for config emitTokensOnly works correctly.

https://github.com/user-attachments/assets/3914602c-d045-4fd2-960f-0511fb3ba142




## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
