### PR TITLE
Add v2 PostCSS plugin

### DIFF
--- a/.changeset/postcss-v2-plugin.md
+++ b/.changeset/postcss-v2-plugin.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/postcss_v2': patch
+---
+
+Add an experimental PostCSS integration backed by the v2 compiler driver.

--- a/packages/cli_v2/postcss.js
+++ b/packages/cli_v2/postcss.js
@@ -1,0 +1,1 @@
+export { default } from '@pandacss/postcss_v2'

--- a/packages/postcss_v2/__tests__/postcss_v2.test.ts
+++ b/packages/postcss_v2/__tests__/postcss_v2.test.ts
@@ -1,0 +1,204 @@
+import type { Driver } from '@pandacss/compiler'
+import postcss from 'postcss'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const PROJECT_CWD = '/project'
+const INPUT = '@layer reset, base, tokens, recipes, utilities;'
+
+interface MockDriver extends Driver {
+  codegen: ReturnType<typeof vi.fn>
+  cssgen: ReturnType<typeof vi.fn>
+  parseFiles: ReturnType<typeof vi.fn>
+  reload: ReturnType<typeof vi.fn>
+  getOutdir: ReturnType<typeof vi.fn>
+  compiler: Driver['compiler'] & {
+    hasLayerDeclaration: ReturnType<typeof vi.fn>
+    sources: ReturnType<typeof vi.fn>
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+describe('@pandacss/postcss_v2', () => {
+  it('skips node_modules CSS files by default', async () => {
+    const { createNodeDriver, run } = await setup()
+
+    const result = await run(INPUT, {}, '/project/node_modules/pkg/styles.css')
+
+    expect(result.css).toBe(INPUT)
+    expect(createNodeDriver).not.toHaveBeenCalled()
+  })
+
+  it('allows configured node_modules CSS files through the guard', async () => {
+    const { createNodeDriver, run } = await setup()
+
+    await run(INPUT, { allow: [/node_modules\/pkg/] }, '/project/node_modules/pkg/styles.css')
+
+    expect(createNodeDriver).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips non-CSS files', async () => {
+    const { createNodeDriver, run } = await setup()
+
+    const result = await run(INPUT, {}, '/project/styles.js')
+
+    expect(result.css).toBe(INPUT)
+    expect(createNodeDriver).not.toHaveBeenCalled()
+  })
+
+  it('skips stylesheets without any layer at-rule before loading the driver', async () => {
+    const { createNodeDriver, run } = await setup()
+    const input = '.btn { color: red }'
+
+    const result = await run(input)
+
+    expect(result.css).toBe(input)
+    expect(createNodeDriver).not.toHaveBeenCalled()
+  })
+
+  it('uses the compiler layer check before injecting generated CSS', async () => {
+    const { driver, run } = await setup()
+    driver.compiler.hasLayerDeclaration.mockReturnValue(false)
+
+    const result = await run('@layer base { .btn { color: red } }')
+
+    expect(result.css).toBe('@layer base { .btn { color: red } }')
+    expect(driver.codegen).not.toHaveBeenCalled()
+    expect(driver.parseFiles).not.toHaveBeenCalled()
+  })
+
+  it('processes the stylesheet root and registers watch dependencies', async () => {
+    const { driver, run } = await setup()
+
+    const result = await run(INPUT)
+
+    expect(driver.codegen).toHaveBeenCalledWith({ cwd: PROJECT_CWD, outdir: undefined })
+    expect(driver.parseFiles).toHaveBeenCalledTimes(1)
+    expect(driver.cssgen).toHaveBeenCalledWith({ emitLayerDeclaration: false })
+    expect(result.css).toContain('.text_red')
+    expect(result.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'dir-dependency',
+          dir: '/project/src',
+          glob: 'src/**/*.tsx',
+          plugin: 'pandacss',
+          parent: '/project/styles.css',
+        }),
+        expect.objectContaining({
+          type: 'dependency',
+          file: '/project/panda.config.ts',
+          plugin: 'pandacss',
+          parent: '/project/styles.css',
+        }),
+        expect.objectContaining({
+          type: 'dependency',
+          file: '/project/panda.tokens.ts',
+          plugin: 'pandacss',
+          parent: '/project/styles.css',
+        }),
+      ]),
+    )
+  })
+
+  it('uses dependency messages for source directories in Rollup watch mode', async () => {
+    vi.stubEnv('ROLLUP_WATCH', 'true')
+    const { run } = await setup()
+
+    const result = await run(INPUT)
+
+    expect(result.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'dependency',
+          file: '/project/src',
+          plugin: 'pandacss',
+        }),
+      ]),
+    )
+  })
+
+  it('reloads an existing driver and regenerates artifacts only when config changes', async () => {
+    const { createNodeDriver, driver, pandacss } = await setup()
+    const processor = postcss([pandacss({ cwd: PROJECT_CWD })])
+
+    await processor.process(INPUT, { from: '/project/one.css' })
+    await processor.process(INPUT, { from: '/project/two.css' })
+
+    expect(createNodeDriver).toHaveBeenCalledTimes(1)
+    expect(driver.reload).toHaveBeenCalledTimes(1)
+    expect(driver.codegen).toHaveBeenCalledTimes(1)
+
+    driver.reload.mockResolvedValueOnce({ hasChanged: true, dependencies: [], recipes: [], patterns: [], changes: [] })
+    await processor.process(INPUT, { from: '/project/three.css' })
+
+    expect(driver.reload).toHaveBeenCalledTimes(2)
+    expect(driver.codegen).toHaveBeenCalledTimes(2)
+  })
+
+  it('serializes concurrent transforms for the same driver key', async () => {
+    const order: string[] = []
+    const { createNodeDriver, pandacss } = await setup({
+      createDelay: async () => {
+        order.push('enter')
+        await Promise.resolve()
+        order.push('leave')
+      },
+    })
+    const processor = postcss([pandacss({ cwd: PROJECT_CWD })])
+
+    await Promise.all(
+      [1, 2, 3, 4].map((index) => processor.process(INPUT, { from: `/project/styles-${index}.css` })),
+    )
+
+    expect(createNodeDriver).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['enter', 'leave'])
+  })
+})
+
+async function setup(options: { createDelay?: () => Promise<void> } = {}) {
+  const driver = createMockDriver()
+  const createNodeDriver = vi.fn(async () => {
+    await options.createDelay?.()
+    return driver
+  })
+
+  vi.doMock('@pandacss/compiler', () => ({
+    createNodeDriver,
+  }))
+
+  const { default: pandacss } = await import('../src/index')
+
+  return {
+    createNodeDriver,
+    driver,
+    pandacss,
+    run: (input: string, pluginOptions = {}, from = '/project/styles.css') =>
+      postcss([pandacss({ cwd: PROJECT_CWD, ...pluginOptions })]).process(input, { from }),
+  }
+}
+
+function createMockDriver(): MockDriver {
+  return {
+    compiler: {
+      hasLayerDeclaration: vi.fn((css: string) => css.includes(INPUT)),
+      sources: vi.fn(() => [{ base: '/project/src', pattern: 'src/**/*.tsx' }]),
+    },
+    configDependencies: ['panda.config.ts', 'panda.tokens.ts'],
+    configPath: '/project/panda.config.ts',
+    codegen: vi.fn(() => ['/project/styled-system/css/css.mjs']),
+    cssgen: vi.fn(() => ({
+      css: '.text_red { color: red }',
+      manifest: { files: [], tokens: [] },
+      layerRanges: {},
+      diagnostics: [],
+    })),
+    getOutdir: vi.fn((outdir?: string) => (outdir ? `/project/${outdir}` : '/project/styled-system')),
+    parseFiles: vi.fn(() => []),
+    reload: vi.fn(async () => ({ hasChanged: false, dependencies: [], recipes: [], patterns: [], changes: [] })),
+  } as unknown as MockDriver
+}

