### PR TITLE
fix(codegen): missing export for JsxFactoryOptions imported in create-style-context.d.ts

### DIFF
--- a/.changeset/whole-items-shop.md
+++ b/.changeset/whole-items-shop.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/generator': patch
+---
+
+Correct exposed type from the generator that was causing errors in the generated .d.ts files.

--- a/packages/generator/src/artifacts/react-jsx/types.ts
+++ b/packages/generator/src/artifacts/react-jsx/types.ts
@@ -48,7 +48,7 @@ interface RecipeFn {
   __type: any
 }
 
-interface JsxFactoryOptions<TProps extends Dict> {
+export interface JsxFactoryOptions<TProps extends Dict> {
   dataAttr?: boolean
   defaultProps?: Partial<TProps>
   shouldForwardProp?: (prop: string, variantKeys: string[]) => boolean


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

<!-- Github issue # here -->

## 📝 Description

Add the missing export for a type in the PandaCSS generator that caused TypeScript errors in the generated `.d.ts` files.  
This export is already present in other JSX-related packages (e.g. `qwik-jsx`).

## ⛳️ Current behavior (updates)

The generator produced the correct type but did not export it, which led to TypeScript errors for consumers of the generated `.d.ts` (the type was unavailable/unexported).

## 🚀 New behavior

The type is now exported by the generator. Generated `.d.ts` files are valid and no longer produce TypeScript errors.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This is a types-only fix (adds an export). No runtime behavior changes.
