### PR TITLE
feat(style-context): implement recipe style context

### DIFF
--- a/.changeset/tame-ligers-collect.md
+++ b/.changeset/tame-ligers-collect.md
@@ -19,7 +19,58 @@
 '@pandacss/studio': major
 '@pandacss/token-dictionary': major
 '@pandacss/types': major
-'docusaurus-ts': major
 ---
 
 Stable release of PandaCSS
+
+### Style Context
+
+Add `createStyleContext` function to framework artifacts for React, Preact, Solid, and Vue frameworks
+
+```tsx
+import { sva } from 'styled-system/css'
+import { createStyleContext } from 'styled-system/jsx'
+
+const card = sva({
+  slots: ['root', 'label'],
+  base: {
+    root: {
+      color: 'red',
+      bg: 'red.300',
+    },
+    label: {
+      fontWeight: 'medium',
+    },
+  },
+  variants: {
+    size: {
+      sm: {
+        root: {
+          padding: '10px',
+        },
+      },
+      md: {
+        root: {
+          padding: '20px',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'sm',
+  },
+})
+
+const { withProvider, withContext } = createStyleContext(card)
+
+const CardRoot = withProvider('div', 'root')
+const CardLabel = withContext('label', 'label')
+```
+
+Then, use like this:
+
+```tsx
+<CardRoot size="sm">
+  <CardLabel>Hello</CardLabel>
+</CardRoot>
+```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.workingDirectories": ["./packages/**", "./sandbox/**", "./sandbox/next-js"]
+  "eslint.workingDirectories": ["./packages/**", "./sandbox/**", "./sandbox/next-js"],
+  "biome.enabled": false
 }

--- a/packages/config/src/config-deps.ts
+++ b/packages/config/src/config-deps.ts
@@ -61,6 +61,7 @@ const artifactConfigDeps: Record<ArtifactId, ConfigPath[]> = {
   'jsx-helpers': jsx,
   'jsx-patterns': jsx.concat('patterns'),
   'jsx-patterns-index': jsx.concat('patterns'),
+  'jsx-create-style-context': jsx,
   'css-index': ['syntax'],
   'package.json': ['forceConsistentTypeExtension', 'outExtension'],
   'types-styles': ['shorthands'],

--- a/packages/generator/__tests__/generate-recipe.test.ts
+++ b/packages/generator/__tests__/generate-recipe.test.ts
@@ -120,11 +120,14 @@ describe('generate recipes', () => {
         [key in keyof TextStyleVariant]: Array<TextStyleVariant[key]>
       }
 
+
+
       export type TextStyleVariantProps = {
         [key in keyof TextStyleVariant]?: ConditionalValue<TextStyleVariant[key]> | undefined
       }
 
       export interface TextStyleRecipe {
+        
         __type: TextStyleVariantProps
         (props?: TextStyleVariantProps): string
         raw: (props?: TextStyleVariantProps) => TextStyleVariantProps
@@ -179,11 +182,14 @@ describe('generate recipes', () => {
         [key in keyof TooltipStyleVariant]: Array<TooltipStyleVariant[key]>
       }
 
+
+
       export type TooltipStyleVariantProps = {
         [key in keyof TooltipStyleVariant]?: ConditionalValue<TooltipStyleVariant[key]> | undefined
       }
 
       export interface TooltipStyleRecipe {
+        
         __type: TooltipStyleVariantProps
         (props?: TooltipStyleVariantProps): string
         raw: (props?: TooltipStyleVariantProps) => TooltipStyleVariantProps
@@ -233,11 +239,14 @@ describe('generate recipes', () => {
         [key in keyof CardStyleVariant]: Array<CardStyleVariant[key]>
       }
 
+
+
       export type CardStyleVariantProps = {
         [key in keyof CardStyleVariant]?: ConditionalValue<CardStyleVariant[key]> | undefined
       }
 
       export interface CardStyleRecipe {
+        
         __type: CardStyleVariantProps
         (props?: CardStyleVariantProps): string
         raw: (props?: CardStyleVariantProps) => CardStyleVariantProps
@@ -298,11 +307,14 @@ describe('generate recipes', () => {
         [key in keyof ButtonStyleVariant]: Array<ButtonStyleVariant[key]>
       }
 
+
+
       export type ButtonStyleVariantProps = {
         [key in keyof ButtonStyleVariant]?: ConditionalValue<ButtonStyleVariant[key]> | undefined
       }
 
       export interface ButtonStyleRecipe {
+        
         __type: ButtonStyleVariantProps
         (props?: ButtonStyleVariantProps): string
         raw: (props?: ButtonStyleVariantProps) => ButtonStyleVariantProps
@@ -367,13 +379,16 @@ describe('generate recipes', () => {
         [key in keyof CheckboxVariant]: Array<CheckboxVariant[key]>
       }
 
+      type CheckboxSlot = "root" | "control" | "label"
+
       export type CheckboxVariantProps = {
         [key in keyof CheckboxVariant]?: ConditionalValue<CheckboxVariant[key]> | undefined
       }
 
       export interface CheckboxRecipe {
+        __slot: CheckboxSlot
         __type: CheckboxVariantProps
-        (props?: CheckboxVariantProps): Pretty<Record<"root" | "control" | "label", string>>
+        (props?: CheckboxVariantProps): Pretty<Record<CheckboxSlot, string>>
         raw: (props?: CheckboxVariantProps) => CheckboxVariantProps
         variantMap: CheckboxVariantMap
         variantKeys: Array<keyof CheckboxVariant>
@@ -420,6 +435,7 @@ describe('generate recipes', () => {
         __recipe__: false,
         __name__: 'checkbox',
         raw: (props) => props,
+        classNameMap: {},
         variantKeys: checkboxVariantKeys,
         variantMap: {
         "size": [
@@ -448,13 +464,16 @@ describe('generate recipes', () => {
         [key in keyof BadgeVariant]: Array<BadgeVariant[key]>
       }
 
+      type BadgeSlot = "title" | "body"
+
       export type BadgeVariantProps = {
         [key in keyof BadgeVariant]?: BadgeVariant[key] | undefined
       }
 
       export interface BadgeRecipe {
+        __slot: BadgeSlot
         __type: BadgeVariantProps
-        (props?: BadgeVariantProps): Pretty<Record<"title" | "body", string>>
+        (props?: BadgeVariantProps): Pretty<Record<BadgeSlot, string>>
         raw: (props?: BadgeVariantProps) => BadgeVariantProps
         variantMap: BadgeVariantMap
         variantKeys: Array<keyof BadgeVariant>
@@ -506,6 +525,7 @@ describe('generate recipes', () => {
         __recipe__: false,
         __name__: 'badge',
         raw: (props) => props,
+        classNameMap: {},
         variantKeys: badgeVariantKeys,
         variantMap: {
         "size": [

--- a/packages/generator/__tests__/setup-artifacts.test.ts
+++ b/packages/generator/__tests__/setup-artifacts.test.ts
@@ -302,6 +302,10 @@ describe('setup-artifacts', () => {
           "jsx/cq.d.ts",
         ],
         [
+          "jsx/create-style-context.mjs",
+          "jsx/create-style-context.d.ts",
+        ],
+        [
           "jsx/index.mjs",
           "jsx/index.d.ts",
         ],

--- a/packages/generator/src/artifacts/js/recipe.ts
+++ b/packages/generator/src/artifacts/js/recipe.ts
@@ -156,6 +156,7 @@ export function generateRecipes(ctx: Context, filters?: ArtifactFilters) {
           __recipe__: false,
           __name__: '${baseName}',
           raw: (props) => props,
+          classNameMap: {},
           variantKeys: ${baseName}VariantKeys,
           variantMap: ${stringify(variantKeyMap)},
           splitVariantProps(props) {
@@ -219,6 +220,8 @@ export function generateRecipes(ctx: Context, filters?: ArtifactFilters) {
           [key in keyof ${upperName}Variant]: Array<${upperName}Variant[key]>
         }
 
+        ${Recipes.isSlotRecipeConfig(config) ? `type ${upperName}Slot = ${unionType(config.slots)}` : ''}
+
         export type ${upperName}VariantProps = {
           [key in keyof ${upperName}Variant]?: ${
             compoundVariants?.length ? `${upperName}Variant[key]` : `ConditionalValue<${upperName}Variant[key]>`
@@ -226,9 +229,10 @@ export function generateRecipes(ctx: Context, filters?: ArtifactFilters) {
         }
 
         export interface ${upperName}Recipe {
+          ${Recipes.isSlotRecipeConfig(config) ? `__slot: ${upperName}Slot` : ''}
           __type: ${upperName}VariantProps
           (props?: ${upperName}VariantProps): ${
-            Recipes.isSlotRecipeConfig(config) ? `Pretty<Record<${unionType(config.slots)}, string>>` : 'string'
+            Recipes.isSlotRecipeConfig(config) ? `Pretty<Record<${upperName}Slot, string>>` : 'string'
           }
           raw: (props?: ${upperName}VariantProps) => ${upperName}VariantProps
           variantMap: ${upperName}VariantMap

--- a/packages/generator/src/artifacts/js/sva.ts
+++ b/packages/generator/src/artifacts/js/sva.ts
@@ -8,14 +8,17 @@ export function generateSvaFn(ctx: Context) {
     ${ctx.file.import('cva', './cva')}
     ${ctx.file.import('cx', './cx')}
 
-    const slotClass = (className, slot) => className + '__' + slot
-
     export function sva(config) {
       const slots = Object.entries(getSlotRecipes(config)).map(([slot, slotCva]) => [slot, cva(slotCva)])
       const defaultVariants = config.defaultVariants ?? {}
 
+      const classNameMap = slots.reduce((acc, [slot, cvaFn]) => {
+        if (config.className) acc[slot] = cvaFn.config.className
+        return acc
+      }, {})
+
       function svaFn(props) {
-        const result = slots.map(([slot, cvaFn]) => [slot, cx(cvaFn(props), config.className && slotClass(config.className, slot))])
+        const result = slots.map(([slot, cvaFn]) => [slot, cx(cvaFn(props), classNameMap[slot])])
         return Object.fromEntries(result)
       }
 
@@ -30,7 +33,7 @@ export function generateSvaFn(ctx: Context) {
       function splitVariantProps(props) {
         return splitProps(props, variantKeys);
       }
-      const getVariantProps = (variants) => ({ ...(defaultVariants || {}), ...compact(variants) })
+      const getVariantProps = (variants) => ({ ...defaultVariants, ...compact(variants) })
 
       const variantMap = Object.fromEntries(
         Object.entries(variants).map(([key, value]) => [key, Object.keys(value)])
@@ -39,8 +42,10 @@ export function generateSvaFn(ctx: Context) {
       return Object.assign(memo(svaFn), {
         __cva__: false,
         raw,
+        config,
         variantMap,
         variantKeys,
+        classNameMap,
         splitVariantProps,
         getVariantProps,
       })

--- a/packages/generator/src/artifacts/jsx.ts
+++ b/packages/generator/src/artifacts/jsx.ts
@@ -1,21 +1,39 @@
 import type { Context } from '@pandacss/core'
 import type { ArtifactFilters, JsxFramework } from '@pandacss/types'
-import { generatePreactJsxFactory, generatePreactJsxPattern, generatePreactJsxTypes } from './preact-jsx'
+import {
+  generatePreactJsxFactory,
+  generatePreactJsxPattern,
+  generatePreactJsxTypes,
+  generatePreactCreateStyleContext,
+} from './preact-jsx'
 import { generatePreactJsxStringLiteralFactory } from './preact-jsx/jsx.string-literal'
 import { generatePreactJsxStringLiteralTypes } from './preact-jsx/types.string-literal'
 import { generateQwikJsxFactory, generateQwikJsxPattern, generateQwikJsxTypes } from './qwik-jsx'
 import { generateQwikJsxStringLiteralFactory } from './qwik-jsx/jsx.string-literal'
 import { generateQwikJsxStringLiteralTypes } from './qwik-jsx/types.string-literal'
-import { generateReactJsxFactory, generateReactJsxPattern, generateReactJsxTypes } from './react-jsx'
+import {
+  generateReactJsxFactory,
+  generateReactJsxPattern,
+  generateReactJsxTypes,
+  generateReactCreateStyleContext,
+} from './react-jsx'
 import { generateReactJsxStringLiteralFactory } from './react-jsx/jsx.string-literal'
 import { generateReactJsxStringLiteralTypes } from './react-jsx/types.string-literal'
-import { generateSolidJsxFactory, generateSolidJsxPattern, generateSolidJsxTypes } from './solid-jsx'
+import {
+  generateSolidJsxFactory,
+  generateSolidJsxPattern,
+  generateSolidJsxTypes,
+  generateSolidCreateStyleContext,
+} from './solid-jsx'
 import { generateSolidJsxStringLiteralFactory } from './solid-jsx/jsx.string-literal'
 import { generateSolidJsxStringLiteralTypes } from './solid-jsx/types.string-literal'
-import { generateVueJsxFactory } from './vue-jsx/jsx'
+import {
+  generateVueJsxFactory,
+  generateVueJsxPattern,
+  generateVueJsxTypes,
+  generateVueCreateStyleContext,
+} from './vue-jsx'
 import { generateVueJsxStringLiteralFactory } from './vue-jsx/jsx.string-literal'
-import { generateVueJsxPattern } from './vue-jsx/pattern'
-import { generateVueJsxTypes } from './vue-jsx/types'
 import { generateVueJsxStringLiteralTypes } from './vue-jsx/types.string-literal'
 
 /* -----------------------------------------------------------------------------
@@ -92,4 +110,22 @@ export function generateJsxPatterns(ctx: Context, filters?: ArtifactFilters) {
   if (ctx.isTemplateLiteralSyntax || ctx.patterns.isEmpty() || !ctx.jsx.framework) return []
   if (!isKnownFramework(ctx.jsx.framework)) return
   return patternMap[ctx.jsx.framework!](ctx, filters)
+}
+
+/* -----------------------------------------------------------------------------
+ * Create Style Context JSX
+ * -----------------------------------------------------------------------------*/
+
+const createStyleContextMap = {
+  react: generateReactCreateStyleContext,
+  preact: generatePreactCreateStyleContext,
+  solid: generateSolidCreateStyleContext,
+  vue: generateVueCreateStyleContext,
+}
+
+export function generateJsxCreateStyleContext(ctx: Context) {
+  if (ctx.isTemplateLiteralSyntax || !ctx.jsx.framework) return
+  if (!isKnownFramework(ctx.jsx.framework)) return
+  const generator = (createStyleContextMap as any)[ctx.jsx.framework]
+  return generator?.(ctx)
 }