--- a/packages/postcss_v2/__tests__/postcss_v2.test.ts
+++ b/packages/postcss_v2/__tests__/postcss_v2.test.ts
@@ -1,20 +1,21 @@
-import type { Driver } from '@pandacss/compiler'
 import postcss from 'postcss'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const PROJECT_CWD = '/project'
 const INPUT = '@layer reset, base, tokens, recipes, utilities;'
 
-interface MockDriver extends Driver {
-  codegen: ReturnType<typeof vi.fn>
-  cssgen: ReturnType<typeof vi.fn>
-  parseFiles: ReturnType<typeof vi.fn>
-  reload: ReturnType<typeof vi.fn>
-  getOutdir: ReturnType<typeof vi.fn>
-  compiler: Driver['compiler'] & {
+interface MockDriver {
+  compiler: {
     hasLayerDeclaration: ReturnType<typeof vi.fn>
     sources: ReturnType<typeof vi.fn>
   }
+  configDependencies: string[]
+  configPath: string
+  codegen: ReturnType<typeof vi.fn>
+  cssgen: ReturnType<typeof vi.fn>
+  getOutdir: ReturnType<typeof vi.fn>
+  parseFiles: ReturnType<typeof vi.fn>
+  reload: ReturnType<typeof vi.fn>
 }
 
 afterEach(() => {
@@ -151,9 +152,7 @@ describe('@pandacss/postcss_v2', () => {
     })
     const processor = postcss([pandacss({ cwd: PROJECT_CWD })])
 
-    await Promise.all(
-      [1, 2, 3, 4].map((index) => processor.process(INPUT, { from: `/project/styles-${index}.css` })),
-    )
+    await Promise.all([1, 2, 3, 4].map((index) => processor.process(INPUT, { from: `/project/styles-${index}.css` })))
 
     expect(createNodeDriver).toHaveBeenCalledTimes(1)
     expect(order).toEqual(['enter', 'leave'])

--- a/packages/postcss_v2/__tests__/postcss_v2.test.ts
+++ b/packages/postcss_v2/__tests__/postcss_v2.test.ts
@@ -30,7 +30,7 @@ describe('@pandacss/postcss_v2', () => {
 
     const result = await run(INPUT, {}, '/project/node_modules/pkg/styles.css')
 
-    expect(result.css).toBe(INPUT)
+    expect(result.css).toMatchInlineSnapshot(`"@layer reset, base, tokens, recipes, utilities;"`)
     expect(createNodeDriver).not.toHaveBeenCalled()
   })
 
@@ -47,7 +47,7 @@ describe('@pandacss/postcss_v2', () => {
 
     const result = await run(INPUT, {}, '/project/styles.js')
 
-    expect(result.css).toBe(INPUT)
+    expect(result.css).toMatchInlineSnapshot(`"@layer reset, base, tokens, recipes, utilities;"`)
     expect(createNodeDriver).not.toHaveBeenCalled()
   })
 
@@ -57,7 +57,7 @@ describe('@pandacss/postcss_v2', () => {
 
     const result = await run(input)
 
-    expect(result.css).toBe(input)
+    expect(result.css).toMatchInlineSnapshot(`".btn { color: red }"`)
     expect(createNodeDriver).not.toHaveBeenCalled()
   })
 
@@ -67,7 +67,7 @@ describe('@pandacss/postcss_v2', () => {
 
     const result = await run('@layer base { .btn { color: red } }')
 
-    expect(result.css).toBe('@layer base { .btn { color: red } }')
+    expect(result.css).toMatchInlineSnapshot(`"@layer base { .btn { color: red } }"`)
     expect(driver.codegen).not.toHaveBeenCalled()
     expect(driver.parseFiles).not.toHaveBeenCalled()
   })
@@ -80,30 +80,32 @@ describe('@pandacss/postcss_v2', () => {
     expect(driver.codegen).toHaveBeenCalledWith({ cwd: PROJECT_CWD, outdir: undefined })
     expect(driver.parseFiles).toHaveBeenCalledTimes(1)
     expect(driver.cssgen).toHaveBeenCalledWith({ emitLayerDeclaration: false })
-    expect(result.css).toContain('.text_red')
-    expect(result.messages).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'dir-dependency',
-          dir: '/project/src',
-          glob: 'src/**/*.tsx',
-          plugin: 'pandacss',
-          parent: '/project/styles.css',
-        }),
-        expect.objectContaining({
-          type: 'dependency',
-          file: '/project/panda.config.ts',
-          plugin: 'pandacss',
-          parent: '/project/styles.css',
-        }),
-        expect.objectContaining({
-          type: 'dependency',
-          file: '/project/panda.tokens.ts',
-          plugin: 'pandacss',
-          parent: '/project/styles.css',
-        }),
-      ]),
+    expect(result.css).toMatchInlineSnapshot(
+      `"@layer reset, base, tokens, recipes, utilities;.text_red { color: red }"`,
     )
+    expect(result.messages).toMatchInlineSnapshot(`
+      [
+        {
+          "dir": "/project/src",
+          "glob": "src/**/*.tsx",
+          "parent": "/project/styles.css",
+          "plugin": "pandacss",
+          "type": "dir-dependency",
+        },
+        {
+          "file": "/project/panda.config.ts",
+          "parent": "/project/styles.css",
+          "plugin": "pandacss",
+          "type": "dependency",
+        },
+        {
+          "file": "/project/panda.tokens.ts",
+          "parent": "/project/styles.css",
+          "plugin": "pandacss",
+          "type": "dependency",
+        },
+      ]
+    `)
   })
 
   it('uses dependency messages for source directories in Rollup watch mode', async () => {
@@ -112,15 +114,28 @@ describe('@pandacss/postcss_v2', () => {
 
     const result = await run(INPUT)
 
-    expect(result.messages).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'dependency',
-          file: '/project/src',
-          plugin: 'pandacss',
-        }),
-      ]),
-    )
+    expect(result.messages).toMatchInlineSnapshot(`
+      [
+        {
+          "file": "/project/src",
+          "parent": "/project/styles.css",
+          "plugin": "pandacss",
+          "type": "dependency",
+        },
+        {
+          "file": "/project/panda.config.ts",
+          "parent": "/project/styles.css",
+          "plugin": "pandacss",
+          "type": "dependency",
+        },
+        {
+          "file": "/project/panda.tokens.ts",
+          "parent": "/project/styles.css",
+          "plugin": "pandacss",
+          "type": "dependency",
+        },
+      ]
+    `)
   })
 
   it('reloads an existing driver and regenerates artifacts only when config changes', async () => {
@@ -155,7 +170,12 @@ describe('@pandacss/postcss_v2', () => {
     await Promise.all([1, 2, 3, 4].map((index) => processor.process(INPUT, { from: `/project/styles-${index}.css` })))
 
     expect(createNodeDriver).toHaveBeenCalledTimes(1)
-    expect(order).toEqual(['enter', 'leave'])
+    expect(order).toMatchInlineSnapshot(`
+      [
+        "enter",
+        "leave",
+      ]
+    `)
   })
 })
 

