### PR TITLE
fix(css): self-nesting works wrong way with conditions

### DIFF
--- a/.changeset/brave-wolves-draw.md
+++ b/.changeset/brave-wolves-draw.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/core": patch
+---
+
+fix(css): self-nesting works wrong way with conditions

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -11,7 +11,7 @@ import { Breakpoints } from './breakpoints'
 import { parseCondition } from './parse-condition'
 import { compareAtRuleOrMixed } from './sort-style-rules'
 
-const order: ConditionType[] = ['at-rule', 'self-nesting', 'combinator-nesting', 'parent-nesting']
+const order: ConditionType[] = ['at-rule', 'self-nesting', 'combinator-nesting', 'parent-nesting', 'mixed']
 
 interface Options {
   conditions?: ConditionsConfig


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixed multiple conditions order with self-nesting, mixed.

> Add a brief description

Repro step
1. Setup panda.config.ts

```typescript
export default defineConfig({
  // ...other options
  conditions: {
  extend: {
      hover: [
        '@media (hover: hover) and (pointer: fine)',
        '&:is(:hover, [data-hover])',
        '&:not(:disabled, [disabled], [data-disabled])',
        '&:not([data-loading])',
      ],
      disabled: ['&:is(:disabled, [disabled], [data-disabled])', '&:not([data-loading])'],
    },
  },
  outdir: 'styled-system',
  outExtension: 'js',
  jsxFramework: 'react',
});
```

2. define self-nesting css that can select multiple elements

```typescript

const Breadcrumb = ({ className }: { className?: string }) => {
  return (
    <nav aria-label='Breadcrumb' className={className}>
      <ul
        className={flex({
          gap: 4,
          align: 'center',
          '& li': {
            display: 'flex',
            alignItems: 'center',
          },
          '& *': {
            color: 'content.default.level-2',
            textStyle: 'Text/M/Strong',
          },
          '& a': {
            transition: 'color .3s',
            _hover: {
              color: 'content.interaction.hover',
            },
          },
        })}
      >
        <li>
          <a href='/'>Home</a>
        </li>
        <li>
          <a href='/blog'>Blog</a>
        </li>
      </ul>
    </nav>
  );
};

export default Breadcrumb;
```

at the above, `_hover` selector is nested in `& a` selector.
but current behavior, that style applied when `ul` is hovered and applied all of `a` elements.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

Maybe No
<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
