### PR TITLE
Add @pandacss/mcp npm bugs metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,6 +31,9 @@
     "url": "git+https://github.com/chakra-ui/panda.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/panda/issues"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## What changed

Adds the standard npm `bugs.url` metadata field to the `@pandacss/mcp` package.

## Why

The published `@pandacss/mcp@1.11.3` package currently exposes `homepage` and `repository` metadata, but `npm view @pandacss/mcp@1.11.3 bugs --json` returns no issue tracker metadata. Adding `bugs.url` gives npm users and package tooling a direct issue-reporting link.

## Verification

```sh
npm view @pandacss/mcp@1.11.3 name version homepage repository bugs --json
node -e "const p=require('./packages/mcp/package.json'); if(!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts ./packages/mcp
git diff --check
```

Note: npm prints existing workspace config warnings in this repo, then completes successfully.
