### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/astro-plugin-studio/package.json
+++ b/packages/astro-plugin-studio/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@pandacss/astro-plugin-studio",
   "version": "1.11.3",
+  "bugs": {
+    "url": "https://github.com/chakra-ui/panda/issues"
+  },
   "description": "Vite plugin for Pandacss Studio",
   "author": "Segun Adebayo <joseshegs@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/astro-plugin-studio/package.json`.