### PR TITLE
ci(rust): gate v2 and fix rustup component install

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v2
     paths:
       - ".github/workflows/rust.yml"
       - ".cargo/**"
@@ -18,6 +19,7 @@ on:
   pull_request:
     branches:
       - main
+      - v2
     paths:
       - ".github/workflows/rust.yml"
       - ".cargo/**"
@@ -46,7 +48,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        run: rustup toolchain install 1.93.0 --profile minimal --component clippy rustfmt
+        run: rustup toolchain install 1.93.0 --profile minimal --component clippy --component rustfmt
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -80,7 +82,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        run: rustup toolchain install 1.93.0 --profile minimal --component clippy rustfmt
+        run: rustup toolchain install 1.93.0 --profile minimal --component clippy --component rustfmt
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
## 📝 Description

split out of #3579. gates the Rust workflow on `v2` and fixes the `rustup` toolchain install so the jobs actually run.

#3579 only added `- v2` to the triggers, which surfaced a pre-existing bug in the `Setup Rust` step: every Lint/Test job died in setup before a single test ran.

## ⛳️ Current behavior

```
rustup toolchain install 1.93.0 --profile minimal --component clippy rustfmt
error: invalid value 'rustfmt' for '[TOOLCHAIN]...': invalid toolchain name: 'rustfmt'
```

`--component` consumes a single token (`clippy`), so `rustfmt` gets parsed as a second positional toolchain name and rustup rejects it. the form worked under older rustup; a recent release tightened arg parsing. on `main` the line hasn't re-triggered, so it stayed green by accident.

## 🚀 New behavior

- `rust.yml` runs on `v2` (push + PR), so the v2 line gets Rust CI.
- `Setup Rust` uses `--component clippy --component rustfmt` in both the lint and test jobs. install succeeds, jobs run.

## 💣 Is this a breaking change (Yes/No):

no — CI only.

## 📝 Additional Information

- keeping the v2 gating here means #3579 drops its `rust.yml` change and stays scoped to the beta-release setup.
- grepped the workflows: these were the only two `--component … …` multi-arg invocations.
