### PR TITLE
docs: rsbuid installation hotfix for highlight

### DIFF
--- a/website/pages/docs/installation/rsbuild.mdx
+++ b/website/pages/docs/installation/rsbuild.mdx
@@ -82,7 +82,7 @@ Install panda and create your `panda.config.ts` file.
 
 Open your `package.json` file and update the `scripts` section as follows:
 
-```diff {3} filename="package.json"
+```diff {5} filename="package.json"
 {
   "scripts": {
     "build": "rsbuild build",


### PR DESCRIPTION
## 📝 Description

In yesterday PR i had small typo for highlighted command, fixed here

## ⛳️ Current behavior (updates)

<img width="726" height="235" alt="Снимок экрана 2025-09-01 в 13 38 35" src="https://github.com/user-attachments/assets/eb3b6a7f-d807-4d7e-8835-15bd633cf25c" />

## 🚀 New behavior

<img width="720" height="243" alt="Снимок экрана 2025-09-01 в 13 38 46" src="https://github.com/user-attachments/assets/5c0c5344-73b4-4106-a095-4629d9491514" />

## 💣 Is this a breaking change (Yes/No):

No