### PR TITLE
[v2] Improve Rust extractor allocation efficiency

### DIFF
--- a/crates/pandacss_extractor/src/calls.rs
+++ b/crates/pandacss_extractor/src/calls.rs
@@ -10,6 +10,7 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use serde::Serialize;
+use smallvec::SmallVec;
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -179,8 +180,8 @@ fn is_raw_category(category: MatchCategory) -> bool {
 
 fn flatten_static_member_path<'a>(
     expr: &'a Expression<'_>,
-) -> Option<(&'a IdentifierReference<'a>, Vec<&'a str>)> {
-    let mut path = Vec::new();
+) -> Option<(&'a IdentifierReference<'a>, SmallVec<[&'a str; 3]>)> {
+    let mut path = SmallVec::new();
     let mut current = expr;
     loop {
         match current {

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -14,6 +14,7 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use serde::Serialize;
 use smallvec::SmallVec;
+use std::borrow::Cow;
 
 /// Member-chain tags like `<styled.div>` are accepted only when the root
 /// name is configured as a JSX factory; otherwise a named import like
@@ -99,8 +100,14 @@ struct Extractor<'walk, 'ctx> {
     out: &'walk mut Vec<ExtractedJsx>,
 }
 
+struct ResolvedTag<'a> {
+    category: MatchCategory,
+    name: Cow<'a, str>,
+    alias: Cow<'a, str>,
+}
+
 impl Extractor<'_, '_> {
-    fn resolve_tag(&self, name: &JSXElementName<'_>) -> Option<(MatchCategory, String, String)> {
+    fn resolve_tag<'a>(&'a self, name: &'a JSXElementName<'_>) -> Option<ResolvedTag<'a>> {
         // Lowercase HTML idents, `JSXNamespacedName` (`<svg:circle>`),
         // and `ThisExpression` (`<this.X>`) are never Panda usages.
         match name {
@@ -122,18 +129,22 @@ impl Extractor<'_, '_> {
                     {
                         return None;
                     }
-                    return Some((
-                        matched.category,
-                        matched.name.clone(),
-                        matched.alias.clone(),
-                    ));
+                    return Some(ResolvedTag {
+                        category: matched.category,
+                        name: Cow::Borrowed(&matched.name),
+                        alias: Cow::Borrowed(&matched.alias),
+                    });
                 }
 
                 let tag_name = id.name.as_str();
                 if !self.ctx.config.jsx.is_component_tag(tag_name) {
                     return None;
                 }
-                Some((MatchCategory::Jsx, tag_name.to_owned(), tag_name.to_owned()))
+                Some(ResolvedTag {
+                    category: MatchCategory::Jsx,
+                    name: Cow::Borrowed(tag_name),
+                    alias: Cow::Borrowed(tag_name),
+                })
             }
             JSXElementName::MemberExpression(member) => {
                 let (root, root_ident, path) = flatten_member(member)?;
@@ -143,12 +154,12 @@ impl Extractor<'_, '_> {
         }
     }
 
-    fn resolve_member(
-        &self,
-        root: &str,
-        root_ident: &IdentifierReference<'_>,
+    fn resolve_member<'a>(
+        &'a self,
+        root: &'a str,
+        root_ident: &'a IdentifierReference<'_>,
         path: &[&str],
-    ) -> Option<(MatchCategory, String, String)> {
+    ) -> Option<ResolvedTag<'a>> {
         if let Some(resolver) = self.ctx.resolver
             && !resolver.is_import_binding(root_ident)
         {
@@ -157,7 +168,11 @@ impl Extractor<'_, '_> {
         let Some(matched) = self.ctx.aliases.get(root) else {
             let display = member_display(root, path);
             if self.ctx.config.jsx.is_component_tag(&display) {
-                return Some((MatchCategory::Jsx, display, root.to_owned()));
+                return Some(ResolvedTag {
+                    category: MatchCategory::Jsx,
+                    name: Cow::Owned(display),
+                    alias: Cow::Borrowed(root),
+                });
             }
             return None;
         };
@@ -178,7 +193,11 @@ impl Extractor<'_, '_> {
                     return None;
                 }
                 let display = member_display(&matched.name, path);
-                Some((matched.category, display, matched.alias.clone()))
+                Some(ResolvedTag {
+                    category: matched.category,
+                    name: Cow::Owned(display),
+                    alias: Cow::Borrowed(&matched.alias),
+                })
             }
             ImportSpecifierKind::Namespace => {
                 let first = path.first()?;
@@ -190,13 +209,17 @@ impl Extractor<'_, '_> {
                 {
                     return None;
                 }
-                Some((matched.category, join_path(path), matched.alias.clone()))
+                Some(ResolvedTag {
+                    category: matched.category,
+                    name: Cow::Owned(join_path(path)),
+                    alias: Cow::Borrowed(&matched.alias),
+                })
             }
             ImportSpecifierKind::Default => None,
         }
     }
 
-    fn resolve_tagged_tag(&self, tag: &Expression<'_>) -> Option<(MatchCategory, String, String)> {
+    fn resolve_tagged_tag<'a>(&'a self, tag: &'a Expression<'_>) -> Option<ResolvedTag<'a>> {
         let Expression::StaticMemberExpression(member) = tag else {
             return None;
         };
@@ -207,21 +230,22 @@ impl Extractor<'_, '_> {
 
 impl<'a> Visit<'a> for Extractor<'_, '_> {
     fn visit_jsx_opening_element(&mut self, element: &JSXOpeningElement<'a>) {
-        if let Some((category, name, alias)) = self.resolve_tag(&element.name) {
-            let mut entries: Vec<(String, Literal)> = Vec::new();
+        if let Some(resolved) = self.resolve_tag(&element.name) {
+            let tag_name = resolved.name.as_ref();
+            let mut entries: Vec<(String, Literal)> = Vec::with_capacity(element.attributes.len());
             for item in &element.attributes {
                 merge_attribute(
                     item,
                     &mut entries,
                     self.ctx.resolver,
                     &self.ctx.config.jsx,
-                    &name,
+                    tag_name,
                 );
             }
             self.out.push(ExtractedJsx {
-                category,
-                name,
-                alias,
+                category: resolved.category,
+                name: resolved.name.into_owned(),
+                alias: resolved.alias.into_owned(),
                 data: Literal::Object(entries),
                 span: Span::from(element.span),
             });
@@ -230,14 +254,14 @@ impl<'a> Visit<'a> for Extractor<'_, '_> {
     }
 
     fn visit_tagged_template_expression(&mut self, tagged: &TaggedTemplateExpression<'a>) {
-        if let Some((category, name, alias)) = self.resolve_tagged_tag(&tagged.tag)
+        if let Some(resolved) = self.resolve_tagged_tag(&tagged.tag)
             && let Some(data @ Literal::Object(_)) =
                 css_template_to_object(&tagged.quasi, self.ctx.resolver)
         {
             self.out.push(ExtractedJsx {
-                category,
-                name,
-                alias,
+                category: resolved.category,
+                name: resolved.name.into_owned(),
+                alias: resolved.alias.into_owned(),
                 data,
                 span: Span::from(tagged.span),
             });

--- a/crates/pandacss_extractor/src/matcher.rs
+++ b/crates/pandacss_extractor/src/matcher.rs
@@ -359,17 +359,26 @@ pub fn match_imports(scan: &ImportScanResult, matchers: &Matchers) -> Vec<Matche
 /// Type-only imports (declaration or specifier level) are skipped.
 #[must_use]
 pub fn match_import_records(records: &[ImportRecord], matchers: &Matchers) -> Vec<MatchedImport> {
-    let index = ImportMatcherIndex::new(records, matchers);
+    let categories = active_categories(matchers);
     let mut out = Vec::new();
     for record in records {
         if record.type_only {
+            continue;
+        }
+        let source_categories: SmallVec<[(MatchCategory, &Matcher); 5]> = categories
+            .iter()
+            .copied()
+            .filter(|(_, matcher)| matcher.accepts_module(&record.module))
+            .collect();
+        if source_categories.is_empty() {
             continue;
         }
         for specifier in &record.specifiers {
             if specifier.type_only || specifier.kind == ImportSpecifierKind::Default {
                 continue;
             }
-            let Some(category) = index.category_for(record, specifier) else {
+            let Some(category) = matching_category_for_specifier(specifier, &source_categories)
+            else {
                 continue;
             };
             out.push(MatchedImport {
@@ -384,67 +393,15 @@ pub fn match_import_records(records: &[ImportRecord], matchers: &Matchers) -> Ve
     out
 }
 
-struct ImportMatcherIndex<'a> {
-    source_name_categories: FxHashMap<(&'a str, &'a str, ImportSpecifierKind), MatchCategory>,
-}
-
-impl<'a> ImportMatcherIndex<'a> {
-    fn new(records: &'a [ImportRecord], matchers: &'a Matchers) -> Self {
-        let categories = active_categories(matchers);
-        let mut source_name_categories = FxHashMap::default();
-        for record in records {
-            if record.type_only {
-                continue;
-            }
-            let source_categories: SmallVec<[(MatchCategory, &Matcher); 5]> = categories
-                .iter()
-                .copied()
-                .filter(|(_, matcher)| matcher.accepts_module(&record.module))
-                .collect();
-            if source_categories.is_empty() {
-                continue;
-            }
-            for specifier in &record.specifiers {
-                if specifier.type_only || specifier.kind == ImportSpecifierKind::Default {
-                    continue;
-                }
-                let name = match specifier.kind {
-                    ImportSpecifierKind::Namespace => "*",
-                    ImportSpecifierKind::Named | ImportSpecifierKind::Default => {
-                        specifier.imported.as_str()
-                    }
-                };
-                let Some((category, _)) = source_categories.iter().find(|(_, matcher)| {
-                    specifier.kind == ImportSpecifierKind::Namespace
-                        || matcher.names.accepts(&specifier.imported)
-                }) else {
-                    continue;
-                };
-                source_name_categories
-                    .entry((record.module.as_str(), name, specifier.kind))
-                    .or_insert(*category);
-            }
-        }
-        Self {
-            source_name_categories,
-        }
-    }
-
-    fn category_for(
-        &self,
-        record: &'a ImportRecord,
-        specifier: &'a ImportSpecifier,
-    ) -> Option<MatchCategory> {
-        let name = match specifier.kind {
-            ImportSpecifierKind::Namespace => "*",
-            ImportSpecifierKind::Named | ImportSpecifierKind::Default => {
-                specifier.imported.as_str()
-            }
-        };
-        self.source_name_categories
-            .get(&(record.module.as_str(), name, specifier.kind))
-            .copied()
-    }
+fn matching_category_for_specifier(
+    specifier: &ImportSpecifier,
+    source_categories: &[(MatchCategory, &Matcher)],
+) -> Option<MatchCategory> {
+    source_categories.iter().find_map(|(category, matcher)| {
+        (specifier.kind == ImportSpecifierKind::Namespace
+            || matcher.names.accepts(&specifier.imported))
+        .then_some(*category)
+    })
 }
 
 fn active_categories(matchers: &Matchers) -> SmallVec<[(MatchCategory, &Matcher); 5]> {

--- a/crates/pandacss_extractor/src/scope.rs
+++ b/crates/pandacss_extractor/src/scope.rs
@@ -24,6 +24,7 @@ use oxc_ast::ast::{
 use oxc_semantic::{Semantic, SemanticBuilder, SymbolFlags, SymbolId};
 use pandacss_tokens::TokenDictionary;
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use crate::cross_file::{CrossFileLookup, CrossFileResolver};
 use crate::literal::expression_to_literal;
@@ -348,8 +349,8 @@ fn is_raw_category(category: MatchCategory) -> bool {
 
 fn flatten_static_member_path<'a>(
     expr: &'a Expression<'_>,
-) -> Option<(&'a IdentifierReference<'a>, Vec<&'a str>)> {
-    let mut path = Vec::new();
+) -> Option<(&'a IdentifierReference<'a>, SmallVec<[&'a str; 3]>)> {
+    let mut path = SmallVec::new();
     let mut current = expr;
     loop {
         match current {

--- a/crates/pandacss_extractor/tests/raw_spreads.rs
+++ b/crates/pandacss_extractor/tests/raw_spreads.rs
@@ -11,7 +11,7 @@ fn run(source: &str) -> ExtractUsage {
 
 #[test]
 fn css_raw_spread_with_computed_property_name_matches_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css } from '@panda/css';
         const baseStyles = css.raw({
           color: 'red',
@@ -25,7 +25,7 @@ fn css_raw_spread_with_computed_property_name_matches_js_fixture() {
             opacity: 0.8
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     assert_yaml_snapshot!(calls.last().expect("final css call").data, @"
     - color: red
@@ -66,7 +66,7 @@ fn css_raw_spread_deeply_nested_conditions_match_js_fixture() {
 
 #[test]
 fn css_raw_conditional_spreads_with_static_test_match_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css } from '@panda/css';
         const baseStyles = css.raw({ color: 'blue', padding: '8px' });
         const isActive = true;
@@ -77,7 +77,7 @@ fn css_raw_conditional_spreads_with_static_test_match_js_fixture() {
             opacity: 0.9
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     assert_yaml_snapshot!(calls.last().expect("final css call").data, @"
     - color: blue
@@ -91,7 +91,7 @@ fn css_raw_conditional_spreads_with_static_test_match_js_fixture() {
 
 #[test]
 fn css_raw_spread_inside_array_value_matches_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css } from '@panda/css';
         const baseStyles = css.raw({ color: 'green', fontSize: '16px' });
         const component = css({
@@ -103,7 +103,7 @@ fn css_raw_spread_inside_array_value_matches_js_fixture() {
             }
           ]
         });
-    "#};
+    "};
     let calls = run(src).calls;
     assert_yaml_snapshot!(calls.last().expect("final css call").data, @"
     - color: green
@@ -117,7 +117,7 @@ fn css_raw_spread_inside_array_value_matches_js_fixture() {
 
 #[test]
 fn css_raw_spread_with_renamed_import_matches_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css as pandaCss } from '@panda/css';
         const baseStyles = pandaCss.raw({
           color: 'purple',
@@ -130,7 +130,7 @@ fn css_raw_spread_with_renamed_import_matches_js_fixture() {
             transform: 'scale(0.98)'
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     assert_yaml_snapshot!(calls.last().expect("final css call").data, @"
     - color: purple
@@ -144,7 +144,7 @@ fn css_raw_spread_with_renamed_import_matches_js_fixture() {
 
 #[test]
 fn css_raw_nullish_spreads_are_ignored_match_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css } from '@panda/css';
         const baseStyles = undefined;
         const nullStyles = null;
@@ -158,7 +158,7 @@ fn css_raw_nullish_spreads_are_ignored_match_js_fixture() {
             opacity: 0.7
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     assert_yaml_snapshot!(calls.last().expect("final css call").data, @"
     - color: orange
@@ -172,7 +172,7 @@ fn css_raw_nullish_spreads_are_ignored_match_js_fixture() {
 
 #[test]
 fn css_raw_function_return_spread_degrades_like_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css } from '@panda/css';
         const baseStyles = css.raw({ display: 'flex', gap: '10px' });
         const getStyles = () => ({
@@ -186,7 +186,7 @@ fn css_raw_function_return_spread_degrades_like_js_fixture() {
             background: 'gray.100'
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     assert_yaml_snapshot!(calls.last().expect("final css call").data, @"
     - _hover:
@@ -198,7 +198,7 @@ fn css_raw_function_return_spread_degrades_like_js_fixture() {
 
 #[test]
 fn css_raw_spread_in_cva_variant_matches_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css, cva } from '@panda/css';
         const hoverStyles = css.raw({ bg: 'blue.500', color: 'white' });
         const button = cva({
@@ -211,7 +211,7 @@ fn css_raw_spread_in_cva_variant_matches_js_fixture() {
             }
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     let cva = calls
         .iter()
@@ -229,7 +229,7 @@ fn css_raw_spread_in_cva_variant_matches_js_fixture() {
 
 #[test]
 fn css_raw_spread_in_sva_slot_matches_js_fixture() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { css, sva } from '@panda/css';
         const rootStyles = css.raw({ display: 'flex', gap: '2' });
         const recipe = sva({
@@ -242,7 +242,7 @@ fn css_raw_spread_in_sva_slot_matches_js_fixture() {
             label: { color: 'gray.700' }
           }
         });
-    "#};
+    "};
     let calls = run(src).calls;
     let sva = calls
         .iter()

--- a/crates/pandacss_extractor/tests/token_calls.rs
+++ b/crates/pandacss_extractor/tests/token_calls.rs
@@ -261,11 +261,11 @@ fn token_folds_inside_template_literal_interpolation() {
     // `border: `1px solid ${token('colors.red.500')}`` — the token() call inside
     // the template interpolation folds and the whole literal concatenates,
     // matching the JS extractor's token-in-template handling.
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { token } from '@panda/tokens';
         import { css } from '@panda/css';
         css({ border: `1px solid ${token('colors.red.500')}` });
-    "#};
+    "};
     assert_yaml_snapshot!(
         css_string_prop(&run_with_tokens(src), "border"),
         @r#""1px solid #ef4444""#
@@ -274,11 +274,11 @@ fn token_folds_inside_template_literal_interpolation() {
 
 #[test]
 fn multiple_token_calls_in_one_template_fold() {
-    let src = indoc! {r#"
+    let src = indoc! {r"
         import { token } from '@panda/tokens';
         import { css } from '@panda/css';
         css({ font: `${token('sizes.sm')} / ${token('colors.red.500')}` });
-    "#};
+    "};
     assert_yaml_snapshot!(
         css_string_prop(&run_with_tokens(src), "font"),
         @r#""4px / #ef4444""#

--- a/crates/pandacss_shared/src/hash.rs
+++ b/crates/pandacss_shared/src/hash.rs
@@ -5,7 +5,7 @@
 /// common case (`colors-red-500`, `spacing-sm`, ...).
 #[must_use]
 pub fn to_hash(value: &str) -> String {
-    to_name(to_phash(5381, value) as u32)
+    to_name(to_phash(5381, value).cast_unsigned())
 }
 
 fn to_phash(mut h: i32, value: &str) -> i32 {
@@ -44,5 +44,7 @@ fn to_name(code: u32) -> String {
 }
 
 fn to_char(code: u32) -> u8 {
-    (code + if code > 25 { 39 } else { 97 }) as u8
+    debug_assert!(code < 52);
+    let byte = code + if code > 25 { 39 } else { 97 };
+    u8::try_from(byte).expect("base52 hash character fits in ASCII")
 }

--- a/crates/pandacss_tokens/src/from_config.rs
+++ b/crates/pandacss_tokens/src/from_config.rs
@@ -6,7 +6,7 @@ use pandacss_config::{
     TokenEntry, TokenGroup, TokenNode, Tokens, UserConfig,
 };
 use pandacss_shared::{capitalize, number_to_js_string, to_hash};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     Token, TokenCategory, TokenDictionary, TokenDictionaryBuilder, TokenError,
@@ -129,7 +129,7 @@ fn collect_tokens(
 ) {
     macro_rules! collect {
         ($name:literal, $category:expr, $group:expr) => {
-            collect_token_category(builder, context, $name, $category, $group, condition);
+            collect_token_category(builder, context, $name, &$category, $group, condition);
         };
     }
 
@@ -190,7 +190,14 @@ fn collect_semantic_tokens(
 ) {
     macro_rules! collect {
         ($name:literal, $category:expr, $group:expr) => {
-            collect_semantic_category(builder, context, $name, $category, $group, forced_condition);
+            collect_semantic_category(
+                builder,
+                context,
+                $name,
+                &$category,
+                $group,
+                forced_condition,
+            );
         };
     }
 
@@ -247,7 +254,7 @@ fn collect_token_category<T: TokenValueString>(
     builder: &mut TokenDictionaryBuilder,
     context: &mut BuildContext<'_>,
     category: &'static str,
-    token_category: TokenCategory,
+    token_category: &TokenCategory,
     group: &TokenGroup<T>,
     condition: Option<&str>,
 ) {
@@ -270,7 +277,7 @@ fn collect_semantic_category<T: TokenValueString>(
     builder: &mut TokenDictionaryBuilder,
     context: &mut BuildContext<'_>,
     category: &'static str,
-    token_category: TokenCategory,
+    token_category: &TokenCategory,
     group: &TokenGroup<SemanticValue<T>>,
     forced_condition: Option<&str>,
 ) {
@@ -593,11 +600,11 @@ fn add_negative_spacing_tokens(builder: &mut TokenDictionaryBuilder) {
         value.push_str(" * -1)");
 
         let mut negative = Token::new(path, value, "", TokenCategory::Spacing);
-        negative.condition = token.condition.clone();
+        negative.condition.clone_from(&token.condition);
         negative.original_value = Some(Arc::clone(&token.value));
-        negative.description = token.description.clone();
+        negative.description.clone_from(&token.description);
         negative.deprecated = token.deprecated;
-        negative.extensions = token.extensions.clone();
+        negative.extensions.clone_from(&token.extensions);
         negative.set_extension("isNegative", "true");
         negative.set_extension("prop", format!("-{last}"));
         negative.set_extension("originalPath", token.path.as_ref());
@@ -623,7 +630,7 @@ fn add_virtual_color_palette_tokens(
         return;
     }
 
-    let mut virtual_paths = FxHashMap::<String, ()>::default();
+    let mut virtual_paths = FxHashSet::<String>::default();
     let mut palette_mappings: Vec<(String, String, Arc<str>)> = Vec::new();
     for token in builder.tokens_mut().iter_mut() {
         if token.category != TokenCategory::Colors
@@ -648,7 +655,7 @@ fn add_virtual_color_palette_tokens(
             let raw_virtual_var = css_var_variable(&virtual_css_var_name, context);
             let palette_name = join_segments(&color_path[..root_len]);
 
-            virtual_paths.insert(virtual_path, ());
+            virtual_paths.insert(virtual_path);
             palette_mappings.push((palette_name, raw_virtual_var, Arc::clone(&token.var)));
 
             if root_len == 1 && token.extension("isDefault") == Some("true") {
@@ -660,7 +667,7 @@ fn add_virtual_color_palette_tokens(
                     let raw_base_virtual_var =
                         css_var_variable(&base_virtual_css_var_name, context);
 
-                    virtual_paths.insert(base_virtual_path.to_owned(), ());
+                    virtual_paths.insert(base_virtual_path.to_owned());
                     palette_mappings.push((
                         special_palette,
                         raw_base_virtual_var,
@@ -672,7 +679,7 @@ fn add_virtual_color_palette_tokens(
         token.set_extension("colorPalette", &color_path_string);
     }
 
-    let mut virtual_paths: Vec<String> = virtual_paths.into_keys().collect();
+    let mut virtual_paths: Vec<String> = virtual_paths.into_iter().collect();
     virtual_paths.sort();
     for path in virtual_paths {
         let token_path = TokenPath::from_owned_path(path);
@@ -848,8 +855,7 @@ fn color_mix(
 
     let color = by_path
         .get(color_path)
-        .map(|index| tokens[*index].var.as_ref())
-        .unwrap_or(color_path);
+        .map_or(color_path, |index| tokens[*index].var.as_ref());
     let mut opacity_path = String::with_capacity("opacity.".len() + raw_opacity.len());
     opacity_path.push_str("opacity.");
     opacity_path.push_str(raw_opacity);

--- a/crates/pandacss_tokens/src/lib.rs
+++ b/crates/pandacss_tokens/src/lib.rs
@@ -375,11 +375,23 @@ impl TokenDictionary {
         TokenDictionaryBuilder::default()
     }
 
+    /// Build a token dictionary from a Panda user config.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when token transforms encounter invalid configured
+    /// values, such as malformed color-mix opacity expressions.
     pub fn from_config(config: &pandacss_config::UserConfig) -> Result<Option<Self>, TokenError> {
         let _span = tracing::debug_span!("token_dictionary_build", source = "config").entered();
         Self::from_options(TokenDictionaryOptions::from_config(config))
     }
 
+    /// Build a token dictionary from normalized token dictionary options.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when token transforms encounter invalid configured
+    /// values, such as malformed color-mix opacity expressions.
     pub fn from_options(options: TokenDictionaryOptions<'_>) -> Result<Option<Self>, TokenError> {
         let _span = tracing::debug_span!("token_dictionary_build", source = "options").entered();
         from_config::create_token_dictionary(options)

--- a/crates/pandacss_tokens/tests/dictionary.rs
+++ b/crates/pandacss_tokens/tests/dictionary.rs
@@ -549,6 +549,10 @@ fn extend_flat_builds_a_usable_dictionary() {
 // --- config-derived construction ---
 
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "fixture-heavy config test keeps related token assertions together"
+)]
 fn from_config_collects_theme_tokens_semantic_tokens_and_breakpoints() {
     let config: UserConfig = serde_json::from_value(json!({
         "theme": {
@@ -1330,6 +1334,10 @@ fn from_config_flattens_deep_semantic_conditions_like_js() {
 }
 
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "fixture-heavy middleware test keeps related spacing assertions together"
+)]
 fn from_config_applies_spacing_middlewares() {
     let config: UserConfig = serde_json::from_value(json!({
         "theme": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Improve Rust extractor performance and memory usage by trimming avoidable allocations in import matching and visitor hot paths, and clean up the clippy blockers in the extractor dependency path.

## ⛳️ Current behavior (updates)

The extractor built an intermediate import matcher index before emitting matched imports, allocated heap-backed member paths for static member chains, and eagerly owned JSX tag/alias strings while resolving tags. The extractor clippy command was also blocked by existing warnings in shared hashing, extractor test raw strings, and token dictionary code reached through the extractor dependency graph.

## 🚀 New behavior

- Match imports in a single pass over scan records without the temporary source/name/category index.
- Use `SmallVec` for common static member-chain paths in call extraction and raw-style resolution.
- Borrow JSX tag/alias names during resolution and only allocate when committing extracted JSX output.
- Pre-size JSX prop entry vectors from the opening element attribute count.
- Fix clippy warnings in `pandacss_shared`, extractor tests, and `pandacss_tokens` so `pandacss_extractor` clippy passes with `-D warnings`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Verification:

- `cargo fmt --all --check`
- `cargo check --locked -p pandacss_extractor`
- `cargo test --locked -p pandacss_shared`
- `cargo test --locked -p pandacss_tokens`
- `cargo test --locked -p pandacss_extractor --test token_calls --test raw_spreads`
- `cargo test --locked -p pandacss_extractor`
- `cargo clippy --locked -p pandacss_tokens --all-targets -- -D warnings`
- `cargo clippy --locked -p pandacss_extractor --all-targets -- -D warnings`
- `cargo run --release -p pandacss_bench --bin jsx_heavy_extract -- --elements 2000 --warm 5 --iterations 20`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e44e209-ad36-415e-85cf-7b19d9634508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e44e209-ad36-415e-85cf-7b19d9634508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

