### PR TITLE
fix(mcp): emit package declarations

### DIFF
--- a/.changeset/fix-mcp-types.md
+++ b/.changeset/fix-mcp-types.md
@@ -1,0 +1,5 @@
+---
+"@pandacss/mcp": patch
+---
+
+Emit declaration files for the MCP package so the published `types` and export-map type entries resolve.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,8 +20,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format=esm,cjs",
-    "build-fast": "tsup src/index.ts --format=esm,cjs",
+    "build": "tsup src/index.ts --format=esm,cjs --dts",
+    "build-fast": "tsup src/index.ts --format=esm,cjs --no-dts",
     "dev": "pnpm build-fast --watch"
   },
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- emit declaration files from the `@pandacss/mcp` build
- keep `build-fast` on the no-declaration path used by other packages
- add a patch changeset for the package

## Why

The published `@pandacss/mcp@1.11.3` manifest advertises `types: "dist/index.d.ts"` and export-map type entries, but the npm tarball only includes:

```text
dist/index.js
dist/index.mjs
```

As a result, TypeScript consumers cannot resolve declarations for the package.

## Published package reproduction

```sh
tmp="$(mktemp -d)"
cd "$tmp"
npm init -y >/dev/null
npm install @pandacss/mcp@1.11.3 typescript @types/node --ignore-scripts --no-audit --no-fund >/dev/null
printf '{"compilerOptions":{"target":"ES2022","module":"NodeNext","moduleResolution":"NodeNext","strict":true,"skipLibCheck":true,"noEmit":true,"types":["node"]},"include":["index.mts"]}\n' > tsconfig.json
printf "import * as m from '@pandacss/mcp';\nconst start: typeof m.startMcpServer = m.startMcpServer;\n" > index.mts
npm exec tsc -- --noEmit
```

Observed:

```text
error TS7016: Could not find a declaration file for module '@pandacss/mcp'.
```

## Validation

```sh
pnpm --filter @pandacss/mcp build
pnpm --dir packages/mcp pack --pack-destination /tmp/pandacss-mcp-fixed-pack --json
```

The packed tarball now includes:

```text
package/dist/index.js
package/dist/index.mjs
package/dist/index.d.ts
package/dist/index.d.mts
```

Clean packed-tarball TypeScript consumer check passes with `skipLibCheck: true`, which isolates this package's declaration resolution from unrelated declaration issues in transitive Panda packages:

```sh
npm install /tmp/pandacss-mcp-fixed-pack/pandacss-mcp-1.11.3.tgz typescript @types/node --ignore-scripts --no-audit --no-fund
npm exec tsc -- --noEmit
```

Result:

```text
typed import ok
```
