### PR TITLE
docs: update conditions to match code preset

### DIFF
--- a/website/content/docs/concepts/conditional-styles.mdx
+++ b/website/content/docs/concepts/conditional-styles.mdx
@@ -534,95 +534,115 @@ function Demo() {
 
 Here's a list of all the condition shortcuts you can use in Panda:
 
-| Condition name         | Selector                                                           |
-| ---------------------- | ------------------------------------------------------------------ |
-| \_hover                | `&:is(:hover, [data-hover])`                                       |
-| \_focus                | `&:is(:focus, [data-focus])`                                       |
-| \_focusWithin          | `&:focus-within`                                                   |
-| \_focusVisible         | `&:is(:focus-visible, [data-focus-visible])`                       |
-| \_disabled             | `&:is(:disabled, [disabled], [data-disabled])`                     |
-| \_active               | `&:is(:active, [data-active])`                                     |
-| \_visited              | `&:visited`                                                        |
-| \_target               | `&:target`                                                         |
-| \_readOnly             | `&:is(:read-only, [data-read-only])`                               |
-| \_readWrite            | `&:read-write`                                                     |
-| \_empty                | `&:is(:empty, [data-empty])`                                       |
-| \_checked              | `&:is(:checked, [data-checked], [aria-checked=true])`              |
-| \_enabled              | `&:enabled`                                                        |
-| \_expanded             | `&:is([aria-expanded=true], [data-expanded])`                      |
-| \_highlighted          | `&[data-highlighted]`                                              |
-| \_before               | `&::before`                                                        |
-| \_after                | `&::after`                                                         |
-| \_firstLetter          | `&::first-letter`                                                  |
-| \_firstLine            | `&::first-line`                                                    |
-| \_marker               | `&::marker`                                                        |
-| \_selection            | `&::selection`                                                     |
-| \_file                 | `&::file-selector-button`                                          |
-| \_backdrop             | `&::backdrop`                                                      |
-| \_first                | `&:first-child`                                                    |
-| \_last                 | `&:last-child`                                                     |
-| \_only                 | `&:only-child`                                                     |
-| \_even                 | `&:even`                                                           |
-| \_odd                  | `&:odd`                                                            |
-| \_firstOfType          | `&:first-of-type`                                                  |
-| \_lastOfType           | `&:last-of-type`                                                   |
-| \_onlyOfType           | `&:only-of-type`                                                   |
-| \_peerFocus            | `.peer:is(:focus, [data-focus]) ~ &`                               |
-| \_peerHover            | `.peer:is(:hover, [data-hover]) ~ &`                               |
-| \_peerActive           | `.peer:is(:active, [data-active]) ~ &`                             |
-| \_peerFocusWithin      | `.peer:focus-within ~ &`                                           |
-| \_peerFocusVisible     | `.peer:is(:focus-visible, [data-focus-visible]) ~ &`               |
-| \_peerDisabled         | `.peer:is(:disabled, [disabled], [data-disabled]) ~ &`             |
-| \_peerChecked          | `.peer:is(:checked, [data-checked], [aria-checked=true]) ~ &`      |
-| \_peerInvalid          | `.peer:is(:invalid, [data-invalid], [aria-invalid=true]) ~ &`      |
-| \_peerExpanded         | `.peer:is([aria-expanded=true], [data-expanded]) ~ &`              |
-| \_peerPlaceholderShown | `.peer:placeholder-shown ~ &`                                      |
-| \_groupFocus           | `.group:is(:focus, [data-focus]) &`                                |
-| \_groupHover           | `.group:is(:hover, [data-hover]) &`                                |
-| \_groupActive          | `.group:is(:active, [data-active]) &`                              |
-| \_groupFocusWithin     | `.group:focus-within &`                                            |
-| \_groupFocusVisible    | `.group:is(:focus-visible, [data-focus-visible]) &`                |
-| \_groupDisabled        | `.group:is(:disabled, [disabled], [data-disabled]) &`              |
-| \_groupChecked         | `.group:is(:checked, [data-checked], [aria-checked=true]) &`       |
-| \_groupExpanded        | `.group:is([aria-expanded=true], [data-expanded]) &`               |
-| \_groupInvalid         | `.group:is(:invalid, [data-invalid]) &`                            |
-| \_indeterminate        | `&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed])` |
-| \_required             | `&:is(:required, [data-required], [aria-required=true])`           |
-| \_valid                | `&:is(:valid, [data-valid])`                                       |
-| \_invalid              | `&:is(:invalid, [data-invalid])`                                   |
-| \_autofill             | `&:autofill`                                                       |
-| \_inRange              | `&:in-range`                                                       |
-| \_outOfRange           | `&:out-of-range`                                                   |
-| \_placeholder          | `&:is(:placeholder, [data-placeholder])`                           |
-| \_placeholderShown     | `&:is(:placeholder-shown, [data-placeholder-shown])`               |
-| \_pressed              | `&:is([aria-pressed=true], [data-pressed])`                        |
-| \_selected             | `&:is([aria-selected=true], [data-selected])`                      |
-| \_default              | `&:default`                                                        |
-| \_optional             | `&:optional`                                                       |
-| \_open                 | `&[open]`                                                          |
-| \_fullscreen           | `&:fullscreen`                                                     |
-| \_loading              | `&:is([data-loading], [aria-busy=true])`                           |
-| \_currentPage          | `&[aria-current=page]`                                             |
-| \_currentStep          | `&[aria-current=step]`                                             |
-| \_motionReduce         | `@media (prefers-reduced-motion: reduce)`                          |
-| \_motionSafe           | `@media (prefers-reduced-motion: no-preference)`                   |
-| \_print                | `@media print`                                                     |
-| \_landscape            | `@media (orientation: landscape)`                                  |
-| \_portrait             | `@media (orientation: portrait)`                                   |
-| \_dark                 | `&.dark, .dark &`                                                  |
-| \_light                | `&.light, .light &`                                                |
-| \_osDark               | `@media (prefers-color-scheme: dark)`                              |
-| \_osLight              | `@media (prefers-color-scheme: light)`                             |
-| \_highContrast         | `@media (forced-colors: active)`                                   |
-| \_lessContrast         | `@media (prefers-contrast: less)`                                  |
-| \_moreContrast         | `@media (prefers-contrast: more)`                                  |
-| \_ltr                  | `[dir=ltr] &`                                                      |
-| \_rtl                  | `[dir=rtl] &`                                                      |
-| \_scrollbar            | `&::-webkit-scrollbar`                                             |
-| \_scrollbarThumb       | `&::-webkit-scrollbar-thumb`                                       |
-| \_scrollbarTrack       | `&::-webkit-scrollbar-track`                                       |
-| \_horizontal           | `&[data-orientation=horizontal]`                                   |
-| \_vertical             | `&[data-orientation=vertical]`                                     |
+| Condition name         | Selector                                                                                         |
+| ---------------------- | -------------------------------------------------------------------------------------------------|
+| \_hover                | `&:is(:hover, [data-hover])`                                                                     |
+| \_focus                | `&:is(:focus, [data-focus])`                                                                     |
+| \_focusWithin          | `&:focus-within`                                                                                 |
+| \_focusVisible         | `&:is(:focus-visible, [data-focus-visible])`                                                     |
+| \_disabled             | `&:is(:disabled, [disabled], [data-disabled], [aria-disabled=true])`                             |
+| \_active               | `&:is(:active, [data-active])`                                                                   |
+| \_visited              | `&:visited`                                                                                      |
+| \_target               | `&:target`                                                                                       |
+| \_readOnly             | `&:is(:read-only, [data-read-only], [aria-readonly=true])`                                       |
+| \_readWrite            | `&:read-write`                                                                                   |
+| \_empty                | `&:is(:empty, [data-empty])`                                                                     |
+| \_checked              | `&:is(:checked, [data-checked], [aria-checked=true], [data-state="checked"])`                    |
+| \_enabled              | `&:enabled`                                                                                      |
+| \_expanded             | `&:is([aria-expanded=true], [data-expanded], [data-state="expanded"])`                           |
+| \_highlighted          | `&[data-highlighted]`                                                                            |
+| \_complete             | `&[data-complete]`                                                                               |
+| \_incomplete           | `&[data-incomplete]`                                                                             |
+| \_dragging             | `&[data-dragging]`                                                                               |
+| \_before               | `&::before`                                                                                      |
+| \_after                | `&::after`                                                                                       |
+| \_firstLetter          | `&::first-letter`                                                                                |
+| \_firstLine            | `&::first-line`                                                                                  |
+| \_marker               | `&::marker, &::-webkit-details-marker`                                                           |
+| \_selection            | `&::selection`                                                                                   |
+| \_file                 | `&::file-selector-button`                                                                        |
+| \_backdrop             | `&::backdrop`                                                                                    |
+| \_first                | `&:first-child`                                                                                  |
+| \_last                 | `&:last-child`                                                                                   |
+| \_only                 | `&:only-child`                                                                                   |
+| \_even                 | `&:nth-child(even)`                                                                              |
+| \_odd                  | `&:nth-child(odd)`                                                                               |
+| \_firstOfType          | `&:first-of-type`                                                                                |
+| \_lastOfType           | `&:last-of-type`                                                                                 |
+| \_onlyOfType           | `&:only-of-type`                                                                                 |
+| \_peerFocus            | `.peer:is(:focus, [data-focus]) ~ &`                                                             |
+| \_peerHover            | `.peer:is(:hover, [data-hover]) ~ &`                                                             |
+| \_peerActive           | `.peer:is(:active, [data-active]) ~ &`                                                           |
+| \_peerFocusWithin      | `.peer:focus-within ~ &`                                                                         |
+| \_peerFocusVisible     | `.peer:is(:focus-visible, [data-focus-visible]) ~ &`                                             |
+| \_peerDisabled         | `.peer:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) ~ &`                     |
+| \_peerChecked          | `.peer:is(:checked, [data-checked], [aria-checked=true], [data-state="checked"]) ~ &`            |
+| \_peerInvalid          | `.peer:is(:invalid, [data-invalid], [aria-invalid=true]) ~ &`                                    |
+| \_peerExpanded         | `.peer:is([aria-expanded=true], [data-expanded], [data-state="expanded"]) ~ &`                   |
+| \_peerPlaceholderShown | `.peer:placeholder-shown ~ &`                                                                    |
+| \_groupFocus           | `.group:is(:focus, [data-focus]) &`                                                              |
+| \_groupHover           | `.group:is(:hover, [data-hover]) &`                                                              |
+| \_groupActive          | `.group:is(:active, [data-active]) &`                                                            |
+| \_groupFocusWithin     | `.group:focus-within &`                                                                          |
+| \_groupFocusVisible    | `.group:is(:focus-visible, [data-focus-visible]) &`                                              |
+| \_groupDisabled        | `.group:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) &`                      |
+| \_groupChecked         | `.group:is(:checked, [data-checked], [aria-checked=true], [data-state="checked"]) &`             |
+| \_groupExpanded        | `.group:is([aria-expanded=true], [data-expanded], [data-state="expanded"]) &`                    |
+| \_groupInvalid         | `.group:is(:invalid, [data-invalid], [aria-invalid=true]) &`                                     |
+| \_indeterminate        | `&:is(:indeterminate, [data-indeterminate], [aria-checked=mixed], [data-state="indeterminate"])` |
+| \_required             | `&:is(:required, [data-required], [aria-required=true])`                                         |
+| \_valid                | `&:is(:valid, [data-valid])`                                                                     |
+| \_invalid              | `&:is(:invalid, [data-invalid], [aria-invalid=true])`                                            |
+| \_autofill             | `&:autofill`                                                                                     |
+| \_inRange              | `&:is(:in-range, [data-in-range])`                                                               |
+| \_outOfRange           | `&:is(:out-of-range, [data-outside-range])`                                                      |
+| \_placeholder          | `&::placeholder, &[data-placeholder]`                                                            |
+| \_placeholderShown     | `&:is(:placeholder-shown, [data-placeholder-shown])`                                             |
+| \_pressed              | `&:is([aria-pressed=true], [data-pressed])`                                                      |
+| \_selected             | `&:is([aria-selected=true], [data-selected])`                                                    |
+| \_grabbed              | `&:is([aria-grabbed=true], [data-grabbed])`                                                      |
+| \_underValue           | `&[data-state=under-value]`                                                                      |
+| \_overValue            | `&[data-state=over-value]`                                                                       |
+| \_atValue              | `&[data-state=at-value]`                                                                         |
+| \_default              | `&:default`                                                                                      |
+| \_optional             | `&:optional`                                                                                     |
+| \_open                 | `&:is([open], [data-open], [data-state="open"], :popover-open)`                                  |
+| \_closed               | `&:is([closed], [data-closed], [data-state="closed"])`                                           |
+| \_fullscreen           | `&:is(:fullscreen, [data-fullscreen])`                                                           |
+| \_loading              | `&:is([data-loading], [aria-busy=true])`                                                         |
+| \_hidden               | `&:is([hidden], [data-hidden])`                                                                  |
+| \_current              | `&:is([aria-current=true], [data-current])`                                                      |
+| \_currentPage          | `&[aria-current=page]`                                                                           |
+| \_currentStep          | `&[aria-current=step]`                                                                           |
+| \_today                | `&[data-today]`                                                                                  |
+| \_unavailable          | `&[data-unavailable]`                                                                            |
+| \_rangeStart           | `&[data-range-start]`                                                                            |
+| \_rangeEnd             | `&[data-range-end]`                                                                              |
+| \_now                  | `&[data-now]`                                                                                    |
+| \_topmost              | `&[data-topmost]`                                                                                |
+| \_motionReduce         | `@media (prefers-reduced-motion: reduce)`                                                        |
+| \_motionSafe           | `@media (prefers-reduced-motion: no-preference)`                                                 |
+| \_print                | `@media print`                                                                                   |
+| \_landscape            | `@media (orientation: landscape)`                                                                |
+| \_portrait             | `@media (orientation: portrait)`                                                                 |
+| \_dark                 | `.dark &`                                                                                        |
+| \_light                | `.light &`                                                                                       |
+| \_osDark               | `@media (prefers-color-scheme: dark)`                                                            |
+| \_osLight              | `@media (prefers-color-scheme: light)`                                                           |
+| \_highContrast         | `@media (forced-colors: active)`                                                                 |
+| \_lessContrast         | `@media (prefers-contrast: less)`                                                                |
+| \_moreContrast         | `@media (prefers-contrast: more)`                                                                |
+| \_ltr                  | `:where([dir=ltr], :dir(ltr)) &`                                                                 |
+| \_rtl                  | `:where([dir=rtl], :dir(rtl)) &`                                                                 |
+| \_scrollbar            | `&::-webkit-scrollbar`                                                                           |
+| \_scrollbarThumb       | `&::-webkit-scrollbar-thumb`                                                                     |
+| \_scrollbarTrack       | `&::-webkit-scrollbar-track`                                                                     |
+| \_horizontal           | `&[data-orientation=horizontal]`                                                                 |
+| \_vertical             | `&[data-orientation=vertical]`                                                                   |
+| \_icon                 | `& :where(svg)`                                                                                  |
+| \_starting             | `@starting-style`                                                                                |
+| \_noscript             | `@media (scripting: none)`                                                                       |
+| \_invertedColors       | `@media (inverted-colors: inverted)`                                                             |
 
 ## Custom conditions
 


### PR DESCRIPTION

## Added Missing Conditions:
- `_complete`, `_incomplete`, `_dragging`
- `_grabbed`, `_underValue`, `_overValue`, `_atValue`
- `_closed`, `_current`, `_today`, `_unavailable`
- `_rangeStart`, `_rangeEnd`, `_now`, `_topmost`, `_hidden`
- `_icon`, `_starting`, `_noscript`, `_invertedColors`

## Corrected Existing Selectors:
- Updated `_disabled` to include `[aria-disabled=true]`
- Updated `_readOnly` to include `[aria-readonly=true]`
- Updated `_checked` to include `[data-state="checked"]`
- Updated `_expanded` to include `[data-state="expanded"]`
- Updated `_indeterminate` to include `[data-state="indeterminate"]`
- Fixed `_even` and `_odd` to use `:nth-child()` syntax
- Updated `_placeholder` to use `::placeholder` pseudo-element
- Corrected `_open` to include multiple state variations
- Fixed `_fullscreen` to include data attribute variant
- Corrected `_dark` and `_light` class selectors
- Updated `_ltr` and `_rtl` to use `:where()` syntax
- Added webkit marker variant to `_marker`
- Updated range selectors to include data attribute variants
