### PR TITLE
fix: add bugs metadata to packages/cli/package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,5 +77,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/panda/issues"
   }
 }


### PR DESCRIPTION
## Summary
The published npm package `@pandacss/dev@1.11.3` is missing the `bugs` field in its `package.json` metadata.

## Fix
Added the `bugs` field to `packages/cli/package.json`:
```json
"bugs": {
  "url": "https://github.com/chakra-ui/panda/issues"
}
```

## Verification
- `npm view @pandacss/dev bugs --json` returns nothing
- No dependencies, runtime code, or build configuration affected