### PR TITLE
fix: spec includes description on string value semantic tokens

### DIFF
--- a/.changeset/gentle-bears-burn.md
+++ b/.changeset/gentle-bears-burn.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/token-dictionary': patch
+'@pandacss/generator': patch
+---
+
+Fix panda spec not generating descriptions and other properties (deprecated, extensions) for semantic tokens set to a
+string value.

--- a/packages/generator/__tests__/spec-tokens.test.ts
+++ b/packages/generator/__tests__/spec-tokens.test.ts
@@ -324,7 +324,7 @@ describe('generateSemanticTokensSpec', () => {
           {
             "cssVar": "var(--colors-text)",
             "deprecated": undefined,
-            "description": undefined,
+            "description": "Text color that adapts to theme",
             "name": "text",
             "values": [
               {

--- a/packages/generator/__tests__/spec-tokens.test.ts
+++ b/packages/generator/__tests__/spec-tokens.test.ts
@@ -279,6 +279,14 @@ describe('generateSemanticTokensSpec', () => {
               value: '{colors.gray.900}',
               description: 'Text color that adapts to theme',
             },
+            typography: {
+              value: '{colors.gray.900}',
+              deprecated: true,
+            },
+            secondary: {
+              value: { base: '{colors.red}' },
+              description: 'Secondary color to contrast primary',
+            },
           },
           spacing: {
             container: { value: '1rem' },
@@ -330,6 +338,30 @@ describe('generateSemanticTokensSpec', () => {
               {
                 "condition": "base",
                 "value": "{colors.gray.900}",
+              },
+            ],
+          },
+          {
+            "cssVar": "var(--colors-typography)",
+            "deprecated": true,
+            "description": undefined,
+            "name": "typography",
+            "values": [
+              {
+                "condition": "base",
+                "value": "{colors.gray.900}",
+              },
+            ],
+          },
+          {
+            "cssVar": "var(--colors-secondary)",
+            "deprecated": undefined,
+            "description": "Secondary color to contrast primary",
+            "name": "secondary",
+            "values": [
+              {
+                "condition": "base",
+                "value": "{colors.red}",
               },
             ],
           },

--- a/packages/token-dictionary/src/dictionary.ts
+++ b/packages/token-dictionary/src/dictionary.ts
@@ -146,7 +146,7 @@ export class TokenDictionary {
       const name = this.formatTokenName(path)
 
       const normalizedToken =
-        isString(token.value) || isCompositeTokenValue(token.value) ? { value: { base: token.value } } : token
+        isString(token.value) || isCompositeTokenValue(token.value) ? { ...token, value: { base: token.value } } : token
 
       const { value, ...restData } = normalizedToken
 


### PR DESCRIPTION
## 📝 Description

Fixes an issue where extra properties, like `description` and `deprecated`, were not being generated with semantic tokens set to a string value.

## ⛳️ Current behavior (updates)

A semantic token with a `description` or `deprecated` property would not be included if the `value` was set to a string.
For example:
```
defineSemanticTokens.colors({
  primary: {
    value: "{colors.red400}",
    description: "Some description",
  },
});
```
generates a semantic-tokens.json that does not contain `description`:
```
{
  "type": "semantic-tokens",
  "data": [
    {
      "type": "colors",
      "values": [
        {
          "name": "primary",
          "values": [
            {
              "value": "{colors.red400}",
              "condition": "base"
            }
          ],
          "cssVar": "var(--Tight-colors-primary)"
        },
...
}
```

A semantic token with a `value` object containing `base` does not have this issue, and generates a semantic-tokens.json containing `description`:
```
defineSemanticTokens.colors({
  primary: {
    value: { base: "{colors.red400}" },
    description: "Some description",
  },
});
```
```
{
  "type": "semantic-tokens",
  "data": [
    {
      "type": "colors",
      "values": [
        {
          "name": "primary",
          "values": [
            {
              "value": "{colors.red400}",
              "condition": "base"
            }
          ],
          "description": "Some description",
          "cssVar": "var(--Tight-colors-primary)"
        },
```

This PR assumes that the intent is to include properties like `description` and `deprecated` are intended to be included in the process output, just like base color tokens.

## 🚀 New behavior

Output is now consistent between semantic tokens with string `values` and object `values`.
Both of these will now generate the same output, including `description`.

```
defineSemanticTokens.colors({
  primary: {
    value: "{colors.red400}",
    description: "Some description",
  },
});
```
```
defineSemanticTokens.colors({
  primary: {
    value: { base: "{colors.red400}" },
    description: "Some description",
  },
});
```
```
// output
{
  "type": "semantic-tokens",
  "data": [
    {
      "type": "colors",
      "values": [
        {
          "name": "primary",
          "values": [
            {
              "value": "{colors.red400}",
              "condition": "base"
            }
          ],
          "description": "Some description",
          "cssVar": "var(--Tight-colors-primary)"
        },
...
```

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
