### PR TITLE
chore(.github): update action version in workflow files

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: pnpm/action-setup@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/composite-actions/install
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/composite-actions/install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Slack Notification
         if: steps.changesets.outputs.published == 'true'
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v2
         with:
           payload: |
             {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Updated the versions of actions in the workflow files, including `actions/setup-node` to `v4`, `actions/checkout` to `v4`, and `slackapi/slack-github-action` to `v2`, to ensure compatibility and leverage the latest features and fixes provided by these releases.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

* The workflow currently uses an older version of `actions/setup-node` (e.g., v2 or v3), which may lack the latest updates or features available in the `v4` release.
* The workflow uses an older version of `actions/checkout` that may not include the improvements and optimizations available in the `v4` release.
* The workflow uses an older version of `slackapi/slack-github-action`, which may not include the updates and fixes provided in the `v2` release.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

* The workflow now uses `actions/setup-node@v4`, providing improved performance, new features, and the latest fixes introduced in the updated version.
* The workflow now uses `actions/checkout@v4`, incorporating the latest enhancements for managing repository checkouts during workflows.
* The workflow now uses `slackapi/slack-github-action@v2`, enabling better integration with Slack and leveraging the latest improvements and fixes.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

No.

## 📝 Additional Information