--- a/packages/generator/src/artifacts/preact-jsx/create-style-context.ts
+++ b/packages/generator/src/artifacts/preact-jsx/create-style-context.ts
@@ -1,0 +1,151 @@
+import type { Context } from '@pandacss/core'
+import { outdent } from 'outdent'
+import { match } from 'ts-pattern'
+
+export function generatePreactCreateStyleContext(ctx: Context) {
+  const { factoryName } = ctx.jsx
+
+  return {
+    js: outdent`
+    ${ctx.file.import('cx, css, sva', '../css/index')}
+    ${ctx.file.import(factoryName, './factory')}
+    import { createContext, useContext, createElement, forwardRef } from 'preact/compat'
+
+    const getDisplayName = (Component) => Component.displayName || Component.name || typeof Component === 'string' ? Component : 'Component'
+    
+    export function createStyleContext(recipe) {
+      const StyleContext = createContext({})
+      const isConfigRecipe = "__recipe__" in recipe
+      const svaFn = isConfigRecipe ? recipe : sva(recipe.config)
+
+      const getResolvedProps = (props, slotStyles) => {
+        const { unstyled, ...restProps } = props
+        if (unstyled) return restProps
+        if (isConfigRecipe) {
+           return { ...restProps, className: cx(slotStyles, restProps.className) }
+        }
+        ${outdent.string(
+          match(ctx.config.jsxStyleProps)
+            .with('all', () => `return { ...slotStyles, ...restProps }`)
+            .with('minimal', () => `return { ...restProps, css: css.raw(slotStyles, restProps.css) }`)
+            .with('none', () => `return { ...restProps, className: cx(css(slotStyles), restProps.className) }`)
+            .otherwise(() => `return restProps`),
+        )}
+      }
+
+      const withRootProvider = (Component) => {
+        const WithRootProvider = (props) => {
+          const [variantProps, otherProps] = svaFn.splitVariantProps(props)
+          
+          const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+          slotStyles._classNameMap = svaFn.classNameMap
+
+          return createElement(StyleContext.Provider, {
+            value: slotStyles,
+            children: createElement(Component, otherProps)
+          })
+        }
+        
+        const componentName = getDisplayName(Component)
+        WithRootProvider.displayName = \`withRootProvider(\${componentName})\`
+        
+        return WithRootProvider
+      }
+
+      const withProvider = (Component, slot, options) => {
+        const StyledComponent = ${factoryName}(Component, {}, options)
+        
+        const WithProvider = forwardRef((props, ref) => {
+          const [variantProps, restProps] = svaFn.splitVariantProps(props)
+          
+          const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+          slotStyles._classNameMap = svaFn.classNameMap
+
+          const resolvedProps = getResolvedProps(restProps, slotStyles[slot])
+          return createElement(StyleContext.Provider, {
+            value: slotStyles,
+            children: createElement(StyledComponent, {
+              ...resolvedProps,
+              className: cx(resolvedProps.className, slotStyles._classNameMap[slot]),
+              ref,
+            })
+          })
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithProvider.displayName = \`withProvider(\${componentName})\`
+        
+        return WithProvider
+      }
+
+      const withContext = (Component, slot) => {
+        const StyledComponent = ${factoryName}(Component)
+        
+        const WithContext = forwardRef((props, ref) => {
+          const slotStyles = useContext(StyleContext)
+          
+          const resolvedProps = getResolvedProps(props, slotStyles[slot])
+          return createElement(StyledComponent, {
+            ...resolvedProps,
+            className: cx(resolvedProps.className, slotStyles._classNameMap[slot]),
+            ref,
+          })
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithContext.displayName = \`withContext(\${componentName})\`
+        
+        return WithContext
+      }
+
+      return {
+        withRootProvider,
+        withProvider,
+        withContext,
+      }
+    }
+    `,
+    dts: outdent`
+    ${ctx.file.importType('SlotRecipeRuntimeFn, RecipeVariantProps', '../types/recipe')}
+    ${ctx.file.importType('JsxHTMLProps, JsxStyleProps, Assign', '../types/system-types')}
+    import type { ComponentType, ComponentProps, JSX } from 'preact/compat'
+
+    type Options = { forwardProps?: string[] }
+    type UnstyledProps = { unstyled?: boolean }
+    type ElementType = JSX.ElementType
+
+    type SvaFn<S extends string = any> = SlotRecipeRuntimeFn<S, any>
+    interface SlotRecipeFn {
+      __type: any
+      __slot: string
+      (props?: any): any
+    }
+    type SlotRecipe = SvaFn | SlotRecipeFn
+
+    type InferSlot<R extends SlotRecipe> = R extends SlotRecipeFn ? R['__slot'] : R extends SvaFn<infer S> ? S : never
+
+    type StyleContextProvider<T extends ElementType, R extends SlotRecipe> = ComponentType<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, Assign<RecipeVariantProps<R>, JsxStyleProps>>
+    >
+    
+    type StyleContextConsumer<T extends ElementType> = ComponentType<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, JsxStyleProps>
+    >
+
+    export interface StyleContext<R extends SlotRecipe> {
+      withRootProvider: <T extends ElementType>(Component: T) => StyleContextProvider<T, R>
+      withProvider: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>,
+        options?: Options
+      ) => StyleContextProvider<T, R>
+      withContext: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>
+      ) => StyleContextConsumer<T>
+    }
+
+    export declare function createStyleContext<R extends SlotRecipe>(recipe: R): StyleContext<R>
+    `,
+  }
+}

