### PR TITLE
docs: fix typo issue

### DIFF
--- a/website/pages/docs/utilities/tables.md
+++ b/website/pages/docs/utilities/tables.md
@@ -36,7 +36,7 @@ Control the horizontal border-spacing property of a table.
 Control the vertical border-spacing property of a table.
 
 ```jsx
-<table className={css({ borderSpacingX: '2' })} />
+<table className={css({ borderSpacingY: '2' })} />
 ```
 
 | Prop             | CSS Property     | Token Category |


### PR DESCRIPTION
## 📝 Description

> Corrected the 'Border Spacing Y' example in the documentation. Changed `borderSpacingX` to `borderSpacingY` to accurately reflect the vertical border-spacing property of a table.