### PR TITLE
chore(deps): update @atlaskit/tokens to v13 and regenerate preset

### DIFF
--- a/.changeset/bump-atlaskit-tokens-v13.md
+++ b/.changeset/bump-atlaskit-tokens-v13.md
@@ -1,5 +1,5 @@
 ---
-'@pandacss/preset-atlaskit': minor
+'@pandacss/preset-atlaskit': patch
 ---
 
 Update `@atlaskit/tokens` to v13 and regenerate the preset. The generated theme had been stuck on ~v7-era values, so this brings it in line with the current Atlassian Design System.

--- a/.changeset/bump-atlaskit-tokens-v13.md
+++ b/.changeset/bump-atlaskit-tokens-v13.md
@@ -1,0 +1,19 @@
+---
+'@pandacss/preset-atlaskit': minor
+---
+
+Update `@atlaskit/tokens` to v13 and regenerate the preset. The generated theme had been stuck on ~v7-era values, so this brings it in line with the current Atlassian Design System.
+
+### What changed
+
+- Core colors refreshed (e.g. yellow palette, and the chart palette is restructured from `chart.1`–`chart.3` to `chart.5`–`chart.7` plus `danger`/`warning`/`success`/`discovery` accents).
+- Elevation/shadow colors moved to the new neutral base (`rgba(9, 30, 66, …)` → `rgba(30, 31, 33, …)`).
+- Several dark-mode semantic colors retuned.
+- Added `radii.xxlarge` (16px).
+- Removed the deprecated `UNSAFE_small` text style and its `fontSizes` / `lineHeights` tokens.
+
+### Migration
+
+- No code changes are needed for most users; expect visual updates to colors and shadows.
+- If you reference `UNSAFE_small` (in `textStyles`, `fontSizes`, or `lineHeights`), switch to the supported `small` scale.
+- If you reference the old `chart.1`–`chart.3` tokens, remap to `chart.5`–`chart.7` or the named accent tokens.

