### PR TITLE
fix: border token reference

### DIFF
--- a/.changeset/young-cats-develop.md
+++ b/.changeset/young-cats-develop.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/generator': patch
+---
+
+Fix issue where `borderWidth` token reference adds an extra `px` to the generated css value

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -1230,4 +1230,37 @@ describe('generator', () => {
       }"
     `)
   })
+
+  test('border widths', () => {
+    const css = tokenCss({
+      eject: true,
+      theme: {
+        tokens: {
+          borderWidths: {
+            sm: { value: '1px' },
+            md: { value: '2px' },
+          },
+          borders: {
+            netural: {
+              value: { width: '{borderWidths.sm}', color: 'blue', style: 'solid' },
+            },
+            success: {
+              value: { width: '{borderWidths.md}', color: 'green', style: 'solid' },
+            },
+          },
+        },
+      },
+    })
+
+    expect(css).toMatchInlineSnapshot(`
+      "@layer tokens {
+        :where(html) {
+          --border-widths-sm: 1px;
+          --border-widths-md: 2px;
+          --borders-netural: var(--border-widths-sm) solid blue;
+          --borders-success: var(--border-widths-md) solid green;
+      }
+      }"
+    `)
+  })
 })

--- a/packages/token-dictionary/src/utils.ts
+++ b/packages/token-dictionary/src/utils.ts
@@ -26,7 +26,7 @@ export function getReferences(value: string) {
   return matches.map((match) => match.replace(curlyBracketRegex, '')).map((value) => value.trim())
 }
 
-export const hasReference = (value: string) => REFERENCE_REGEX.test(value)
+export const hasReference = (value: string) => getReferences(value).length > 0
 
 const tokenFunctionRegex = /token\(([^)]+)\)/g
 const closingParenthesisRegex = /\)$/g


### PR DESCRIPTION
Closes #3275

## 📝 Description

Fix issue where `borderWidth` token reference adds an extra `px` to the generated css value