--- a/packages/generator/src/artifacts/preact-jsx/index.ts
+++ b/packages/generator/src/artifacts/preact-jsx/index.ts
@@ -1,3 +1,4 @@
 export { generatePreactJsxFactory } from './jsx'
 export { generatePreactJsxPattern } from './pattern'
 export { generatePreactJsxTypes } from './types'
+export { generatePreactCreateStyleContext } from './create-style-context'

--- a/packages/generator/src/artifacts/react-jsx/create-style-context.ts
+++ b/packages/generator/src/artifacts/react-jsx/create-style-context.ts
@@ -1,0 +1,154 @@
+import type { Context } from '@pandacss/core'
+import { outdent } from 'outdent'
+import { match } from 'ts-pattern'
+
+export function generateReactCreateStyleContext(ctx: Context) {
+  const { factoryName } = ctx.jsx
+
+  return {
+    js: outdent`
+    ${ctx.file.import('cx, css, sva', '../css/index')}
+    ${ctx.file.import(factoryName, './factory')}
+    import { createContext, useContext, createElement, forwardRef } from 'react'
+
+    const getDisplayName = (Component) => Component.displayName || Component.name || typeof Component === 'string' ? Component : 'Component'
+    
+    export function createStyleContext(recipe) {
+      const StyleContext = createContext({})
+      const isConfigRecipe = "__recipe__" in recipe
+      const svaFn = isConfigRecipe ? recipe : sva(recipe.config)
+
+      const getResolvedProps = (props, slotStyles) => {
+        const { unstyled, ...restProps } = props
+        if (unstyled) return restProps
+        if (isConfigRecipe) {
+           return { ...restProps, className: cx(slotStyles, restProps.className) }
+        }
+        ${outdent.string(
+          match(ctx.config.jsxStyleProps)
+            .with('all', () => `return { ...slotStyles, ...restProps }`)
+            .with('minimal', () => `return { ...restProps, css: css.raw(slotStyles, restProps.css) }`)
+            .with('none', () => `return { ...restProps, className: cx(css(slotStyles), restProps.className) }`)
+            .otherwise(() => `return restProps`),
+        )}
+      }
+
+      const withRootProvider = (Component) => {
+        const WithRootProvider = (props) => {
+          const [variantProps, otherProps] = svaFn.splitVariantProps(props)
+          
+          const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+          slotStyles._classNameMap = svaFn.classNameMap
+
+          return createElement(StyleContext.Provider, {
+            value: slotStyles,
+            children: createElement(Component, otherProps)
+          })
+        }
+        
+        const componentName = getDisplayName(Component)
+        WithRootProvider.displayName = \`withRootProvider(\${componentName})\`
+        
+        return WithRootProvider
+      }
+
+      const withProvider = (Component, slot, options) => {
+        const StyledComponent = ${factoryName}(Component, {}, options)
+        
+        const WithProvider = forwardRef((props, ref) => {
+          const [variantProps, restProps] = svaFn.splitVariantProps(props)
+          
+          const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+          slotStyles._classNameMap = svaFn.classNameMap
+
+          const resolvedProps = getResolvedProps(restProps, slotStyles[slot])
+          return createElement(StyleContext.Provider, {
+            value: slotStyles,
+            children: createElement(StyledComponent, {
+              ...resolvedProps,
+              className: cx(resolvedProps.className, slotStyles._classNameMap[slot]),
+              ref,
+            })
+          })
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithProvider.displayName = \`withProvider(\${componentName})\`
+        
+        return WithProvider
+      }
+
+      const withContext = (Component, slot) => {
+        const StyledComponent = ${factoryName}(Component)
+        
+        const WithContext = forwardRef((props, ref) => {
+          const slotStyles = useContext(StyleContext)
+  
+          const resolvedProps = getResolvedProps(props, slotStyles[slot])
+          return createElement(StyledComponent, {
+            ...resolvedProps,
+            className: cx(resolvedProps.className, slotStyles._classNameMap[slot]),
+            ref,
+          })
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithContext.displayName = \`withContext(\${componentName})\`
+        
+        return WithContext
+      }
+
+      return {
+        withRootProvider,
+        withProvider,
+        withContext,
+      }
+    }
+    `,
+    dts: outdent`
+    ${ctx.file.importType('SlotRecipeRuntimeFn, RecipeVariantProps', '../types/recipe')}
+    ${ctx.file.importType('JsxHTMLProps, JsxStyleProps, Assign', '../types/system-types')}
+    import type { ComponentType, ElementType, ComponentPropsWithoutRef, ElementRef, Ref } from 'react'
+
+    type Options = { forwardProps?: string[] }
+    type UnstyledProps = { unstyled?: boolean }
+
+    type SvaFn<S extends string = any> = SlotRecipeRuntimeFn<S, any>
+    interface SlotRecipeFn {
+      __type: any
+      __slot: string
+      (props?: any): any
+    }
+    type SlotRecipe = SvaFn | SlotRecipeFn
+    
+    type InferSlot<R extends SlotRecipe> = R extends SlotRecipeFn ? R['__slot'] : R extends SvaFn<infer S> ? S : never
+    
+    type ComponentProps<T extends ElementType> = Omit<ComponentPropsWithoutRef<T>, 'ref'> & {
+      ref?: Ref<ElementRef<T>>
+    }
+
+    type StyleContextProvider<T extends ElementType, R extends SlotRecipe> = ComponentType<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, Assign<RecipeVariantProps<R>, JsxStyleProps>>
+    >
+    
+    type StyleContextConsumer<T extends ElementType> = ComponentType<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, JsxStyleProps>
+    >
+
+    export interface StyleContext<R extends SlotRecipe> {
+      withRootProvider: <T extends ElementType>(Component: T) => StyleContextProvider<T, R>
+      withProvider: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>,
+        options?: Options
+      ) => StyleContextProvider<T, R>
+      withContext: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>
+      ) => StyleContextConsumer<T>
+    }
+
+    export declare function createStyleContext<R extends SlotRecipe>(recipe: R): StyleContext<R>
+    `,
+  }
+}

