### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -10,7 +10,6 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: 22
-        registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
 
     - name: Setup Git User

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - '.changeset/**'
@@ -12,6 +13,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push tags and the Version Packages PR
+      pull-requests: write # open the Version Packages PR
+      id-token: write # OIDC handshake with npm (trusted publishing)
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -30,8 +35,8 @@ jobs:
         with:
           publish: pnpm release
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Slack Notification
         if: steps.changesets.outputs.published == 'true'

--- a/scripts/setup-trusted-publishing.md
+++ b/scripts/setup-trusted-publishing.md
@@ -1,0 +1,67 @@
+# Trusted publishing (npm OIDC)
+
+Releases authenticate to npm with a short-lived OIDC credential instead of an
+`NPM_TOKEN`, so there is nothing to rotate or leak. Companion script:
+`setup-trusted-publishing.mjs`.
+
+`pnpm release` runs `changeset publish`, which shells out to `pnpm publish`, which
+does the OIDC handshake (pnpm 10.16+). The release job grants `id-token: write`
+and passes no token. Each package must have a trusted publisher configured on npm
+first, pointing at `chakra-ui/panda` + `release.yml`.
+
+## Gotcha
+
+`npm trust` can't use a token (npm rejects automation / bypass-2FA tokens by
+design), so configuring trust needs an interactive login. A new package must exist
+on npm before it can be trusted, so onboarding does one first publish. That publish
+uses your `npm login` session by default (may prompt for an OTP); set `NPM_TOKEN`
+only if you want it non-interactive.
+
+## Examples
+
+Configure trust for packages already on npm:
+
+```bash
+npm login --auth-type=web
+node scripts/setup-trusted-publishing.mjs
+```
+
+Onboard new packages (e.g. from the v2 branch): build, publish each missing one,
+then trust it. The login session handles the publish:
+
+```bash
+npm login --auth-type=web
+node scripts/setup-trusted-publishing.mjs --first-publish
+```
+
+Same thing non-interactively (no OTP prompt on publish) by adding a token:
+
+```bash
+NPM_TOKEN=<token> node scripts/setup-trusted-publishing.mjs --first-publish
+```
+
+Preview without changing anything:
+
+```bash
+node scripts/setup-trusted-publishing.mjs --dry-run
+```
+
+Target a different repo or workflow file:
+
+```bash
+node scripts/setup-trusted-publishing.mjs --repo my-org/my-repo --file publish.yml
+```
+
+Flags: `--repo <owner/repo>` (default: git origin), `--file <workflow>` (default:
+`release.yml`), `--first-publish`, `--dry-run`, `--yes` (skip the pre-publish
+pause). Needs npm 11.10+ for `npm trust`; falls back to `npx npm@latest`. Idempotent.
+
+## Release fails with E404?
+
+That's an auth failure in disguise. Check, in order:
+
+1. Is a trusted publisher configured for the failing package? New packages need
+   the `--first-publish` step above.
+2. Does the workflow still have `id-token: write` and no stray `NODE_AUTH_TOKEN`?
+3. Did `setup-node` reintroduce `registry-url`? It writes an empty-token `.npmrc`
+   that makes pnpm skip the OIDC exchange.

