### PR TITLE
docs(faq): wrap image in `url()` in Vite imported image example

### DIFF
--- a/website/pages/docs/overview/faq.md
+++ b/website/pages/docs/overview/faq.md
@@ -54,7 +54,7 @@ const Demo = () => {
   return (
     <p
       className={css({ bg: 'red.300', backgroundRepeat: 'repeat' })}
-      style={{ backgroundImage: myImageBackground }}
+      style={{ backgroundImage: `url("${myImageBackground}")` }}
     >
       Hello World
     </p>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When importing an image, Vite only returns the URL. Because of this, to use an image as a `backgroundImage` it needs to be wrapped in `url()`

## ⛳️ Current behavior (updates)

The code example from the docs doesn't work 😢

## 🚀 New behavior

The new code example works 🥳

## 💣 Is this a breaking change (Yes/No):

No