### PR TITLE
docs: fix nextjs panda.config example

### DIFF
--- a/website/content/docs/installation/nextjs.mdx
+++ b/website/content/docs/installation/nextjs.mdx
@@ -166,15 +166,18 @@ file.
 import { defineConfig } from "@pandacss/dev"
 
 export default defineConfig({
-// Whether to use css reset
-preflight: true,
+  // Whether to use css reset
+  preflight: true,
 
-// Where to look for your css declarations include: ["./src/components/**/*.{ts,tsx,js,jsx}",
-"./src/app/**/*.{ts,tsx,js,jsx}"],
+  // Where to look for your css declarations
+  include: ["./src/components/**/*.{ts,tsx,js,jsx}", "./src/app/**/*.{ts,tsx,js,jsx}"],
 
-// Files to exclude exclude: [],
+  // Files to exclude
+  exclude: [],
 
-// The output directory for your css system outdir: "styled-system", })
+  // The output directory for your css system
+  outdir: "styled-system",
+})
 
 ````
 {/* <!-- prettier-ignore-end --> */}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

NextJS docs bad formatting on panda.config.ts

## ⛳️ Current behavior (updates)

<img width="755" height="303" alt="Instalação Next js Panda CSS" src="https://github.com/user-attachments/assets/bd689250-f87b-409f-8bf9-8cc432cf2703" />


## 🚀 New behavior

Well formatted

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing Panda users. -->

## 📝 Additional Information

I think it's an issue with VS Code Format on Save function once the prettier ignore command has no effect on it
The only way I found was to make the changes then save using Cmd+Shift+P > File: Save without Formatting
Even after saved, if I press Cmd+S it gets bad formatting again