### PR TITLE
fix(cli): re-export AnimationStyles type from @pandacss/dev

### DIFF
--- a/.changeset/cli-animation-styles-type-export.md
+++ b/.changeset/cli-animation-styles-type-export.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/dev': patch
+---
+
+Re-export the `AnimationStyles` type from `@pandacss/dev` so the return type of `defineAnimationStyles` can be resolved by consumers. Previously only `TextStyles` and `LayerStyles` were re-exported, which caused the generated `.d.ts` to fall back to a deep qualified name (`_pandacss_types.AnimationStyles`) for `defineAnimationStyles`'s inferred return type. When consumers could not resolve that path, the value was inferred as `any` and triggered `@typescript-eslint/no-unsafe-assignment` at call sites.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { PandaError } from '@pandacss/shared'
 import type {
+  AnimationStyles,
   CompositionStyles,
   Config,
   CssKeyframes,
@@ -134,6 +135,7 @@ export function defineAnimationStyles(definition: CompositionStyles['animationSt
 }
 
 export type {
+  AnimationStyles,
   CompositionStyles,
   Config,
   CssKeyframes,


### PR DESCRIPTION
Closes # <!-- no tracking issue -->

## 📝 Description

Re-export the `AnimationStyles` type from `@pandacss/dev` so that the return type of `defineAnimationStyles` is resolvable by consumers, bringing it in line with its sibling composition-style helpers `defineTextStyles` / `defineLayerStyles`.

## ⛳️ Current behavior (updates)

`packages/cli/src/index.ts` re-exports `TextStyles` and `LayerStyles` but not `AnimationStyles`. Because the type is not part of the public export surface, tsup's dts rollup falls back to a deep qualified name (`_pandacss_types.AnimationStyles`) for `defineAnimationStyles`'s inferred return type in the generated `packages/cli/dist/index.d.ts`. When consumers' TypeScript setup cannot resolve that qualified path, the return type degrades to `any` and `@typescript-eslint/no-unsafe-assignment` is reported at call sites of `defineAnimationStyles`.

## 🚀 New behavior

`AnimationStyles` is added to both the `import type { ... }` and `export type { ... }` blocks in `packages/cli/src/index.ts`. The generated `.d.ts` now uses the top-level `AnimationStyles` name for `defineAnimationStyles`'s return type, just like `TextStyles` / `LayerStyles` for their counterparts, so the type is fully resolvable by consumers and the `no-unsafe-assignment` regression disappears.

There are no runtime behavior changes — the change is strictly to the public type export surface.

## 💣 Is this a breaking change (Yes/No):

No. This only adds a missing type to the public export surface; existing imports continue to work unchanged.

## 📝 Additional Information

- Verified by rebuilding `@pandacss/dev` (`pnpm --filter @pandacss/dev build`) and inspecting `packages/cli/dist/index.d.ts`: `AnimationStyles` now appears in both the `import` and `export` lists, and `defineAnimationStyles`'s return type is reported as `AnimationStyles` instead of `_pandacss_types.AnimationStyles`.
- No CSS output tests are affected; this is a pure type-surface fix.
- A changeset is included as a `@pandacss/dev` patch.