### PR TITLE
Update template-literals.md

### DIFF
--- a/website/pages/docs/concepts/template-literals.md
+++ b/website/pages/docs/concepts/template-literals.md
@@ -1,11 +1,11 @@
 ---
-title: Template Literals
-description: Panda allows you to write styles using template literals.
+title: Template/Object Literals
+description: Panda allows you to write styles using template or object literals.
 ---
 
-# Template Literals
+# Template/Object Literals
 
-Panda allows you use the [template literal syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates) as an alternative to the object literal syntax.
+Panda allows you use both [template literal syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates) and object literal syntax.
 
 This provides a similar experience to [styled-components](https://styled-components.com/) and [emotion](https://emotion.sh/), except that Panda generates atomic class names instead of a single unique class name.
 
@@ -23,6 +23,16 @@ export default defineConfig({
   // ...
   syntax: 'template-literal', // required
   jsxFramework: 'react' // optional
+})
+```
+
+For object literals, you just have to set `jsxFramework` in your `panda.config.ts` file to `react`:
+
+```ts
+// panda.config.ts
+export default defineConfig({
+  // ...
+  jsxFramework: 'react' // required
 })
 ```
 


### PR DESCRIPTION
## 📝 Description

(This is related to the discussion https://github.com/chakra-ui/panda/discussions/3277 )

Currently, these docs mention that template literals are an alternative to object literals but there are actually no docs for setting up object literals except for the styled components migration docs.

In my opinion, styled components and emotion have supported object literals for so many years that the two approaches go hand in hand. And so I think it makes sense to point out how to set up both, independently from the migration section. Especially since I would argue that this process is more straightforward if one already has a basic panda setup.

(I felt it would be best to just show a WIP like this. I understand that if this was merged as is, it might not look pretty in the sidebar. Or maybe you think that this should be structured/done differently.)