### PR TITLE
docs: fix wrong config link at cli reference

### DIFF
--- a/website/pages/docs/references/cli.md
+++ b/website/pages/docs/references/cli.md
@@ -55,7 +55,7 @@ Whether to run the codegen process
 
 The extension of the generated js files (default: 'mjs')
 
-Related: [`config.outExtension`](/docs/references/config#outExtension)
+Related: [`config.outExtension`](/docs/references/config#outextension)
 
 #### `--outdir <dir>`
 
@@ -67,7 +67,7 @@ Related: [`config.outdir`](/docs/references/config#outdir)
 
 The jsx framework to use
 
-Related: [`config.jsxFramework`](/docs/references/config#jsxFramework)
+Related: [`config.jsxFramework`](/docs/references/config#jsxframework)
 
 #### `--syntax <syntax>`
 
@@ -79,7 +79,7 @@ Related: [`config.syntax`](/docs/references/config#syntax)
 
 Set strictTokens to true
 
-Related: [`config.strictTokens`](/docs/references/config#strictTokens)
+Related: [`config.strictTokens`](/docs/references/config#stricttokens)
 
 #### `--logfile <file>`
 


### PR DESCRIPTION
Closes # 

## 📝 Description

https://github.com/chakra-ui/panda/pull/2969#issuecomment-2466089602


Fixed additional incorrect links.
- outExtension
- jsxFramework
- strictTokens

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

The shortcut for config doesn't work correctly.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

The shortcut for config works correctly.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
The cli reference page no longer seems to have any incorrect links.
