### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "panda",
   "version": "0.0.1",
+  "bugs": {
+    "url": "https://github.com/chakra-ui/panda/issues"
+  },
   "private": true,
   "type": "module",
   "description": "The repository of css panda",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.