--- a/packages/generator/src/artifacts/react-jsx/index.ts
+++ b/packages/generator/src/artifacts/react-jsx/index.ts
@@ -1,3 +1,4 @@
 export { generateReactJsxFactory } from './jsx'
 export { generateReactJsxPattern } from './pattern'
 export { generateReactJsxTypes } from './types'
+export { generateReactCreateStyleContext } from './create-style-context'

--- a/packages/generator/src/artifacts/setup-artifacts.ts
+++ b/packages/generator/src/artifacts/setup-artifacts.ts
@@ -14,7 +14,7 @@ import { generatePattern } from './js/pattern'
 import { generateCreateRecipe, generateRecipes } from './js/recipe'
 import { generateSvaFn } from './js/sva'
 import { generateTokenJs } from './js/token'
-import { generateJsxFactory, generateJsxPatterns, generateJsxTypes } from './jsx'
+import { generateJsxFactory, generateJsxPatterns, generateJsxTypes, generateJsxCreateStyleContext } from './jsx'
 import { getGeneratedSystemTypes, getGeneratedTypes } from './types/generated'
 import { generateTypesEntry } from './types/main'
 import { generatePropTypes } from './types/prop-types'
@@ -322,6 +322,22 @@ function setupJsxPatterns(ctx: Context, filters?: ArtifactFilters): Artifact | u
   }
 }
 
