### PR TITLE
fix(studio): fix base font size

### DIFF
--- a/packages/studio/panda.config.ts
+++ b/packages/studio/panda.config.ts
@@ -66,10 +66,6 @@ export default {
     ':root': {
       '--global-color-border': 'colors.border',
       '--global-color-placeholder': 'colors.neutral.500',
-      fontFamily: 'Inter, Avenir, Helvetica, Arial, sans-serif',
-      fontSize: '0.84em',
-      lineHeight: 'normal',
-      fontWeight: 'normal',
       colorScheme: 'light dark',
     },
     body: {
@@ -77,6 +73,10 @@ export default {
       minHeight: '100dvh',
       background: 'bg',
       color: 'text',
+      fontFamily: 'Inter, Avenir, Helvetica, Arial, sans-serif',
+      fontSize: '0.84em',
+      lineHeight: 'normal',
+      fontWeight: 'normal',
     },
     a: {
       color: 'unset',

--- a/packages/studio/styled-system/styles.css
+++ b/packages/studio/styled-system/styles.css
@@ -175,10 +175,6 @@
     --made-with-panda: '🐼';
     --global-color-border: var(--colors-border);
     --global-color-placeholder: var(--colors-neutral-500);
-    font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-    font-size: 0.84em;
-    line-height: var(--line-heights-normal);
-    font-weight: var(--font-weights-normal);
     color-scheme: light dark;
 }
 
@@ -186,6 +182,10 @@
     margin: var(--spacing-0);
     background: var(--colors-bg);
     color: var(--colors-text);
+    font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+    font-size: 0.84em;
+    line-height: var(--line-heights-normal);
+    font-weight: var(--font-weights-normal);
     min-height: 100dvh;
 }
 


### PR DESCRIPTION
## 📝 Description

Fixes an issue where `font-size` set on `:root` affects design tokens.
The cause is the use of `rem` units.

## ⛳️ Current behavior (updates)

Font sizes and sizes, Spacing are not displayed as expected.

## 🚀 New behavior

Sizes now display as intended.

⛳️ Current | 🚀 New
:-|:-
![image](https://github.com/user-attachments/assets/c853ad81-c3ea-453b-be84-7f941b8a4478) | ![image](https://github.com/user-attachments/assets/af5000a1-e148-4b62-8e9e-e2f44098eb6b)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Font-related styles have also been moved to `body`.
I considered adjusting `font-size` to an integer value like `md` ([change](https://github.com/chakra-ui/panda/commit/7a492d72ce1eb3e1926e59a717844022aa0e5587#diff-352a4e21e13ea047fed0b13a634a4ff13711590d6ca8a9570150197e4519cf0fR70), [before](https://github.com/chakra-ui/panda/blob/411fc5eb92bf60d888d932f47c9815c270062a91/packages/studio/panda.config.ts#L88-L92)) or `0.875rem`.