### PR TITLE
docs: update Update Vite React guide to include jsxFramework: 'react', Emphasis using post css as recommend integration method.

### DIFF
--- a/website/pages/docs/installation/vite.mdx
+++ b/website/pages/docs/installation/vite.mdx
@@ -114,6 +114,9 @@ export default defineConfig({
  // Files to exclude
  exclude: [],
 
+ // Generates JSX utilities with options of React, Preact, Qwik, Solid, Vue 
+ jsxFramework: 'react',
+
  // The output directory for your css system
  outdir: "styled-system",
 })

--- a/website/pages/docs/overview/getting-started.mdx
+++ b/website/pages/docs/overview/getting-started.mdx
@@ -19,7 +19,7 @@ Panda combines the developer experience of CSS-in-JS and the performance of atom
 - [Panda CLI](/docs/installation/cli):
   The simplest way to use Panda is with the Panda CLI tool.
 
-- [Using PostCSS](/docs/installation/postcss):
+- [Using PostCSS](/docs/installation/postcss): (**Recommended**)
   Installing Panda as a PostCSS plugin is the recommended way to integrate it with your project.
 
 ### Framework Guides


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # N/A

## 📝 Description
Contains some small enhancements to the docs.
1. within the panda.config file since the vite example is using React I found the need to include `jsxFramework: 'react'` for codegen to create the jsx folder under styled-system to allow you to take advantage of  `import { styled } from "../styled-system/jsx;`.
2. Adds a bolded (**Recommended **) prefix to the getting-started-mdx file to add a bit more emphasis on Panda CSS recommended integration method.



## ⛳️ Current behavior (updates)
1. When following the video series from the pandamastery site the 'Panda CSS in 120 seconds' demo imports `import { styled } from "../styled-system/jsx;` but the installation guide does not include `jsxFramework: 'react'` within the panda.config file. This prevents the directory from being generated and stops you in your learning process to replicate the design and markup showcased on the video.
2. The getting started guide highlights "Panda CLI" as the "Simplest way to use Panda" however the recommended approach is to use PostCSS. Adds a bolded (Recommend) prefix to the "Using PostCSS" line just to add some extra emphasis.



## 🚀 New behavior
1.  Updates the Vite installation guide within the context of getting started with a react template.
2. Addes emphasis to "PostCSS" integration method on the getting started page.



## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information
Currently taking the pandamastery class and uncovered these small items during.
