### PR TITLE
fix(mcp): exit instead of spinning at 100% CPU on host disconnect

### DIFF
--- a/.changeset/mcp-lifecycle-guard.md
+++ b/.changeset/mcp-lifecycle-guard.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/mcp': patch
+---
+
+Fix `panda mcp` orphaning and spinning at 100% CPU after the host disconnects. The server now
+exits on stdin close and exits (instead of looping) on fatal errors.

--- a/packages/mcp/__tests__/process-lifecycle.test.ts
+++ b/packages/mcp/__tests__/process-lifecycle.test.ts
@@ -1,0 +1,88 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, test, vi } from 'vitest'
+import { watchProcessLifecycle, type ProcessLike } from '../src/server'
+
+function createFakeProcess() {
+  const stdin = new EventEmitter()
+  const stdout = Object.assign(new EventEmitter(), { write: vi.fn((_chunk: string) => true) })
+  const stderr = Object.assign(new EventEmitter(), { write: vi.fn((_chunk: string) => true) })
+  const proc = Object.assign(new EventEmitter(), { stdin, stdout, stderr })
+  return { proc: proc as unknown as ProcessLike, raw: proc, stdin, stdout, stderr }
+}
+
+function setup() {
+  const fake = createFakeProcess()
+  const server = { close: vi.fn().mockResolvedValue(undefined) }
+  const exit = vi.fn()
+  watchProcessLifecycle(server, { process: fake.proc, exit })
+  return { ...fake, server, exit }
+}
+
+describe('watchProcessLifecycle', () => {
+  test('exits cleanly when the host closes stdin', () => {
+    const { stdin, server, exit } = setup()
+
+    stdin.emit('end')
+
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(server.close).toHaveBeenCalledOnce()
+  })
+
+  test('exits on a broken pipe instead of recursing', () => {
+    const { stdout, exit } = setup()
+
+    stdout.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  test('ignores non-EPIPE stream errors', () => {
+    const { stdout, exit } = setup()
+
+    stdout.emit('error', Object.assign(new Error('boom'), { code: 'ECONNRESET' }))
+
+    expect(exit).not.toHaveBeenCalled()
+  })
+
+  test('logs and exits non-zero on an uncaught exception', () => {
+    const { raw, stderr, exit } = setup()
+
+    raw.emit('uncaughtException', new Error('kaboom'))
+
+    expect(stderr.write).toHaveBeenCalledOnce()
+    expect(stderr.write.mock.calls[0][0]).toContain('uncaught exception')
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  test('exits non-zero on an unhandled rejection', () => {
+    const { raw, exit } = setup()
+
+    raw.emit('unhandledRejection', new Error('nope'))
+
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  test('still exits when writing the error to stderr itself fails', () => {
+    const fake = createFakeProcess()
+    fake.stderr.write.mockImplementation(() => {
+      throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+    })
+    const server = { close: vi.fn().mockResolvedValue(undefined) }
+    const exit = vi.fn()
+    watchProcessLifecycle(server, { process: fake.proc, exit })
+
+    expect(() => fake.raw.emit('uncaughtException', new Error('kaboom'))).not.toThrow()
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  test('exits only once even if multiple signals fire', () => {
+    const { stdin, raw, server, exit } = setup()
+
+    stdin.emit('end')
+    raw.emit('uncaughtException', new Error('late'))
+    stdin.emit('close')
+
+    expect(exit).toHaveBeenCalledOnce()
+    expect(server.close).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/mcp/__tests__/process-lifecycle.test.ts
+++ b/packages/mcp/__tests__/process-lifecycle.test.ts
@@ -28,6 +28,15 @@ describe('watchProcessLifecycle', () => {
     expect(server.close).toHaveBeenCalledOnce()
   })
 
+  test('exits cleanly on SIGTERM', () => {
+    const { raw, server, exit } = setup()
+
+    raw.emit('SIGTERM')
+
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(server.close).toHaveBeenCalledOnce()
+  })
+
   test('exits on a broken pipe instead of recursing', () => {
     const { stdout, exit } = setup()
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -201,6 +201,11 @@ export async function startMcpServer(options: StartMcpServerOptions = {}) {
   const serverTransport = transport ?? new StdioServerTransport()
   await server.connect(serverTransport)
 
+  // Only own the lifecycle for the default stdio transport, not injected test ones.
+  if (!transport) {
+    watchProcessLifecycle(server)
+  }
+
   // Use stderr for logging (stdout is reserved for MCP protocol)
   console.error('Panda CSS MCP server started')
   console.error(`Working directory: ${resolvedCwd}`)
@@ -209,4 +214,63 @@ export async function startMcpServer(options: StartMcpServerOptions = {}) {
   }
 
   return server
+}
+
+type LifecycleListener = (arg: any) => void
+
+export interface ProcessLike {
+  stdin: { on(event: string, listener: LifecycleListener): unknown }
+  stdout: { on(event: string, listener: LifecycleListener): unknown; write(data: string): unknown }
+  stderr: { on(event: string, listener: LifecycleListener): unknown; write(data: string): unknown }
+  on(event: string, listener: LifecycleListener): unknown
+}
+
+export interface ProcessLifecycleOptions {
+  process?: ProcessLike
+  exit?: (code: number) => void
+}
+
+/**
+ * Exit the stdio MCP server on host disconnect or fatal error instead of orphaning
+ * and spinning at 100% CPU. See https://github.com/chakra-ui/panda/issues/3553.
+ */
+export function watchProcessLifecycle(server: Pick<McpServer, 'close'>, options: ProcessLifecycleOptions = {}) {
+  const proc = options.process ?? process
+  const exit = options.exit ?? ((code: number) => process.exit(code))
+
+  let exiting = false
+  const shutdown = (code: number) => {
+    if (exiting) return
+    exiting = true
+    void Promise.resolve(server.close()).catch(() => {})
+    exit(code)
+  }
+
+  // Host closed the pipe (session ended) -> stop instead of orphaning.
+  proc.stdin.on('end', () => shutdown(0))
+  proc.stdin.on('close', () => shutdown(0))
+
+  // Swallow broken pipes so they don't reach the fatal path and spin.
+  for (const stream of [proc.stdout, proc.stderr]) {
+    stream.on('error', (err: NodeJS.ErrnoException) => {
+      if (err?.code === 'EPIPE') shutdown(0)
+    })
+  }
+
+  const onFatal = (label: string) => (err: unknown) => {
+    try {
+      proc.stderr.write(`[panda mcp] ${label}, exiting: ${formatError(err)}\n`)
+    } catch {
+      // stderr may also be a broken pipe; swallow so we exit, not loop.
+    }
+    shutdown(1)
+  }
+  proc.on('uncaughtException', onFatal('uncaught exception'))
+  proc.on('unhandledRejection', onFatal('unhandled rejection'))
+
+  return shutdown
+}
+
+function formatError(err: unknown) {
+  return err instanceof Error ? err.stack ?? err.message : String(err)
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -250,6 +250,10 @@ export function watchProcessLifecycle(server: Pick<McpServer, 'close'>, options:
   proc.stdin.on('end', () => shutdown(0))
   proc.stdin.on('close', () => shutdown(0))
 
+  // Honor termination signals so an explicit kill exits cleanly too.
+  proc.on('SIGINT', () => shutdown(0))
+  proc.on('SIGTERM', () => shutdown(0))
+
   // Swallow broken pipes so they don't reach the fatal path and spin.
   for (const stream of [proc.stdout, proc.stderr]) {
     stream.on('error', (err: NodeJS.ErrnoException) => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -242,7 +242,7 @@ export function watchProcessLifecycle(server: Pick<McpServer, 'close'>, options:
   const shutdown = (code: number) => {
     if (exiting) return
     exiting = true
-    void Promise.resolve(server.close()).catch(() => {})
+    void Promise.resolve(server.close()).catch(() => undefined)
     exit(code)
   }
 


### PR DESCRIPTION
Closes #3553

## Problem

When `panda mcp` runs as a stdio MCP server and the host (editor) goes away, the process pegs a CPU core at ~100% forever and orphans instead of exiting.

Two compounding causes:

1. The SDK's `StdioServerTransport` listens on stdin `data` but never on `end`/`close`. When the host closes the pipe there's nothing to react to, and the `data` listener keeps stdin referenced, so the process never exits (it reparents to PID 1).
2. A later write hits the now broken pipe and throws `EPIPE`. With no `uncaughtException` guard, Node's default handler writes the error to the same dead pipe, throws again, and recurses, which is the `TriggerUncaughtException → InspectorConsoleCall` tight loop in the issue's stack trace.

## Fix

Add `watchProcessLifecycle`, wired only for the default stdio transport (tests inject their own and drive exit themselves):

- exit on stdin `end`/`close` (host disconnected)
- swallow `EPIPE` on stdout/stderr so a broken pipe never reaches the fatal path
- `uncaughtException` / `unhandledRejection` handlers that log once (guarded, since stderr may also be dead) and exit through an idempotent shutdown

This covers the reporter's suggested guard and also fixes the plain orphan-on-disconnect case it wouldn't have caught.

## Tests

`packages/mcp/__tests__/process-lifecycle.test.ts` (7 tests): stdin close, EPIPE, non-EPIPE passthrough, uncaught/unhandled rejection, stderr-write-also-fails, and exit-once. All green; package builds clean.

Thanks @cloud-walker for the precise diagnosis and repro.