### PR TITLE
test: cover digit-leading breakpoint selectors

### DIFF
--- a/packages/core/__tests__/atomic-rule.test.ts
+++ b/packages/core/__tests__/atomic-rule.test.ts
@@ -80,6 +80,28 @@ describe('atomic / with basic style object', () => {
     `)
   })
 
+  test('should escape digit-leading breakpoint selectors', () => {
+    expect(css({ bg: { '2xl': 'orange.500' } })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        @media screen and (min-width: 96rem) {
+          .\\32xl\\:bg_orange\\.500 {
+            background: var(--colors-orange-500);
+      }
+      }
+      }"
+    `)
+
+    expect(css({ '2xl': { bg: 'orange.500' } })).toMatchInlineSnapshot(`
+      "@layer utilities {
+        @media screen and (min-width: 96rem) {
+          .\\32xl\\:bg_orange\\.500 {
+            background: var(--colors-orange-500);
+      }
+      }
+      }"
+    `)
+  })
+
   test('should resolve responsive array with gaps', () => {
     expect(css({ width: ['50px', null, '60px'] })).toMatchInlineSnapshot(`
       "@layer utilities {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #817

## 📝 Description

Adds a core atomic CSS regression test for breakpoint names that start with a digit, such as `2xl`.

## ⛳️ Current behavior (updates)

The v2 escape helper already handles leading-digit class selectors, but the behavior did not have focused atomic CSS coverage for breakpoint-generated selectors.

## 🚀 New behavior

The test now confirms both responsive object syntax and top-level breakpoint condition syntax emit `.\32xl\:...` selectors under the `2xl` media query.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Verified with `pnpm test packages/core/__tests__/atomic-rule.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16ffb9b6-2ff0-4d8b-866e-2694f08cfc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16ffb9b6-2ff0-4d8b-866e-2694f08cfc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