--- a/scripts/setup-trusted-publishing.mjs
+++ b/scripts/setup-trusted-publishing.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// Configure npm trusted publishing (OIDC) for every publishable @pandacss/* package.
+//
+// Why this exists: npm's `npm trust` cannot be driven by a long-lived token, and a
+// package must already exist on the registry before you can trust it. This script
+// glues those two facts together so onboarding (including new v2 packages) is one command.
+//
+// Usage:
+//   npm login --auth-type=web                 # one-time, gives the session npm trust needs
+//   node scripts/setup-trusted-publishing.mjs # configure trust for all existing packages
+//
+//   # Onboard brand-new packages that aren't on npm yet (uses NPM_TOKEN for the first publish):
+//   NPM_TOKEN=xxxx node scripts/setup-trusted-publishing.mjs --first-publish
+//
+// Flags:
+//   --repo <owner/repo>   GitHub repo for the trusted publisher (default: git origin)
+//   --file <workflow>     Workflow filename on the repo (default: release.yml)
+//   --first-publish       Publish packages missing from npm before trusting them (needs NPM_TOKEN)
+//   --dry-run             Print what would happen, change nothing
+//   --yes                 Don't pause for confirmation before publishing
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, readdirSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const REGISTRY = 'https://registry.npmjs.org'
+
+const args = parseArgs(process.argv.slice(2))
+const repo = args.repo ?? detectRepo()
+const workflowFile = args.file ?? 'release.yml'
+
+if (!repo) fail('Could not determine the GitHub repo. Pass --repo owner/repo.')
+
+const npm = resolveNpm() // a binary new enough for `npm trust` (>= 11.10.0)
+
+console.log(`repo:     ${repo}`)
+console.log(`workflow: ${workflowFile}`)
+console.log(`npm:      ${[npm.cmd, ...npm.args].join(' ')} (${npm.version})`)
+console.log(`mode:     ${args.dryRun ? 'dry-run' : 'live'}\n`)
+
+const me = whoami()
+if (!me && !args.dryRun) {
+  fail('Not logged in to npm. Run `npm login --auth-type=web` first (trust needs a 2FA session, not a token).')
+}
+if (me) console.log(`logged in as: ${me}\n`)
+
+const packages = discoverPackages()
+if (!packages.length) fail('No publishable @pandacss/* packages found in packages/.')
+
+let built = false
+const done = []
+const needsManual = []
+const failed = []
+
+for (const pkg of packages) {
+  const exists = existsOnRegistry(pkg.name)
+
+  if (!exists) {
+    if (args.firstPublish) {
+      try {
+        if (!built) {
+          run('pnpm', ['build'], { cwd: ROOT })
+          built = true
+        }
+        confirmPublish(pkg.name)
+        firstPublish(pkg)
+        waitForRegistry(pkg.name)
+      } catch (err) {
+        console.error(`  ✗ first publish failed: ${err.message}`)
+        failed.push(pkg.name)
+        continue
+      }
+    } else {
+      console.log(`  ⤼ ${pkg.name} — not on npm yet, skipping (re-run with --first-publish to onboard)`)
+      needsManual.push(pkg.name)
+      continue
+    }
+  }
+
+  if (args.dryRun) {
+    console.log(`  • would trust ${pkg.name}`)
+    done.push(pkg.name)
+    continue
+  }
+
+  try {
+    trust(pkg.name)
+    console.log(`  ✓ ${pkg.name}`)
+    done.push(pkg.name)
+  } catch (err) {
+    console.error(`  ✗ ${pkg.name} — ${err.message.split('\n')[0]}`)
+    failed.push(pkg.name)
+  }
+}
+
+console.log(`\nconfigured: ${done.length}`)
+if (needsManual.length) {
+  console.log(`needs first publish (re-run with --first-publish): ${needsManual.join(', ')}`)
+}
+if (failed.length) {
+  console.log(`failed: ${failed.join(', ')}`)
+  process.exit(1)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function discoverPackages() {
+  const pkgsDir = join(ROOT, 'packages')
+  const out = []
+  for (const entry of readdirSync(pkgsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const manifest = join(pkgsDir, entry.name, 'package.json')
+    if (!existsSync(manifest)) continue
+    const json = JSON.parse(readFileSync(manifest, 'utf8'))
+    if (json.private) continue
+    if (!json.name?.startsWith('@pandacss/')) continue
+    out.push({ name: json.name, dir: join(pkgsDir, entry.name) })
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function trust(name) {
+  // Relies on the interactive `npm login --auth-type=web` session, not a token.
+  run(npm.cmd, [...npm.args, 'trust', 'github', name, '--repo', repo, '--file', workflowFile, '--allow-publish', '-y'], {
+    cwd: ROOT,
+    stdio: 'inherit', // surface any OTP prompt
+  })
+}
+
+function firstPublish(pkg) {
+  // A package must exist before it can be trusted. Publish with NPM_TOKEN if set
+  // (non-interactive), otherwise fall back to the `npm login` session (may prompt for OTP).
+  console.log(`  ↑ publishing ${pkg.name} for the first time`)
+  const cmd = ['--filter', pkg.name, 'publish', '--no-git-checks', '--access', 'public']
+
+  if (!process.env.NPM_TOKEN) {
+    run('pnpm', cmd, { cwd: ROOT })
+    return
+  }
+
+  const npmrc = join(tmpdir(), `panda-oidc-${pkg.name.replace(/[^a-z0-9]/gi, '-')}.npmrc`)
+  writeFileSync(npmrc, `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`)
+  try {
+    run('pnpm', cmd, { cwd: ROOT, env: { ...process.env, NPM_CONFIG_USERCONFIG: npmrc } })
+  } finally {
+    rmSync(npmrc, { force: true })
+  }
+}
+
+function existsOnRegistry(name) {
+  try {
+    execFileSync('npm', ['view', name, 'version', '--registry', REGISTRY], { stdio: ['ignore', 'pipe', 'ignore'] })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function waitForRegistry(name, attempts = 20) {
+  process.stdout.write(`  … waiting for ${name} to appear on npm`)
+  for (let i = 0; i < attempts; i++) {
+    if (existsOnRegistry(name)) {
+      process.stdout.write(' ok\n')
+      return
+    }
+    process.stdout.write('.')
+    sleep(3000)
+  }
+  process.stdout.write('\n')
+  throw new Error(`${name} did not show up on the registry in time`)
+}
+
+function whoami() {
+  try {
+    return execFileSync('npm', ['whoami', '--registry', REGISTRY], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+function resolveNpm() {
+  try {
+    const v = execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim()
+    if (gte(v, '11.10.0')) return { cmd: 'npm', args: [], version: v }
+    console.log(`local npm ${v} is too old for \`npm trust\`, falling back to \`npx npm@latest\``)
+  } catch {}
+  return { cmd: 'npx', args: ['-y', 'npm@latest'], version: 'latest via npx' }
+}
+
+function confirmPublish(name) {
+  if (args.yes || args.dryRun) return
+  // Publishing is irreversible (npm only allows unpublish within 72h). Give a beat to bail.
+  console.log(`  ! about to publish ${name} to npm. Ctrl-C within 5s to abort.`)
+  sleep(5000)
+}
+
+function detectRepo() {
+  try {
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: ROOT, encoding: 'utf8' }).trim()
+    const m = url.match(/github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/)
+    return m ? m[1] : null
+  } catch {
+    return null
+  }
+}
+
+function parseArgs(argv) {
+  const out = { dryRun: false, firstPublish: false, yes: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry-run') out.dryRun = true
+    else if (a === '--first-publish') out.firstPublish = true
+    else if (a === '--yes' || a === '-y') out.yes = true
+    else if (a === '--repo') out.repo = argv[++i]
+    else if (a === '--file') out.file = argv[++i]
+    else fail(`Unknown argument: ${a}`)
+  }
+  return out
+}
+
+function run(cmd, cmdArgs, opts = {}) {
+  return execFileSync(cmd, cmdArgs, { stdio: 'inherit', ...opts })
+}
+
+function gte(a, b) {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false
+  }
+  return true
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+function fail(msg) {
+  console.error(`error: ${msg}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## What

Move npm releases from a long-lived `NPM_TOKEN` to npm trusted publishing (OIDC).

The token authenticating releases expired and broke the 1.11.2 publish. Every package failed with `E404` (npm masks an auth failure as "not found"), so nothing shipped and npm `latest` is still 1.11.1 while the repo is at 1.11.2. OIDC removes the long-lived secret entirely, so there's nothing to rotate or leak.

## Changes

- Grant the release job `id-token: write` and drop `NODE_AUTH_TOKEN`. `changeset publish` shells out to `pnpm publish` in this workspace, and pnpm (11.x) does the OIDC handshake.
- Turn on provenance via `NPM_CONFIG_PROVENANCE`.
- Remove `registry-url` from `setup-node`. Without a token it writes an empty `_authToken` into `.npmrc`, which makes pnpm think it's authenticated and skip the OIDC exchange.
- Add `workflow_dispatch` so the release can be run manually (needed to ship the already-bumped 1.11.2 without an unrelated `packages/` change).
- Add `scripts/setup-trusted-publishing.mjs` (+ short doc) to configure trusted publishers for every `@pandacss/*` package. Reusable on the v2 branch for new packages.

## Before this merges helps anyone

Trusted publishers must be configured on npm first (done via the script). If a release runs before trust is set up, it 404s the same way an expired token does.

## Shipping 1.11.2

After merge:

\`\`\`bash
gh workflow run release.yml --ref main
\`\`\`

No pending changesets + 1.11.2 missing from npm means the run takes the publish path and ships it over OIDC.