### PR TITLE
fix(studio): fix CLI outdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ __generated__
 styled-system
 styled-system-static
 panda
-panda-static
 outdir
 ts-import-map-outdir
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare-studio": "pnpm --filter=./packages/studio codegen",
     "build-studio": "pnpm --filter=./sandbox/vite-ts exec pnpm panda studio --build",
     "deploy-studio": "pnpm prepare-studio && pnpm build-studio",
-    "serve-studio": "npx serve ./sandbox/vite-ts/panda-static",
+    "serve-studio": "npx serve ./sandbox/vite-ts/styled-system-studio",
     "website": "pnpm --filter=./website",
     "mdx-check": "mdx-local-link-checker docs && mdx-local-link-checker website/pages/docs"
   },


### PR DESCRIPTION
## 📝 Description

Fixed an issue where Panda Studio could not be accessed.  
This was likely due to outdated directory structure changes in Panda Studio.

## ⛳️ Current behavior (updates)

After running `pnpm build-studio && pnpm serve-studio`,  
accessing http://localhost:3000/ shows a `404` error

## 🚀 New behavior

Panda Studio is displayed.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Related changes (probably):

1. [`const outDir = ..., 'panda-static')`](https://github.com/chakra-ui/panda/pull/15/files#diff-fa0bbb9e69ed035ce0715fe34ac3bdeb9e0f7156e2b0dda9a7ab2944e732ccc5)
1. [serve-docs](https://github.com/chakra-ui/panda/commit/ad89fdf7e11f842d4d036b4f72bdd5ea5b903f2b)
1. [CoreContext: `this.studio = { outdir: `${config.outdir}-studio`, ...`](https://github.com/chakra-ui/panda/pull/1860/files#diff-8cdff7aebde349d2e609762456a1ba82d73245df741ed73f8c86e517ccaff800R78)