+function setupJsxCreateStyleContext(ctx: Context): Artifact | undefined {
+  if (!ctx.jsx.framework || ctx.isTemplateLiteralSyntax) return
+
+  const createStyleContext = generateJsxCreateStyleContext(ctx)
+  if (!createStyleContext) return
+
+  return {
+    id: 'jsx-create-style-context',
+    dir: ctx.paths.jsx,
+    files: [
+      { file: ctx.file.ext('create-style-context'), code: createStyleContext.js },
+      { file: ctx.file.extDts('create-style-context'), code: createStyleContext.dts },
+    ],
+  }
+}
+
 function setupJsxPatternsIndex(ctx: Context): Artifact | undefined {
   if (!ctx.jsx.framework) return
 
@@ -332,11 +348,13 @@ function setupJsxPatternsIndex(ctx: Context): Artifact | undefined {
     js: outdent`
   ${ctx.file.exportStar('./factory')}
   ${isStyleProp ? ctx.file.exportStar('./is-valid-prop') : ''}
+  ${isStyleProp ? ctx.file.exportStar('./create-style-context') : ''}
   ${isStyleProp ? outdent.string(patternNames.map((file) => ctx.file.exportStar(`./${file}`)).join('\n')) : ''}
   `,
     dts: outdent`
   ${ctx.file.exportTypeStar('./factory')}
   ${isStyleProp ? ctx.file.exportTypeStar('./is-valid-prop') : ''}
+  ${isStyleProp ? ctx.file.exportTypeStar('./create-style-context') : ''}
   ${isStyleProp ? outdent.string(patternNames.map((file) => ctx.file.exportTypeStar(`./${file}`)).join('\n')) : ''}
   ${ctx.file.exportType([ctx.jsx.typeName, ctx.jsx.componentName].join(', '), '../types/jsx')}
     `,
@@ -472,6 +490,7 @@ const entries: ArtifactEntry[] = [
   ['jsx-factory', setupJsxFactory],
   ['jsx-helpers', setupJsxHelpers],
   ['jsx-patterns', setupJsxPatterns],
+  ['jsx-create-style-context', setupJsxCreateStyleContext],
   ['jsx-patterns-index', setupJsxPatternsIndex],
   ['css-index', setupCssIndex],
   ['themes', setupThemes],

--- a/packages/generator/src/artifacts/solid-jsx/create-style-context.ts
+++ b/packages/generator/src/artifacts/solid-jsx/create-style-context.ts
@@ -1,0 +1,177 @@
+import type { Context } from '@pandacss/core'
+import { outdent } from 'outdent'
+import { match } from 'ts-pattern'
+
+export function generateSolidCreateStyleContext(ctx: Context) {
+  const { factoryName } = ctx.jsx
+
+  return {
+    js: outdent`
+    ${ctx.file.import('cx, css, sva', '../css/index')}
+    ${ctx.file.import(factoryName, './factory')}
+    import { createComponent, mergeProps } from 'solid-js/web'
+    import { createContext, useContext, createMemo } from 'solid-js'
+
+    const getDisplayName = (Component) => Component.displayName || Component.name || typeof Component === 'string' ? Component : 'Component'
+    
+    export function createStyleContext(recipe) {
+      const StyleContext = createContext({})
+      const isConfigRecipe = "__recipe__" in recipe
+      const svaFn = isConfigRecipe ? recipe : sva(recipe.config)
+
+      const getResolvedProps = (props, slotStyles) => {
+        const { unstyled, ...restProps } = props
+        if (unstyled) return restProps
+        if (isConfigRecipe) {
+          return { ...restProps, className: cx(slotStyles, restProps.className) }
+        }
+        ${outdent.string(
+          match(ctx.config.jsxStyleProps)
+            .with('all', () => `return { ...slotStyles, ...restProps }`)
+            .with('minimal', () => `return { ...restProps, css: css.raw(slotStyles, restProps.css) }`)
+            .with('none', () => `return { ...restProps, class: cx(css(slotStyles), restProps.class) }`)
+            .otherwise(() => `return restProps`),
+        )}
+      }
+      
+
+      const withRootProvider = (Component) => {
+        const WithRootProvider = (props) => {
+          const finalProps = createMemo(() => {
+            const [variantProps, restProps] = svaFn.splitVariantProps(props)
+            
+            const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+            slotStyles._classNameMap = svaFn.classNameMap
+      
+            return { restProps, slotStyles }
+          })
+
+          return createComponent(StyleContext.Provider, {
+            value: finalProps().slotStyles,
+            get children() {
+              return createComponent(
+                Component,
+                mergeProps(finalProps().restProps, {
+                  get children() {
+                    return props.children
+                  },
+                }),
+              )
+            },
+          })
+        }
+        
+        const componentName = getDisplayName(Component)
+        WithRootProvider.displayName = \`withRootProvider(\${componentName})\`
+        
+        return WithRootProvider
+      }
+
+      const withProvider = (Component, slot, options) => {
+        const StyledComponent = ${factoryName}(Component, {}, options)
+        
+        const WithProvider = (props) => {
+          const finalProps = createMemo(() => {
+            const [variantProps, restProps] = svaFn.splitVariantProps(props)
+
+            const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+            slotStyles._classNameMap = svaFn.classNameMap
+
+            const resolvedProps = getResolvedProps(restProps, slotStyles[slot])
+            resolvedProps.class = cx(resolvedProps.class, slotStyles._classNameMap[slot])
+            
+            return { slotStyles, resolvedProps }
+          })
+
+          return createComponent(StyleContext.Provider, {
+            value: finalProps().slotStyles,
+            get children() {
+              return createComponent(
+                StyledComponent,
+                mergeProps(finalProps().resolvedProps, {
+                  get children() {
+                    return props.children
+                  },
+                }),
+              )
+            },
+          })
+        }
+        
+        const componentName = getDisplayName(Component)
+        WithProvider.displayName = \`withProvider(\${componentName})\`
+        
+        return WithProvider
+      }
+
+      const withContext = (Component, slot) => {
+        const StyledComponent = ${factoryName}(Component)
+        
+        const WithContext = (props) => {
+          const slotStyles = useContext(StyleContext)
+          const finalProps = createMemo(() => {
+            const resolvedProps = getResolvedProps(props, slotStyles[slot])
+            resolvedProps.class = cx(resolvedProps.class, resolvedProps.className, slotStyles._classNameMap?.[slot])
+            return resolvedProps
+          })
+
+          return createComponent(StyledComponent, finalProps())
+        }
+        
+        const componentName = getDisplayName(Component)
+        WithContext.displayName = \`withContext(\${componentName})\`
+        
+        return WithContext
+      }
+
+      return {
+        withRootProvider,
+        withProvider,
+        withContext,
+      }
+    }
+    `,
+    dts: outdent`
+    ${ctx.file.importType('SlotRecipeRuntimeFn, RecipeVariantProps', '../types/recipe')}
+    ${ctx.file.importType('JsxHTMLProps, JsxStyleProps, Assign', '../types/system-types')}
+    import type { Component, JSX, ComponentProps } from 'solid-js'
+
+    type Options = { forwardProps?: string[] }
+    type UnstyledProps = { unstyled?: boolean }
+    type ElementType<P extends Record<string, any> = {}> = keyof JSX.IntrinsicElements | Component<P>
+
+    type SvaFn<S extends string = any> = SlotRecipeRuntimeFn<S, any>
+    interface SlotRecipeFn {
+      __type: any
+      __slot: string
+      (props?: any): any
+    }
+    type SlotRecipe = SvaFn | SlotRecipeFn
+
+    type InferSlot<R extends SlotRecipe> = R extends SlotRecipeFn ? R['__slot'] : R extends SvaFn<infer S> ? S : never
+
+    type StyleContextProvider<T extends ElementType, R extends SlotRecipe> = Component<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, Assign<RecipeVariantProps<R>, JsxStyleProps>>
+    >
+    
+    type StyleContextConsumer<T extends ElementType> = Component<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, JsxStyleProps>
+    >
+
+    export interface StyleContext<R extends SlotRecipe> {
+      withRootProvider: <T extends ElementType>(Component: T) => StyleContextProvider<T, R>
+      withProvider: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>,
+        options?: Options
+      ) => StyleContextProvider<T, R>
+      withContext: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>
+      ) => StyleContextConsumer<T>
+    }
+
+    export declare function createStyleContext<R extends SlotRecipe>(recipe: R): StyleContext<R>
+    `,
+  }
+}

--- a/packages/generator/src/artifacts/solid-jsx/index.ts
+++ b/packages/generator/src/artifacts/solid-jsx/index.ts
@@ -1,3 +1,4 @@
 export { generateSolidJsxFactory } from './jsx'
 export { generateSolidJsxPattern } from './pattern'
 export { generateSolidJsxTypes } from './types'
+export { generateSolidCreateStyleContext } from './create-style-context'

--- a/packages/generator/src/artifacts/vue-jsx/create-style-context.ts
+++ b/packages/generator/src/artifacts/vue-jsx/create-style-context.ts
@@ -1,0 +1,174 @@
+import type { Context } from '@pandacss/core'
+import { outdent } from 'outdent'
+import { match } from 'ts-pattern'
+
+export function generateVueCreateStyleContext(ctx: Context) {
+  const { factoryName } = ctx.jsx
+
+  return {
+    js: outdent`
+    ${ctx.file.import('cx, css, sva', '../css/index')}
+    ${ctx.file.import(factoryName, './factory')}
+    import { defineComponent, provide, inject, computed, h } from 'vue'
+
+    const getDisplayName = (Component) => Component.displayName || Component.name || typeof Component === 'string' ? Component : 'Component'
+    
+    export function createStyleContext(recipe) {
+      const StyleContext = Symbol('StyleContext')
+      const isConfigRecipe = "__recipe__" in recipe
+      const svaFn = isConfigRecipe ? recipe : sva(recipe.config)
+ 
+      const getResolvedProps = (props, slotStyles) => {
+        const { unstyled, ...restProps } = props
+        if (unstyled) return restProps
+        if (isConfigRecipe) {
+           return { ...restProps, className: cx(slotStyles, restProps.className) }
+        }
+        ${outdent.string(
+          match(ctx.config.jsxStyleProps)
+            .with('all', () => `return { ...slotStyles, ...restProps }`)
+            .with('minimal', () => `return { ...restProps, css: css.raw(slotStyles, restProps.css) }`)
+            .with('none', () => `return { ...restProps, className: cx(css(slotStyles), restProps.className) }`)
+            .otherwise(() => `return restProps`),
+        )}
+      }
+
+      const withRootProvider = (Component) => {
+        const WithRootProvider = defineComponent({
+          props: svaFn.variantKeys,
+          setup(props, { slots }) {
+            const [variantProps, otherProps] = svaFn.splitVariantProps(props)
+
+            const slotStyles = computed(() => {
+              const styles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+              styles._classNameMap = svaFn.classNameMap
+              return styles
+            })
+
+            provide(StyleContext, slotStyles)
+
+            return () => h(Component, otherProps, slots)
+          },
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithRootProvider.displayName = \`withRootProvider(\${componentName})\`
+        
+        return WithRootProvider
+      }
+
+      const withProvider = (Component, slot, options) => {
+        const StyledComponent = ${factoryName}(Component, {}, options)
+        
+        const WithProvider = defineComponent({
+          props: ["unstyled", ...svaFn.variantKeys],
+          setup(inProps, { slots, attrs }) {
+            const props = computed(() => Object.assign({}, inProps, attrs))
+            const res = computed(() => {
+              const [variantProps, restProps] = svaFn.splitVariantProps(props.value)
+              return { variantProps, restProps }
+            })
+            
+            const slotStyles = computed(() => {
+              const styles = isConfigRecipe ? svaFn(res.value.variantProps) : svaFn.raw(res.value.variantProps)
+              styles._classNameMap = svaFn.classNameMap
+              return styles
+            })
+
+            provide(StyleContext, slotStyles)
+
+            return () => {
+              const resolvedProps = getResolvedProps(res.value.restProps, slotStyles.value[slot])
+              resolvedProps.class = cx(resolvedProps.class, slotStyles.value._classNameMap[slot], attrs.class)
+              return h(StyledComponent, resolvedProps, slots)
+            }
+          },
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithProvider.displayName = \`withProvider(\${componentName})\`
+        
+        return WithProvider
+      }
+
+      const withContext = (Component, slot) => {
+        const StyledComponent = ${factoryName}(Component)
+        
+        const WithContext = defineComponent({
+          props: ["unstyled"],
+          setup(props, { slots, attrs }) {
+            const slotStyles = inject(StyleContext)
+
+            return () => {
+              const resolvedProps = getResolvedProps(props, slotStyles.value[slot])
+              resolvedProps.class = cx(resolvedProps.class, slotStyles.value._classNameMap[slot], attrs.class)
+              return h(StyledComponent, resolvedProps, slots)
+            }
+          },
+        })
+        
+        const componentName = getDisplayName(Component)
+        WithContext.displayName = \`withContext(\${componentName})\`
+        
+        return WithContext
+      }
+
+      return {
+        withRootProvider,
+        withProvider,
+        withContext,
+      }
+    }
+    `,
+    dts: outdent`
+    ${ctx.file.importType('SlotRecipeRuntimeFn, RecipeVariantProps', '../types/recipe')}
+    ${ctx.file.importType('JsxHTMLProps, JsxStyleProps, Assign', '../types/system-types')}
+    import type { Component, FunctionalComponent, NativeElements } from 'vue'
+
+    type Options = { forwardProps?: string[] }
+    type UnstyledProps = { unstyled?: boolean }
+
+    type SvaFn<S extends string = any> = SlotRecipeRuntimeFn<S, any>
+    interface SlotRecipeFn {
+      __type: any
+      __slot: string
+      (props?: any): any
+    }
+    type SlotRecipe = SvaFn | SlotRecipeFn
+
+    type InferSlot<R extends SlotRecipe> = R extends SlotRecipeFn ? R['__slot'] : R extends SvaFn<infer S> ? S : never
+
+    type IntrinsicElement = keyof NativeElements
+    type ElementType = IntrinsicElement | Component
+
+    type ComponentProps<T extends ElementType> = T extends IntrinsicElement
+      ? NativeElements[T]
+      : T extends Component<infer Props>
+      ? Props
+      : never
+
+    type StyleContextProvider<T extends ElementType, R extends SlotRecipe> = FunctionalComponent<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, Assign<RecipeVariantProps<R>, JsxStyleProps>>
+    >
+    
+    type StyleContextConsumer<T extends ElementType> = FunctionalComponent<
+      JsxHTMLProps<ComponentProps<T> & UnstyledProps, JsxStyleProps>
+    >
+
+    export interface StyleContext<R extends SlotRecipe> {
+      withRootProvider: <T extends ElementType>(Component: T) => StyleContextProvider<T, R>
+      withProvider: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>,
+        options?: Options
+      ) => StyleContextProvider<T, R>
+      withContext: <T extends ElementType>(
+        Component: T,
+        slot: InferSlot<R>
+      ) => StyleContextConsumer<T>
+    }
+
+    export declare function createStyleContext<R extends SlotRecipe>(recipe: R): StyleContext<R>
+    `,
+  }
+}

--- a/packages/generator/src/artifacts/vue-jsx/index.ts
+++ b/packages/generator/src/artifacts/vue-jsx/index.ts
@@ -1,0 +1,4 @@
+export { generateVueJsxFactory } from './jsx'
+export { generateVueJsxPattern } from './pattern'
+export { generateVueJsxTypes } from './types'
+export { generateVueCreateStyleContext } from './create-style-context'

--- a/packages/studio/styled-system/css/sva.mjs
+++ b/packages/studio/styled-system/css/sva.mjs
@@ -2,14 +2,17 @@ import { compact, getSlotRecipes, memo, splitProps } from '../helpers.mjs';
 import { cva } from './cva.mjs';
 import { cx } from './cx.mjs';
 
-const slotClass = (className, slot) => className + '__' + slot
-
 export function sva(config) {
   const slots = Object.entries(getSlotRecipes(config)).map(([slot, slotCva]) => [slot, cva(slotCva)])
   const defaultVariants = config.defaultVariants ?? {}
 
+  const classNameMap = slots.reduce((acc, [slot, cvaFn]) => {
+    if (config.className) acc[slot] = cvaFn.config.className
+    return acc
+  }, {})
+
   function svaFn(props) {
-    const result = slots.map(([slot, cvaFn]) => [slot, cx(cvaFn(props), config.className && slotClass(config.className, slot))])
+    const result = slots.map(([slot, cvaFn]) => [slot, cx(cvaFn(props), classNameMap[slot])])
     return Object.fromEntries(result)
   }
 
@@ -24,7 +27,7 @@ export function sva(config) {
   function splitVariantProps(props) {
     return splitProps(props, variantKeys);
   }
-  const getVariantProps = (variants) => ({ ...(defaultVariants || {}), ...compact(variants) })
+  const getVariantProps = (variants) => ({ ...defaultVariants, ...compact(variants) })
 
   const variantMap = Object.fromEntries(
     Object.entries(variants).map(([key, value]) => [key, Object.keys(value)])
@@ -33,8 +36,10 @@ export function sva(config) {
   return Object.assign(memo(svaFn), {
     __cva__: false,
     raw,
+    config,
     variantMap,
     variantKeys,
+    classNameMap,
     splitVariantProps,
     getVariantProps,
   })

--- a/packages/studio/styled-system/jsx/create-style-context.d.ts
+++ b/packages/studio/styled-system/jsx/create-style-context.d.ts
@@ -1,0 +1,44 @@
+/* eslint-disable */
+import type { SlotRecipeRuntimeFn, RecipeVariantProps } from '../types/recipe';
+import type { JsxHTMLProps, JsxStyleProps, Assign } from '../types/system-types';
+import type { ComponentType, ElementType, ComponentPropsWithoutRef, ElementRef, Ref } from 'react'
+
+type Options = { forwardProps?: string[] }
+type UnstyledProps = { unstyled?: boolean }
+
+type SvaFn<S extends string = any> = SlotRecipeRuntimeFn<S, any>
+interface SlotRecipeFn {
+  __type: any
+  __slot: string
+  (props?: any): any
+}
+type SlotRecipe = SvaFn | SlotRecipeFn
+
+type InferSlot<R extends SlotRecipe> = R extends SlotRecipeFn ? R['__slot'] : R extends SvaFn<infer S> ? S : never
+
+type ComponentProps<T extends ElementType> = Omit<ComponentPropsWithoutRef<T>, 'ref'> & {
+  ref?: Ref<ElementRef<T>>
+}
+
+type StyleContextProvider<T extends ElementType, R extends SlotRecipe> = ComponentType<
+  JsxHTMLProps<ComponentProps<T> & UnstyledProps, Assign<RecipeVariantProps<R>, JsxStyleProps>>
+>
+
+type StyleContextConsumer<T extends ElementType> = ComponentType<
+  JsxHTMLProps<ComponentProps<T> & UnstyledProps, JsxStyleProps>
+>
+
+export interface StyleContext<R extends SlotRecipe> {
+  withRootProvider: <T extends ElementType>(Component: T) => StyleContextProvider<T, R>
+  withProvider: <T extends ElementType>(
+    Component: T,
+    slot: InferSlot<R>,
+    options?: Options
+  ) => StyleContextProvider<T, R>
+  withContext: <T extends ElementType>(
+    Component: T,
+    slot: InferSlot<R>
+  ) => StyleContextConsumer<T>
+}
+
+export declare function createStyleContext<R extends SlotRecipe>(recipe: R): StyleContext<R>

--- a/packages/studio/styled-system/jsx/create-style-context.mjs
+++ b/packages/studio/styled-system/jsx/create-style-context.mjs
@@ -1,0 +1,91 @@
+import { cx, css, sva } from '../css/index.mjs';
+import { panda } from './factory.mjs';
+import { createContext, useContext, createElement, forwardRef } from 'react'
+
+const getDisplayName = (Component) => Component.displayName || Component.name || typeof Component === 'string' ? Component : 'Component'
+
+export function createStyleContext(recipe) {
+  const StyleContext = createContext({})
+  const isConfigRecipe = "__recipe__" in recipe
+  const svaFn = isConfigRecipe ? recipe : sva(recipe.config)
+
+  const getResolvedProps = (props, slotStyles) => {
+    const { unstyled, ...restProps } = props
+    if (unstyled) return restProps
+    if (isConfigRecipe) {
+       return { ...restProps, className: cx(slotStyles, restProps.className) }
+    }
+    return { ...slotStyles, ...restProps }
+  }
+
+  const withRootProvider = (Component) => {
+    const WithRootProvider = (props) => {
+      const [variantProps, otherProps] = svaFn.splitVariantProps(props)
+      
+      const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+      slotStyles._classNameMap = svaFn.classNameMap
+
+      return createElement(StyleContext.Provider, {
+        value: slotStyles,
+        children: createElement(Component, otherProps)
+      })
+    }
+    
+    const componentName = getDisplayName(Component)
+    WithRootProvider.displayName = `withRootProvider(${componentName})`
+    
+    return WithRootProvider
+  }
+
+  const withProvider = (Component, slot, options) => {
+    const StyledComponent = panda(Component, {}, options)
+    
+    const WithProvider = forwardRef((props, ref) => {
+      const [variantProps, restProps] = svaFn.splitVariantProps(props)
+      
+      const slotStyles = isConfigRecipe ? svaFn(variantProps) : svaFn.raw(variantProps)
+      slotStyles._classNameMap = svaFn.classNameMap
+
+      const resolvedProps = getResolvedProps(restProps, slotStyles[slot])
+      return createElement(StyleContext.Provider, {
+        value: slotStyles,
+        children: createElement(StyledComponent, {
+          ...resolvedProps,
+          className: cx(resolvedProps.className, slotStyles._classNameMap[slot]),
+          ref,
+        })
+      })
+    })
+    
+    const componentName = getDisplayName(Component)
+    WithProvider.displayName = `withProvider(${componentName})`
+    
+    return WithProvider
+  }
+
+  const withContext = (Component, slot) => {
+    const StyledComponent = panda(Component)
+    
+    const WithContext = forwardRef((props, ref) => {
+      const slotStyles = useContext(StyleContext)
+
+      const resolvedProps = getResolvedProps(props, slotStyles[slot])
+      return createElement(StyledComponent, {
+        ...resolvedProps,
+        className: cx(resolvedProps.className, slotStyles._classNameMap[slot]),
+        ref,
+      })
+    })
+    
+    const componentName = getDisplayName(Component)
+    WithContext.displayName = `withContext(${componentName})`
+    
+    return WithContext
+  }
+
+  return {
+    withRootProvider,
+    withProvider,
+    withContext,
+  }
+}

--- a/packages/studio/styled-system/jsx/index.d.ts
+++ b/packages/studio/styled-system/jsx/index.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 export * from './factory';
 export * from './is-valid-prop';
+export * from './create-style-context';
 export * from './box';
 export * from './flex';
 export * from './stack';

--- a/packages/studio/styled-system/jsx/index.mjs
+++ b/packages/studio/styled-system/jsx/index.mjs
@@ -1,5 +1,6 @@
 export * from './factory.mjs';
 export * from './is-valid-prop.mjs';
+export * from './create-style-context.mjs';
 export * from './box.mjs';
 export * from './flex.mjs';
 export * from './stack.mjs';

--- a/packages/types/src/artifact.ts
+++ b/packages/types/src/artifact.ts
@@ -23,6 +23,7 @@ export type ArtifactId =
   | 'jsx-helpers'
   | 'jsx-factory'
   | 'jsx-patterns'
+  | 'jsx-create-style-context'
   | 'jsx-patterns-index'
   | 'css-index'
   | 'themes'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1768,6 +1768,10 @@ packages:
     resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.28.0':
+    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.24.7':
     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
     engines: {node: '>=6.9.0'}
@@ -1831,6 +1835,10 @@ packages:
     resolution: {integrity: sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.24.8':
     resolution: {integrity: sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==}
@@ -2001,6 +2009,11 @@ packages:
 
   '@babel/parser@7.27.5':
     resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3060,6 +3073,10 @@ packages:
     resolution: {integrity: sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.28.0':
+    resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.25.2':
     resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
     engines: {node: '>=6.9.0'}
@@ -3078,6 +3095,10 @@ packages:
 
   '@babel/types@7.27.6':
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.1':
+    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
     engines: {node: '>=6.9.0'}
 
   '@braintree/sanitize-url@6.0.4':
@@ -4717,6 +4738,9 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -4739,8 +4763,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@jspm/core@2.0.1':
     resolution: {integrity: sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==}
@@ -4903,8 +4933,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mui/core-downloads-tracker@5.17.1':
-    resolution: {integrity: sha512-OcZj+cs6EfUD39IoPBOgN61zf1XFVY+imsGoBDwXeSq2UHJZE3N59zzBOVjclck91Ne3e9gudONOeILvHCIhUA==}
+  '@mui/core-downloads-tracker@5.18.0':
+    resolution: {integrity: sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==}
 
   '@mui/material@5.16.6':
     resolution: {integrity: sha512-0LUIKBOIjiFfzzFNxXZBRAyr9UQfmTAFzbt6ziOU2FDXhorNN2o3N9/32mNJbCA8zJo2FqFU6d3dtoqUDyIEfA==}
@@ -4933,8 +4963,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@5.16.14':
-    resolution: {integrity: sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==}
+  '@mui/styled-engine@5.18.0':
+    resolution: {integrity: sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -4946,8 +4976,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@5.17.1':
-    resolution: {integrity: sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==}
+  '@mui/system@5.18.0':
+    resolution: {integrity: sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -4970,8 +5000,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.4.3':
-    resolution: {integrity: sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==}
+  '@mui/types@7.4.4':
+    resolution: {integrity: sha512-p63yhbX52MO/ajXC7hDHJA5yjzJekvWD3q4YDLl1rSg+OXLczMYPvTuSuviPRCgRX8+E42RXz1D/dz9SxPSlWg==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -16982,6 +17012,9 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsup@8.0.2:
     resolution: {integrity: sha512-NY8xtQXdH7hDUAZwcQdY/Vzlw9johQsaqf7iwZ6g1DOUlFYQ5/AtVAjTvihhEyeRlGo4dLRVHtrRaL35M1daqQ==}
     engines: {node: '>=18'}
@@ -18490,7 +18523,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.5
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.26.9
       '@babel/traverse': 7.27.4
       '@babel/types': 7.27.6
       babel-preset-fbjs: 3.4.0(@babel/core@7.26.10)
@@ -18838,6 +18871,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
+  '@babel/generator@7.28.0':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.1
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
       '@babel/types': 7.27.6
@@ -18961,6 +19002,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-globals@7.28.0': {}
+
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
       '@babel/traverse': 7.27.4
@@ -18992,8 +19035,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.1
     transitivePeerDependencies:
       - supports-color
 
@@ -19178,6 +19221,10 @@ snapshots:
   '@babel/parser@7.27.5':
     dependencies:
       '@babel/types': 7.27.6
+
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.1
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3(@babel/core@7.26.10)':
     dependencies:
@@ -20537,6 +20584,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.28.0':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.0
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.0
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.1
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.25.2':
     dependencies:
       '@babel/helper-string-parser': 7.24.8
@@ -20559,6 +20618,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.27.6':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.28.1':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -22314,7 +22378,7 @@ snapshots:
 
   '@gatsbyjs/parcel-namer-relative-to-cwd@2.14.0(@parcel/core@2.8.3)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.26.9
       '@parcel/namer-default': 2.8.3(@parcel/core@2.8.3)
       '@parcel/plugin': 2.8.3(@parcel/core@2.8.3)
       gatsby-core-utils: 4.14.0
@@ -22641,6 +22705,11 @@ snapshots:
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
+  '@jridgewell/gen-mapping@0.3.12':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
+
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -22664,10 +22733,17 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.4': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.29':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@jspm/core@2.0.1': {}
 
@@ -22884,14 +22960,14 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@mui/core-downloads-tracker@5.17.1': {}
+  '@mui/core-downloads-tracker@5.18.0': {}
 
   '@mui/material@5.16.6(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.27.6
-      '@mui/core-downloads-tracker': 5.17.1
-      '@mui/system': 5.17.1(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0)
-      '@mui/types': 7.4.3(@types/react@18.2.55)
+      '@mui/core-downloads-tracker': 5.18.0
+      '@mui/system': 5.18.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0)
+      '@mui/types': 7.4.4(@types/react@18.2.55)
       '@mui/utils': 5.17.1(@types/react@18.2.55)(react@18.2.0)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.12(@types/react@18.2.55)
@@ -22916,10 +22992,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.55
 
-  '@mui/styled-engine@5.16.14(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(react@18.2.0)':
+  '@mui/styled-engine@5.18.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
@@ -22927,11 +23004,11 @@ snapshots:
       '@emotion/react': 11.13.0(@types/react@18.2.55)(react@18.2.0)
       '@emotion/styled': 11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0)
 
-  '@mui/system@5.17.1(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0)':
+  '@mui/system@5.18.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@mui/private-theming': 5.17.1(@types/react@18.2.55)(react@18.2.0)
-      '@mui/styled-engine': 5.16.14(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(react@18.2.0)
+      '@mui/styled-engine': 5.18.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.2.55)(react@18.2.0))(@types/react@18.2.55)(react@18.2.0))(react@18.2.0)
       '@mui/types': 7.2.24(@types/react@18.2.55)
       '@mui/utils': 5.17.1(@types/react@18.2.55)(react@18.2.0)
       clsx: 2.1.1
@@ -22947,7 +23024,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.55
 
-  '@mui/types@7.4.3(@types/react@18.2.55)':
+  '@mui/types@7.4.4(@types/react@18.2.55)':
     dependencies:
       '@babel/runtime': 7.27.6
     optionalDependencies:
@@ -27612,9 +27689,9 @@ snapshots:
   babel-eslint@10.1.0(eslint@7.32.0):
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.27.5
-      '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
+      '@babel/parser': 7.28.0
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.1
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.22.10
@@ -29981,7 +30058,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.1(eslint@8.56.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.1(eslint@8.56.0)(typescript@5.6.2))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -30031,7 +30108,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.1(eslint@8.56.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.1(eslint@8.56.0)(typescript@5.6.2))(eslint@8.56.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -30133,6 +30210,33 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.0.1(eslint@8.56.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.56.0)
+      hasown: 2.0.2
+      is-core-module: 2.15.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.0.1(eslint@8.56.0)(typescript@5.6.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.0.1(eslint@8.56.0)(typescript@5.6.2))(eslint@8.56.0):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.56.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -32782,7 +32886,7 @@ snapshots:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.6.2
+      tslib: 2.8.1
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
@@ -36935,7 +37039,7 @@ snapshots:
 
   relay-runtime@12.0.0:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.26.9
       fbjs: 3.0.5
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -38578,6 +38682,8 @@ snapshots:
   tslib@2.4.1: {}
 
   tslib@2.6.2: {}
+
+  tslib@2.8.1: {}
 
   tsup@8.0.2(@swc/core@1.7.6(@swc/helpers@0.4.36))(postcss@8.5.3)(typescript@5.6.2):
     dependencies:


### PR DESCRIPTION
### Style Context

Add `createStyleContext` function to framework artifacts for React, Preact, Solid, and Vue frameworks

```tsx
import { sva } from 'styled-system/css'
import { createStyleContext } from 'styled-system/jsx'

const card = sva({
  slots: ['root', 'label'],
  base: {
    root: {
      color: 'red',
      bg: 'red.300',
    },
    label: {
      fontWeight: 'medium',
    },
  },
  variants: {
    size: {
      sm: {
        root: {
          padding: '10px',
        },
      },
      md: {
        root: {
          padding: '20px',
        },
      },
    },
  },
  defaultVariants: {
    size: 'sm',
  },
})

const { withProvider, withContext } = createStyleContext(card)

const CardRoot = withProvider('div', 'root')
const CardLabel = withContext('label', 'label')
```

Then, use like this:

```tsx
<CardRoot size="sm">
  <CardLabel>Hello</CardLabel>
</CardRoot>
```
