### PR TITLE
fix(node): skip writing unchanged artifacts in OutputEngine

### DIFF
--- a/.changeset/skip-unchanged-artifacts.md
+++ b/.changeset/skip-unchanged-artifacts.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/node': patch
+---
+
+Skip writing a generated artifact when its content is byte-identical to what is already on disk.
+
+`panda --watch` re-emits the full `styled-system` output on its initial build, and codegen re-runs on config changes. Rewriting unchanged files bumped their mtime and triggered needless dev-server reloads (e.g. a Vite full page reload or webpack recompile) for tools watching the output directory.

--- a/.changeset/skip-unchanged-artifacts.md
+++ b/.changeset/skip-unchanged-artifacts.md
@@ -4,4 +4,4 @@
 
 Skip writing a generated artifact when its content is byte-identical to what is already on disk.
 
-`panda --watch` re-emits the full `styled-system` output on its initial build, and codegen re-runs on config changes. Rewriting unchanged files bumped their mtime and triggered needless dev-server reloads (e.g. a Vite full page reload or webpack recompile) for tools watching the output directory.
+`panda --watch` re-emits the full `styled-system` output on its initial build, and codegen re-runs on config changes. Rewriting unchanged files bumped their mtime and triggered needless dev-server reloads (e.g. a Vite full page reload or webpack recompile) for tools watching the output directory. Watch-mode incremental CSS updates now route through the same write path.

--- a/packages/node/__tests__/output-engine.test.ts
+++ b/packages/node/__tests__/output-engine.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from 'vitest'
+import { OutputEngine } from '../src/output-engine'
+
+function createEngine(fs: {
+  readFileSync: ReturnType<typeof vi.fn>
+  writeFile: ReturnType<typeof vi.fn>
+  ensureDirSync: ReturnType<typeof vi.fn>
+}) {
+  return new OutputEngine({
+    paths: { root: ['styled-system'] },
+    runtime: {
+      fs: {
+        readFileSync: fs.readFileSync,
+        writeFile: fs.writeFile,
+        ensureDirSync: fs.ensureDirSync,
+      },
+      path: {
+        join: (...parts: string[]) => parts.join('/'),
+        dirname: (p: string) => p.split('/').slice(0, -1).join('/'),
+        resolve: (...parts: string[]) => parts.join('/'),
+        extname: (p: string) => p.slice(p.lastIndexOf('.')),
+        relative: (from: string, to: string) => to.replace(`${from}/`, ''),
+        isAbsolute: (p: string) => p.startsWith('/'),
+        sep: '/',
+        abs: (_cwd: string, p: string) => p,
+      },
+      cwd: () => '/project',
+      env: () => undefined,
+    },
+    hooks: {},
+  } as any)
+}
+
+describe('OutputEngine.write', () => {
+  test('writes when the file does not exist', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    const ensureDirSync = vi.fn()
+
+    const engine = createEngine({ readFileSync, writeFile, ensureDirSync })
+
+    await engine.write({
+      id: 'styles.css',
+      files: [{ file: 'styles.css', code: '.foo { color: red; }' }],
+    })
+
+    expect(writeFile).toHaveBeenCalledWith('styled-system/styles.css', '.foo { color: red; }')
+  })
+
+  test('skips the write when content is unchanged', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const readFileSync = vi.fn().mockReturnValue('.foo { color: red; }')
+    const ensureDirSync = vi.fn()
+
+    const engine = createEngine({ readFileSync, writeFile, ensureDirSync })
+
+    await engine.write({
+      id: 'styles.css',
+      files: [{ file: 'styles.css', code: '.foo { color: red; }' }],
+    })
+
+    expect(readFileSync).toHaveBeenCalledWith('styled-system/styles.css')
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  test('writes when content changed', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const readFileSync = vi.fn().mockReturnValue('.foo { color: red; }')
+    const ensureDirSync = vi.fn()
+
+    const engine = createEngine({ readFileSync, writeFile, ensureDirSync })
+
+    await engine.write({
+      id: 'styles.css',
+      files: [{ file: 'styles.css', code: '.foo { color: blue; }' }],
+    })
+
+    expect(writeFile).toHaveBeenCalledWith('styled-system/styles.css', '.foo { color: blue; }')
+  })
+})

--- a/packages/node/src/generate.ts
+++ b/packages/node/src/generate.ts
@@ -45,7 +45,6 @@ export async function generate(config: Config, configPath?: string) {
     )
 
     const bundleStyles = async (ctx: PandaContext, changedFilePath: string) => {
-      const outfile = ctx.runtime.path.join(...ctx.paths.root, 'styles.css')
       const parserResult = ctx.project.parseSourceFile(changedFilePath)
 
       if (parserResult) {
@@ -54,8 +53,7 @@ export async function generate(config: Config, configPath?: string) {
         ctx.appendLayerParams(sheet)
         ctx.appendBaselineCss(sheet)
         ctx.appendParserCss(sheet)
-        const css = ctx.getCss(sheet)
-        await ctx.runtime.fs.writeFile(outfile, css)
+        await ctx.writeCss(sheet)
         done()
       }
     }

--- a/packages/node/src/output-engine.ts
+++ b/packages/node/src/output-engine.ts
@@ -44,6 +44,17 @@ export class OutputEngine {
         const { file, code } = artifact
         const absPath = this.path.join(...dir, file)
 
+        // Skip the write when the generated artifact is byte-identical to what's
+        // already on disk. `panda --watch` re-emits the full output on its initial
+        // build (and codegen re-runs on config changes); rewriting unchanged files
+        // bumps their mtime and triggers needless dev-server reloads (e.g. a Vite
+        // full page reload / webpack recompile) for tools watching the output dir.
+        try {
+          if (this.fs.readFileSync(absPath) === code) return
+        } catch {
+          // file does not exist yet — fall through and write
+        }
+
         logger.debug('write:file', dir.slice(-1).concat(file).join('/'))
         return this.fs.writeFile(absPath, code)
       }),


### PR DESCRIPTION
## Problem

`OutputEngine.write` writes every generated artifact unconditionally:

```ts
return this.fs.writeFile(absPath, code)
```

`panda --watch` runs a full `generate()` on its initial build (before entering the watch loop), and codegen re-runs on config changes. When the output hasn't changed, these still **rewrite byte-identical files**, bumping their mtime. Build tools watch the *filesystem event*, not the content, so they react to these no-op writes:

- **Vite** fires a full page reload for the re-emitted `styled-system/*.mjs` (a reload "storm" right after `vite dev` boot) and an `(ssr) page reload` for the SSR importer of `styles.css`.
- **webpack** performs a redundant second compilation (see #3110).

## Fix

Skip the write when the artifact is byte-identical to what's already on disk, reusing the existing `Runtime['fs'].readFileSync` (utf8):

```ts
try {
  if (this.fs.readFileSync(absPath) === code) return
} catch {
  // file does not exist yet — fall through and write
}
```

`OutputEngine.write` is the single chokepoint for all artifact writes (codegen `.mjs`/`.d.ts`, `styles.css`, split CSS, config), so this covers them all. `ensureDirSync` still runs; first-write / `--clean` / changed-content all still write (a missing file throws → falls through to the write). Emitted output is unchanged — only redundant identical writes (and their mtime bumps) are skipped.

This is the standard "write-if-changed" pattern (TypeScript's internal `writeFileIfUpdated`, GraphQL Code Generator's unchanged-file skip, CMake `configure_file`, …) applied to Panda's artifact writer.

A changeset (`@pandacss/node: patch`) is included.

Refs #3110.
