### PR TITLE
docs: fix svg example tag

### DIFF
--- a/website/pages/docs/utilities/svg.md
+++ b/website/pages/docs/utilities/svg.md
@@ -24,7 +24,7 @@ Change the fill color of an SVG element.
 Change the stroke color of an SVG element.
 
 ```jsx
-<div className={css({ stroke: 'blue.500' })} />
+<svg className={css({ stroke: 'blue.500' })} />
 ```
 
 | Prop     | CSS Property | Token Category |
@@ -36,9 +36,9 @@ Change the stroke color of an SVG element.
 Change the stroke width of an SVG element.
 
 ```jsx
-<div className={css({ strokeWidth: '1px' })} />
+<svg className={css({ strokeWidth: '1px' })} />
 ```
 
-| Prop          | CSS Property | Token Category |
-| ------------- | ------------ | -------------- |
-| `strokeWidth` | `stroke-width`     | borderWidths   |
+| Prop          | CSS Property   | Token Category |
+| ------------- | -------------- | -------------- |
+| `strokeWidth` | `stroke-width` | borderWidths   |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

SVG examples are using wrong tag at https://panda-css.com/docs/utilities/svg

## ⛳️ Current behavior (updates)

Uses `<div />`

## 🚀 New behavior

Uses `<svg />`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The IDE auto-formatted the props table but no visual changes were made