--- a/packages/preset-atlaskit/package.json
+++ b/packages/preset-atlaskit/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@atlaskit/motion": "^6.0.0",
-    "@atlaskit/tokens": "8.4.0"
+    "@atlaskit/tokens": "13.0.2"
   },
   "engines": {
     "node": ">=20"

--- a/packages/preset-atlaskit/scripts/generate-theme.mjs
+++ b/packages/preset-atlaskit/scripts/generate-theme.mjs
@@ -20,9 +20,9 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const srcDir = join(__dirname, '../src')
 
-// Version compatibility - this script was built for @atlaskit/tokens 7.x
-const COMPATIBLE_VERSION_RANGE = '7.x'
-const TESTED_VERSION = '7.0.0'
+// Version compatibility - this script was built for @atlaskit/tokens 13.x
+const COMPATIBLE_VERSION_RANGE = '13.x'
+const TESTED_VERSION = '13.0.2'
 
 /**
  * Check @atlaskit/tokens version compatibility

--- a/packages/preset-atlaskit/src/colors/core.ts
+++ b/packages/preset-atlaskit/src/colors/core.ts
@@ -9,20 +9,35 @@ export const colors: Tokens['colors'] = {
     },
     warning: {
       bold: {
-        DEFAULT: { value: '#F5CD47' },
-        hovered: { value: '#E2B203' },
-        pressed: { value: '#CF9F02' },
+        DEFAULT: { value: '#FBC828' },
+        hovered: { value: '#FCA700' },
+        pressed: { value: '#F68909' },
       },
     },
   },
   chart: {
     categorical: {
-      '1': {
-        DEFAULT: { value: '#2898BD' },
+      '5': {
+        DEFAULT: { value: '#1558BC' },
       },
-      '3': {
-        DEFAULT: { value: '#E56910' },
+      '6': {
+        DEFAULT: { value: '#964AC0' },
       },
+      '7': {
+        DEFAULT: { value: '#42B2D7' },
+      },
+    },
+    danger: {
+      DEFAULT: { value: '#E2483D' },
+    },
+    warning: {
+      DEFAULT: { value: '#F68909' },
+    },
+    success: {
+      DEFAULT: { value: '#82B536' },
+    },
+    discovery: {
+      DEFAULT: { value: '#BF63F3' },
     },
   },
 }

--- a/packages/preset-atlaskit/src/colors/semantic.ts
+++ b/packages/preset-atlaskit/src/colors/semantic.ts
@@ -4,8 +4,8 @@ export const semanticColors: SemanticTokens['colors'] = {
   text: {
     DEFAULT: {
       value: {
-        _light: '#172B4D',
-        _dark: '#B6C2CF',
+        _light: '#292A2E',
+        _dark: '#CECFD2',
       },
     },
     accent: {
@@ -40,14 +40,14 @@ export const semanticColors: SemanticTokens['colors'] = {
       orange: {
         DEFAULT: {
           value: {
-            _light: '#A54800',
-            _dark: '#FEC195',
+            _light: '#9E4C00',
+            _dark: '#FBC828',
           },
         },
         bolder: {
           value: {
-            _light: '#702E00',
-            _dark: '#FEDEC8',
+            _light: '#693200',
+            _dark: '#FCE4A6',
           },
         },
       },
@@ -55,13 +55,13 @@ export const semanticColors: SemanticTokens['colors'] = {
         DEFAULT: {
           value: {
             _light: '#7F5F01',
-            _dark: '#F5CD47',
+            _dark: '#EED12B',
           },
         },
         bolder: {
           value: {
             _light: '#533F04',
-            _dark: '#F8E6A0',
+            _dark: '#F5E989',
           },
         },
       },
@@ -96,28 +96,28 @@ export const semanticColors: SemanticTokens['colors'] = {
       blue: {
         DEFAULT: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#1558BC',
+            _dark: '#8FB8F6',
           },
         },
         bolder: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#123263',
+            _dark: '#CFE1FD',
           },
         },
       },
       purple: {
         DEFAULT: {
           value: {
-            _light: '#5E4DB2',
-            _dark: '#B8ACF6',
+            _light: '#803FA5',
+            _dark: '#D8A0F7',
           },
         },
         bolder: {
           value: {
-            _light: '#352C63',
-            _dark: '#DFD8FD',
+            _light: '#48245D',
+            _dark: '#EED7FC',
           },
         },
       },
@@ -138,117 +138,155 @@ export const semanticColors: SemanticTokens['colors'] = {
       gray: {
         DEFAULT: {
           value: {
-            _light: '#44546F',
-            _dark: '#9FADBC',
+            _light: '#505258',
+            _dark: '#A9ABAF',
           },
         },
         bolder: {
           value: {
-            _light: '#091E42',
-            _dark: '#DEE4EA',
+            _light: '#1E1F21',
+            _dark: '#E2E3E4',
           },
         },
       },
     },
     disabled: {
       value: {
-        _light: '#091E424F',
-        _dark: '#BFDBF847',
+        _light: '#080F214A',
+        _dark: '#E5E9F640',
       },
     },
     inverse: {
       value: {
         _light: '#FFFFFF',
-        _dark: '#1D2125',
+        _dark: '#1F1F21',
       },
     },
     selected: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     brand: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     danger: {
-      value: {
-        _light: '#AE2E24',
-        _dark: '#FD9891',
+      DEFAULT: {
+        value: {
+          _light: '#AE2E24',
+          _dark: '#FD9891',
+        },
+      },
+      bolder: {
+        value: {
+          _light: '#5D1F1A',
+          _dark: '#FFD5D2',
+        },
       },
     },
     warning: {
       DEFAULT: {
         value: {
-          _light: '#A54800',
-          _dark: '#F5CD47',
+          _light: '#9E4C00',
+          _dark: '#FBC828',
         },
       },
       inverse: {
         value: {
-          _light: '#172B4D',
-          _dark: '#1D2125',
+          _light: '#292A2E',
+          _dark: '#1F1F21',
+        },
+      },
+      bolder: {
+        value: {
+          _light: '#693200',
+          _dark: '#FCE4A6',
         },
       },
     },
     success: {
-      value: {
-        _light: '#216E4E',
-        _dark: '#7EE2B8',
+      DEFAULT: {
+        value: {
+          _light: '#4C6B1F',
+          _dark: '#B3DF72',
+        },
+      },
+      bolder: {
+        value: {
+          _light: '#37471F',
+          _dark: '#D3F1A7',
+        },
       },
     },
     discovery: {
-      value: {
-        _light: '#5E4DB2',
-        _dark: '#B8ACF6',
+      DEFAULT: {
+        value: {
+          _light: '#803FA5',
+          _dark: '#D8A0F7',
+        },
+      },
+      bolder: {
+        value: {
+          _light: '#48245D',
+          _dark: '#EED7FC',
+        },
       },
     },
     information: {
-      value: {
-        _light: '#0055CC',
-        _dark: '#85B8FF',
+      DEFAULT: {
+        value: {
+          _light: '#1558BC',
+          _dark: '#8FB8F6',
+        },
+      },
+      bolder: {
+        value: {
+          _light: '#123263',
+          _dark: '#CFE1FD',
+        },
       },
     },
     subtlest: {
       value: {
-        _light: '#626F86',
-        _dark: '#8C9BAB',
+        _light: '#6B6E76',
+        _dark: '#96999E',
       },
     },
     subtle: {
       value: {
-        _light: '#44546F',
-        _dark: '#9FADBC',
+        _light: '#505258',
+        _dark: '#A9ABAF',
       },
     },
   },
   link: {
     DEFAULT: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     pressed: {
       value: {
-        _light: '#0055CC',
-        _dark: '#85B8FF',
+        _light: '#1558BC',
+        _dark: '#8FB8F6',
       },
     },
     visited: {
       DEFAULT: {
         value: {
-          _light: '#5E4DB2',
-          _dark: '#B8ACF6',
+          _light: '#803FA5',
+          _dark: '#D8A0F7',
         },
       },
       pressed: {
         value: {
-          _light: '#352C63',
-          _dark: '#DFD8FD',
+          _light: '#48245D',
+          _dark: '#EED7FC',
         },
       },
     },
@@ -256,8 +294,8 @@ export const semanticColors: SemanticTokens['colors'] = {
   icon: {
     DEFAULT: {
       value: {
-        _light: '#44546F',
-        _dark: '#9FADBC',
+        _light: '#292A2E',
+        _dark: '#CECFD2',
       },
     },
     accent: {
@@ -275,14 +313,14 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       orange: {
         value: {
-          _light: '#E56910',
-          _dark: '#F38A3F',
+          _light: '#E06C00',
+          _dark: '#F68909',
         },
       },
       yellow: {
         value: {
           _light: '#B38600',
-          _dark: '#F5CD47',
+          _dark: '#EED12B',
         },
       },
       green: {
@@ -299,14 +337,14 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       blue: {
         value: {
-          _light: '#1D7AFC',
-          _dark: '#388BFF',
+          _light: '#357DE8',
+          _dark: '#4688EC',
         },
       },
       purple: {
         value: {
-          _light: '#8270DB',
-          _dark: '#8F7EE7',
+          _light: '#AF59E1',
+          _dark: '#BF63F3',
         },
       },
       magenta: {
@@ -317,33 +355,33 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       gray: {
         value: {
-          _light: '#758195',
-          _dark: '#738496',
+          _light: '#7D818A',
+          _dark: '#7E8188',
         },
       },
     },
     disabled: {
       value: {
-        _light: '#091E424F',
-        _dark: '#BFDBF847',
+        _light: '#080F214A',
+        _dark: '#E5E9F640',
       },
     },
     inverse: {
       value: {
         _light: '#FFFFFF',
-        _dark: '#1D2125',
+        _dark: '#1F1F21',
       },
     },
     selected: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     brand: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     danger: {
@@ -355,53 +393,53 @@ export const semanticColors: SemanticTokens['colors'] = {
     warning: {
       DEFAULT: {
         value: {
-          _light: '#E56910',
-          _dark: '#F5CD47',
+          _light: '#E06C00',
+          _dark: '#FBC828',
         },
       },
       inverse: {
         value: {
-          _light: '#172B4D',
-          _dark: '#1D2125',
+          _light: '#292A2E',
+          _dark: '#1F1F21',
         },
       },
     },
     success: {
       value: {
-        _light: '#22A06B',
-        _dark: '#2ABB7F',
+        _light: '#6A9A23',
+        _dark: '#82B536',
       },
     },
     discovery: {
       value: {
-        _light: '#8270DB',
-        _dark: '#8F7EE7',
+        _light: '#AF59E1',
+        _dark: '#BF63F3',
       },
     },
     information: {
       value: {
-        _light: '#1D7AFC',
-        _dark: '#388BFF',
+        _light: '#357DE8',
+        _dark: '#4688EC',
       },
     },
     subtlest: {
       value: {
-        _light: '#626F86',
-        _dark: '#8C9BAB',
+        _light: '#6B6E76',
+        _dark: '#96999E',
       },
     },
     subtle: {
       value: {
-        _light: '#626F86',
-        _dark: '#8C9BAB',
+        _light: '#505258',
+        _dark: '#A9ABAF',
       },
     },
   },
   border: {
     DEFAULT: {
       value: {
-        _light: '#091E4224',
-        _dark: '#A6C5E229',
+        _light: '#0B120E24',
+        _dark: '#E3E4F21F',
       },
     },
     accent: {
@@ -419,8 +457,8 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       orange: {
         value: {
-          _light: '#E56910',
-          _dark: '#F38A3F',
+          _light: '#E06C00',
+          _dark: '#F68909',
         },
       },
       yellow: {
@@ -443,14 +481,14 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       blue: {
         value: {
-          _light: '#1D7AFC',
-          _dark: '#388BFF',
+          _light: '#357DE8',
+          _dark: '#4688EC',
         },
       },
       purple: {
         value: {
-          _light: '#8270DB',
-          _dark: '#8F7EE7',
+          _light: '#AF59E1',
+          _dark: '#BF63F3',
         },
       },
       magenta: {
@@ -461,45 +499,45 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       gray: {
         value: {
-          _light: '#758195',
-          _dark: '#738496',
+          _light: '#7D818A',
+          _dark: '#7E8188',
         },
       },
     },
     disabled: {
       value: {
-        _light: '#091E420F',
-        _dark: '#A1BDD914',
+        _light: '#0515240F',
+        _dark: '#CECED912',
       },
     },
     focused: {
       value: {
-        _light: '#388BFF',
-        _dark: '#85B8FF',
+        _light: '#4688EC',
+        _dark: '#8FB8F6',
       },
     },
     input: {
       value: {
-        _light: '#8590A2',
-        _dark: '#738496',
+        _light: '#8C8F97',
+        _dark: '#7E8188',
       },
     },
     inverse: {
       value: {
         _light: '#FFFFFF',
-        _dark: '#161A1D',
+        _dark: '#18191A',
       },
     },
     selected: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     brand: {
       value: {
-        _light: '#0C66E4',
-        _dark: '#579DFF',
+        _light: '#1868DB',
+        _dark: '#669DF1',
       },
     },
     danger: {
@@ -510,32 +548,32 @@ export const semanticColors: SemanticTokens['colors'] = {
     },
     warning: {
       value: {
-        _light: '#E56910',
-        _dark: '#CF9F02',
+        _light: '#E06C00',
+        _dark: '#F68909',
       },
     },
     success: {
       value: {
-        _light: '#22A06B',
-        _dark: '#2ABB7F',
+        _light: '#6A9A23',
+        _dark: '#82B536',
       },
     },
     discovery: {
       value: {
-        _light: '#8270DB',
-        _dark: '#8F7EE7',
+        _light: '#AF59E1',
+        _dark: '#BF63F3',
       },
     },
     information: {
       value: {
-        _light: '#1D7AFC',
-        _dark: '#388BFF',
+        _light: '#357DE8',
+        _dark: '#4688EC',
       },
     },
     bold: {
       value: {
-        _light: '#758195',
-        _dark: '#738496',
+        _light: '#7D818A',
+        _dark: '#7E8188',
       },
     },
   },
@@ -557,8 +595,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#B3DF72',
-              _dark: '#4C6B1F',
+              _light: '#BDE97C',
+              _dark: '#3F5224',
             },
           },
         },
@@ -571,14 +609,14 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           hovered: {
             value: {
-              _light: '#B3DF72',
-              _dark: '#4C6B1F',
+              _light: '#BDE97C',
+              _dark: '#3F5224',
             },
           },
           pressed: {
             value: {
-              _light: '#94C748',
-              _dark: '#5B7F24',
+              _light: '#B3DF72',
+              _dark: '#4C6B1F',
             },
           },
         },
@@ -592,13 +630,13 @@ export const semanticColors: SemanticTokens['colors'] = {
           hovered: {
             value: {
               _light: '#B3DF72',
-              _dark: '#37471F',
+              _dark: '#3F5224',
             },
           },
           pressed: {
             value: {
-              _light: '#D3F1A7',
-              _dark: '#28311B',
+              _light: '#BDE97C',
+              _dark: '#37471F',
             },
           },
         },
@@ -617,8 +655,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#37471F',
-              _dark: '#D3F1A7',
+              _light: '#3F5224',
+              _dark: '#BDE97C',
             },
           },
         },
@@ -639,8 +677,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#FD9891',
-              _dark: '#AE2E24',
+              _light: '#FFB8B2',
+              _dark: '#872821',
             },
           },
         },
@@ -653,14 +691,14 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           hovered: {
             value: {
-              _light: '#FD9891',
-              _dark: '#AE2E24',
+              _light: '#FFB8B2',
+              _dark: '#872821',
             },
           },
           pressed: {
             value: {
-              _light: '#F87168',
-              _dark: '#C9372C',
+              _light: '#FD9891',
+              _dark: '#AE2E24',
             },
           },
         },
@@ -674,13 +712,13 @@ export const semanticColors: SemanticTokens['colors'] = {
           hovered: {
             value: {
               _light: '#FD9891',
-              _dark: '#5D1F1A',
+              _dark: '#872821',
             },
           },
           pressed: {
             value: {
-              _light: '#FFD5D2',
-              _dark: '#42221F',
+              _light: '#FFB8B2',
+              _dark: '#5D1F1A',
             },
           },
         },
@@ -699,8 +737,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#5D1F1A',
-              _dark: '#FFD5D2',
+              _light: '#872821',
+              _dark: '#FFB8B2',
             },
           },
         },
@@ -709,80 +747,80 @@ export const semanticColors: SemanticTokens['colors'] = {
         subtlest: {
           DEFAULT: {
             value: {
-              _light: '#FFF3EB',
-              _dark: '#38291E',
+              _light: '#FFF5DB',
+              _dark: '#3A2C1F',
             },
           },
           hovered: {
             value: {
-              _light: '#FEDEC8',
-              _dark: '#702E00',
+              _light: '#FCE4A6',
+              _dark: '#693200',
             },
           },
           pressed: {
             value: {
-              _light: '#FEC195',
-              _dark: '#A54800',
+              _light: '#FBD779',
+              _dark: '#7A3B00',
             },
           },
         },
         subtler: {
           DEFAULT: {
             value: {
-              _light: '#FEDEC8',
-              _dark: '#702E00',
+              _light: '#FCE4A6',
+              _dark: '#693200',
             },
           },
           hovered: {
             value: {
-              _light: '#FEC195',
-              _dark: '#A54800',
+              _light: '#FBD779',
+              _dark: '#7A3B00',
             },
           },
           pressed: {
             value: {
-              _light: '#FEA362',
-              _dark: '#C25100',
+              _light: '#FBC828',
+              _dark: '#9E4C00',
             },
           },
         },
         subtle: {
           DEFAULT: {
             value: {
-              _light: '#FEA362',
-              _dark: '#A54800',
+              _light: '#FCA700',
+              _dark: '#9E4C00',
             },
           },
           hovered: {
             value: {
-              _light: '#FEC195',
-              _dark: '#702E00',
+              _light: '#FBC828',
+              _dark: '#7A3B00',
             },
           },
           pressed: {
             value: {
-              _light: '#FEDEC8',
-              _dark: '#38291E',
+              _light: '#FBD779',
+              _dark: '#693200',
             },
           },
         },
         bolder: {
           DEFAULT: {
             value: {
-              _light: '#C25100',
-              _dark: '#FEA362',
+              _light: '#BD5B00',
+              _dark: '#FCA700',
             },
           },
           hovered: {
             value: {
-              _light: '#A54800',
-              _dark: '#FEC195',
+              _light: '#9E4C00',
+              _dark: '#FBC828',
             },
           },
           pressed: {
             value: {
-              _light: '#702E00',
-              _dark: '#FEDEC8',
+              _light: '#7A3B00',
+              _dark: '#FBD779',
             },
           },
         },
@@ -791,60 +829,60 @@ export const semanticColors: SemanticTokens['colors'] = {
         subtlest: {
           DEFAULT: {
             value: {
-              _light: '#FFF7D6',
+              _light: '#FEF7C8',
               _dark: '#332E1B',
             },
           },
           hovered: {
             value: {
-              _light: '#F8E6A0',
+              _light: '#F5E989',
               _dark: '#533F04',
             },
           },
           pressed: {
             value: {
-              _light: '#F5CD47',
-              _dark: '#7F5F01',
+              _light: '#EFDD4E',
+              _dark: '#614A05',
             },
           },
         },
         subtler: {
           DEFAULT: {
             value: {
-              _light: '#F8E6A0',
+              _light: '#F5E989',
               _dark: '#533F04',
             },
           },
           hovered: {
             value: {
-              _light: '#F5CD47',
-              _dark: '#7F5F01',
+              _light: '#EFDD4E',
+              _dark: '#614A05',
             },
           },
           pressed: {
             value: {
-              _light: '#E2B203',
-              _dark: '#946F00',
+              _light: '#EED12B',
+              _dark: '#7F5F01',
             },
           },
         },
         subtle: {
           DEFAULT: {
             value: {
-              _light: '#F5CD47',
+              _light: '#EED12B',
               _dark: '#7F5F01',
             },
           },
           hovered: {
             value: {
-              _light: '#E2B203',
-              _dark: '#533F04',
+              _light: '#DDB30E',
+              _dark: '#614A05',
             },
           },
           pressed: {
             value: {
-              _light: '#CF9F02',
-              _dark: '#332E1B',
+              _light: '#EFDD4E',
+              _dark: '#533F04',
             },
           },
         },
@@ -852,19 +890,19 @@ export const semanticColors: SemanticTokens['colors'] = {
           DEFAULT: {
             value: {
               _light: '#946F00',
-              _dark: '#E2B203',
+              _dark: '#DDB30E',
             },
           },
           hovered: {
             value: {
               _light: '#7F5F01',
-              _dark: '#F5CD47',
+              _dark: '#EED12B',
             },
           },
           pressed: {
             value: {
-              _light: '#533F04',
-              _dark: '#F8E6A0',
+              _light: '#614A05',
+              _dark: '#EFDD4E',
             },
           },
         },
@@ -885,8 +923,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#7EE2B8',
-              _dark: '#216E4E',
+              _light: '#97EDC9',
+              _dark: '#19573D',
             },
           },
         },
@@ -899,14 +937,14 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           hovered: {
             value: {
-              _light: '#7EE2B8',
-              _dark: '#216E4E',
+              _light: '#97EDC9',
+              _dark: '#19573D',
             },
           },
           pressed: {
             value: {
-              _light: '#4BCE97',
-              _dark: '#1F845A',
+              _light: '#7EE2B8',
+              _dark: '#216E4E',
             },
           },
         },
@@ -920,13 +958,13 @@ export const semanticColors: SemanticTokens['colors'] = {
           hovered: {
             value: {
               _light: '#7EE2B8',
-              _dark: '#164B35',
+              _dark: '#19573D',
             },
           },
           pressed: {
             value: {
-              _light: '#BAF3DB',
-              _dark: '#1C3329',
+              _light: '#97EDC9',
+              _dark: '#164B35',
             },
           },
         },
@@ -945,8 +983,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#164B35',
-              _dark: '#BAF3DB',
+              _light: '#19573D',
+              _dark: '#97EDC9',
             },
           },
         },
@@ -967,8 +1005,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#9DD9EE',
-              _dark: '#206A83',
+              _light: '#B1E4F7',
+              _dark: '#1A5265',
             },
           },
         },
@@ -981,14 +1019,14 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           hovered: {
             value: {
-              _light: '#9DD9EE',
-              _dark: '#206A83',
+              _light: '#B1E4F7',
+              _dark: '#1A5265',
             },
           },
           pressed: {
             value: {
-              _light: '#6CC3E0',
-              _dark: '#227D9B',
+              _light: '#9DD9EE',
+              _dark: '#206A83',
             },
           },
         },
@@ -1002,13 +1040,13 @@ export const semanticColors: SemanticTokens['colors'] = {
           hovered: {
             value: {
               _light: '#9DD9EE',
-              _dark: '#164555',
+              _dark: '#1A5265',
             },
           },
           pressed: {
             value: {
-              _light: '#C6EDFB',
-              _dark: '#1E3137',
+              _light: '#B1E4F7',
+              _dark: '#164555',
             },
           },
         },
@@ -1027,8 +1065,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#164555',
-              _dark: '#C6EDFB',
+              _light: '#1A5265',
+              _dark: '#B1E4F7',
             },
           },
         },
@@ -1037,80 +1075,80 @@ export const semanticColors: SemanticTokens['colors'] = {
         subtlest: {
           DEFAULT: {
             value: {
-              _light: '#E9F2FF',
-              _dark: '#1C2B41',
+              _light: '#E9F2FE',
+              _dark: '#1C2B42',
             },
           },
           hovered: {
             value: {
-              _light: '#CCE0FF',
-              _dark: '#09326C',
+              _light: '#CFE1FD',
+              _dark: '#123263',
             },
           },
           pressed: {
             value: {
-              _light: '#85B8FF',
-              _dark: '#0055CC',
+              _light: '#ADCBFB',
+              _dark: '#144794',
             },
           },
         },
         subtler: {
           DEFAULT: {
             value: {
-              _light: '#CCE0FF',
-              _dark: '#09326C',
+              _light: '#CFE1FD',
+              _dark: '#123263',
             },
           },
           hovered: {
             value: {
-              _light: '#85B8FF',
-              _dark: '#0055CC',
+              _light: '#ADCBFB',
+              _dark: '#144794',
             },
           },
           pressed: {
             value: {
-              _light: '#579DFF',
-              _dark: '#0C66E4',
+              _light: '#8FB8F6',
+              _dark: '#1558BC',
             },
           },
         },
         subtle: {
           DEFAULT: {
             value: {
-              _light: '#579DFF',
-              _dark: '#0055CC',
+              _light: '#669DF1',
+              _dark: '#1558BC',
             },
           },
           hovered: {
             value: {
-              _light: '#85B8FF',
-              _dark: '#09326C',
+              _light: '#8FB8F6',
+              _dark: '#144794',
             },
           },
           pressed: {
             value: {
-              _light: '#CCE0FF',
-              _dark: '#1C2B41',
+              _light: '#ADCBFB',
+              _dark: '#123263',
             },
           },
         },
         bolder: {
           DEFAULT: {
             value: {
-              _light: '#0C66E4',
-              _dark: '#579DFF',
+              _light: '#1868DB',
+              _dark: '#669DF1',
             },
           },
           hovered: {
             value: {
-              _light: '#0055CC',
-              _dark: '#85B8FF',
+              _light: '#1558BC',
+              _dark: '#8FB8F6',
             },
           },
           pressed: {
             value: {
-              _light: '#09326C',
-              _dark: '#CCE0FF',
+              _light: '#144794',
+              _dark: '#ADCBFB',
             },
           },
         },
@@ -1119,80 +1157,80 @@ export const semanticColors: SemanticTokens['colors'] = {
         subtlest: {
           DEFAULT: {
             value: {
-              _light: '#F3F0FF',
-              _dark: '#2B273F',
+              _light: '#F8EEFE',
+              _dark: '#35243F',
             },
           },
           hovered: {
             value: {
-              _light: '#DFD8FD',
-              _dark: '#352C63',
+              _light: '#EED7FC',
+              _dark: '#48245D',
             },
           },
           pressed: {
             value: {
-              _light: '#B8ACF6',
-              _dark: '#5E4DB2',
+              _light: '#E3BDFA',
+              _dark: '#673286',
             },
           },
         },
         subtler: {
           DEFAULT: {
             value: {
-              _light: '#DFD8FD',
-              _dark: '#352C63',
+              _light: '#EED7FC',
+              _dark: '#48245D',
             },
           },
           hovered: {
             value: {
-              _light: '#B8ACF6',
-              _dark: '#5E4DB2',
+              _light: '#E3BDFA',
+              _dark: '#673286',
             },
           },
           pressed: {
             value: {
-              _light: '#9F8FEF',
-              _dark: '#6E5DC6',
+              _light: '#D8A0F7',
+              _dark: '#803FA5',
             },
           },
         },
         subtle: {
           DEFAULT: {
             value: {
-              _light: '#9F8FEF',
-              _dark: '#5E4DB2',
+              _light: '#C97CF4',
+              _dark: '#803FA5',
             },
           },
           hovered: {
             value: {
-              _light: '#B8ACF6',
-              _dark: '#352C63',
+              _light: '#D8A0F7',
+              _dark: '#673286',
             },
           },
           pressed: {
             value: {
-              _light: '#DFD8FD',
-              _dark: '#2B273F',
+              _light: '#E3BDFA',
+              _dark: '#48245D',
             },
           },
         },
         bolder: {
           DEFAULT: {
             value: {
-              _light: '#6E5DC6',
-              _dark: '#9F8FEF',
+              _light: '#964AC0',
+              _dark: '#C97CF4',
             },
           },
           hovered: {
             value: {
-              _light: '#5E4DB2',
-              _dark: '#B8ACF6',
+              _light: '#803FA5',
+              _dark: '#D8A0F7',
             },
           },
           pressed: {
             value: {
-              _light: '#352C63',
-              _dark: '#DFD8FD',
+              _light: '#673286',
+              _dark: '#E3BDFA',
             },
           },
         },
@@ -1213,8 +1251,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#F797D2',
-              _dark: '#943D73',
+              _light: '#FCB6E1',
+              _dark: '#77325B',
             },
           },
         },
@@ -1227,14 +1265,14 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           hovered: {
             value: {
-              _light: '#F797D2',
-              _dark: '#943D73',
+              _light: '#FCB6E1',
+              _dark: '#77325B',
             },
           },
           pressed: {
             value: {
-              _light: '#E774BB',
-              _dark: '#AE4787',
+              _light: '#F797D2',
+              _dark: '#943D73',
             },
           },
         },
@@ -1248,13 +1286,13 @@ export const semanticColors: SemanticTokens['colors'] = {
           hovered: {
             value: {
               _light: '#F797D2',
-              _dark: '#50253F',
+              _dark: '#77325B',
             },
           },
           pressed: {
             value: {
-              _light: '#FDD0EC',
-              _dark: '#3D2232',
+              _light: '#FCB6E1',
+              _dark: '#50253F',
             },
           },
         },
@@ -1273,8 +1311,8 @@ export const semanticColors: SemanticTokens['colors'] = {
           },
           pressed: {
             value: {
-              _light: '#50253F',
-              _dark: '#FDD0EC',
+              _light: '#77325B',
+              _dark: '#FCB6E1',
             },
           },
         },
@@ -1283,80 +1321,80 @@ export const semanticColors: SemanticTokens['colors'] = {
         subtlest: {
           DEFAULT: {
             value: {
-              _light: '#F1F2F4',
-              _dark: '#2C333A',
+              _light: '#F0F1F2',
+              _dark: '#303134',
             },
           },
           hovered: {
             value: {
-              _light: '#DCDFE4',
-              _dark: '#38414A',
+              _light: '#DDDEE1',
+              _dark: '#3D3F43',
             },
           },
           pressed: {
             value: {
-              _light: '#B3B9C4',
-              _dark: '#454F59',
+              _light: '#B7B9BE',
+              _dark: '#4B4D51',
             },
           },
         },
         subtler: {
           DEFAULT: {
             value: {
-              _light: '#DCDFE4',
-              _dark: '#454F59',
+              _light: '#DDDEE1',
+              _dark: '#4B4D51',
             },
           },
           hovered: {
             value: {
-              _light: '#B3B9C4',
-              _dark: '#596773',
+              _light: '#B7B9BE',
+              _dark: '#63666B',
             },
           },
           pressed: {
             value: {
-              _light: '#8590A2',
-              _dark: '#738496',
+              _light: '#8C8F97',
+              _dark: '#7E8188',
             },
           },
         },
         subtle: {
           DEFAULT: {
             value: {
-              _light: '#8590A2',
-              _dark: '#596773',
+              _light: '#8C8F97',
+              _dark: '#63666B',
             },
           },
           hovered: {
             value: {
-              _light: '#B3B9C4',
-              _dark: '#454F59',
+              _light: '#B7B9BE',
+              _dark: '#4B4D51',
             },
           },
           pressed: {
             value: {
-              _light: '#DCDFE4',
-              _dark: '#38414A',
+              _light: '#DDDEE1',
+              _dark: '#3D3F43',
             },
           },
         },
         bolder: {
           DEFAULT: {
             value: {
-              _light: '#626F86',
-              _dark: '#8C9BAB',
+              _light: '#6B6E76',
+              _dark: '#96999E',
             },
           },
           hovered: {
             value: {
-              _light: '#44546F',
-              _dark: '#9FADBC',
+              _light: '#505258',
+              _dark: '#A9ABAF',
             },
           },
           pressed: {
             value: {
-              _light: '#2C3E5D',
-              _dark: '#B6C2CF',
+              _light: '#3B3D42',
+              _dark: '#BFC1C4',
             },
           },
         },
@@ -1364,27 +1402,27 @@ export const semanticColors: SemanticTokens['colors'] = {
     },
     disabled: {
       value: {
-        _light: '#091E4208',
-        _dark: '#BCD6F00A',
+        _light: '#17171708',
+        _dark: '#BDBDBD0A',
       },
     },
     input: {
       DEFAULT: {
         value: {
           _light: '#FFFFFF',
-          _dark: '#22272B',
+          _dark: '#242528',
         },
       },
       hovered: {
         value: {
-          _light: '#F7F8F9',
-          _dark: '#282E33',
+          _light: '#F8F8F8',
+          _dark: '#2B2C2F',
         },
       },
       pressed: {
         value: {
           _light: '#FFFFFF',
-          _dark: '#22272B',
+          _dark: '#242528',
         },
       },
     },
@@ -1413,53 +1451,53 @@ export const semanticColors: SemanticTokens['colors'] = {
     neutral: {
       DEFAULT: {
         value: {
-          _light: '#091E420F',
-          _dark: '#A1BDD914',
+          _light: '#0515240F',
+          _dark: '#CECED912',
         },
       },
       hovered: {
         value: {
-          _light: '#091E4224',
-          _dark: '#A6C5E229',
+          _light: '#0B120E24',
+          _dark: '#E3E4F21F',
         },
       },
       pressed: {
         value: {
-          _light: '#091E424F',
-          _dark: '#BFDBF847',
+          _light: '#080F214A',
+          _dark: '#E5E9F640',
         },
       },
       subtle: {
         hovered: {
           value: {
-            _light: '#091E420F',
-            _dark: '#A1BDD914',
+            _light: '#0515240F',
+            _dark: '#CECED912',
           },
         },
         pressed: {
           value: {
-            _light: '#091E4224',
-            _dark: '#A6C5E229',
+            _light: '#0B120E24',
+            _dark: '#E3E4F21F',
           },
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#44546F',
-            _dark: '#9FADBC',
+            _light: '#292A2E',
+            _dark: '#CECFD2',
           },
         },
         hovered: {
           value: {
-            _light: '#2C3E5D',
-            _dark: '#B6C2CF',
+            _light: '#3B3D42',
+            _dark: '#BFC1C4',
           },
         },
         pressed: {
           value: {
-            _light: '#172B4D',
-            _dark: '#C7D1DB',
+            _light: '#505258',
+            _dark: '#A9ABAF',
           },
         },
       },
@@ -1467,39 +1505,39 @@ export const semanticColors: SemanticTokens['colors'] = {
     selected: {
       DEFAULT: {
         value: {
-          _light: '#E9F2FF',
-          _dark: '#1C2B41',
+          _light: '#E9F2FE',
+          _dark: '#1C2B42',
         },
       },
       hovered: {
         value: {
-          _light: '#CCE0FF',
-          _dark: '#09326C',
+          _light: '#CFE1FD',
+          _dark: '#123263',
         },
       },
       pressed: {
         value: {
-          _light: '#85B8FF',
-          _dark: '#0055CC',
+          _light: '#8FB8F6',
+          _dark: '#1558BC',
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#0C66E4',
-            _dark: '#579DFF',
+            _light: '#1868DB',
+            _dark: '#669DF1',
           },
         },
         hovered: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#1558BC',
+            _dark: '#8FB8F6',
           },
         },
         pressed: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#123263',
+            _dark: '#CFE1FD',
           },
         },
       },
@@ -1508,60 +1546,60 @@ export const semanticColors: SemanticTokens['colors'] = {
       subtlest: {
         DEFAULT: {
           value: {
-            _light: '#E9F2FF',
-            _dark: '#1C2B41',
+            _light: '#E9F2FE',
+            _dark: '#1C2B42',
           },
         },
         hovered: {
           value: {
-            _light: '#CCE0FF',
-            _dark: '#09326C',
+            _light: '#CFE1FD',
+            _dark: '#123263',
           },
         },
         pressed: {
           value: {
-            _light: '#85B8FF',
-            _dark: '#0055CC',
+            _light: '#ADCBFB',
+            _dark: '#144794',
           },
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#0C66E4',
-            _dark: '#579DFF',
+            _light: '#1868DB',
+            _dark: '#669DF1',
           },
         },
         hovered: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#1558BC',
+            _dark: '#8FB8F6',
           },
         },
         pressed: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#144794',
+            _dark: '#ADCBFB',
           },
         },
       },
       boldest: {
         DEFAULT: {
           value: {
-            _light: '#1C2B41',
-            _dark: '#E9F2FF',
+            _light: '#1C2B42',
+            _dark: '#E9F2FE',
           },
         },
         hovered: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#123263',
+            _dark: '#CFE1FD',
           },
         },
         pressed: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#144794',
+            _dark: '#ADCBFB',
           },
         },
       },
@@ -1581,8 +1619,28 @@ export const semanticColors: SemanticTokens['colors'] = {
       },
       pressed: {
         value: {
-          _light: '#FD9891',
-          _dark: '#AE2E24',
+          _light: '#FFB8B2',
+          _dark: '#872821',
+        },
+      },
+      subtler: {
+        DEFAULT: {
+          value: {
+            _light: '#FFD5D2',
+            _dark: '#5D1F1A',
+          },
+        },
+        hovered: {
+          value: {
+            _light: '#FFB8B2',
+            _dark: '#872821',
+          },
+        },
+        pressed: {
+          value: {
+            _light: '#FD9891',
+            _dark: '#AE2E24',
+          },
         },
       },
       bold: {
@@ -1600,8 +1658,8 @@ export const semanticColors: SemanticTokens['colors'] = {
         },
         pressed: {
           value: {
-            _light: '#5D1F1A',
-            _dark: '#FFD5D2',
+            _light: '#872821',
+            _dark: '#FFB8B2',
           },
         },
       },
@@ -1609,59 +1667,99 @@ export const semanticColors: SemanticTokens['colors'] = {
     warning: {
       DEFAULT: {
         value: {
-          _light: '#FFF7D6',
-          _dark: '#332E1B',
+          _light: '#FFF5DB',
+          _dark: '#3A2C1F',
         },
       },
       hovered: {
         value: {
-          _light: '#F8E6A0',
-          _dark: '#533F04',
+          _light: '#FCE4A6',
+          _dark: '#693200',
         },
       },
       pressed: {
         value: {
-          _light: '#F5CD47',
-          _dark: '#7F5F01',
+          _light: '#FBD779',
+          _dark: '#7A3B00',
+        },
+      },
+      subtler: {
+        DEFAULT: {
+          value: {
+            _light: '#FCE4A6',
+            _dark: '#693200',
+          },
+        },
+        hovered: {
+          value: {
+            _light: '#FBD779',
+            _dark: '#7A3B00',
+          },
+        },
+        pressed: {
+          value: {
+            _light: '#FBC828',
+            _dark: '#9E4C00',
+          },
         },
       },
     },
     success: {
       DEFAULT: {
         value: {
-          _light: '#DCFFF1',
-          _dark: '#1C3329',
+          _light: '#EFFFD6',
+          _dark: '#28311B',
         },
       },
       hovered: {
         value: {
-          _light: '#BAF3DB',
-          _dark: '#164B35',
+          _light: '#D3F1A7',
+          _dark: '#37471F',
         },
       },
       pressed: {
         value: {
-          _light: '#7EE2B8',
-          _dark: '#216E4E',
+          _light: '#BDE97C',
+          _dark: '#3F5224',
+        },
+      },
+      subtler: {
+        DEFAULT: {
+          value: {
+            _light: '#D3F1A7',
+            _dark: '#37471F',
+          },
+        },
+        hovered: {
+          value: {
+            _light: '#BDE97C',
+            _dark: '#3F5224',
+          },
+        },
+        pressed: {
+          value: {
+            _light: '#B3DF72',
+            _dark: '#4C6B1F',
+          },
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#1F845A',
-            _dark: '#4BCE97',
+            _light: '#5B7F24',
+            _dark: '#94C748',
           },
         },
         hovered: {
           value: {
-            _light: '#216E4E',
-            _dark: '#7EE2B8',
+            _light: '#4C6B1F',
+            _dark: '#B3DF72',
           },
         },
         pressed: {
           value: {
-            _light: '#164B35',
-            _dark: '#BAF3DB',
+            _light: '#3F5224',
+            _dark: '#BDE97C',
           },
         },
       },
@@ -1669,39 +1767,59 @@ export const semanticColors: SemanticTokens['colors'] = {
     discovery: {
       DEFAULT: {
         value: {
-          _light: '#F3F0FF',
-          _dark: '#2B273F',
+          _light: '#F8EEFE',
+          _dark: '#35243F',
         },
       },
       hovered: {
         value: {
-          _light: '#DFD8FD',
-          _dark: '#352C63',
+          _light: '#EED7FC',
+          _dark: '#48245D',
         },
       },
       pressed: {
         value: {
-          _light: '#B8ACF6',
-          _dark: '#5E4DB2',
+          _light: '#E3BDFA',
+          _dark: '#673286',
+        },
+      },
+      subtler: {
+        DEFAULT: {
+          value: {
+            _light: '#EED7FC',
+            _dark: '#48245D',
+          },
+        },
+        hovered: {
+          value: {
+            _light: '#E3BDFA',
+            _dark: '#673286',
+          },
+        },
+        pressed: {
+          value: {
+            _light: '#D8A0F7',
+            _dark: '#803FA5',
+          },
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#6E5DC6',
-            _dark: '#9F8FEF',
+            _light: '#964AC0',
+            _dark: '#C97CF4',
           },
         },
         hovered: {
           value: {
-            _light: '#5E4DB2',
-            _dark: '#B8ACF6',
+            _light: '#803FA5',
+            _dark: '#D8A0F7',
           },
         },
         pressed: {
           value: {
-            _light: '#352C63',
-            _dark: '#DFD8FD',
+            _light: '#673286',
+            _dark: '#E3BDFA',
           },
         },
       },
@@ -1709,39 +1827,59 @@ export const semanticColors: SemanticTokens['colors'] = {
     information: {
       DEFAULT: {
         value: {
-          _light: '#E9F2FF',
-          _dark: '#1C2B41',
+          _light: '#E9F2FE',
+          _dark: '#1C2B42',
         },
       },
       hovered: {
         value: {
-          _light: '#CCE0FF',
-          _dark: '#09326C',
+          _light: '#CFE1FD',
+          _dark: '#123263',
         },
       },
       pressed: {
         value: {
-          _light: '#85B8FF',
-          _dark: '#0055CC',
+          _light: '#ADCBFB',
+          _dark: '#144794',
+        },
+      },
+      subtler: {
+        DEFAULT: {
+          value: {
+            _light: '#CFE1FD',
+            _dark: '#123263',
+          },
+        },
+        hovered: {
+          value: {
+            _light: '#ADCBFB',
+            _dark: '#144794',
+          },
+        },
+        pressed: {
+          value: {
+            _light: '#8FB8F6',
+            _dark: '#1558BC',
+          },
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#0C66E4',
-            _dark: '#579DFF',
+            _light: '#1868DB',
+            _dark: '#669DF1',
           },
         },
         hovered: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#1558BC',
+            _dark: '#8FB8F6',
           },
         },
         pressed: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#144794',
+            _dark: '#ADCBFB',
           },
         },
       },
@@ -1750,7 +1888,7 @@ export const semanticColors: SemanticTokens['colors'] = {
   blanket: {
     DEFAULT: {
       value: {
-        _light: '#091E427D',
+        _light: '#050C1F75',
         _dark: '#10121499',
       },
     },
@@ -1784,116 +1922,110 @@ export const semanticColors: SemanticTokens['colors'] = {
   skeleton: {
     DEFAULT: {
       value: {
-        _light: '#091E420F',
-        _dark: '#A1BDD914',
+        _light: '#0515240F',
+        _dark: '#CECED912',
       },
     },
     subtle: {
       value: {
-        _light: '#091E4208',
-        _dark: '#BCD6F00A',
+        _light: '#17171708',
+        _dark: '#BDBDBD0A',
       },
     },
   },
   chart: {
     categorical: {
       '1': {
+        DEFAULT: {
+          value: {
+            _light: '#357DE8',
+            _dark: '#4688EC',
+          },
+        },
         hovered: {
           value: {
-            _light: '#227D9B',
-            _dark: '#42B2D7',
+            _light: '#1868DB',
+            _dark: '#669DF1',
           },
         },
       },
       '2': {
         DEFAULT: {
           value: {
-            _light: '#5E4DB2',
-            _dark: '#B8ACF6',
+            _light: '#82B536',
+            _dark: '#94C748',
           },
         },
         hovered: {
           value: {
-            _light: '#352C63',
-            _dark: '#DFD8FD',
+            _light: '#6A9A23',
+            _dark: '#B3DF72',
           },
         },
       },
       '3': {
+        DEFAULT: {
+          value: {
+            _light: '#BF63F3',
+            _dark: '#C97CF4',
+          },
+        },
         hovered: {
           value: {
-            _light: '#C25100',
-            _dark: '#F38A3F',
+            _light: '#AF59E1',
+            _dark: '#D8A0F7',
           },
         },
       },
       '4': {
         DEFAULT: {
           value: {
-            _light: '#943D73',
-            _dark: '#F797D2',
+            _light: '#F68909',
+            _dark: '#FCA700',
           },
         },
         hovered: {
           value: {
-            _light: '#50253F',
-            _dark: '#FDD0EC',
+            _light: '#E06C00',
+            _dark: '#FBC828',
           },
         },
       },
       '5': {
-        DEFAULT: {
-          value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
-          },
-        },
         hovered: {
           value: {
-            _light: '#1C2B41',
-            _dark: '#E9F2FF',
+            _light: '#123263',
+            _dark: '#1868DB',
           },
         },
       },
       '6': {
-        DEFAULT: {
-          value: {
-            _light: '#8F7EE7',
-            _dark: '#8270DB',
-          },
-        },
         hovered: {
           value: {
-            _light: '#8270DB',
-            _dark: '#8F7EE7',
+            _light: '#803FA5',
+            _dark: '#AF59E1',
           },
         },
       },
       '7': {
-        DEFAULT: {
-          value: {
-            _light: '#50253F',
-            _dark: '#FDD0EC',
-          },
-        },
         hovered: {
           value: {
-            _light: '#3D2232',
-            _dark: '#FFECF8',
+            _light: '#2898BD',
+            _dark: '#6CC3E0',
           },
         },
       },
       '8': {
         DEFAULT: {
           value: {
-            _light: '#A54800',
-            _dark: '#FEC195',
+            _light: '#BD5B00',
+            _dark: '#E06C00',
           },
         },
         hovered: {
           value: {
-            _light: '#702E00',
-            _dark: '#FEDEC8',
+            _light: '#7A3B00',
+            _dark: '#FBD779',
           },
         },
       },
@@ -1945,14 +2077,14 @@ export const semanticColors: SemanticTokens['colors'] = {
     neutral: {
       DEFAULT: {
         value: {
-          _light: '#8590A2',
-          _dark: '#738496',
+          _light: '#8C8F97',
+          _dark: '#7E8188',
         },
       },
       hovered: {
         value: {
-          _light: '#758195',
-          _dark: '#8C9BAB',
+          _light: '#7D818A',
+          _dark: '#96999E',
         },
       },
     },
@@ -2004,42 +2136,42 @@ export const semanticColors: SemanticTokens['colors'] = {
       bold: {
         DEFAULT: {
           value: {
-            _light: '#E56910',
-            _dark: '#F38A3F',
+            _light: '#E06C00',
+            _dark: '#F68909',
           },
         },
         hovered: {
           value: {
-            _light: '#C25100',
-            _dark: '#FEA362',
+            _light: '#BD5B00',
+            _dark: '#FCA700',
           },
         },
       },
       bolder: {
         DEFAULT: {
           value: {
-            _light: '#C25100',
-            _dark: '#FEA362',
+            _light: '#BD5B00',
+            _dark: '#FCA700',
           },
         },
         hovered: {
           value: {
-            _light: '#A54800',
-            _dark: '#FEC195',
+            _light: '#9E4C00',
+            _dark: '#FBC828',
           },
         },
       },
       boldest: {
         DEFAULT: {
           value: {
-            _light: '#A54800',
-            _dark: '#FEC195',
+            _light: '#7A3B00',
+            _dark: '#FBD779',
           },
         },
         hovered: {
           value: {
-            _light: '#702E00',
-            _dark: '#FEDEC8',
+            _light: '#693200',
+            _dark: '#FCE4A6',
           },
         },
       },
@@ -2055,7 +2187,7 @@ export const semanticColors: SemanticTokens['colors'] = {
         hovered: {
           value: {
             _light: '#946F00',
-            _dark: '#E2B203',
+            _dark: '#DDB30E',
           },
         },
       },
@@ -2063,13 +2195,13 @@ export const semanticColors: SemanticTokens['colors'] = {
         DEFAULT: {
           value: {
             _light: '#946F00',
-            _dark: '#E2B203',
+            _dark: '#DDB30E',
           },
         },
         hovered: {
           value: {
             _light: '#7F5F01',
-            _dark: '#F5CD47',
+            _dark: '#EED12B',
           },
         },
       },
@@ -2077,13 +2209,13 @@ export const semanticColors: SemanticTokens['colors'] = {
         DEFAULT: {
           value: {
             _light: '#7F5F01',
-            _dark: '#F5CD47',
+            _dark: '#EED12B',
           },
         },
         hovered: {
           value: {
             _light: '#533F04',
-            _dark: '#F8E6A0',
+            _dark: '#F5E989',
           },
         },
       },
@@ -2180,42 +2312,42 @@ export const semanticColors: SemanticTokens['colors'] = {
       bold: {
         DEFAULT: {
           value: {
-            _light: '#388BFF',
-            _dark: '#1D7AFC',
+            _light: '#4688EC',
+            _dark: '#357DE8',
           },
         },
         hovered: {
           value: {
-            _light: '#1D7AFC',
-            _dark: '#388BFF',
+            _light: '#357DE8',
+            _dark: '#4688EC',
           },
         },
       },
       bolder: {
         DEFAULT: {
           value: {
-            _light: '#1D7AFC',
-            _dark: '#388BFF',
+            _light: '#357DE8',
+            _dark: '#4688EC',
           },
         },
         hovered: {
           value: {
-            _light: '#0C66E4',
-            _dark: '#579DFF',
+            _light: '#1868DB',
+            _dark: '#669DF1',
           },
         },
       },
       boldest: {
         DEFAULT: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#1558BC',
+            _dark: '#8FB8F6',
           },
         },
         hovered: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#123263',
+            _dark: '#CFE1FD',
           },
         },
       },
@@ -2224,42 +2356,42 @@ export const semanticColors: SemanticTokens['colors'] = {
       bold: {
         DEFAULT: {
           value: {
-            _light: '#8F7EE7',
-            _dark: '#8270DB',
+            _light: '#BF63F3',
+            _dark: '#AF59E1',
           },
         },
         hovered: {
           value: {
-            _light: '#8270DB',
-            _dark: '#8F7EE7',
+            _light: '#AF59E1',
+            _dark: '#BF63F3',
           },
         },
       },
       bolder: {
         DEFAULT: {
           value: {
-            _light: '#8270DB',
-            _dark: '#8F7EE7',
+            _light: '#AF59E1',
+            _dark: '#BF63F3',
           },
         },
         hovered: {
           value: {
-            _light: '#6E5DC6',
-            _dark: '#9F8FEF',
+            _light: '#964AC0',
+            _dark: '#C97CF4',
           },
         },
       },
       boldest: {
         DEFAULT: {
           value: {
-            _light: '#5E4DB2',
-            _dark: '#B8ACF6',
+            _light: '#803FA5',
+            _dark: '#D8A0F7',
           },
         },
         hovered: {
           value: {
-            _light: '#352C63',
-            _dark: '#DFD8FD',
+            _light: '#48245D',
+            _dark: '#EED7FC',
           },
         },
       },
@@ -2312,42 +2444,42 @@ export const semanticColors: SemanticTokens['colors'] = {
       bold: {
         DEFAULT: {
           value: {
-            _light: '#8590A2',
-            _dark: '#738496',
+            _light: '#8C8F97',
+            _dark: '#7E8188',
           },
         },
         hovered: {
           value: {
-            _light: '#758195',
-            _dark: '#8C9BAB',
+            _light: '#7D818A',
+            _dark: '#96999E',
           },
         },
       },
       bolder: {
         DEFAULT: {
           value: {
-            _light: '#758195',
-            _dark: '#8C9BAB',
+            _light: '#7D818A',
+            _dark: '#96999E',
           },
         },
         hovered: {
           value: {
-            _light: '#626F86',
-            _dark: '#9FADBC',
+            _light: '#6B6E76',
+            _dark: '#A9ABAF',
           },
         },
       },
       boldest: {
         DEFAULT: {
           value: {
-            _light: '#44546F',
-            _dark: '#9FADBC',
+            _light: '#505258',
+            _dark: '#A9ABAF',
           },
         },
         hovered: {
           value: {
-            _light: '#2C3E5D',
-            _dark: '#B6C2CF',
+            _light: '#3B3D42',
+            _dark: '#BFC1C4',
           },
         },
       },
@@ -2355,125 +2487,101 @@ export const semanticColors: SemanticTokens['colors'] = {
     brand: {
       DEFAULT: {
         value: {
-          _light: '#1D7AFC',
-          _dark: '#388BFF',
+          _light: '#357DE8',
+          _dark: '#4688EC',
         },
       },
       hovered: {
         value: {
-          _light: '#0C66E4',
-          _dark: '#579DFF',
+          _light: '#1868DB',
+          _dark: '#669DF1',
         },
       },
     },
     danger: {
-      DEFAULT: {
-        value: {
-          _light: '#F15B50',
-          _dark: '#E2483D',
-        },
-      },
       hovered: {
         value: {
-          _light: '#E2483D',
+          _light: '#C9372C',
           _dark: '#F15B50',
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#AE2E24',
-            _dark: '#FD9891',
+            _light: '#872821',
+            _dark: '#FFB8B2',
           },
         },
         hovered: {
           value: {
             _light: '#5D1F1A',
-            _dark: '#FFD5D2',
+            _dark: '#FD9891',
           },
         },
       },
     },
     warning: {
-      DEFAULT: {
-        value: {
-          _light: '#B38600',
-          _dark: '#CF9F02',
-        },
-      },
       hovered: {
         value: {
-          _light: '#946F00',
-          _dark: '#E2B203',
+          _light: '#E06C00',
+          _dark: '#FCA700',
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#7F5F01',
-            _dark: '#F5CD47',
+            _light: '#BD5B00',
+            _dark: '#FBC828',
           },
         },
         hovered: {
           value: {
-            _light: '#533F04',
-            _dark: '#F8E6A0',
+            _light: '#9E4C00',
+            _dark: '#FCE4A6',
           },
         },
       },
     },
     success: {
-      DEFAULT: {
-        value: {
-          _light: '#22A06B',
-          _dark: '#2ABB7F',
-        },
-      },
       hovered: {
         value: {
-          _light: '#1F845A',
-          _dark: '#4BCE97',
+          _light: '#6A9A23',
+          _dark: '#94C748',
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#216E4E',
-            _dark: '#7EE2B8',
+            _light: '#5B7F24',
+            _dark: '#B3DF72',
           },
         },
         hovered: {
           value: {
-            _light: '#164B35',
-            _dark: '#BAF3DB',
+            _light: '#4C6B1F',
+            _dark: '#D3F1A7',
           },
         },
       },
     },
     discovery: {
-      DEFAULT: {
-        value: {
-          _light: '#8F7EE7',
-          _dark: '#8270DB',
-        },
-      },
       hovered: {
         value: {
-          _light: '#8270DB',
-          _dark: '#8F7EE7',
+          _light: '#AF59E1',
+          _dark: '#C97CF4',
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#5E4DB2',
-            _dark: '#B8ACF6',
+            _light: '#803FA5',
+            _dark: '#D8A0F7',
           },
         },
         hovered: {
           value: {
-            _light: '#352C63',
-            _dark: '#DFD8FD',
+            _light: '#964AC0',
+            _dark: '#EED7FC',
           },
         },
       },
@@ -2481,27 +2589,27 @@ export const semanticColors: SemanticTokens['colors'] = {
     information: {
       DEFAULT: {
         value: {
-          _light: '#388BFF',
-          _dark: '#1D7AFC',
+          _light: '#357DE8',
+          _dark: '#4688EC',
         },
       },
       hovered: {
         value: {
-          _light: '#1D7AFC',
-          _dark: '#388BFF',
+          _light: '#1868DB',
+          _dark: '#669DF1',
         },
       },
       bold: {
         DEFAULT: {
           value: {
-            _light: '#0055CC',
-            _dark: '#85B8FF',
+            _light: '#1558BC',
+            _dark: '#8FB8F6',
           },
         },
         hovered: {
           value: {
-            _light: '#09326C',
-            _dark: '#CCE0FF',
+            _light: '#123263',
+            _dark: '#CFE1FD',
           },
         },
       },

--- a/packages/preset-atlaskit/src/radii.ts
+++ b/packages/preset-atlaskit/src/radii.ts
@@ -6,6 +6,7 @@ export const radii: Tokens['radii'] = {
   medium: { value: '6px' },
   large: { value: '8px' },
   xlarge: { value: '12px' },
+  xxlarge: { value: '16px' },
   full: { value: '9999px' },
   tile: { value: '25%' },
 }

--- a/packages/preset-atlaskit/src/shadows.ts
+++ b/packages/preset-atlaskit/src/shadows.ts
@@ -4,21 +4,21 @@ export const semanticShadows: SemanticTokens['shadows'] = {
   overflow: {
     DEFAULT: {
       value: {
-        _light: '0px 0px 8px rgba(9, 30, 66, 0.16),0px 0px 1px rgba(9, 30, 66, 0.12)',
-        _dark: '0px 0px 12px rgba(3, 4, 4, 0.56),0px 0px 1px rgba(3, 4, 4, 0.5)',
+        _light: '0px 0px 8px rgba(30, 31, 33, 0.16),0px 0px 1px rgba(30, 31, 33, 0.12)',
+        _dark: '0px 0px 12px rgba(1, 4, 4, 0.56),0px 0px 1px rgba(1, 4, 4, 0.5)',
       },
     },
   },
   overlay: {
     value: {
-      _light: '0px 8px 12px rgba(9, 30, 66, 0.15),0px 0px 1px rgba(9, 30, 66, 0.31)',
-      _dark: '0px 0px 0px rgba(57, 66, 74, 1),0px 8px 12px rgba(3, 4, 4, 0.36),0px 0px 1px rgba(3, 4, 4, 0.5)',
+      _light: '0px 8px 12px rgba(30, 31, 33, 0.15),0px 0px 1px rgba(30, 31, 33, 0.31)',
+      _dark: '0px 0px 0px rgba(189, 189, 189, 0.12),0px 8px 12px rgba(1, 4, 4, 0.36),0px 0px 1px rgba(1, 4, 4, 0.5)',
     },
   },
   raised: {
     value: {
-      _light: '0px 1px 1px rgba(9, 30, 66, 0.25),0px 0px 1px rgba(9, 30, 66, 0.31)',
-      _dark: '0px 0px 0px rgba(0, 0, 0, 0),0px 1px 1px rgba(3, 4, 4, 0.5),0px 0px 1px rgba(3, 4, 4, 0.5)',
+      _light: '0px 1px 1px rgba(30, 31, 33, 0.25),0px 0px 1px rgba(30, 31, 33, 0.31)',
+      _dark: '0px 0px 0px rgba(0, 0, 0, 0),0px 1px 1px rgba(1, 4, 4, 0.5),0px 0px 1px rgba(1, 4, 4, 0.5)',
     },
   },
 }

--- a/packages/preset-atlaskit/src/textStyles.ts
+++ b/packages/preset-atlaskit/src/textStyles.ts
@@ -84,14 +84,6 @@ export const textStyles: Theme['textStyles'] = {
         lineHeight: '16px',
       },
     },
-    UNSAFE_small: {
-      value: {
-        fontFamily: 'Atlassian Sans',
-        fontWeight: '400',
-        fontSize: '12px',
-        lineHeight: '16px',
-      },
-    },
   },
   metric: {
     large: {

--- a/packages/preset-atlaskit/src/typography/lineHeights.ts
+++ b/packages/preset-atlaskit/src/typography/lineHeights.ts
@@ -14,7 +14,6 @@ export const lineHeights: Tokens['lineHeights'] = {
     large: { value: '24px' },
     DEFAULT: { value: '20px' },
     small: { value: '16px' },
-    UNSAFE_small: { value: '16px' },
   },
   metric: {
     large: { value: '32px' },

--- a/packages/preset-atlaskit/src/typography/sizes.ts
+++ b/packages/preset-atlaskit/src/typography/sizes.ts
@@ -14,7 +14,6 @@ export const fontSizes: Tokens['fontSizes'] = {
     large: { value: '16px' },
     DEFAULT: { value: '14px' },
     small: { value: '12px' },
-    UNSAFE_small: { value: '12px' },
   },
   metric: {
     large: { value: '28px' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,8 +670,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.4(react@19.2.0)
       '@atlaskit/tokens':
-        specifier: 8.4.0
-        version: 8.4.0(@types/react@19.2.7)(react@19.2.0)
+        specifier: 13.0.2
+        version: 13.0.2(react@19.2.0)
 
   packages/preset-base:
     dependencies:
@@ -1880,11 +1880,6 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  '@atlaskit/ds-lib@5.3.0':
-    resolution: {integrity: sha512-j3DLHqBACSJsG3XqSgCIwZqvJhYkpSC8i+24n/JYCRjIxYEJMsuSXOtdeu0qBajREwgzmAFP6AVfVZh1zAWG/A==}
-    peerDependencies:
-      react: ^18.2.0
-
   '@atlaskit/ds-lib@7.0.0':
     resolution: {integrity: sha512-Uqywr6YMi6uBpD0BtbRmG8f81fteRT7NBf62J8zzWPSs7u3Jq9G3Oruwm3y+57Dxv6IqfRwrS10WJARlCJdBLw==}
     peerDependencies:
@@ -1901,15 +1896,15 @@ packages:
   '@atlaskit/platform-feature-flags@1.1.2':
     resolution: {integrity: sha512-PM+fVkV4Yn4/0keiN6ioAap2Y+odTyw1Z4uf+TA0zMmg3/lp/rVNJEc4a24dvd8DfVs5m9bxa/hbO1qJarhCBw==}
 
+  '@atlaskit/tokens@13.0.2':
+    resolution: {integrity: sha512-kzU0yebKEUI7zeH4hBdTfj63nfI3+Ya+SVqqsin7bwM0TVAgCZycZAqdtHY5bIHhLDuUGhHl1D0Zuk5B2Afa4w==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+
   '@atlaskit/tokens@13.1.1':
     resolution: {integrity: sha512-YNa0EO38NlW7S4xEBFS6mYDB5jDmqBHM9bJflYHM2KuVrEFVHkKd0TiHmUscD4mwvQoI1KK4BgVUIuyP3ZUwfw==}
     peerDependencies:
       react: ^18.2.0 || ^19.0.0
-
-  '@atlaskit/tokens@8.4.0':
-    resolution: {integrity: sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==}
-    peerDependencies:
-      react: ^18.2.0
 
   '@babel/code-frame@7.12.11':
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
@@ -14738,16 +14733,6 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
-  react-uid@2.4.0:
-    resolution: {integrity: sha512-+MVs/25NrcZuGrmlVRWPOSsbS8y72GJOBsR7d68j3/wqOrRBF52U29XAw4+XSelw0Vm6s5VmGH5mCbTCPGVCVg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
@@ -18153,17 +18138,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@atlaskit/ds-lib@5.3.0(@types/react@19.2.7)(react@19.2.0)':
-    dependencies:
-      '@atlaskit/platform-feature-flags': 1.1.2(react@19.2.0)
-      '@babel/runtime': 7.28.4
-      bind-event-listener: 3.0.0
-      react: 19.2.0
-      react-uid: 2.4.0(@types/react@19.2.7)(react@19.2.0)
-      tiny-invariant: 1.3.3
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@atlaskit/ds-lib@7.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -18202,7 +18176,7 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@atlaskit/tokens@13.1.1(react@19.2.0)':
+  '@atlaskit/tokens@13.0.2(react@19.2.0)':
     dependencies:
       '@atlaskit/ds-lib': 7.0.0(react@19.2.0)
       '@atlaskit/platform-feature-flags': 1.1.2(react@19.2.0)
@@ -18214,17 +18188,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@atlaskit/tokens@8.4.0(@types/react@19.2.7)(react@19.2.0)':
+  '@atlaskit/tokens@13.1.1(react@19.2.0)':
     dependencies:
-      '@atlaskit/ds-lib': 5.3.0(@types/react@19.2.7)(react@19.2.0)
+      '@atlaskit/ds-lib': 7.0.0(react@19.2.0)
       '@atlaskit/platform-feature-flags': 1.1.2(react@19.2.0)
-      '@babel/runtime': 7.28.4
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/runtime': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       bind-event-listener: 3.0.0
       react: 19.2.0
     transitivePeerDependencies:
-      - '@types/react'
       - supports-color
 
   '@babel/code-frame@7.12.11':
@@ -18508,7 +18481,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -35112,13 +35085,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-
-  react-uid@2.4.0(@types/react@19.2.7)(react@19.2.0):
-    dependencies:
-      react: 19.2.0
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.7
 
   react@19.2.0: {}
 


### PR DESCRIPTION
Supersedes #3530 (Renovate).

## what

Bump `@atlaskit/tokens` `8.4.0` -> `13.0.2` in `@pandacss/preset-atlaskit` and regenerate the theme via `scripts/generate-theme.mjs`.

Unlike the motion bump (#3562, which was a no-op), this is a real token change. The committed `src/` had drifted to ~v7-era values (package.json said 8.4.0 but the files were never regenerated), so this also brings the preset back in sync with the generator.

## script

`@atlaskit/tokens` v13 keeps the same token schema (`path` / `value` / `cleanName`, `[default]` handling, typography shorthand strings), so the processing logic is unchanged. The only script change is bumping the version-compat guard from 7.x to 13.x.

I kept the preset on the base `atlassian-light` / `atlassian-dark` themes; v13 also ships `brand-refresh` / `future` / `increased-contrast` variants, but adopting those is a separate design decision.

## token changes

- Core colors refreshed; chart palette restructured (`chart.1`–`chart.3` -> `chart.5`–`chart.7` + `danger`/`warning`/`success`/`discovery`)
- Elevation/shadow colors moved to the new neutral base
- Several dark-mode semantic colors retuned
- Added `radii.xxlarge` (16px)
- Removed the deprecated `UNSAFE_small` typography (text style + `fontSizes`/`lineHeights`)

The changeset includes a migration guide. Regeneration ran with no skipped/unparsed tokens, and the preset builds.