### PR TITLE
fix: update object literal syntax in styled components migration docs

### DIFF
--- a/website/pages/docs/migration/styled-components.md
+++ b/website/pages/docs/migration/styled-components.md
@@ -307,7 +307,7 @@ In Panda, you can use the pseudo props API to define responsive styles.
 ```tsx
 import { styled } from '../styled-system/jsx'
 
-const Button = styled.button({
+const Button = styled('button', {
   base: {
     backgroundColor: '#fff',
     border: '1px solid #000',


### PR DESCRIPTION


## 📝 Description

Noticed a small typo in the docs where the `styled` helper is invoked in a way that returns an JSX element rather than a component.

## ⛳️ Current behavior (updates)

`styled.button({})` returns a JSX element, not a component, and is intended to be used directly in JSX, e.g. `<styled.button />`

## 🚀 New behavior

`styled('button', {})` returns a `StyledComponent` instance which is the intended behavior here.

## 💣 Is this a breaking change (Yes/No):

No, docs-only change -- and it's described correctly earlier on the same page ([here](https://panda-css.com/docs/migration/styled-components#object-syntax))

## 📝 Additional Information

Thank you!