### PR TITLE
wip: file-matcher

### DIFF
--- a/packages/core/__tests__/file-matcher.test.ts
+++ b/packages/core/__tests__/file-matcher.test.ts
@@ -105,7 +105,7 @@ describe('file matcher', () => {
     expect(file.isValidPattern('stack')).toMatchInlineSnapshot('true')
 
     expect(file.isValidPattern('__vstack')).toMatchInlineSnapshot('true')
-    expect(file.isValidPattern('vstack')).toMatchInlineSnapshot('true')
+    expect(file.isValidPattern('vstack')).toMatchInlineSnapshot('false') // This shouldnt match vstack is aliased as __vstack
   })
 
   test('is valid recipe', () => {
@@ -126,10 +126,10 @@ describe('file matcher', () => {
     ])
 
     expect(file.isValidRecipe('randxxx')).toMatchInlineSnapshot('false')
-    expect(file.isValidRecipe('button')).toMatchInlineSnapshot('true')
+    expect(file.isValidRecipe('button')).toMatchInlineSnapshot('false') // this shouldnt match button is aliased as buttonStyle
 
     expect(file.isValidRecipe('buttonStyle')).toMatchInlineSnapshot('true')
-    expect(file.isValidRecipe('button')).toMatchInlineSnapshot('true')
+    expect(file.isValidRecipe('button')).toMatchInlineSnapshot('false') // Redundant test?
     expect(file.isValidRecipe('xxxbutton')).toMatchInlineSnapshot('false')
   })
 
@@ -137,16 +137,23 @@ describe('file matcher', () => {
     const ctx = createContext()
 
     const file = ctx.imports.file([
+      { mod: 'other-system/css', name: 'css', alias: 'css' },
       { mod: 'styled-system/css', name: 'css', alias: 'xcss' },
       { mod: 'styled-system/css', name: 'cva', alias: 'cva' },
       { mod: 'styled-system/patterns', name: 'stack', alias: 'stack' },
+      { mod: 'styled-system/patterns', name: 'grid', alias: 'aliasedGrid' },
     ])
 
-    expect(file.isRawFn('css')).toMatchInlineSnapshot('true')
-    expect(file.isRawFn('xcss')).toMatchInlineSnapshot('false')
+    expect(file.isRawFn('css')).toMatchInlineSnapshot('false')
+    expect(file.isRawFn('xcss')).toMatchInlineSnapshot('true')
 
-    expect(file.isRawFn('css.raw')).toMatchInlineSnapshot('true')
+    expect(file.isRawFn('css.raw')).toMatchInlineSnapshot('false')
+    expect(file.isRawFn('xcss.raw')).toMatchInlineSnapshot('true')
+
     expect(file.isRawFn('stack.raw')).toMatchInlineSnapshot('true')
+
+    expect(file.isRawFn('card.raw')).toMatchInlineSnapshot('false')
+    expect(file.isRawFn('aliasedGrid.raw')).toMatchInlineSnapshot('true')
 
     expect(file.isRawFn('cva.raw')).toMatchInlineSnapshot('false')
   })

--- a/packages/core/src/file-matcher.ts
+++ b/packages/core/src/file-matcher.ts
@@ -145,8 +145,11 @@ export class FileMatcher {
         if (mod.kind === 'namespace') {
           return keys.includes(id.replace(`${mod.alias}.`, ''))
         }
-
-        return mod.alias === id || mod.name === id
+        // prefer alias
+        if (mod.alias) {
+          return mod.alias === id
+        }
+        return mod.name === id
       })
     })
   }
@@ -177,9 +180,16 @@ export class FileMatcher {
     return this._recipesMatcher(id)
   }
 
+  private _cssMatcher: ReturnType<typeof this.createMatch> | undefined
+
+  isValidCss = (id: string) => {
+    this._cssMatcher ||= this.createMatch(this.importMap.css, ['css'])
+    return this._cssMatcher(id)
+  }
+
   isRawFn = (fnName: string) => {
     const name = fnName.split('.raw')[0] ?? ''
-    return name === 'css' || this.isValidPattern(name) || this.isValidRecipe(name)
+    return this.isValidCss(name) || this.isValidPattern(name) || this.isValidRecipe(name)
   }
 
   isNamespaced = (fnName: string) => {


### PR DESCRIPTION
## 📝 Description

Only parse styles using the `css` function when they are valid sources provided by `importMap`.

## ⛳️ Current behavior (updates)

`file-matcher` is too greedy and parses any encounter of `css` in the file. This leads to additional CSS styles being generated that shouldn't be included.


## 🚀 New behavior

1. Parse `css` only when the CSS function is used from a valid `importMap` source.
2. Prefer matching using `alias` instead of matching both on `key` and `alias`. `key` could be anything arbitrary (something from another import source perhaps) See: https://play.panda-css.com/AFgHUiMXKl 


## 💣 Is this a breaking change (Yes/No):

Yes. With more strictness other tests fail which IMO should have failed. 
For example, the test [ast parser[without import] should not parse](https://github.com/chakra-ui/panda/blob/046521b6a21160bfdf1d97925cb58127fca161c5/packages/parser/__tests__/css-2.test.ts#L5) doesn't have an import to `styled-system` yet, it's producing CSS.


## 📝 Additional Information

There's a lot to Panda, and this change only scratches the surface. My hope is this can aid the team in providing a proper fix.
I intentionally left other tests in a broken state so they could be reviewed by the team, a majority of the failures are due to the tests not having a proper import statement to `styled-system`. These test snapshots need to be updated because `css` isn't parsed unless it's present in a valid import.