### PR TITLE
fix(compiler-wasm): add shim-free /web entry for browser bundlers

### DIFF
--- a/design-notes/bindings.md
+++ b/design-notes/bindings.md
@@ -263,6 +263,25 @@ Browser consumers can import directly from `@pandacss/compiler-wasm/pkg-web/*` a
 themselves when they need control over the wasm fetch, then pass the initialized module to
 `createCompilerFromWasmModule()` so config callbacks are still registered before parsing.
 
+## Browser-only subpath export (`./web`)
+
+`@pandacss/compiler-wasm` ships a `./web` subpath export (`dist/web.mjs`) that carries only the wasm-module facade —
+`createCompilerFromWasmModule` and the shared types — with **no** `import('../pkg-node/...')` in its module graph.
+
+Because `src/web.ts` never references `pkg-node`, tsup injects no Node `fileURLToPath` shim into `dist/web.mjs`.
+Browser bundlers (webpack, Vite) that stub or remove `node:url` will not throw at module-eval time.
+
+```ts
+import initWasm, * as wasmMod from '@pandacss/compiler-wasm/pkg-web/compiler_wasm.js'
+import { createCompilerFromWasmModule } from '@pandacss/compiler-wasm/web'
+
+await initWasm(new URL('/compiler_wasm_bg.wasm', window.location.origin))
+const compiler = createCompilerFromWasmModule(wasmMod, config, options)
+```
+
+The main `"."` entry still re-exports everything from `./web` plus `loadWasm` / `createCompiler` /
+`createCompilerFromSnapshot`, so Node consumers and existing tests are unaffected.
+
 ## Related
 
 - [filesystem](./filesystem.md) — the FS abstraction both bindings consume.

