### PR TITLE
fix(mcp): point generated mcp config at the @pandacss/dev binary

### DIFF
--- a/.changeset/mcp-npx-command.md
+++ b/.changeset/mcp-npx-command.md
@@ -2,6 +2,9 @@
 '@pandacss/mcp': patch
 ---
 
-Fix `panda init-mcp` generating a server config that AI clients can't run. The config used `npx panda mcp`, but `panda` is an unrelated package on npm with no executable, so clients failed with "could not determine executable to run" (the same happens with `bunx panda mcp`).
+Fix `panda init-mcp` generating an MCP server config that AI clients couldn't run, or that couldn't find your Panda
+config.
 
-The generated config now runs `npx -y --package @pandacss/dev panda mcp`, which resolves the correct binary and falls back to the local install when one is present.
+The command was `npx panda mcp`, which resolves an unrelated `panda` package on npm and fails with "could not determine
+executable to run". It now runs `npx -y --package @pandacss/dev panda mcp` and sets the server's `cwd` to your project,
+so the correct binary runs and your config is always found.

--- a/.changeset/mcp-npx-command.md
+++ b/.changeset/mcp-npx-command.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/mcp': patch
+---
+
+Fix `panda init-mcp` generating a server config that AI clients can't run. The config used `npx panda mcp`, but `panda` is an unrelated package on npm with no executable, so clients failed with "could not determine executable to run" (the same happens with `bunx panda mcp`).
+
+The generated config now runs `npx -y --package @pandacss/dev panda mcp`, which resolves the correct binary and falls back to the local install when one is present.

--- a/packages/mcp/__tests__/clients.test.ts
+++ b/packages/mcp/__tests__/clients.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+import { generateMcpConfig, MCP_CLIENTS } from '../src/clients'
+
+describe('generateMcpConfig', () => {
+  test('uses an npx command that resolves the @pandacss/dev binary', () => {
+    // `npx panda` resolves an unrelated `panda` package on npm (no bin), which fails with
+    // "npm error could not determine executable to run". Reference @pandacss/dev explicitly
+    // and pass the `panda` bin name so npx runs the right executable.
+    expect(generateMcpConfig(MCP_CLIENTS.claude)).toMatchInlineSnapshot(`
+      {
+        "mcpServers": {
+          "panda": {
+            "args": [
+              "-y",
+              "--package",
+              "@pandacss/dev",
+              "panda",
+              "mcp",
+            ],
+            "command": "npx",
+          },
+        },
+      }
+    `)
+  })
+
+  test('honors the client config key (vscode uses `servers`)', () => {
+    const config = generateMcpConfig(MCP_CLIENTS.vscode)
+    expect(config).toHaveProperty('servers.panda')
+    expect((config as any).servers.panda.args).toEqual(['-y', '--package', '@pandacss/dev', 'panda', 'mcp'])
+  })
+})

--- a/packages/mcp/__tests__/clients.test.ts
+++ b/packages/mcp/__tests__/clients.test.ts
@@ -2,11 +2,8 @@ import { describe, expect, test } from 'vitest'
 import { generateMcpConfig, MCP_CLIENTS } from '../src/clients'
 
 describe('generateMcpConfig', () => {
-  test('uses an npx command that resolves the @pandacss/dev binary', () => {
-    // `npx panda` resolves an unrelated `panda` package on npm (no bin), which fails with
-    // "npm error could not determine executable to run". Reference @pandacss/dev explicitly
-    // and pass the `panda` bin name so npx runs the right executable.
-    expect(generateMcpConfig(MCP_CLIENTS.claude)).toMatchInlineSnapshot(`
+  test('resolves the @pandacss/dev binary and pins the project cwd', () => {
+    expect(generateMcpConfig(MCP_CLIENTS.claude, '/project')).toMatchInlineSnapshot(`
       {
         "mcpServers": {
           "panda": {
@@ -18,6 +15,7 @@ describe('generateMcpConfig', () => {
               "mcp",
             ],
             "command": "npx",
+            "cwd": "/project",
           },
         },
       }
@@ -25,8 +23,8 @@ describe('generateMcpConfig', () => {
   })
 
   test('honors the client config key (vscode uses `servers`)', () => {
-    const config = generateMcpConfig(MCP_CLIENTS.vscode)
+    const config = generateMcpConfig(MCP_CLIENTS.vscode, '/project')
     expect(config).toHaveProperty('servers.panda')
-    expect((config as any).servers.panda.args).toEqual(['-y', '--package', '@pandacss/dev', 'panda', 'mcp'])
+    expect((config as any).servers.panda.cwd).toBe('/project')
   })
 })

--- a/packages/mcp/src/clients.ts
+++ b/packages/mcp/src/clients.ts
@@ -50,10 +50,11 @@ export function getClientConfig(client: McpClient): McpClientConfig {
   return MCP_CLIENTS[client]
 }
 
-export function generateMcpConfig(clientConfig: McpClientConfig) {
+export function generateMcpConfig(clientConfig: McpClientConfig, cwd: string) {
   const serverConfig = {
     command: 'npx',
     args: ['-y', '--package', '@pandacss/dev', 'panda', 'mcp'],
+    cwd,
   }
 
   return {

--- a/packages/mcp/src/clients.ts
+++ b/packages/mcp/src/clients.ts
@@ -53,7 +53,7 @@ export function getClientConfig(client: McpClient): McpClientConfig {
 export function generateMcpConfig(clientConfig: McpClientConfig) {
   const serverConfig = {
     command: 'npx',
-    args: ['panda', 'mcp'],
+    args: ['-y', '--package', '@pandacss/dev', 'panda', 'mcp'],
   }
 
   return {

--- a/packages/mcp/src/init.ts
+++ b/packages/mcp/src/init.ts
@@ -61,7 +61,7 @@ export async function initMcpConfig(options: InitMcpConfigOptions = {}) {
     }
 
     // Generate new config
-    const newConfig = generateMcpConfig(clientConfig)
+    const newConfig = generateMcpConfig(clientConfig, cwd)
 
     // Check if config file already exists
     let finalConfig = newConfig


### PR DESCRIPTION
## what

`panda init-mcp` generated a server config that runs `npx panda mcp`. that command can't run: `panda` is an unrelated package on npm with no bin. the generated config now runs `npx -y --package @pandacss/dev panda mcp`.

## why

AI clients spawn the generated command to start the mcp server. with `npx panda mcp` they fail with `could not determine executable to run`, so the server never starts. came in as a user report. `bunx panda mcp` fails the same way.

## notes

- the same args work under `bunx`. npx ships with node, so pnpm/yarn users still get a runnable command without per-manager handling.
- this is the npx half of the report. the other half (config loading throwing `Please pass in filename to use require` under bun) is a separate `bundle-n-require`/`node-eval` issue and is not in this PR.

## test plan

- [ ] `pnpm test packages/mcp` (new `clients.test.ts`, 2 tests)
- [ ] `npx -y --package @pandacss/dev panda mcp` resolves the binary in a clean dir (only fails on the missing config, as expected)
- [ ] `bunx --package @pandacss/dev panda mcp` and `pnpm --package=@pandacss/dev dlx panda mcp` resolve too; `npx panda mcp` / `bunx panda mcp` reproduce the original failure