### PR TITLE
Add missing comma in code listing in FAQs

### DIFF
--- a/website/pages/docs/overview/faq.md
+++ b/website/pages/docs/overview/faq.md
@@ -18,8 +18,8 @@ When you combine shorthand and longhand properties, Panda will resolve the style
 import { css } from '../styled-system/css'
 
 const styles = css({
-  paddingTop: '20px'
-  padding: "10px",
+  paddingTop: '20px',
+  padding: '10px',
 })
 ```
 


### PR DESCRIPTION
## 📝 Description

Adds a missing comma in the first code listing on the FAQ page (https://panda-css.com/docs/overview/faq) and changes to quotes from double quotes to single quotes.

## ⛳️ Current behavior (updates)

Current example code is incorrect and contains a mix of single quotes and double quotes.

## 🚀 New behavior

Updated example code is correct and contains only single quotes.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
