### PR TITLE
fix(core): order border side shorthands before colors

### DIFF
--- a/.changeset/fuzzy-borders-dance.md
+++ b/.changeset/fuzzy-borders-dance.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/core': patch
+---
+
+Fix border side shorthand ordering so declarations like `borderBottom` are emitted before border color declarations.

--- a/packages/core/__tests__/atomic-rule.test.ts
+++ b/packages/core/__tests__/atomic-rule.test.ts
@@ -64,6 +64,30 @@ describe('atomic / with basic style object', () => {
     `)
   })
 
+  test('should order compound border declarations before border color', () => {
+    expect(
+      css({
+        borderColor: 'white',
+        border: '1px solid',
+        borderBottom: '1px solid',
+      }),
+    ).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .bd_1px_solid {
+          border: 1px solid;
+      }
+
+        .bd-b_1px_solid {
+          border-bottom: 1px solid;
+      }
+
+        .bd-c_white {
+          border-color: var(--colors-white);
+      }
+      }"
+    `)
+  })
+
   test('should resolve responsive array', () => {
     expect(css({ width: ['50px', '60px'] })).toMatchInlineSnapshot(`
       "@layer utilities {

--- a/packages/core/src/sort-style-rules.ts
+++ b/packages/core/src/sort-style-rules.ts
@@ -115,9 +115,41 @@ export const compareAtRuleOrMixed = (a: WithConditions, b: WithConditions) => {
 
 export interface WithConditions extends Pick<AtomicStyleResult, 'conditions' | 'entry'> {}
 
+const borderSideShorthands = new Set([
+  'borderBlockStart',
+  'borderTop',
+  'borderBlockEnd',
+  'borderBottom',
+  'borderInlineStart',
+  'borderLeft',
+  'borderInlineEnd',
+  'borderRight',
+])
+
+const borderDimensionShorthands = new Set([
+  'borderColor',
+  'borderStyle',
+  'borderWidth',
+  'borderInlineColor',
+  'borderInlineStyle',
+  'borderInlineWidth',
+])
+
+// Side shorthands reset width, style, and color; keep them before dimension-only border shorthands.
+const sortByBorderPriority = (a: string, b: string) => {
+  const aScore = borderSideShorthands.has(a) ? 1 : borderDimensionShorthands.has(a) ? 2 : 0
+  const bScore = borderSideShorthands.has(b) ? 1 : borderDimensionShorthands.has(b) ? 2 : 0
+
+  return aScore && bScore ? aScore - bScore : 0
+}
+
 const sortByPropertyPriority = (a: WithConditions, b: WithConditions) => {
   if (a.entry.prop === b.entry.prop) return 0
-  return getPropertyPriority(a.entry.prop) - getPropertyPriority(b.entry.prop)
+
+  const priority = getPropertyPriority(a.entry.prop) - getPropertyPriority(b.entry.prop)
+  if (priority !== 0) return priority
+
+  return sortByBorderPriority(a.entry.prop, b.entry.prop)
 }
 
 /**


### PR DESCRIPTION
Closes #3516

## Description

Fix atomic CSS ordering for border side shorthands and border color declarations.

## Current behavior (updates)

`borderBottom: "1px solid"` can be emitted after `borderColor: "white"` because both declarations share the same broad property priority. The later shorthand resets border color to `currentColor`.

## New behavior

Border side shorthands now sort before dimension-only border declarations when their broad property priority ties. Exact border color declarations keep winning in the cascade.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Added an atomic-rule regression and a patch changeset for `@pandacss/core`.

Local verification:

- `pnpm exec prettier --check .changeset/fuzzy-borders-dance.md packages/core/src/sort-style-rules.ts packages/core/__tests__/atomic-rule.test.ts`
- `pnpm test packages/core/__tests__/atomic-rule.test.ts --run`
- `pnpm test packages/core/__tests__/sort-style-rules.test.ts --run`