--- a/packages/postcss_v2/package.json
+++ b/packages/postcss_v2/package.json
@@ -1,23 +1,18 @@
 {
-  "name": "@pandacss/cli",
+  "name": "@pandacss/postcss_v2",
   "version": "0.0.0",
-  "description": "Experimental v2 CLI for the Panda Rust compiler",
+  "description": "PostCSS integration for the Panda CSS v2 compiler",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "license": "MIT",
-  "bin": {
-    "panda": "bin.js",
-    "pandacss": "bin.js"
-  },
   "exports": {
     ".": {
       "source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./postcss": "./postcss.js",
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -25,27 +20,28 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/panda.git",
-    "directory": "packages/cli_v2"
+    "directory": "packages/postcss_v2"
   },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/cli-main.ts --format=esm --dts --no-splitting --shims",
-    "build-fast": "tsup src/index.ts src/cli-main.ts --format=esm --no-dts --no-splitting --shims",
+    "build": "tsup src/index.ts --format=esm --platform=node --dts --no-splitting",
+    "build-fast": "tsup src/index.ts --format=esm --platform=node --no-dts --no-splitting",
     "dev": "pnpm build-fast --watch src",
     "test": "vitest run"
   },
   "files": [
-    "dist",
-    "bin.js",
-    "postcss.js"
+    "dist"
   ],
   "dependencies": {
     "@pandacss/compiler": "workspace:*",
-    "@pandacss/compiler-shared": "workspace:*",
-    "@pandacss/postcss_v2": "workspace:*",
-    "@parcel/watcher": "2.5.1",
-    "citty": "0.1.6"
+    "@pandacss/compiler-shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "postcss": ">=8"
+  },
+  "devDependencies": {
+    "postcss": "8.5.6"
   }
 }

