### PR TITLE
docs: adds `jsxFramework` requirement for template literals

### DIFF
--- a/website/content/docs/concepts/template-literals.mdx
+++ b/website/content/docs/concepts/template-literals.mdx
@@ -20,7 +20,7 @@ To use template literals, you need to set the `syntax` option in your `panda.con
 export default defineConfig({
   // ...
   syntax: 'template-literal', // required
-  jsxFramework: 'react' // optional
+  jsxFramework: 'react' // required for JSX utilities, e.g. `styled`
 })
 ```
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3427

## 📝 Description

Adds `jsxFramework` requirement to use JSX utilities for template literals docs page. See #3428.

## ⛳️ Current behavior (updates)

Currently, template literal concept docs describe using `styled` but describe `jsxFramework` as optional at the top of the page.

## 🚀 New behavior

The current docs confused me, and may confuse others, so this is a proposal to be a little more specific about the config dependency. 

Open to moving the note to somewhere else if it seems appropriate. This seemed like the most straightforward option being right at the top of that page.

## 💣 Is this a breaking change (Yes/No):

No