### PR TITLE
fix(postcss): strip @layer order declaration when polyfill is enabled

### DIFF
--- a/packages/node/src/builder.ts
+++ b/packages/node/src/builder.ts
@@ -196,6 +196,17 @@ export class Builder {
     ctx.appendBaselineCss(sheet)
     const css = ctx.getCss(sheet)
 
+    // When polyfill is enabled, the generated CSS has already been processed
+    // by @csstools/postcss-cascade-layers (in sheet.toCss()). The user's
+    // entry CSS still contains the @layer order declaration which must be
+    // removed to prevent downstream polyfill tools from producing bloated
+    // :not(#\#) specificity selectors.
+    if (ctx.config.polyfill) {
+      root.walkAtRules('layer', (rule) => {
+        rule.remove()
+      })
+    }
+
     root.append(css)
   }
 

--- a/packages/postcss/__tests__/postcss.test.ts
+++ b/packages/postcss/__tests__/postcss.test.ts
@@ -49,6 +49,18 @@ describe('PostCSS plugin', () => {
     expect(result.css.length).toBeGreaterThan(2)
   })
 
+  test('strip layer declarations when polyfill is enabled', async () => {
+    const input = '@layer reset, base, tokens, recipes, utilities;'
+    const configPath = join(__dirname, 'samples', 'panda.polyfill.config.cjs')
+
+    builder.context = undefined
+    const result = await run(input, { configPath })
+
+    expect(result.css).not.toContain('@layer reset, base, tokens, recipes, utilities;')
+    expect(result.css).not.toContain('@layer')
+    expect(result.css.length).toBeGreaterThan(2)
+  })
+
   test('register `include` as dependencies', async () => {
     const input = '@layer reset, base, tokens, recipes, utilities;'
     const configPath = join(__dirname, 'samples', 'panda.config.cjs')

--- a/packages/postcss/__tests__/samples/panda.polyfill.config.cjs
+++ b/packages/postcss/__tests__/samples/panda.polyfill.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  preflight: true,
+  presets: ['@pandacss/dev/presets'],
+  include: ['./src/**/*.{ts,tsx,jsx}', './src/**/*.{css,pcss}'],
+  exclude: [],
+  jsxFramework: 'react',
+  polyfill: true,
+}


### PR DESCRIPTION
Fixes #3540

## Problem

When polyfill: true is set in panda config, the PostCSS plugin correctly applies @csstools/postcss-cascade-layers to the **generated** CSS (in sheet.toCss()). However, the user's entry CSS still contains the @layer reset, base, tokens, recipes, utilities; order declaration — it is never removed from the PostCSS root.

This orphaned declaration causes downstream polyfill tools (like postcss-preset-env) to produce bloated :not(#\#) specificity selectors on all styles, because they try to rewrite the order declaration but find no matching @layer blocks.

## Fix

Strip all @layer at-rules from the PostCSS root before appending the polyfilled CSS, when polyfill: true is enabled. This is safe because:
1. The generated CSS has already been polyfilled (no @layer rules remain)
2. The CSS is emitted in correct cascade order (reset → utilities)
3. Only the user's entry CSS is in the root at this point