### PR TITLE
fix: generated `CssVarKeys` type cannot provide autocomplete correctly

### DIFF
--- a/.changeset/funny-plums-brake.md
+++ b/.changeset/funny-plums-brake.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Fix issue where generated `CssVarKeys` type cannot provide autocomplete correctly

--- a/packages/generator/__tests__/generate-style-props.test.ts
+++ b/packages/generator/__tests__/generate-style-props.test.ts
@@ -14,8 +14,8 @@ describe('generate property types', () => {
       type CssVars = \`var(--\${string})\`
       type CssVarValue = ConditionalValue<Token | AnyString | (number & {})>
 
-      type CssVarName =  | AnyString
-      type CssVarKeys = \`--\${CssVarName}\`
+      type CssVarName = AnyString
+      type CssVarKeys = \`--\${CssVarName}\` | \`--\${string}\` & {}
 
       export type CssVarProperties = {
         [key in CssVarKeys]?: CssVarValue
@@ -7510,8 +7510,8 @@ describe('generate property types', () => {
       type CssVars = \`var(--\${string})\`
       type CssVarValue = ConditionalValue<Token | AnyString | (number & {})>
 
-      type CssVarName =  | AnyString
-      type CssVarKeys = \`--\${CssVarName}\`
+      type CssVarName = AnyString
+      type CssVarKeys = \`--\${CssVarName}\` | \`--\${string}\` & {}
 
       export type CssVarProperties = {
         [key in CssVarKeys]?: CssVarValue
@@ -15024,8 +15024,8 @@ describe('generate property types', () => {
       type CssVars = "var(--random-color)" | "var(--button-color)"
       type CssVarValue = ConditionalValue<Token | CssVars | AnyString | (number & {})>
 
-      type CssVarName = "random-color" | "button-color" | AnyString
-      type CssVarKeys = \`--\${CssVarName}\`
+      type CssVarName = "random-color" | "button-color"
+      type CssVarKeys = \`--\${CssVarName}\` | \`--\${string}\` & {}
 
       export type CssVarProperties = {
         [key in CssVarKeys]?: CssVarValue

--- a/packages/generator/src/artifacts/types/style-props.ts
+++ b/packages/generator/src/artifacts/types/style-props.ts
@@ -22,8 +22,8 @@ export function generateStyleProps(ctx: Context) {
     type CssVars = ${[cssVars || '`var(--${string})`'].filter(Boolean).join(' | ')}
     type CssVarValue = ConditionalValue<Token${ctx.globalVars.isEmpty() ? '' : ' | CssVars'} | AnyString | (number & {})>
 
-    type CssVarName = ${unionType(ctx.globalVars.names)} | AnyString
-    type CssVarKeys = \`--\${CssVarName}\`
+    type CssVarName = ${unionType(ctx.globalVars.names) || 'AnyString'}
+    type CssVarKeys = \`--\${CssVarName}\` | \`--\${string}\` & {}
 
     export type CssVarProperties = {
       [key in CssVarKeys]?: CssVarValue

--- a/packages/studio/styled-system/types/conditions.d.ts
+++ b/packages/studio/styled-system/types/conditions.d.ts
@@ -146,7 +146,7 @@ export interface Conditions {
 	"_open": string
 	/** `&:is([closed], [data-closed], [data-state="closed"])` */
 	"_closed": string
-	/** `&is(:fullscreen, [data-fullscreen])` */
+	/** `&:is(:fullscreen, [data-fullscreen])` */
 	"_fullscreen": string
 	/** `&:is([data-loading], [aria-busy=true])` */
 	"_loading": string

--- a/packages/studio/styled-system/types/style-props.d.ts
+++ b/packages/studio/styled-system/types/style-props.d.ts
@@ -8,8 +8,8 @@ type AnyString = (string & {})
 type CssVars = `var(--${string})`
 type CssVarValue = ConditionalValue<Token | AnyString | (number & {})>
 
-type CssVarName =  | AnyString
-type CssVarKeys = `--${CssVarName}`
+type CssVarName = 
+type CssVarKeys = `--${CssVarName}` | `--${string}` & {}
 
 export type CssVarProperties = {
   [key in CssVarKeys]?: CssVarValue


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fix issue where generated `CssVarKeys` type cannot provide autocomplete correctly

## ⛳️ Current behavior (updates)

It provides suggestion as if it is just `string` type.

## 🚀 New behavior

Correctly provides declared css variable keys along with `string` type.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

You can easily see the difference of this PR in ts playground: https://www.typescriptlang.org/play/?#code/C4TwDgpgBGDCDO8BqBDATgORQW2gXigHIBrCEAWhUKgB8jSKAjaugCnmDQEsA7AcygAyKAG8AvgEoAUKEgwEydAGkyUAgANy5ACQi4iVJhwQx6qQHpzUawD0A-FJnhoPBYay419MpRbemhE5yrgbKqhpauiGKRrimtFCaOiIc3PzxwuIWVrZ2QA