--- a/packages/postcss_v2/src/index.ts
+++ b/packages/postcss_v2/src/index.ts
@@ -1,6 +1,6 @@
 import { createNodeDriver, type Driver } from '@pandacss/compiler'
 import { extname, normalize, resolve } from 'node:path'
-import type { Message, PluginCreator, Result, TransformCallback } from 'postcss'
+import type { Message, PluginCreator, Result, Root, TransformCallback } from 'postcss'
 
 const PLUGIN_NAME = 'pandacss'
 
@@ -29,7 +29,7 @@ export const pandacss: PluginCreator<PluginOptions> = (options = {}) => {
 
     if (shouldSkip(fileName, options.allow)) return
 
-    const inputCss = result.opts.css ?? root.toString()
+    const inputCss = getInputCss(root, result)
     if (!inputCss.includes('@layer')) return
 
     const cwd = resolve(options.cwd ?? process.cwd())
@@ -101,6 +101,11 @@ const shouldSkip = (fileName: string | undefined, allow: PluginOptions['allow'])
 
 function getDriverKey(cwd: string, configPath: string | undefined) {
   return `${cwd}:${configPath ?? ''}`
+}
+
+function getInputCss(root: Root, result: Result) {
+  const opts = result.opts as Result['opts'] & { css?: string }
+  return opts.css ?? root.toString()
 }
 
 function ensureCodegen(state: DriverState, options: { cwd: string; outdir: string | undefined }) {

--- a/packages/postcss_v2/src/index.ts
+++ b/packages/postcss_v2/src/index.ts
@@ -1,0 +1,165 @@
+import { createNodeDriver, type Driver } from '@pandacss/compiler'
+import { extname, normalize, resolve } from 'node:path'
+import type { Message, PluginCreator, Result, TransformCallback } from 'postcss'
+
+const PLUGIN_NAME = 'pandacss'
+
+export interface PluginOptions {
+  /** Explicit config file (relative to `cwd`); otherwise discovered upward. */
+  configPath?: string
+  /** Project root. Defaults to the current working directory. */
+  cwd?: string
+  /** Where codegen artifacts are written. Defaults to the config `outdir`. */
+  outdir?: string
+  /** Allow selected `node_modules` CSS files through the processing guard. */
+  allow?: RegExp[]
+}
+
+interface DriverState {
+  driver: Driver
+  generatedOutdirs: Set<string>
+}
+
+const driverStates = new Map<string, DriverState>()
+let driverGuard: Promise<void> | undefined
+
+export const pandacss: PluginCreator<PluginOptions> = (options = {}) => {
+  const postcssProcess: TransformCallback = async (root, result) => {
+    const fileName = result.opts.from
+
+    if (shouldSkip(fileName, options.allow)) return
+
+    const inputCss = result.opts.css ?? root.toString()
+    if (!inputCss.includes('@layer')) return
+
+    const cwd = resolve(options.cwd ?? process.cwd())
+    const key = getDriverKey(cwd, options.configPath)
+
+    let state = driverStates.get(key)
+    if (!state) {
+      const driver = await createNodeDriver({ cwd, configPath: options.configPath })
+      state = { driver, generatedOutdirs: new Set() }
+      driverStates.set(key, state)
+    } else {
+      const diff = await state.driver.reload()
+      if (diff.hasChanged) {
+        state.generatedOutdirs.clear()
+      }
+    }
+
+    const { driver } = state
+
+    if (!driver.compiler.hasLayerDeclaration(inputCss)) return
+
+    ensureCodegen(state, { cwd, outdir: options.outdir })
+    driver.parseFiles()
+    registerDependencies(driver, result, cwd, fileName)
+
+    const output = driver.cssgen({ emitLayerDeclaration: false })
+    emitDiagnostics(result, output.diagnostics)
+    root.append(output.css)
+
+    root.walk((node) => {
+      if (!node.source) {
+        node.source = root.source
+      }
+    })
+  }
+
+  return {
+    postcssPlugin: PLUGIN_NAME,
+    plugins: [
+      function (...args) {
+        driverGuard = Promise.resolve(driverGuard)
+          .catch(() => {
+            /** keep the queue alive after a failed run */
+          })
+          .then(() => postcssProcess(...args))
+        return driverGuard
+      },
+    ],
+  }
+}
+
+pandacss.postcss = true
+
+export default pandacss
+
+const nodeModulesRegex = /node_modules/
+
+function isValidCss(file: string) {
+  const [filePath] = file.split('?')
+  return extname(filePath) === '.css'
+}
+
+const shouldSkip = (fileName: string | undefined, allow: PluginOptions['allow']) => {
+  if (!fileName) return true
+  if (!isValidCss(fileName)) return true
+  if (allow?.some((pattern) => pattern.test(fileName))) return false
+  return nodeModulesRegex.test(fileName)
+}
+
+function getDriverKey(cwd: string, configPath: string | undefined) {
+  return `${cwd}:${configPath ?? ''}`
+}
+
+function ensureCodegen(state: DriverState, options: { cwd: string; outdir: string | undefined }) {
+  const outdirKey = state.driver.getOutdir(options.outdir)
+  if (state.generatedOutdirs.has(outdirKey)) return
+
+  state.driver.codegen({ cwd: options.cwd, outdir: options.outdir })
+  state.generatedOutdirs.add(outdirKey)
+}
+
+function registerDependencies(driver: Driver, result: Result, cwd: string, parent: string | undefined) {
+  for (const source of driver.compiler.sources()) {
+    result.messages.push(
+      withPluginMetadata(
+        createSourceDependency({
+          dir: normalize(resolve(cwd, source.base)),
+          glob: source.pattern,
+        }),
+        parent,
+      ),
+    )
+  }
+
+  const configDeps = new Set(driver.configDependencies)
+  if (driver.configPath) {
+    configDeps.add(driver.configPath)
+  }
+
+  for (const file of configDeps) {
+    result.messages.push(
+      withPluginMetadata(
+        {
+          type: 'dependency',
+          file: normalize(resolve(cwd, file)),
+        },
+        parent,
+      ),
+    )
+  }
+}
+
+function createSourceDependency(source: { dir: string; glob: string }): Message {
+  if (process.env.ROLLUP_WATCH === 'true') {
+    return { type: 'dependency', file: source.dir }
+  }
+
+  return { type: 'dir-dependency', dir: source.dir, glob: source.glob }
+}
+
+function withPluginMetadata(message: Message, parent: string | undefined): Message {
+  return {
+    ...message,
+    plugin: PLUGIN_NAME,
+    parent,
+  }
+}
+
+function emitDiagnostics(result: Result, diagnostics: { message: string }[]) {
+  for (const diagnostic of diagnostics) {
+    result.warn(diagnostic.message, { plugin: PLUGIN_NAME })
+  }
+}

--- a/packages/postcss_v2/src/index.ts
+++ b/packages/postcss_v2/src/index.ts
@@ -129,9 +129,9 @@ function registerDependencies(driver: Driver, result: Result, cwd: string, paren
     )
   }
 
-  const configDeps = new Set(driver.configDependencies)
+  const configDeps = new Set(driver.configDependencies.map((file) => normalize(resolve(cwd, file))))
   if (driver.configPath) {
-    configDeps.add(driver.configPath)
+    configDeps.add(normalize(resolve(cwd, driver.configPath)))
   }
 
   for (const file of configDeps) {
@@ -139,7 +139,7 @@ function registerDependencies(driver: Driver, result: Result, cwd: string, paren
       withPluginMetadata(
         {
           type: 'dependency',
-          file: normalize(resolve(cwd, file)),
+          file,
         },
         parent,
       ),

--- a/packages/postcss_v2/vitest.config.ts
+++ b/packages/postcss_v2/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: 15_000,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@pandacss/compiler-shared':
         specifier: workspace:*
         version: link:../compiler-shared
+      '@pandacss/postcss_v2':
+        specifier: workspace:*
+        version: link:../postcss_v2
       '@parcel/watcher':
         specifier: 2.5.1
         version: 2.5.1
@@ -740,6 +743,19 @@ importers:
         specifier: workspace:*
         version: link:../logger
 
+  packages/postcss_v2:
+    dependencies:
+      '@pandacss/compiler':
+        specifier: workspace:*
+        version: link:../compiler
+      '@pandacss/compiler-shared':
+        specifier: workspace:*
+        version: link:../compiler-shared
+    devDependencies:
+      postcss:
+        specifier: 8.5.6
+        version: 8.5.6
+
   packages/preset-atlaskit:
     dependencies:
       '@pandacss/types':
@@ -1217,7 +1233,7 @@ importers:
         version: link:../css-lib
       nuxt:
         specifier: 4.2.1
-        version: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+        version: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -1354,7 +1370,7 @@ importers:
         version: link:../../packages/cli
       nuxt:
         specifier: 4.2.1
-        version: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+        version: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -6013,11 +6029,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@pandacss/vite@file:packages/vite':
-    resolution: {directory: packages/vite, type: directory}
-    peerDependencies:
-      vite: '>=6.0.0'
 
   '@parcel/bundler-default@2.8.3':
     resolution: {integrity: sha512-yJvRsNWWu5fVydsWk3O2L4yIy3UZiKWO2cPDukGOIWMgp/Vbpp+2Ct5IygVRtE22bnseW/E/oe0PV3d2IkEJGg==}
@@ -24062,12 +24073,6 @@ snapshots:
 
   '@oxc-transform/binding-win32-x64-msvc@0.96.0':
     optional: true
-
-  '@pandacss/vite@file:packages/vite(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@pandacss/compiler': link:packages/compiler
-      '@pandacss/compiler-shared': link:packages/compiler-shared
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@parcel/bundler-default@2.8.3(@parcel/core@2.8.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1644,6 +1644,37 @@ importers:
         specifier: 7.2.6
         version: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
+  sandbox/vite-react-postcss:
+    dependencies:
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@pandacss/postcss_v2':
+        specifier: workspace:*
+        version: link:../../packages/postcss_v2
+      '@types/react':
+        specifier: 19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: 5.1.1
+        version: 5.1.1(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      postcss:
+        specifier: 8.5.6
+        version: 8.5.6
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+      vite:
+        specifier: 7.2.6
+        version: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+
   sandbox/vite-ts:
     dependencies:
       react:
@@ -18862,10 +18893,10 @@ snapshots:
   '@ardatan/relay-compiler@12.0.0(graphql@16.12.0)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.1
       '@babel/parser': 7.29.0
       '@babel/runtime': 7.28.6
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       babel-preset-fbjs: 3.4.0(@babel/core@7.28.5)
       chalk: 4.1.2
@@ -18953,7 +18984,7 @@ snapshots:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.2
+      lru-cache: 11.3.3
 
   '@asamuzakjp/dom-selector@6.7.4':
     dependencies:
@@ -19179,13 +19210,13 @@ snapshots:
 
   '@babel/core@7.12.9':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.12.9)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 1.9.0
       debug: 4.4.3
@@ -19220,15 +19251,15 @@ snapshots:
 
   '@babel/core@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -19282,7 +19313,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -19309,7 +19340,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -19320,7 +19351,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -19335,27 +19366,27 @@ snapshots:
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.12.9)':
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19372,7 +19403,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19381,13 +19412,13 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -19400,15 +19431,15 @@ snapshots:
 
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.28.4':
     dependencies:
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
   '@babel/highlight@7.25.9':
@@ -19430,7 +19461,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19457,7 +19488,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19601,14 +19632,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -19648,7 +19679,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19656,13 +19687,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19725,7 +19756,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19771,7 +19802,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19811,7 +19842,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19931,7 +19962,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
@@ -20118,7 +20149,7 @@ snapshots:
 
   '@babel/template@7.27.2':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
@@ -22240,7 +22271,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@graphql-tools/utils': 9.2.1(graphql@16.12.0)
       graphql: 16.12.0
@@ -25541,8 +25572,8 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
@@ -26560,9 +26591,9 @@ snapshots:
 
   '@vue/babel-plugin-resolve-type@2.0.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/parser': 7.29.0
       '@vue/compiler-sfc': 3.5.25
@@ -31032,7 +31063,7 @@ snapshots:
 
   fork-ts-checker-webpack-plugin@6.5.3(eslint@7.32.0)(typescript@6.0.2)(webpack@5.98.0(@swc/core@1.15.3(@swc/helpers@0.5.17))(esbuild@0.27.0)):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
       chokidar: 3.6.0
@@ -35407,7 +35438,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -39546,7 +39577,7 @@ snapshots:
 
   vite-plugin-checker@0.11.0(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@6.0.2)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1

--- a/sandbox/vite-react-postcss/index.html
+++ b/sandbox/vite-react-postcss/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Panda v2 PostCSS Sandbox</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/sandbox/vite-react-postcss/package.json
+++ b/sandbox/vite-react-postcss/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "sandbox-vite-react-postcss",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "pnpm postcss:prepare && vite build",
+    "build:deps": "pnpm --filter @pandacss/compiler-shared build-fast && pnpm --filter @pandacss/config-loader build-fast && pnpm --filter @pandacss/compiler build-fast && pnpm --filter @pandacss/compiler build:native && pnpm --filter @pandacss/postcss_v2 build-fast",
+    "clean": "rm -rf dist styled-system",
+    "postcss:prepare": "node ./process-postcss.mjs",
+    "test": "pnpm clean && pnpm build:deps && pnpm build && node ./test-output.mjs"
+  },
+  "dependencies": {
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@pandacss/postcss_v2": "workspace:*",
+    "@types/react": "19.2.7",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.1.1",
+    "postcss": "8.5.6",
+    "typescript": "6.0.2",
+    "vite": "7.2.6"
+  }
+}

--- a/sandbox/vite-react-postcss/panda.config.ts
+++ b/sandbox/vite-react-postcss/panda.config.ts
@@ -1,0 +1,45 @@
+export default {
+  preflight: true,
+  include: ['src/**/*.tsx'],
+  exclude: [],
+  outdir: 'styled-system',
+  codegenImportExtensions: true,
+  importMap: {
+    css: ['../styled-system/css/index.mjs'],
+    recipe: ['../styled-system/recipes/index.mjs'],
+    pattern: ['../styled-system/patterns/index.mjs'],
+    jsx: ['../styled-system/jsx/index.mjs'],
+    tokens: ['../styled-system/tokens/index.mjs'],
+  },
+  theme: {
+    tokens: {
+      colors: {
+        brand: {
+          50: { value: '#eef6ff' },
+          500: { value: '#2563eb' },
+          700: { value: '#1d4ed8' },
+        },
+      },
+    },
+  },
+  utilities: {
+    alignItems: { className: 'items' },
+    backgroundColor: { className: 'bg', values: 'colors', shorthand: 'bgColor' },
+    borderRadius: { className: 'rounded' },
+    boxShadow: { className: 'shadow' },
+    color: { className: 'text', values: 'colors' },
+    display: { className: 'd' },
+    fontSize: { className: 'text-size' },
+    fontWeight: { className: 'font' },
+    gap: { className: 'gap' },
+    minHeight: { className: 'min-h' },
+    padding: { className: 'p' },
+    placeItems: { className: 'place-items' },
+  },
+  globalCss: {
+    body: {
+      margin: '0',
+      fontFamily: 'Inter, system-ui, sans-serif',
+    },
+  },
+}

--- a/sandbox/vite-react-postcss/postcss.config.mjs
+++ b/sandbox/vite-react-postcss/postcss.config.mjs
@@ -1,0 +1,5 @@
+import pandacss from '@pandacss/postcss_v2'
+
+export default {
+  plugins: [pandacss()],
+}

--- a/sandbox/vite-react-postcss/process-postcss.mjs
+++ b/sandbox/vite-react-postcss/process-postcss.mjs
@@ -1,0 +1,9 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import postcss from 'postcss'
+import config from './postcss.config.mjs'
+
+const from = join(new URL('.', import.meta.url).pathname, 'src', 'index.css')
+const css = await readFile(from, 'utf8')
+
+await postcss(config.plugins).process(css, { from })

--- a/sandbox/vite-react-postcss/src/App.tsx
+++ b/sandbox/vite-react-postcss/src/App.tsx
@@ -1,0 +1,36 @@
+import { css } from '../styled-system/css/index.mjs'
+
+export function App() {
+  return (
+    <main
+      className={css({
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+        backgroundColor: 'brand.50',
+        color: 'brand.700',
+      })}
+    >
+      <section
+        className={css({
+          display: 'grid',
+          gap: '24px',
+          padding: '32px',
+          borderRadius: '16px',
+          backgroundColor: 'white',
+          boxShadow: '0 20px 60px rgba(15, 23, 42, 0.16)',
+        })}
+      >
+        <p
+          className={css({
+            fontSize: '18px',
+            fontWeight: '700',
+            color: 'brand.500',
+          })}
+        >
+          Panda v2 PostCSS Sandbox
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/sandbox/vite-react-postcss/src/index.css
+++ b/sandbox/vite-react-postcss/src/index.css
@@ -1,0 +1,1 @@
+@layer reset, base, tokens, recipes, utilities;

--- a/sandbox/vite-react-postcss/src/main.tsx
+++ b/sandbox/vite-react-postcss/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/sandbox/vite-react-postcss/src/vite-env.d.ts
+++ b/sandbox/vite-react-postcss/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/sandbox/vite-react-postcss/test-output.mjs
+++ b/sandbox/vite-react-postcss/test-output.mjs
@@ -1,0 +1,24 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = new URL('.', import.meta.url).pathname
+const styledSystemCss = join(root, 'styled-system', 'css', 'index.mjs')
+const assetsDir = join(root, 'dist', 'assets')
+
+if (!existsSync(styledSystemCss)) {
+  throw new Error('Expected PostCSS plugin to generate styled-system/css/index.mjs')
+}
+
+const cssFile = readdirSync(assetsDir).find((file) => file.endsWith('.css'))
+if (!cssFile) {
+  throw new Error('Expected Vite to emit a CSS asset')
+}
+
+const css = readFileSync(join(assetsDir, cssFile), 'utf8')
+const expected = ['--colors-brand-500', 'background-color:var(--colors-brand-50)', 'min-height:100vh']
+
+for (const snippet of expected) {
+  if (!css.includes(snippet)) {
+    throw new Error(`Expected bundled CSS to contain ${snippet}`)
+  }
+}

--- a/sandbox/vite-react-postcss/tsconfig.json
+++ b/sandbox/vite-react-postcss/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "customConditions": ["source"],
+    "ignoreDeprecations": "6.0",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts", "styled-system"]
+}

--- a/sandbox/vite-react-postcss/vite.config.ts
+++ b/sandbox/vite-react-postcss/vite.config.ts
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    conditions: ['source'],
+  },
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Add an experimental `@pandacss/postcss_v2` package backed by the v2 compiler driver.

## ⛳️ Current behavior (updates)

The existing PostCSS integration uses the legacy node builder path.

## 🚀 New behavior

The new v2 package initializes and caches compiler drivers by config, validates stylesheet roots through the compiler layer check, emits generated CSS, registers PostCSS dependency messages for source and config files, and exposes a `@pandacss/cli/postcss` passthrough.

This also adds a `sandbox/vite-react-postcss` Vite + React sandbox that integrates the new PostCSS plugin and includes a smoke test for generated artifacts and bundled CSS output.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Includes focused tests with inline snapshots for skip guards, root validation, dependency registration, Rollup watch dependency handling, reload/codegen behavior, and concurrent transforms.

Validation:
- `pnpm test packages/postcss_v2`
- `pnpm --filter @pandacss/postcss_v2 build`
- `pnpm --filter @pandacss/cli build-fast`
- `pnpm --filter sandbox-vite-react-postcss test`
- `pnpm exec prettier --check ".changeset/postcss-v2-plugin.md" "packages/cli_v2/package.json" "packages/cli_v2/postcss.js" "packages/postcss_v2/**/*.{ts,json}"`
- `pnpm exec prettier --check "sandbox/vite-react-postcss/**/*.{ts,tsx,js,mjs,json,css,html}"`

Note: `pnpm typecheck` still fails on existing compiler-wasm generated binding and condition typing errors outside this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f48d18f-d827-4aab-9f9b-aa1101605189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f48d18f-d827-4aab-9f9b-aa1101605189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