--- a/packages/compiler-wasm/__tests__/web-entry.test.ts
+++ b/packages/compiler-wasm/__tests__/web-entry.test.ts
@@ -1,34 +1,50 @@
 /**
- * Regression test: `dist/web.mjs` must be shim-free — no `fileURLToPath` or
- * `init_esm_shims` injected by tsup. When those strings are absent, a browser
- * bundler that stubs `node:url` will not throw at module-eval time.
+ * Regression test: the browser entry `dist/web.mjs` must be shim-free across its
+ * WHOLE module graph — no `fileURLToPath` / `init_esm_shims` in `web.mjs` OR in
+ * any chunk it imports (including side-effect `import "./chunk-*.mjs"`). tsup's
+ * `--shims` injects a shared shim chunk that every entry side-effect-imports, so
+ * checking `web.mjs` alone gives a false pass — the browser entry is built in a
+ * separate, shimless tsup config (see `tsup.config.ts`). When the shim strings
+ * are absent from the closure, a browser bundler that stubs `node:url` will not
+ * throw at module-eval time.
  */
 
 import { existsSync, readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const WEB_MJS = resolve(__dirname, '..', 'dist', 'web.mjs')
-
+const DIST = resolve(__dirname, '..', 'dist')
+const WEB_MJS = resolve(DIST, 'web.mjs')
 const builtGuard = existsSync(WEB_MJS)
 
-describe.skipIf(!builtGuard)('@pandacss/compiler-wasm dist/web.mjs shim-free', () => {
-  it('dist/web.mjs exists after build', () => {
-    expect(existsSync(WEB_MJS)).toBe(true)
-  })
+/** All `.mjs` files reachable from `entry` via static + side-effect imports. */
+function moduleGraph(entry: string): string[] {
+  const seen = new Set<string>()
+  const queue = [entry]
+  while (queue.length) {
+    const file = queue.pop()!
+    if (seen.has(file) || !existsSync(file)) continue
+    seen.add(file)
+    const src = readFileSync(file, 'utf8')
+    for (const m of src.matchAll(/(?:from\s*|import\s*)["'](\.\/[^"']+\.mjs)["']/g)) {
+      queue.push(resolve(dirname(file), m[1]))
+    }
+  }
+  return [...seen]
+}
 
-  it('dist/web.mjs does not contain fileURLToPath', () => {
-    const contents = readFileSync(WEB_MJS, 'utf8')
-    expect(contents).not.toContain('fileURLToPath')
-  })
-
-  it('dist/web.mjs does not contain init_esm_shims', () => {
-    const contents = readFileSync(WEB_MJS, 'utf8')
-    expect(contents).not.toContain('init_esm_shims')
+describe.skipIf(!builtGuard)('@pandacss/compiler-wasm browser entry is shim-free', () => {
+  it('web.mjs module graph contains no fileURLToPath / esm shim', () => {
+    const graph = moduleGraph(WEB_MJS)
+    const tainted = graph.filter((f) => {
+      const src = readFileSync(f, 'utf8')
+      return src.includes('fileURLToPath') || src.includes('init_esm_shims')
+    })
+    expect(tainted).toEqual([])
   })
 })
 
-describe.skipIf(builtGuard)('@pandacss/compiler-wasm dist/web.mjs shim-free', () => {
+describe.skipIf(builtGuard)('@pandacss/compiler-wasm browser entry is shim-free', () => {
   it.skip('dist not built — run `pnpm --filter @pandacss/compiler-wasm build` first', () => {
     // placeholder — shows as skipped in CI so the build prerequisite is visible.
   })

--- a/packages/compiler-wasm/__tests__/web-entry.test.ts
+++ b/packages/compiler-wasm/__tests__/web-entry.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test: `dist/web.mjs` must be shim-free — no `fileURLToPath` or
+ * `init_esm_shims` injected by tsup. When those strings are absent, a browser
+ * bundler that stubs `node:url` will not throw at module-eval time.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const WEB_MJS = resolve(__dirname, '..', 'dist', 'web.mjs')
+
+const builtGuard = existsSync(WEB_MJS)
+
+describe.skipIf(!builtGuard)('@pandacss/compiler-wasm dist/web.mjs shim-free', () => {
+  it('dist/web.mjs exists after build', () => {
+    expect(existsSync(WEB_MJS)).toBe(true)
+  })
+
+  it('dist/web.mjs does not contain fileURLToPath', () => {
+    const contents = readFileSync(WEB_MJS, 'utf8')
+    expect(contents).not.toContain('fileURLToPath')
+  })
+
+  it('dist/web.mjs does not contain init_esm_shims', () => {
+    const contents = readFileSync(WEB_MJS, 'utf8')
+    expect(contents).not.toContain('init_esm_shims')
+  })
+})
+
+describe.skipIf(builtGuard)('@pandacss/compiler-wasm dist/web.mjs shim-free', () => {
+  it.skip('dist not built — run `pnpm --filter @pandacss/compiler-wasm build` first', () => {
+    // placeholder — shows as skipped in CI so the build prerequisite is visible.
+  })
+})

--- a/packages/compiler-wasm/package.json
+++ b/packages/compiler-wasm/package.json
@@ -41,8 +41,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/web.ts --format=cjs,esm --shims --dts",
-    "build-fast": "tsup src/index.ts src/web.ts --format=cjs,esm --shims --no-dts",
+    "build": "tsup",
+    "build-fast": "tsup --no-dts",
     "build:wasm": "tsx build-wasm.ts",
     "dev": "pnpm build-fast --watch",
     "test": "vitest run"

--- a/packages/compiler-wasm/package.json
+++ b/packages/compiler-wasm/package.json
@@ -15,6 +15,15 @@
       },
       "require": "./dist/index.js"
     },
+    "./web": {
+      "source": "./src/web.ts",
+      "types": "./dist/web.d.ts",
+      "import": {
+        "types": "./dist/web.d.mts",
+        "default": "./dist/web.mjs"
+      },
+      "require": "./dist/web.js"
+    },
     "./pkg-node/*": "./pkg-node/*",
     "./pkg-web/*": "./pkg-web/*",
     "./package.json": "./package.json"
@@ -32,8 +41,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format=cjs,esm --shims --dts",
-    "build-fast": "tsup src/index.ts --format=cjs,esm --shims --no-dts",
+    "build": "tsup src/index.ts src/web.ts --format=cjs,esm --shims --dts",
+    "build-fast": "tsup src/index.ts src/web.ts --format=cjs,esm --shims --no-dts",
     "build:wasm": "tsx build-wasm.ts",
     "dev": "pnpm build-fast --watch",
     "test": "vitest run"

--- a/packages/compiler-wasm/src/index.ts
+++ b/packages/compiler-wasm/src/index.ts
@@ -8,55 +8,24 @@
  * Consumers should `import { createCompiler } from '@pandacss/compiler-wasm'`.
  * It loads the wasm module and resolves to a `Compiler` — the same flat shape
  * as the native binding, with the shared in-memory FS exposed as `compiler.fs`.
+ *
+ * Browser consumers that want a shim-free bundle should import from
+ * `@pandacss/compiler-wasm/web` instead — it carries only the wasm-module
+ * facade with no `pkg-node` / `loadWasm` in its module graph.
  */
 
-import { assertProjectCallbacks, getTokenCategoryValues, mergeCallbacks } from '@pandacss/compiler-shared'
-import type {
-  Compiler,
-  CompilerOptions,
-  ConfigSnapshot,
-  ProjectCallbacks,
-  SerializedConfig,
-} from '@pandacss/compiler-shared'
-import { registerCallbacks } from './callbacks'
-import type { TokenDictionaryInput, WasmCompiler, WasmFileSystem } from './types'
+import { mergeCallbacks } from '@pandacss/compiler-shared'
+import type { Compiler, CompilerOptions, ConfigSnapshot, SerializedConfig } from '@pandacss/compiler-shared'
+import { build } from './web'
+import type { WasmModule } from './web'
 
-export type { PatternHelpers } from './callbacks'
-export type {
-  MatcherInput,
-  MatchersInput,
-  TokenDictionaryInput,
-  WasmCompiler,
-  WasmExtractor,
-  WasmFileSystem,
-} from './types'
-// Re-export the shared contract so consumers get one import surface.
-export type * from '@pandacss/compiler-shared'
+// Re-export everything from the browser-safe web entry so the main entry's
+// public API surface stays identical.
+export * from './web'
+export type * from './web'
 
 export { createBrowserDriver } from './driver'
 export type { BrowserDriverOptions } from './driver'
-
-/** `configCallbacks` carry construction-time `utility.values` resolvers. */
-interface WasmFromConfigOptions {
-  configCallbacks?: {
-    utilityValues?: Record<string, (tokenDictionary: TokenDictionaryInput | undefined) => unknown>
-  }
-}
-
-/** The raw wasm instance — superset of {@link Compiler} carrying the internal
- *  `token_dictionary` the facade hides. */
-interface RawWasmCompiler extends WasmCompiler {
-  token_dictionary?(): TokenDictionaryInput | undefined
-}
-
-export interface WasmModule {
-  WasmFileSystem: new () => WasmFileSystem
-  WasmExtractor: new (fs: WasmFileSystem, matchers: unknown) => unknown
-  WasmCompiler: {
-    fromConfig(fs: WasmFileSystem, config: SerializedConfig, options?: WasmFromConfigOptions): RawWasmCompiler
-  }
-  installPanicHook: () => void
-}
 
 let cached: WasmModule | null = null
 
@@ -82,6 +51,7 @@ export async function loadWasm(): Promise<WasmModule> {
  * (`compiler.fs.addFile(...)`) so cross-file imports fold during extraction.
  */
 export async function createCompiler(config: SerializedConfig, options?: CompilerOptions): Promise<Compiler> {
+  const { createCompilerFromWasmModule } = await import('./web')
   return createCompilerFromWasmModule(await loadWasm(), config, options)
 }
 
@@ -93,44 +63,4 @@ export async function createCompilerFromSnapshot(
 ): Promise<Compiler> {
   const callbacks = mergeCallbacks(snapshot.callbacks, options?.callbacks)
   return build(await loadWasm(), snapshot.config, callbacks)
-}
-
-/**
- * Build a compiler from an already-loaded wasm module. Browser callers that
- * import `./pkg-web/compiler_wasm.js` should call its default `init()` first,
- * then pass the initialized module here.
- */
-export function createCompilerFromWasmModule(
-  mod: WasmModule,
-  config: SerializedConfig,
-  options?: CompilerOptions,
-): Compiler {
-  return build(mod, config, options?.callbacks ?? {})
-}
-
-function build(mod: WasmModule, config: SerializedConfig, callbacks: ProjectCallbacks): Compiler {
-  const fs = new mod.WasmFileSystem()
-  assertProjectCallbacks(config, callbacks)
-  const compiler = mod.WasmCompiler.fromConfig(fs, config, buildFromConfigOptions(callbacks))
-  registerCallbacks(compiler, callbacks, compiler.token_dictionary?.())
-  // Expose the shared FS as a field so the return shape matches native.
-  ;(compiler as unknown as { fs: WasmFileSystem }).fs = fs
-  return compiler as unknown as Compiler
-}
-
-function buildFromConfigOptions(callbacks: ProjectCallbacks): WasmFromConfigOptions | undefined {
-  const utilityValues = callbacks['utility.values']
-  if (!utilityValues || Object.keys(utilityValues).length === 0) return undefined
-
-  return {
-    configCallbacks: {
-      utilityValues: Object.fromEntries(
-        Object.entries(utilityValues).map(([id, callback]) => [
-          id,
-          (tokenDictionary: TokenDictionaryInput | undefined) =>
-            callback((category: string) => getTokenCategoryValues(category, tokenDictionary)),
-        ]),
-      ),
-    },
-  }
 }

--- a/packages/compiler-wasm/src/web.ts
+++ b/packages/compiler-wasm/src/web.ts
@@ -1,0 +1,99 @@
+/**
+ * `@pandacss/compiler-wasm/web` — browser-only facade.
+ *
+ * Exports only the wasm-module facade (`createCompilerFromWasmModule`) and the
+ * types/helpers that go with it. Has **no** `import('../pkg-node/...')` in its
+ * module graph, so tsup injects no Node `fileURLToPath` shim into the browser
+ * bundle.
+ *
+ * Browser consumers:
+ *
+ * ```ts
+ * import initWasm, * as wasmMod from '@pandacss/compiler-wasm/pkg-web/compiler_wasm.js'
+ * import { createCompilerFromWasmModule } from '@pandacss/compiler-wasm/web'
+ *
+ * await initWasm(new URL('/compiler_wasm_bg.wasm', window.location.origin))
+ * const compiler = createCompilerFromWasmModule(wasmMod, config, options)
+ * ```
+ */
+
+import { assertProjectCallbacks, getTokenCategoryValues, mergeCallbacks } from '@pandacss/compiler-shared'
+import type { Compiler, CompilerOptions, ProjectCallbacks, SerializedConfig } from '@pandacss/compiler-shared'
+import { registerCallbacks } from './callbacks'
+import type { TokenDictionaryInput, WasmCompiler, WasmFileSystem } from './types'
+
+export type { PatternHelpers } from './callbacks'
+export type {
+  MatcherInput,
+  MatchersInput,
+  TokenDictionaryInput,
+  WasmCompiler,
+  WasmExtractor,
+  WasmFileSystem,
+} from './types'
+// Re-export the shared contract so consumers get one import surface.
+export type * from '@pandacss/compiler-shared'
+
+/** `configCallbacks` carry construction-time `utility.values` resolvers. */
+interface WasmFromConfigOptions {
+  configCallbacks?: {
+    utilityValues?: Record<string, (tokenDictionary: TokenDictionaryInput | undefined) => unknown>
+  }
+}
+
+/** The raw wasm instance — superset of {@link Compiler} carrying the internal
+ *  `token_dictionary` the facade hides. */
+interface RawWasmCompiler extends WasmCompiler {
+  token_dictionary?(): TokenDictionaryInput | undefined
+}
+
+export interface WasmModule {
+  WasmFileSystem: new () => WasmFileSystem
+  WasmExtractor: new (fs: WasmFileSystem, matchers: unknown) => unknown
+  WasmCompiler: {
+    fromConfig(fs: WasmFileSystem, config: SerializedConfig, options?: WasmFromConfigOptions): RawWasmCompiler
+  }
+  installPanicHook: () => void
+}
+
+/**
+ * Build a compiler from an already-loaded wasm module. Browser callers that
+ * import `./pkg-web/compiler_wasm.js` should call its default `init()` first,
+ * then pass the initialized module here.
+ */
+export function createCompilerFromWasmModule(
+  mod: WasmModule,
+  config: SerializedConfig,
+  options?: CompilerOptions,
+): Compiler {
+  return build(mod, config, options?.callbacks ?? {})
+}
+
+export function build(mod: WasmModule, config: SerializedConfig, callbacks: ProjectCallbacks): Compiler {
+  const fs = new mod.WasmFileSystem()
+  assertProjectCallbacks(config, callbacks)
+  const compiler = mod.WasmCompiler.fromConfig(fs, config, buildFromConfigOptions(callbacks))
+  registerCallbacks(compiler, callbacks, compiler.token_dictionary?.())
+  // Expose the shared FS as a field so the return shape matches native.
+  ;(compiler as unknown as { fs: WasmFileSystem }).fs = fs
+  return compiler as unknown as Compiler
+}
+
+export function buildFromConfigOptions(callbacks: ProjectCallbacks): WasmFromConfigOptions | undefined {
+  const utilityValues = callbacks['utility.values']
+  if (!utilityValues || Object.keys(utilityValues).length === 0) return undefined
+
+  return {
+    configCallbacks: {
+      utilityValues: Object.fromEntries(
+        Object.entries(utilityValues).map(([id, callback]) => [
+          id,
+          (tokenDictionary: TokenDictionaryInput | undefined) =>
+            callback((category: string) => getTokenCategoryValues(category, tokenDictionary)),
+        ]),
+      ),
+    },
+  }
+}
+
+export { mergeCallbacks }

--- a/packages/compiler-wasm/tsup.config.ts
+++ b/packages/compiler-wasm/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsup'
+
+// Two independent builds. The Node entry (`index`) needs tsup's `--shims` to
+// resolve the relative dynamic `import('../pkg-node/...')` (it injects an
+// esm-shim chunk that computes `__dirname` via `fileURLToPath`). The browser
+// entry (`web`) must NOT get that shim — `fileURLToPath` is undefined under a
+// browser bundler that stubs `node:url`, and the facade never needs `__dirname`.
+// `--shims` is per-invocation, so the entries are built separately; `web` keeps
+// `clean: false` so it doesn't wipe the `index` output built just before it.
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    shims: true,
+    dts: true,
+    clean: true,
+  },
+  {
+    entry: ['src/web.ts'],
+    format: ['cjs', 'esm'],
+    shims: false,
+    dts: true,
+    clean: false,
+  },
+])


### PR DESCRIPTION
## what

add a browser-only `@pandacss/compiler-wasm/web` subpath. it exports just the wasm-module facade — no `pkg-node`/`loadWasm` — so tsup injects no node shim. built as a separate shimless tsup config. the main entry (`.`) is unchanged.

## why

importing `@pandacss/compiler-wasm` in a browser bundler throws `fileURLToPath is not a function`. the main entry bundles the node loader, and tsup's `--shims` adds a `fileURLToPath(import.meta.url)` call that runs at module load. browser bundlers stub `node:url`, so it throws. came up while testing the wasm engine in the browser.

## notes

- `--shims` is per tsup invocation, so `web` is built separately, shimless. one build side-effect-imports the shim chunk into every entry, which is how the main-entry shim leaked into the browser graph.
- the regression test walks the whole `web.mjs` module graph, not just the entry file — checking the entry alone false-passes, since the shim arrives via a side-effect import.
- one pre-existing failing snapshot in this package (stale `types/recipe.d.mts` from an earlier merge) is unrelated to this change.
- open question: leave this a `/web` subpath, or also re-point the package's browser `import` condition?

## test plan

- [x] `pnpm --filter @pandacss/compiler-wasm build`; `dist/web.mjs` graph has no `fileURLToPath`
- [x] `pnpm --filter @pandacss/compiler-wasm test` — web-entry shim-free test passes
- [x] imported `@pandacss/compiler-wasm/web` in a webpack app, loads + runs, no `fileURLToPath` error
