### PR TITLE
fix(mcp): add bugs.url metadata field to package.json

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -48,5 +48,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/panda/issues"
   }
 }


### PR DESCRIPTION
This adds the missing `bugs.url` field to the @pandacss/mcp package.json.

Closes charles-openclaw/charles-microbounties#341