### PR TITLE
fix: properly handle pseudo element ordering

### DIFF
--- a/.changeset/fix-pseudo-element-ordering.md
+++ b/.changeset/fix-pseudo-element-ordering.md
@@ -1,0 +1,12 @@
+---
+"@pandacss/core": patch
+---
+
+Fix pseudo-element conditions (::before, ::after) being placed before pseudo-class selectors in generated CSS
+
+When a pseudo-element condition like `_before` was combined with a mixed condition like `_hover` (defined as an array with a media query + selector), the pseudo-element would incorrectly appear before the pseudo-class in the generated CSS selector.
+
+**Before (broken):** `.class::before:is(:hover, ...)` - invalid CSS
+**After (fixed):** `.class:is(:hover, ...)::before` - valid CSS
+
+The fix ensures pseudo-element selectors are always sorted last in the condition chain, matching the CSS specification requirement that pseudo-elements must appear at the end of a selector.

--- a/packages/core/__tests__/conditions.test.ts
+++ b/packages/core/__tests__/conditions.test.ts
@@ -204,6 +204,71 @@ describe('Conditions', () => {
     expect(compareAtRuleOrMixed(m, n)).toBe(0)
   })
 
+  test('pseudo-elements sort after pseudo-classes and mixed conditions', () => {
+    // Simulates a real-world case: _before condition combined with a mixed hover condition
+    // (e.g. hover: ['@media (hover: hover)', '&:is(:hover, [data-hover]):not(:active, :disabled)'])
+    // The pseudo-element (::before) must come LAST in the selector chain per CSS spec.
+    const css = new Conditions({
+      conditions: {
+        hover: ['@media (hover: hover) and (pointer: fine)', '&:is(:hover, [data-hover]):not(:active, :disabled)'],
+        before: '&::before',
+        after: '&::after',
+        active: ['&:is(:active, [data-active]):not(:disabled)'],
+        focus: '&:is(:focus, [data-focus])',
+      },
+    })
+
+    // When _before appears first in the conditions array (as it does when nested inside _before in style objects),
+    // it should still be sorted to appear AFTER the hover selector parts.
+    // Without this fix, ::before would appear before :hover in the CSS selector, producing invalid CSS.
+    const sorted = css.sort(['_before', '_hover'])
+    expect(sorted.map((c) => c.raw)).toMatchInlineSnapshot(`
+      [
+        "@media (hover: hover) and (pointer: fine)",
+        "&:is(:hover, [data-hover]):not(:active, :disabled)",
+        "&::before",
+      ]
+    `)
+
+    // Same test with ::after
+    const sortedAfter = css.sort(['_after', '_hover'])
+    expect(sortedAfter.map((c) => c.raw)).toMatchInlineSnapshot(`
+      [
+        "@media (hover: hover) and (pointer: fine)",
+        "&:is(:hover, [data-hover]):not(:active, :disabled)",
+        "&::after",
+      ]
+    `)
+
+    // Pseudo-element with a non-mixed self-nesting condition
+    const sortedFocus = css.sort(['_before', '_focus'])
+    expect(sortedFocus.map((c) => c.raw)).toMatchInlineSnapshot(`
+      [
+        "&:is(:focus, [data-focus])",
+        "&::before",
+      ]
+    `)
+
+    // Pseudo-element with an array-wrapped self-nesting condition (active is ['&:is(...)'])
+    const sortedActive = css.sort(['_before', '_active'])
+    expect(sortedActive.map((c) => c.raw)).toMatchInlineSnapshot(`
+      [
+        "&:is(:active, [data-active]):not(:disabled)",
+        "&::before",
+      ]
+    `)
+
+    // When pseudo-element appears last naturally, order is preserved
+    const sortedNatural = css.sort(['_hover', '_before'])
+    expect(sortedNatural.map((c) => c.raw)).toMatchInlineSnapshot(`
+      [
+        "@media (hover: hover) and (pointer: fine)",
+        "&:is(:hover, [data-hover]):not(:active, :disabled)",
+        "&::before",
+      ]
+    `)
+  })
+
   test('theme conditions', () => {
     const css = new Conditions({
       themes: {

--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -16,6 +16,12 @@ import { compareAtRuleOrMixed } from './sort-style-rules'
 const isAtRule = (cond: ConditionDetails): boolean => cond.type === 'at-rule'
 
 /**
+ * Checks if a condition is a pseudo-element selector (::before, ::after, etc.)
+ * Pseudo-elements must appear at the end of CSS selector chains per the CSS spec.
+ */
+const isPseudoElement = (cond: ConditionDetails): boolean => typeof cond.raw === 'string' && cond.raw.includes('::')
+
+/**
  * Flattens a condition, extracting parts from mixed conditions.
  * Returns an array of { condition, originalIndex } to track source order.
  */
@@ -186,7 +192,7 @@ export class Conditions {
     // Flatten all conditions while tracking original index for stable sorting
     const flattened = rawConditions.flatMap((cond, index) => flattenCondition(cond, index))
 
-    // Sort: at-rules first, then selectors in original order
+    // Sort: at-rules first, pseudo-elements last, then selectors in original order
     flattened.sort((a, b) => {
       const aIsAtRule = isAtRule(a.cond)
       const bIsAtRule = isAtRule(b.cond)
@@ -194,6 +200,15 @@ export class Conditions {
       // At-rules come first
       if (aIsAtRule && !bIsAtRule) return -1
       if (!aIsAtRule && bIsAtRule) return 1
+
+      // Among non-at-rules: pseudo-elements (::before, ::after, etc.) must come last
+      // CSS requires pseudo-elements at the end of selector chains
+      if (!aIsAtRule && !bIsAtRule) {
+        const aIsPseudoElement = isPseudoElement(a.cond)
+        const bIsPseudoElement = isPseudoElement(b.cond)
+        if (aIsPseudoElement && !bIsPseudoElement) return 1
+        if (!aIsPseudoElement && bIsPseudoElement) return -1
+      }
 
       // Within same category, preserve original source order
       return a.originalIndex - b.originalIndex

--- a/packages/studio/styled-system/patterns/divider.d.ts
+++ b/packages/studio/styled-system/patterns/divider.d.ts
@@ -6,7 +6,7 @@ import type { DistributiveOmit } from '../types/system-types';
 import type { Tokens } from '../tokens/index';
 
 export interface DividerProperties {
-   orientation?: "horizontal" | "vertical"
+   orientation?: ConditionalValue<"horizontal" | "vertical">
 	thickness?: ConditionalValue<Tokens["sizes"] | Properties["borderWidth"]>
 	color?: ConditionalValue<Tokens["colors"] | Properties["borderColor"]>
 }

--- a/packages/studio/styled-system/patterns/float.d.ts
+++ b/packages/studio/styled-system/patterns/float.d.ts
@@ -9,7 +9,7 @@ export interface FloatProperties {
    offsetX?: ConditionalValue<Tokens["spacing"] | Properties["left"]>
 	offsetY?: ConditionalValue<Tokens["spacing"] | Properties["top"]>
 	offset?: ConditionalValue<Tokens["spacing"] | Properties["top"]>
-	placement?: "bottom-end" | "bottom-start" | "top-end" | "top-start" | "bottom-center" | "top-center" | "middle-center" | "middle-end" | "middle-start"
+	placement?: ConditionalValue<"bottom-end" | "bottom-start" | "top-end" | "top-start" | "bottom-center" | "top-center" | "middle-center" | "middle-end" | "middle-start">
 }
 
 interface FloatStyles extends FloatProperties, DistributiveOmit<SystemStyleObject, keyof FloatProperties > {}


### PR DESCRIPTION
I was just trying to update to latest version in my project and found another regression introduce in `v0.34.0`.

## 📝 Description

Fix pseudo-element conditions (`::before`, `::after`) being placed before pseudo-class selectors in generated CSS when combined with mixed (array-based) conditions.

## ⛳️ Current behavior (updates)

When a pseudo-element condition like `_before` is combined with a mixed condition like `_hover` (defined as an array, e.g. `hover: ['@media (hover: hover)', '&:is(:hover, ...)']`), the generated CSS selector places the pseudo-element before the pseudo-class:

`.class::before:is(:hover, ...)` — invalid CSS

This was introduced in 0.54.0 when `"mixed"` was added to the condition type ordering array for the theme conditions fix (commit [57343c1](https://github.com/chakra-ui/panda/commit/57343c1a58ee336e76489cc241981fa580a28ccb)). Mixed conditions moved from index -1 (not in array, sorted first) to index 4 (sorted after self-nesting pseudo-elements at index 1).

## 🚀 New behavior

Pseudo-element conditions always sort last among non-at-rule conditions in the selector chain, matching the CSS spec requirement:

`.class:is(:hover, ...)::before` — valid CSS

Adds an `isPseudoElement` check to the `sort()` method that pushes `::before`, `::after`, and other pseudo-elements to the end, regardless of other condition types.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

New test case with 5 assertions covering `_before`/`_after` combined with mixed, simple, and array-wrapped conditions. Full `@pandacss/core` test suite passes (233/233).