### PR TITLE
docs: add v2 beta guide and migration doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@
 
 <br/>
 
+## 🐼 Panda v2 (beta)
+
+Panda v2 is in **beta** — the compiler is rewritten in Rust (Oxc engine). v1 stays on the `latest` tag; try v2 with `@pandacss/dev@beta`. See the **[v2 beta guide & migration](./V2_MIGRATION.md)**.
+
 ## Documentation
 
 Visit our [official documentation](https://panda-css.com/).

--- a/TONE_OF_VOICE.md
+++ b/TONE_OF_VOICE.md
@@ -6,7 +6,7 @@ this before you write prose, and run the checklist before you ship it.
 ## The short version
 
 Write like you're explaining it to one sharp person, out loud, with no time to waste. Plain words. Short sentences. Say
-the thing.
+the thing. 🐼
 
 ## Principles
 
@@ -29,7 +29,8 @@ the thing.
 - **Filler openers:** "In today's...", "When it comes to...", "It's important to note that...", "Let's dive in".
 - **Padding transitions:** "Additionally", "Moreover", "Furthermore", "That said," used to connect nothing.
 - **Over-hedging:** "arguably", "in many cases", "generally speaking" when you can just state it.
-- **Emoji bullet lists** used as decoration.
+- **Emoji as decoration.** A purposeful one is fine (a ✅/❌, the odd 🐼). What to cut is rows of them dressing up every
+  bullet or heading.
 - **Over-bolding.** Bold stops meaning anything when half the line is bold. Bold the one word that matters, or none.
 - **Em-dash pile-ups.** One thought per sentence; a period usually beats a dash.
 - **Marketing title case.** Sentence case in headings reads human.

--- a/V2_MIGRATION.md
+++ b/V2_MIGRATION.md
@@ -1,45 +1,49 @@
-# Panda CSS v2 — Beta Guide & Migration
+# Panda CSS v2 — beta guide and migration
 
-> **Status:** v2 is in **beta** (`2.0.0-beta`). The authoring API you already know is stable; what changed lives underneath. This guide is for v1 users who want to try the beta or start migrating — and for new users who want to start a fresh project on v2.
-
-> 🆕 **New to Panda?** Skip straight to [Get started (new project)](#get-started-new-project).
+> v2 is in beta (`2.0.0-beta`). You write the same Panda you already know — `css()`, recipes, patterns, tokens,
+> conditions, JSX props. What changed is the engine underneath. This guide is for v1 users trying the beta, and for
+> anyone starting fresh on v2.
+>
+> New to Panda? Go straight to [Get started (new project)](#get-started-new-project).
 
 ---
 
-## Introducing Panda v2
+## What v2 is
 
-Panda v2 keeps the framework you know — `css()`, recipes, patterns, tokens, conditions, JSX style props — and **rewrites the compiler hot path in Rust** on top of the [Oxc](https://oxc.rs) toolchain.
+v2 keeps the framework and rewrites the compiler's hot path in Rust, on the [Oxc](https://oxc.rs) toolchain.
 
-In v1, extraction and evaluation ran through `ts-morph` + `ts-evaluator` in Node. v2 replaces that pipeline with a native engine:
+v1 ran extraction and evaluation through `ts-morph` and `ts-evaluator` in Node. v2 replaces that with a native engine,
+shipped two ways:
 
-- **`@pandacss/compiler`** — a native NAPI binding around the Rust engine. This is the path the CLI and bundler integrations use.
-- **`@pandacss/compiler-wasm`** — a `wasm-bindgen` build of the same engine for the browser (powers the playground and in-browser tooling).
+- **`@pandacss/compiler`** — a native NAPI binding. The CLI and bundler plugins use this.
+- **`@pandacss/compiler-wasm`** — a `wasm-bindgen` build of the same engine for the browser. The playground runs on it.
 
-Both consume the **same** Rust crates, so Node and browser builds share one source of truth for extraction and CSS emission.
+Both wrap the same Rust crates, so Node and browser builds produce the same CSS.
 
-**Why it matters**
+What you get:
 
-- ⚡️ Faster, lighter extraction — single parse per file, no TypeScript program in the hot path.
-- 🧱 One engine, two runtimes — identical output from native and wasm builds.
-- 🪶 Smaller install — the `ts-morph`/`ts-evaluator` dependency tree is gone.
-- 🎯 Same CSS contract — output is intentionally kept in parity with v1 (see [What changed](#what-changed-in-v2)).
+- Faster extraction. One parse per file, no TypeScript program in the hot path.
+- A smaller install. The `ts-morph` / `ts-evaluator` dependency tree is gone.
+- The same CSS. Output stays in parity with v1 (see [What changed](#what-changed-in-v2)).
 
-> **Beta expectations:** the public authoring API is stable. Internal package layout, the exact Node floor, and a few CLI/tooling surfaces are still being finalized — see [Still being finalized](#still-being-finalized).
+The authoring API is stable. The internal package layout, the exact Node floor, and a few CLI surfaces are not finished
+yet — see [Still being finalized](#still-being-finalized).
 
 ---
 
 ## Release channels
 
-Panda v1 and v2 are published side by side on npm:
+v1 and v2 ship side by side on npm.
 
-| Channel | Versions | Install tag |
-| --- | --- | --- |
-| **`latest`** | v1 — `1.x` (stable) | `@pandacss/dev` |
-| **`beta`** | v2 — `2.0.0-beta` | `@pandacss/dev@beta` |
+| Channel  | Versions           | Install              |
+| -------- | ------------------ | -------------------- |
+| `latest` | v1 (`1.x`, stable) | `@pandacss/dev`      |
+| `beta`   | v2 (`2.0.0-beta`)  | `@pandacss/dev@beta` |
 
-- Installing without a tag (`@pandacss/dev`) still gives you **stable v1** — your existing projects are not affected.
-- v2 only arrives when you explicitly opt in with `@beta`.
-- All `@pandacss/*` packages move in lockstep (fixed version group), so every published package shares the same `2.0.0-beta` version. Don't mix a v1 package with a v2 one.
+Install without a tag and you get stable v1. Existing projects don't change. You get v2 only when you ask for `@beta`.
+
+All `@pandacss/*` packages move together on one version, so every published package shares the same `2.0.0-beta`. Don't
+mix a v1 package with a v2 one.
 
 ---
 
@@ -47,12 +51,14 @@ Panda v1 and v2 are published side by side on npm:
 
 ### 1. Requirements
 
-- **ESM-only.** v2 ships ES modules only — there is no CommonJS build. Your project must be able to `import` Panda (use `"type": "module"`, `.mjs`, or a bundler/loader that consumes ESM). `require('@pandacss/dev')` will not work.
-- **Modern Node.** Use an actively-supported Node (Node 20+; Node 22+ recommended). The exact `engines.node` floor is being pinned for the stable release — see [Still being finalized](#still-being-finalized).
+- **ESM only.** There is no CommonJS build. Your project has to `import` Panda — set `"type": "module"`, use `.mjs`, or
+  run it through a bundler that handles ESM. `require('@pandacss/dev')` won't work.
+- **Node 20 or newer** (22+ recommended). The exact `engines.node` floor is still being pinned — see
+  [Still being finalized](#still-being-finalized).
 
 ### 2. Install
 
-Add the beta to a project (most users only need `@pandacss/dev`):
+Most projects only need `@pandacss/dev`:
 
 ```bash
 # pnpm
@@ -68,35 +74,39 @@ yarn add -D @pandacss/dev@beta
 bun add -d @pandacss/dev@beta
 ```
 
-Add integrations as needed (all on the same `@beta` tag):
+Add integrations on the same `@beta` tag when you need them:
 
 ```bash
-pnpm add -D @pandacss/postcss@beta   # standalone PostCSS plugin (v2 compiler driver)
+pnpm add -D @pandacss/postcss@beta   # standalone PostCSS plugin
 pnpm add -D @pandacss/vite@beta      # Vite plugin
 ```
 
-> **Two ways to wire up PostCSS** — both valid:
-> - **`@pandacss/postcss`** — the standalone plugin (key: `'@pandacss/postcss'`).
-> - **`@pandacss/dev/postcss`** — a re-export of the same plugin, so you don't need a second install if you already have `@pandacss/dev` (this is what `panda init --postcss` scaffolds).
+You can wire up PostCSS two ways:
 
-> Pin to an exact beta (`@pandacss/dev@2.0.0-beta.0`) if you want reproducible installs — `@beta` always resolves to the newest pre-release.
+- `@pandacss/postcss` — the standalone plugin (key: `'@pandacss/postcss'`).
+- `@pandacss/dev/postcss` — the same plugin re-exported, so you don't need a second install if you already have
+  `@pandacss/dev`. This is what `panda init --postcss` writes.
+
+Want reproducible installs? Pin an exact version (`@pandacss/dev@2.0.0-beta.0`). `@beta` always resolves to the newest
+pre-release.
 
 ### 3. Build
 
-On an **existing v1 project**, your `panda.config.ts` carries over — just regenerate:
+On an existing v1 project, your `panda.config.ts` carries over. Regenerate:
 
 ```bash
 panda          # codegen + cssgen in one pass
 panda --watch  # rebuild on change
 ```
 
-The `panda` / `pandacss` binaries are unchanged from v1. **Starting fresh?** See [Get started (new project)](#get-started-new-project).
+The `panda` and `pandacss` binaries are the same as v1. Starting fresh? See
+[Get started (new project)](#get-started-new-project).
 
 ---
 
 ## Get started (new project)
 
-New to Panda? Here's the happy path on v2. (Already on v1? Jump to [migration](#breaking-changes--migration).)
+Already on v1? Jump to [migration](#breaking-changes--migration).
 
 ### 1. Install
 
@@ -104,22 +114,22 @@ New to Panda? Here's the happy path on v2. (Already on v1? Jump to [migration](#
 pnpm add -D @pandacss/dev@beta
 ```
 
-Make sure your project resolves ESM — add `"type": "module"` to `package.json` if it isn't already there.
+Make sure the project resolves ESM — add `"type": "module"` to `package.json` if it isn't there.
 
 ### 2. Initialize
 
-`panda init` scaffolds a `panda.config.ts` and runs the first codegen into `styled-system/`. Handy flags:
+`panda init` writes a `panda.config.ts` and runs the first codegen into `styled-system/`. Useful flags:
 
 ```bash
-panda init --postcss          # also write a postcss.config.cjs
-panda init --gitignore        # add styled-system to .gitignore (on by default)
-panda init --jsxFramework react   # generate JSX-aware helpers (react | preact | vue | solid | qwik)
+panda init --postcss              # also write postcss.config.cjs
+panda init --gitignore            # add styled-system to .gitignore (on by default)
+panda init --jsxFramework react   # JSX helpers (react | preact | vue | solid | qwik)
 panda init --outdir src/styled-system
 ```
 
-### 3. Configure what to scan
+### 3. Tell Panda what to scan
 
-In `panda.config.ts`, point `include` at the files you write styles in:
+Point `include` at the files where you write styles:
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
@@ -134,13 +144,13 @@ export default defineConfig({
 
 ### 4. Add Panda to your CSS
 
-Add the cascade layers to your root stylesheet (e.g. `src/index.css`):
+Declare the cascade layers in your root stylesheet (e.g. `src/index.css`):
 
 ```css
 @layer reset, base, tokens, recipes, utilities;
 ```
 
-Process it with the PostCSS plugin (`panda init --postcss` writes this for you):
+Run it through the PostCSS plugin (`panda init --postcss` writes this for you):
 
 ```js
 // postcss.config.cjs
@@ -157,48 +167,59 @@ module.exports = {
 import { css } from '../styled-system/css'
 
 export const Button = () => (
-  <button className={css({ bg: 'red.400', color: 'white', px: '4', py: '2', rounded: 'md' })}>
-    Hello 🐼
-  </button>
+  <button className={css({ bg: 'red.400', color: 'white', px: '4', py: '2', rounded: 'md' })}>Hello 🐼</button>
 )
 ```
 
 ### 6. Build
 
 ```bash
-panda          # one-shot codegen + cssgen
+panda          # codegen + cssgen
 panda --watch  # rebuild on change
 ```
 
-> The CLI generates types and helpers under `styled-system/`. Re-run `panda codegen` (or keep `--watch` running) whenever you change tokens, recipes, or patterns. For the full tutorial — recipes, patterns, conditions, theming — see the [official docs](https://panda-css.com).
+The CLI writes types and helpers under `styled-system/`. Re-run `panda codegen` (or keep `--watch` running) whenever you
+change tokens, recipes, or patterns. For the full tutorial — recipes, patterns, conditions, theming — see the
+[docs](https://panda-css.com).
 
 ---
 
 ## What changed in v2
 
-The Rust engine targets **CSS-output parity** with v1. The user-facing differences below are the deliberate ones:
+The engine aims for the same CSS as v1. These are the differences you'll notice, and they're on purpose.
 
 ### CSS output
 
-- **Native token CSS.** Token CSS variables are emitted by the Rust stylesheet compiler. The default `cssVarRoot` is aligned with v1 output: `:where(:root, :host)`.
-- **Merged adjacent selectors.** Consecutive rules that share an identical declaration block are coalesced into one comma-joined rule (parity with v1's merge-rules pass). The merge is adjacency-only (cascade-safe) and applies to the atomic and `globalCss` layers — functionally identical CSS, just smaller.
-- **Grouped `@media` / `@supports` emit.** Rules that share a media/supports wrapper are tree-grouped before being written.
-- **Modern breakpoint syntax.** Responsive conditions normalize to range syntax — `@media (width >= Nrem)` — with px/em normalized to `rem`.
-- **Container queries sort by size.** Container conditions (`@container (inline-size >= …)`) now sort by resolved length across every size axis (`width`, `inline-size`, `height`, `block-size`), in both modern (`>=`/`<`) and legacy (`min-*`/`max-*`) forms — fixing mobile-first cascade ordering for theme container breakpoints.
-- **Eager compound variants.** Compound variants are emitted at build time by default; runtime combo classes still apply for dynamic usage. Opt into narrowing with `optimize.smartCompoundVariants: true` to emit only selected variant combinations instead of every permutation.
+- **Native token CSS.** Token variables come from the Rust stylesheet compiler. The default `cssVarRoot` matches v1:
+  `:where(:root, :host)`.
+- **Merged adjacent selectors.** Consecutive rules with an identical declaration block collapse into one comma-joined
+  rule (same as v1's merge-rules pass). It only merges adjacent rules, so the cascade is safe, and it applies to the
+  atomic and `globalCss` layers. Same CSS, fewer bytes.
+- **Grouped `@media` / `@supports`.** Rules that share a wrapper are grouped before they're written.
+- **Modern breakpoint syntax.** Responsive conditions use range syntax, `@media (width >= Nrem)`, with px and em
+  normalized to `rem`.
+- **Container queries sort by size.** Container conditions sort by resolved length across every axis (`width`,
+  `inline-size`, `height`, `block-size`), in both modern (`>=`/`<`) and legacy (`min-*`/`max-*`) forms. This fixes
+  mobile-first ordering for theme container breakpoints.
+- **Eager compound variants.** Compound variants are emitted at build time by default; runtime combo classes still apply
+  for dynamic usage. Set `optimize.smartCompoundVariants: true` to emit only the combinations you use instead of every
+  permutation.
 
 ### Extraction
 
-- **Compiled-JSX runtime extraction.** `css` props are now recognized from framework runtime helper output (the compiled `jsx(...)` / `_jsx(...)` calls), covering **React, Preact, Vue, Solid, and Qwik** builds — not just raw JSX source.
-- **Custom utility `transform` grouping.** A custom utility whose `transform` returns a multi-declaration object emits a **single** class keyed on the utility's `className` (matching v1) instead of shattering into per-property atoms. Token resolution, `!important`, and conditions returned by the transform are all preserved — in atomic styles and recipes alike.
+- **Compiled-JSX extraction.** `css` props are picked up from compiled runtime helpers (`jsx(...)` / `_jsx(...)`), so
+  React, Preact, Vue, Solid, and Qwik builds work — not just raw JSX source.
+- **Custom utility `transform` grouping.** A custom utility whose `transform` returns a multi-declaration object emits
+  one class keyed on the utility's `className` (like v1), instead of splitting into per-property atoms. Token
+  resolution, `!important`, and conditions from the transform are kept, in atomic styles and recipes alike.
 
 ---
 
 ## Breaking changes & migration
 
-### ESM-only (no CommonJS)
+### ESM only
 
-v2 drops the CJS build. If your config or tooling used `require()`:
+There is no CJS build. If your config or tooling used `require()`:
 
 ```js
 // ❌ v1 (CJS)
@@ -208,85 +229,127 @@ const { defineConfig } = require('@pandacss/dev')
 import { defineConfig } from '@pandacss/dev'
 ```
 
-Make sure the project resolves Panda as ESM — set `"type": "module"` in `package.json`, use `.mjs`, or rely on a bundler/loader that handles ESM. `panda.config.ts` is loaded as ESM.
+Set `"type": "module"`, use `.mjs`, or run through an ESM-aware bundler. `panda.config.ts` loads as ESM.
 
 ### MCP moved out of the CLI
 
-MCP execution now lives in its own package, **`@pandacss/mcp`**, with a dedicated `panda-mcp` binary:
+MCP runs from its own package, `@pandacss/mcp`, with a `panda-mcp` binary:
 
 ```bash
 # ❌ v1
 panda mcp
 panda init-mcp
 
-# ✅ v2 — run the server directly, no install needed
+# ✅ v2 — run it directly, nothing to install
 npx -y @pandacss/mcp
 # or
 pnpm dlx @pandacss/mcp
 ```
 
-The `panda mcp` and `panda init-mcp` bridge commands are removed.
+`panda mcp` and `panda init-mcp` are gone.
 
-### Packages removed / folded into the engine
+### Packages folded into the engine
 
-Several v1 packages were internal to the old Node pipeline and **no longer exist** in v2 — their work moved into the Rust engine behind `@pandacss/compiler`. If you imported any of these directly, you'll need to remove those imports:
+Several v1 packages were internals of the old Node pipeline. They no longer exist in v2 — that work moved into the Rust
+engine behind `@pandacss/compiler`. Remove any direct imports of:
 
-`@pandacss/core`, `@pandacss/extractor`, `@pandacss/generator`, `@pandacss/node`, `@pandacss/parser`, `@pandacss/token-dictionary`, `@pandacss/is-valid-prop`, `@pandacss/logger`, `@pandacss/reporter`, plus the standalone plugin packages and the Astro `@pandacss/studio`.
+`@pandacss/core`, `@pandacss/extractor`, `@pandacss/generator`, `@pandacss/node`, `@pandacss/parser`,
+`@pandacss/token-dictionary`, `@pandacss/is-valid-prop`, `@pandacss/logger`, `@pandacss/reporter`, the standalone plugin
+packages, and the Astro `@pandacss/studio`.
 
-> Most apps only ever depend on `@pandacss/dev` (plus a bundler/postcss plugin), so this is a no-op for typical setups. It only bites if you reached into Panda's internals.
+Most apps only depend on `@pandacss/dev` plus a bundler or PostCSS plugin, so this changes nothing for them. It only
+bites if you reached into Panda's internals.
 
-**Packages kept and published on the beta:**
-`@pandacss/dev`, `@pandacss/cli`, `@pandacss/compiler`, `@pandacss/compiler-wasm`, `@pandacss/compiler-shared`, `@pandacss/config`, `@pandacss/postcss`, `@pandacss/vite`, `@pandacss/types`, `@pandacss/preset-base`, `@pandacss/preset-panda`, `@pandacss/mcp`.
+Kept and published on the beta: `@pandacss/dev`, `@pandacss/cli`, `@pandacss/compiler`, `@pandacss/compiler-wasm`,
+`@pandacss/compiler-shared`, `@pandacss/config`, `@pandacss/postcss`, `@pandacss/vite`, `@pandacss/types`,
+`@pandacss/preset-base`, `@pandacss/preset-panda`, `@pandacss/mcp`.
 
-### Experimental PostCSS plugin
+### PostCSS plugin is experimental
 
-`@pandacss/postcss` v2 is backed by the new compiler driver and is **experimental** during the beta. If you hit issues, the Vite plugin or the CLI build is the more battle-tested path right now.
+`@pandacss/postcss` v2 runs on the new compiler driver and is experimental during the beta. If it gives you trouble, the
+Vite plugin or the CLI build is the steadier path right now.
+
+### `createStyleContext` is now two helpers
+
+`createStyleContext` is removed from the generated `styled-system/jsx`. Two helpers replace it, one per recipe kind:
+
+- `createRecipeContext` — for a config recipe (`cva`). Returns `{ withContext }`.
+- `createSlotRecipeContext` — for a slot recipe (`sva`). Returns `{ withRootProvider, withProvider, withContext }`.
+
+```tsx
+// ❌ v1 — one helper for both
+import { createStyleContext } from 'styled-system/jsx'
+
+const { withProvider, withContext } = createStyleContext(card)
+const CardRoot = withProvider('div', 'root')
+const CardTitle = withContext('h3', 'title')
+```
+
+```tsx
+// ✅ v2 — slot recipe (sva)
+import { createSlotRecipeContext } from 'styled-system/jsx'
+
+const { withRootProvider, withProvider, withContext } = createSlotRecipeContext(card)
+const CardRoot = withProvider('div', 'root')
+const CardTitle = withContext('h3', 'title')
+
+// ✅ v2 — config recipe (cva)
+import { createRecipeContext } from 'styled-system/jsx'
+
+const { withContext } = createRecipeContext(button)
+const Button = withContext('button')
+```
+
+`withRootProvider` is new. Use it for the root of a slot recipe when the root doesn't render a slot of its own.
 
 ---
 
 ## CLI commands
 
-The beta command surface:
+| Command           | What it does                                                                                                                                                                                                                                                               |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `panda`           | Default build. Runs codegen then cssgen in one pass. Flags: `--outdir`, `--outfile`, `--splitting`, `--clean`, `--check`, `--watch`. `--outdir` moves both the generated system and the CSS file; codegen runs first, so `--clean` wipes the outdir before CSS is written. |
+| `panda init`      | Scaffold `panda.config.ts` and run the first codegen.                                                                                                                                                                                                                      |
+| `panda codegen`   | Generate the `styled-system` output only.                                                                                                                                                                                                                                  |
+| `panda cssgen`    | Generate the CSS only.                                                                                                                                                                                                                                                     |
+| `panda debug`     | Dump resolved config and per-file extraction for bug reports. Writes `info.json`, `config.json`, `<file>.extract.json`, and `styles.css` under `<outdir>/debug`. Flags: `--outdir`, `--dry` (print to stdout), `--only-config`.                                            |
+| `panda inspect`   | Inspect the resolved Panda artifacts.                                                                                                                                                                                                                                      |
+| `panda validate`  | Validate config and tokens.                                                                                                                                                                                                                                                |
+| `panda buildinfo` | Emit build metadata.                                                                                                                                                                                                                                                       |
 
-| Command | What it does |
-| --- | --- |
-| `panda` | **Default build** — runs codegen + cssgen in one driver pass. Flags: `--outdir`, `--outfile`, `--splitting`, `--clean`, `--check`, `--watch`. `--outdir` relocates both the generated system and the CSS file; codegen runs first so `--clean` wipes the outdir before CSS is written. |
-| `panda init` | Scaffold `panda.config.ts` and run the first codegen. |
-| `panda codegen` | Generate the `styled-system` output only. |
-| `panda cssgen` | Generate the CSS only. |
-| `panda debug` | Dump resolved config + per-file extraction for bug reports — writes `info.json`, `config.json`, `<file>.extract.json`, and the project `styles.css` under `<outdir>/debug`. Flags: `--outdir`, `--dry` (print to stdout), `--only-config`. |
-| `panda inspect` | Inspect the resolved Panda artifacts. |
-| `panda validate` | Validate config and tokens. |
-| `panda buildinfo` | Emit build metadata. |
-
-**Routing rule (important):** subcommands must come **first**.
+One routing rule: subcommands come first.
 
 ```bash
 panda codegen --cwd ./app   # ✅ subcommand, then flags
-panda --watch               # ✅ leading flag → default build
-panda --cwd ./app codegen   # ❌ first token is read as a flag → runs default build
+panda --watch               # ✅ leading flag runs the default build
+panda --cwd ./app codegen   # ❌ first token reads as a flag, so it runs the default build
 ```
 
-A leading **flag** runs the default build (`panda --watch`); a leading **word** (or `--help`) goes to the subcommand dispatcher.
+A leading flag runs the default build. A leading word (or `--help`) goes to the subcommand dispatcher.
 
 ---
 
 ## Still being finalized
 
-These are known gaps in the beta — expect changes before stable:
+Known gaps in the beta. Expect them to change before stable:
 
-- **Exact Node floor.** v2 is ESM-only and targets modern Node, but the precise `engines.node` minimum is still being pinned. Use Node 20+ (22+ recommended) in the meantime.
-- **Studio.** The Astro-based `@pandacss/studio` is removed; a lighter, CLI-generated studio (token/color visualization without a separate Storybook) is planned.
-- **Removed presets/plugins.** Some v1 community presets (e.g. `preset-atlaskit`, `preset-open-props`) and standalone plugins are not part of the beta. Verify Rust-engine coverage before relying on them.
-- **CSS minification parity.** Native CSS emission is done; full minify parity with the v1 LightningCSS path is an open follow-up.
-- **PostCSS plugin.** Experimental (see above).
-- **CLI `[files]` positional override.** The v1 positional include override for `panda build` isn't wired yet — the build uses the config `include`.
+- **Node floor.** v2 is ESM-only and targets modern Node, but the exact `engines.node` minimum isn't pinned. Use Node
+  20+ (22+ recommended) for now.
+- **Studio.** The Astro-based `@pandacss/studio` is gone. A lighter, CLI-generated studio (token and color views without
+  a separate Storybook) is planned.
+- **Some presets and plugins.** A few v1 community presets (`preset-atlaskit`, `preset-open-props`) and standalone
+  plugins aren't in the beta. Check Rust-engine coverage before you rely on them.
+- **CSS minification.** Native emission is done; full minify parity with the v1 LightningCSS path is still open.
+- **PostCSS plugin.** Experimental (above).
+- **CLI `[files]` override.** The v1 positional include override for `panda build` isn't wired yet. The build uses the
+  config `include`.
 
 ---
 
 ## Feedback
 
-v2 is a beta — bug reports are exactly what it needs. When filing an issue, attach a `panda debug` dump (`panda debug` → `<outdir>/debug`) so maintainers can reproduce.
+It's a beta, so bug reports are the most useful thing you can send. Attach a `panda debug` dump (`panda debug` →
+`<outdir>/debug`) so maintainers can reproduce.
 
 - Issues: <https://github.com/chakra-ui/panda/issues>
 - Docs: <https://panda-css.com>

--- a/V2_MIGRATION.md
+++ b/V2_MIGRATION.md
@@ -1,0 +1,292 @@
+# Panda CSS v2 — Beta Guide & Migration
+
+> **Status:** v2 is in **beta** (`2.0.0-beta`). The authoring API you already know is stable; what changed lives underneath. This guide is for v1 users who want to try the beta or start migrating — and for new users who want to start a fresh project on v2.
+
+> 🆕 **New to Panda?** Skip straight to [Get started (new project)](#get-started-new-project).
+
+---
+
+## Introducing Panda v2
+
+Panda v2 keeps the framework you know — `css()`, recipes, patterns, tokens, conditions, JSX style props — and **rewrites the compiler hot path in Rust** on top of the [Oxc](https://oxc.rs) toolchain.
+
+In v1, extraction and evaluation ran through `ts-morph` + `ts-evaluator` in Node. v2 replaces that pipeline with a native engine:
+
+- **`@pandacss/compiler`** — a native NAPI binding around the Rust engine. This is the path the CLI and bundler integrations use.
+- **`@pandacss/compiler-wasm`** — a `wasm-bindgen` build of the same engine for the browser (powers the playground and in-browser tooling).
+
+Both consume the **same** Rust crates, so Node and browser builds share one source of truth for extraction and CSS emission.
+
+**Why it matters**
+
+- ⚡️ Faster, lighter extraction — single parse per file, no TypeScript program in the hot path.
+- 🧱 One engine, two runtimes — identical output from native and wasm builds.
+- 🪶 Smaller install — the `ts-morph`/`ts-evaluator` dependency tree is gone.
+- 🎯 Same CSS contract — output is intentionally kept in parity with v1 (see [What changed](#what-changed-in-v2)).
+
+> **Beta expectations:** the public authoring API is stable. Internal package layout, the exact Node floor, and a few CLI/tooling surfaces are still being finalized — see [Still being finalized](#still-being-finalized).
+
+---
+
+## Release channels
+
+Panda v1 and v2 are published side by side on npm:
+
+| Channel | Versions | Install tag |
+| --- | --- | --- |
+| **`latest`** | v1 — `1.x` (stable) | `@pandacss/dev` |
+| **`beta`** | v2 — `2.0.0-beta` | `@pandacss/dev@beta` |
+
+- Installing without a tag (`@pandacss/dev`) still gives you **stable v1** — your existing projects are not affected.
+- v2 only arrives when you explicitly opt in with `@beta`.
+- All `@pandacss/*` packages move in lockstep (fixed version group), so every published package shares the same `2.0.0-beta` version. Don't mix a v1 package with a v2 one.
+
+---
+
+## Try the beta
+
+### 1. Requirements
+
+- **ESM-only.** v2 ships ES modules only — there is no CommonJS build. Your project must be able to `import` Panda (use `"type": "module"`, `.mjs`, or a bundler/loader that consumes ESM). `require('@pandacss/dev')` will not work.
+- **Modern Node.** Use an actively-supported Node (Node 20+; Node 22+ recommended). The exact `engines.node` floor is being pinned for the stable release — see [Still being finalized](#still-being-finalized).
+
+### 2. Install
+
+Add the beta to a project (most users only need `@pandacss/dev`):
+
+```bash
+# pnpm
+pnpm add -D @pandacss/dev@beta
+
+# npm
+npm i -D @pandacss/dev@beta
+
+# yarn
+yarn add -D @pandacss/dev@beta
+
+# bun
+bun add -d @pandacss/dev@beta
+```
+
+Add integrations as needed (all on the same `@beta` tag):
+
+```bash
+pnpm add -D @pandacss/postcss@beta   # standalone PostCSS plugin (v2 compiler driver)
+pnpm add -D @pandacss/vite@beta      # Vite plugin
+```
+
+> **Two ways to wire up PostCSS** — both valid:
+> - **`@pandacss/postcss`** — the standalone plugin (key: `'@pandacss/postcss'`).
+> - **`@pandacss/dev/postcss`** — a re-export of the same plugin, so you don't need a second install if you already have `@pandacss/dev` (this is what `panda init --postcss` scaffolds).
+
+> Pin to an exact beta (`@pandacss/dev@2.0.0-beta.0`) if you want reproducible installs — `@beta` always resolves to the newest pre-release.
+
+### 3. Build
+
+On an **existing v1 project**, your `panda.config.ts` carries over — just regenerate:
+
+```bash
+panda          # codegen + cssgen in one pass
+panda --watch  # rebuild on change
+```
+
+The `panda` / `pandacss` binaries are unchanged from v1. **Starting fresh?** See [Get started (new project)](#get-started-new-project).
+
+---
+
+## Get started (new project)
+
+New to Panda? Here's the happy path on v2. (Already on v1? Jump to [migration](#breaking-changes--migration).)
+
+### 1. Install
+
+```bash
+pnpm add -D @pandacss/dev@beta
+```
+
+Make sure your project resolves ESM — add `"type": "module"` to `package.json` if it isn't already there.
+
+### 2. Initialize
+
+`panda init` scaffolds a `panda.config.ts` and runs the first codegen into `styled-system/`. Handy flags:
+
+```bash
+panda init --postcss          # also write a postcss.config.cjs
+panda init --gitignore        # add styled-system to .gitignore (on by default)
+panda init --jsxFramework react   # generate JSX-aware helpers (react | preact | vue | solid | qwik)
+panda init --outdir src/styled-system
+```
+
+### 3. Configure what to scan
+
+In `panda.config.ts`, point `include` at the files you write styles in:
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  preflight: true, // CSS reset
+  include: ['./src/**/*.{js,jsx,ts,tsx}'],
+  exclude: [],
+  outdir: 'styled-system',
+})
+```
+
+### 4. Add Panda to your CSS
+
+Add the cascade layers to your root stylesheet (e.g. `src/index.css`):
+
+```css
+@layer reset, base, tokens, recipes, utilities;
+```
+
+Process it with the PostCSS plugin (`panda init --postcss` writes this for you):
+
+```js
+// postcss.config.cjs
+module.exports = {
+  plugins: {
+    '@pandacss/dev/postcss': {},
+  },
+}
+```
+
+### 5. Write styles
+
+```tsx
+import { css } from '../styled-system/css'
+
+export const Button = () => (
+  <button className={css({ bg: 'red.400', color: 'white', px: '4', py: '2', rounded: 'md' })}>
+    Hello 🐼
+  </button>
+)
+```
+
+### 6. Build
+
+```bash
+panda          # one-shot codegen + cssgen
+panda --watch  # rebuild on change
+```
+
+> The CLI generates types and helpers under `styled-system/`. Re-run `panda codegen` (or keep `--watch` running) whenever you change tokens, recipes, or patterns. For the full tutorial — recipes, patterns, conditions, theming — see the [official docs](https://panda-css.com).
+
+---
+
+## What changed in v2
+
+The Rust engine targets **CSS-output parity** with v1. The user-facing differences below are the deliberate ones:
+
+### CSS output
+
+- **Native token CSS.** Token CSS variables are emitted by the Rust stylesheet compiler. The default `cssVarRoot` is aligned with v1 output: `:where(:root, :host)`.
+- **Merged adjacent selectors.** Consecutive rules that share an identical declaration block are coalesced into one comma-joined rule (parity with v1's merge-rules pass). The merge is adjacency-only (cascade-safe) and applies to the atomic and `globalCss` layers — functionally identical CSS, just smaller.
+- **Grouped `@media` / `@supports` emit.** Rules that share a media/supports wrapper are tree-grouped before being written.
+- **Modern breakpoint syntax.** Responsive conditions normalize to range syntax — `@media (width >= Nrem)` — with px/em normalized to `rem`.
+- **Container queries sort by size.** Container conditions (`@container (inline-size >= …)`) now sort by resolved length across every size axis (`width`, `inline-size`, `height`, `block-size`), in both modern (`>=`/`<`) and legacy (`min-*`/`max-*`) forms — fixing mobile-first cascade ordering for theme container breakpoints.
+- **Eager compound variants.** Compound variants are emitted at build time by default; runtime combo classes still apply for dynamic usage. Opt into narrowing with `optimize.smartCompoundVariants: true` to emit only selected variant combinations instead of every permutation.
+
+### Extraction
+
+- **Compiled-JSX runtime extraction.** `css` props are now recognized from framework runtime helper output (the compiled `jsx(...)` / `_jsx(...)` calls), covering **React, Preact, Vue, Solid, and Qwik** builds — not just raw JSX source.
+- **Custom utility `transform` grouping.** A custom utility whose `transform` returns a multi-declaration object emits a **single** class keyed on the utility's `className` (matching v1) instead of shattering into per-property atoms. Token resolution, `!important`, and conditions returned by the transform are all preserved — in atomic styles and recipes alike.
+
+---
+
+## Breaking changes & migration
+
+### ESM-only (no CommonJS)
+
+v2 drops the CJS build. If your config or tooling used `require()`:
+
+```js
+// ❌ v1 (CJS)
+const { defineConfig } = require('@pandacss/dev')
+
+// ✅ v2 (ESM)
+import { defineConfig } from '@pandacss/dev'
+```
+
+Make sure the project resolves Panda as ESM — set `"type": "module"` in `package.json`, use `.mjs`, or rely on a bundler/loader that handles ESM. `panda.config.ts` is loaded as ESM.
+
+### MCP moved out of the CLI
+
+MCP execution now lives in its own package, **`@pandacss/mcp`**, with a dedicated `panda-mcp` binary:
+
+```bash
+# ❌ v1
+panda mcp
+panda init-mcp
+
+# ✅ v2 — run the server directly, no install needed
+npx -y @pandacss/mcp
+# or
+pnpm dlx @pandacss/mcp
+```
+
+The `panda mcp` and `panda init-mcp` bridge commands are removed.
+
+### Packages removed / folded into the engine
+
+Several v1 packages were internal to the old Node pipeline and **no longer exist** in v2 — their work moved into the Rust engine behind `@pandacss/compiler`. If you imported any of these directly, you'll need to remove those imports:
+
+`@pandacss/core`, `@pandacss/extractor`, `@pandacss/generator`, `@pandacss/node`, `@pandacss/parser`, `@pandacss/token-dictionary`, `@pandacss/is-valid-prop`, `@pandacss/logger`, `@pandacss/reporter`, plus the standalone plugin packages and the Astro `@pandacss/studio`.
+
+> Most apps only ever depend on `@pandacss/dev` (plus a bundler/postcss plugin), so this is a no-op for typical setups. It only bites if you reached into Panda's internals.
+
+**Packages kept and published on the beta:**
+`@pandacss/dev`, `@pandacss/cli`, `@pandacss/compiler`, `@pandacss/compiler-wasm`, `@pandacss/compiler-shared`, `@pandacss/config`, `@pandacss/postcss`, `@pandacss/vite`, `@pandacss/types`, `@pandacss/preset-base`, `@pandacss/preset-panda`, `@pandacss/mcp`.
+
+### Experimental PostCSS plugin
+
+`@pandacss/postcss` v2 is backed by the new compiler driver and is **experimental** during the beta. If you hit issues, the Vite plugin or the CLI build is the more battle-tested path right now.
+
+---
+
+## CLI commands
+
+The beta command surface:
+
+| Command | What it does |
+| --- | --- |
+| `panda` | **Default build** — runs codegen + cssgen in one driver pass. Flags: `--outdir`, `--outfile`, `--splitting`, `--clean`, `--check`, `--watch`. `--outdir` relocates both the generated system and the CSS file; codegen runs first so `--clean` wipes the outdir before CSS is written. |
+| `panda init` | Scaffold `panda.config.ts` and run the first codegen. |
+| `panda codegen` | Generate the `styled-system` output only. |
+| `panda cssgen` | Generate the CSS only. |
+| `panda debug` | Dump resolved config + per-file extraction for bug reports — writes `info.json`, `config.json`, `<file>.extract.json`, and the project `styles.css` under `<outdir>/debug`. Flags: `--outdir`, `--dry` (print to stdout), `--only-config`. |
+| `panda inspect` | Inspect the resolved Panda artifacts. |
+| `panda validate` | Validate config and tokens. |
+| `panda buildinfo` | Emit build metadata. |
+
+**Routing rule (important):** subcommands must come **first**.
+
+```bash
+panda codegen --cwd ./app   # ✅ subcommand, then flags
+panda --watch               # ✅ leading flag → default build
+panda --cwd ./app codegen   # ❌ first token is read as a flag → runs default build
+```
+
+A leading **flag** runs the default build (`panda --watch`); a leading **word** (or `--help`) goes to the subcommand dispatcher.
+
+---
+
+## Still being finalized
+
+These are known gaps in the beta — expect changes before stable:
+
+- **Exact Node floor.** v2 is ESM-only and targets modern Node, but the precise `engines.node` minimum is still being pinned. Use Node 20+ (22+ recommended) in the meantime.
+- **Studio.** The Astro-based `@pandacss/studio` is removed; a lighter, CLI-generated studio (token/color visualization without a separate Storybook) is planned.
+- **Removed presets/plugins.** Some v1 community presets (e.g. `preset-atlaskit`, `preset-open-props`) and standalone plugins are not part of the beta. Verify Rust-engine coverage before relying on them.
+- **CSS minification parity.** Native CSS emission is done; full minify parity with the v1 LightningCSS path is an open follow-up.
+- **PostCSS plugin.** Experimental (see above).
+- **CLI `[files]` positional override.** The v1 positional include override for `panda build` isn't wired yet — the build uses the config `include`.
+
+---
+
+## Feedback
+
+v2 is a beta — bug reports are exactly what it needs. When filing an issue, attach a `panda debug` dump (`panda debug` → `<outdir>/debug`) so maintainers can reproduce.
+
+- Issues: <https://github.com/chakra-ui/panda/issues>
+- Docs: <https://panda-css.com>

--- a/tone_of_voice.md
+++ b/tone_of_voice.md
@@ -1,0 +1,51 @@
+# Tone of voice
+
+How we write anything users read — docs, guides, READMEs, changelogs, release notes, CLI output, error messages. Read
+this before you write prose, and run the checklist before you ship it.
+
+## The short version
+
+Write like you're explaining it to one sharp person, out loud, with no time to waste. Plain words. Short sentences. Say
+the thing.
+
+## Principles
+
+1. **Write to one person.** Use "you". Talk to the reader like a colleague, not a crowd or a brand.
+2. **Write like you talk.** Read it back aloud. If you wouldn't say it, rewrite it. Contractions are fine.
+3. **Keep it short.** Prefer short words to long ones. One idea per sentence. Short paragraphs. Break up walls of text.
+4. **Lead with the point.** Put it in the first sentence. Cut throat-clearing ("In this section we'll...", "It's worth
+   noting that...").
+5. **Be specific.** Names, numbers, exact commands, real examples. Vague claims ("powerful", "seamless", "robust") carry
+   no information — delete them or replace them with the fact behind them.
+6. **Cut the fluff.** Every word earns its place. If you can delete a word without losing meaning, delete it.
+7. **Be honest.** Say what's rough, experimental, or unfinished, plainly. Candor builds more trust than polish.
+8. **Keep them moving.** Each sentence should make the reader want the next one. No dead weight, no detours.
+9. **Show, don't sell.** A code block or a concrete before/after beats any adjective.
+
+## Cut these (the usual tells)
+
+- **Hype words:** powerful, seamless, robust, blazing-fast, cutting-edge, effortless, unlock, elevate, leverage, delve,
+  supercharge, next-level, game-changing.
+- **Filler openers:** "In today's...", "When it comes to...", "It's important to note that...", "Let's dive in".
+- **Padding transitions:** "Additionally", "Moreover", "Furthermore", "That said," used to connect nothing.
+- **Over-hedging:** "arguably", "in many cases", "generally speaking" when you can just state it.
+- **Emoji bullet lists** used as decoration.
+- **Over-bolding.** Bold stops meaning anything when half the line is bold. Bold the one word that matters, or none.
+- **Em-dash pile-ups.** One thought per sentence; a period usually beats a dash.
+- **Marketing title case.** Sentence case in headings reads human.
+
+## Before / after
+
+- ❌ "Panda v2 introduces a powerful, blazing-fast Rust engine that seamlessly unlocks next-level performance."
+- ✅ "v2 rewrites the compiler's hot path in Rust. One parse per file, no TypeScript program in the hot path."
+
+- ❌ "It's worth noting that, in many cases, you may want to consider pinning your version."
+- ✅ "Want reproducible installs? Pin an exact version."
+
+## Checklist before you ship copy
+
+- Could you read it aloud without wincing?
+- Is the first sentence the point?
+- Any word you can delete without losing meaning? Delete it.
+- Any claim without a specific behind it? Add the specific, or cut the claim.
+- Did you say what's still rough or unfinished?


### PR DESCRIPTION
## what

add `V2_MIGRATION.md` — a beta guide for v1 users trying v2 and for new projects starting on v2.

covers: intro to the rust/oxc engine, release channels (`latest` = v1, `beta` = v2), beta install, a getting-started path for new projects, what changed (css output + extraction), breaking changes (esm-only, mcp moved to `@pandacss/mcp`, removed/kept packages, postcss), the cli command surface, and known gaps.

## why

There's no single place to send people who want to try the beta or move from v1. this is that page until the website docs catch up.

## notes

- standalone `.md` at the repo root, not a website docs page, portable, links cleanly from a beta release. maps into `website/content/docs/migration/` later.

## test plan

- [x] links resolve (`./V2_MIGRATION.md` from readme)
- [x] code claims grepped against `crates/` + `packages/`
