### PR TITLE
fix(compiler): name object-map utility classes by the author key, not a token alias

### DIFF
--- a/.changeset/fix-classname-value-token-reverse-map.md
+++ b/.changeset/fix-classname-value-token-reverse-map.md
@@ -1,0 +1,11 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix cssgen naming a class by a token alias the runtime never emits, so the rule silently never matched.
+
+When a utility's `values` is an object map (e.g. preset-base `width`/`minHeight`, whose maps include `screen: '100vw'` / `screen: '100vh'`), the native engine reverse-mapped an authored *resolved value* back to its alias when naming the class: `css({ minHeight: '100vh' })` placed `min-h_100vh` on the element (the runtime hashes `propKey + withoutSpace(value)` verbatim, with no token dictionary) but cssgen wrote only `.min-h_screen`, so `min-height` never applied. Same for `width: '100vw'`, `maxWidth: '100vw'`, and the general object-map case `marginBottom: '0.5rem'` → element `mb_0.5rem`, rule `.mb_2`.
+
+The engine now keeps the author's value-map key on the atom and resolves it to CSS only at emit time, matching the runtime exactly (`min-h_100vh`, `w_100vw`, `mb_0.5rem`) — and matching legacy Panda, which named these by the literal too. Authoring the token *key* is unaffected (`css({ marginBottom: '2' })` → `.mb_2`), and `token()` calls keep their resolved-value class (they are evaluated before `css()`).
+
+Note: `compiler.atoms()` now reports the author's value-map key (e.g. `'sm'`, `'full'`) instead of the pre-resolved CSS — the resolved value is recovered when declarations are written.

--- a/crates/pandacss_project/tests/config.rs
+++ b/crates/pandacss_project/tests/config.rs
@@ -196,12 +196,16 @@ fn utility_values_normalize_aliases() {
     );
 
     assert_eq!(report.css_calls, 1);
+    // Atoms keep the author's value-map *key* (`sm`/`md`), not the resolved CSS.
+    // The runtime hashes the class name from this key (`s_sm`); resolution to
+    // `4px`/`8px` happens at emit time when declarations are written. Carrying
+    // the resolved value here would name a class the runtime never emits.
     assert_yaml_snapshot!(sorted_atoms(&project), @r#"
     - prop: spacing
-      value: 4px
+      value: sm
       conditions: []
     - prop: spacing
-      value: 8px
+      value: md
       conditions:
         - _hover
     "#);

--- a/crates/pandacss_stylesheet/tests/atomic.rs
+++ b/crates/pandacss_stylesheet/tests/atomic.rs
@@ -82,6 +82,44 @@ fn object_map_values_name_classes_by_alias_key() {
 }
 
 #[test]
+fn object_map_values_name_classes_by_literal_value() {
+    // When the author writes the *resolved value* (not the token key), the
+    // class name must mirror that literal — matching the runtime `css()`, which
+    // hashes `propKey + withoutSpace(value)` with no value->alias reverse map.
+    // Legacy named `css({ marginBottom: '0.5rem' })` `.mb_0\.5rem`; reverse-
+    // mapping it back to the `2` alias here produced `.mb_2`, a class the
+    // runtime never emits, so the rule silently never matched.
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": {
+            "marginBottom": {
+                "className": "mb",
+                "values": { "2": "0.5rem", "4": "1rem" }
+            },
+            "minHeight": {
+                "className": "min-h",
+                "values": { "screen": "100vh" }
+            }
+        }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ marginBottom: '0.5rem', minHeight: '100vh' })",
+        &[StylesheetLayer::Utilities],
+    );
+    assert_snapshot!(css, @r"
+@layer utilities {
+  .mb_0\.5rem {
+    margin-bottom: 0.5rem;
+  }
+  .min-h_100vh {
+    min-height: 100vh;
+  }
+}
+");
+}
+
+#[test]
 fn hashes_atomic_class_names_with_prefix_conditions_and_important() {
     let config = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },

--- a/crates/pandacss_utility/src/lib.rs
+++ b/crates/pandacss_utility/src/lib.rs
@@ -339,28 +339,19 @@ impl Utility {
         Some(self.transform_str(prop, &value))
     }
 
-    /// Value alias for class naming (author key, not resolved CSS).
+    /// Class-name segment for a value (the author key, never the resolved CSS).
+    ///
+    /// The runtime `css()` hashes `propKey + withoutSpace(value)` verbatim — it
+    /// has no token dictionary and never reverse-maps a value to a token alias.
+    /// The class name placed on the element is whatever the author wrote, so
+    /// cssgen must mirror that exactly or it emits a rule the runtime's class
+    /// never matches (e.g. `css({ minHeight: '100vh' })` → element `min-h_100vh`
+    /// but cssgen reverse-mapped `100vh` to the `screen` alias and wrote only
+    /// `.min-h_screen`, leaving the style dead). Legacy Panda named these by the
+    /// literal too (`.mb_0\.5rem`, `.w_100vw`), so this matches v1 as well.
     #[must_use]
-    pub fn class_name_value(&self, prop: &str, value: &str) -> String {
-        let key = self.resolve_shorthand(prop);
-        let normalized = without_space(value);
-        let Some(config) = self.properties.get(key) else {
-            return normalized;
-        };
-
-        if config.values.contains_key(normalized.as_str()) {
-            return normalized;
-        }
-
-        if !config.values.is_empty() {
-            for (alias, literal) in &config.values {
-                if literal_matches_class_input(literal, &normalized) {
-                    return without_space(alias);
-                }
-            }
-        }
-
-        normalized
+    pub fn class_name_value(&self, _prop: &str, value: &str) -> String {
+        without_space(value)
     }
 
     #[must_use]
@@ -424,51 +415,29 @@ impl Utility {
         self.normalize_property_value_cow(prop, value).into_owned()
     }
 
-    /// Borrow-preserving variant — returns `Cow::Borrowed(value)` when no
-    /// alias maps, avoiding the unconditional clone of the input Literal.
-    /// Hot path: the fused encoder walker calls this per leaf.
+    /// Leaf normalization for the encoder walker.
+    ///
+    /// This intentionally leaves the author's value-map *key* on the atom and
+    /// never substitutes its resolved CSS here. The runtime `css()` hashes the
+    /// class name from the literal the author wrote (`s_sm`, `mb_2`) with no
+    /// value-map lookup, so cssgen must keep that same key to name a matching
+    /// rule — substituting `sm`→`4px` / `2`→`0.5rem` onto the atom produced a
+    /// class (`.s_4px`, `.mb_0\.5rem`) the runtime never emits, leaving the
+    /// style dead. The resolved CSS is recovered downstream by
+    /// [`Self::raw_property_value`] / [`Self::default_style`] at emit time, which
+    /// look the key up in `values` when writing declarations. (`token()` calls
+    /// are already resolved to their CSS string at extraction, so they reach the
+    /// emitter pre-resolved and keep their value-named class — see the emitter's
+    /// `class_input`.)
+    ///
+    /// Always borrows; kept as `_cow` for call-site/source compatibility.
     #[must_use]
     pub fn normalize_property_value_cow<'a>(
         &self,
-        prop: &str,
+        _prop: &str,
         value: &'a Literal,
     ) -> Cow<'a, Literal> {
-        let Some(config) = self.properties.get(prop) else {
-            return Cow::Borrowed(value);
-        };
-        // Props with a JS transform need the original alias as `args.raw`
-        // (legacy passes the alias, resolving the value separately). Keep the
-        // alias on the atom; the transform/emit path resolves it.
-        if config.transform_callback_id.is_some() {
-            return Cow::Borrowed(value);
-        }
-        let mapped = match value {
-            Literal::String(value) | Literal::Token { value, .. } => {
-                config.values.get(value.as_str())
-            }
-            Literal::Bool(true) => config.values.get("true"),
-            Literal::Bool(false) => config.values.get("false"),
-            Literal::Number(value) => {
-                let key = number_to_js_string(*value);
-                config.values.get(key.as_str())
-            }
-            Literal::Null | Literal::Object(_) | Literal::Array(_) | Literal::Conditional(_) => {
-                None
-            }
-        };
-        // Only substitute scalar → scalar mappings here. Object/Array/Conditional
-        // mappings (e.g. composition utilities) keep the original lookup key on
-        // the atom; the substitution happens at emit time in `default_style`.
-        match mapped {
-            Some(
-                scalar @ (Literal::String(_)
-                | Literal::Token { .. }
-                | Literal::Number(_)
-                | Literal::Bool(_)
-                | Literal::Null),
-            ) => Cow::Owned(scalar.clone()),
-            _ => Cow::Borrowed(value),
-        }
+        Cow::Borrowed(value)
     }
 
     fn raw_property_value(&self, prop: &str, value: &str) -> Literal {
@@ -1012,15 +981,6 @@ fn join_class_name(prop: &str, separator: &str, value: &str) -> String {
 
 fn without_space(value: &str) -> String {
     value.replace(' ', "_")
-}
-
-fn literal_matches_class_input(literal: &Literal, value: &str) -> bool {
-    match literal {
-        Literal::String(s) | Literal::Token { value: s, .. } => without_space(s) == value,
-        Literal::Number(n) => number_to_js_string(*n) == value,
-        Literal::Bool(b) => b.to_string() == value,
-        Literal::Null | Literal::Object(_) | Literal::Array(_) | Literal::Conditional(_) => false,
-    }
 }
 
 #[must_use]

--- a/crates/pandacss_utility/tests/utility.rs
+++ b/crates/pandacss_utility/tests/utility.rs
@@ -74,7 +74,7 @@ fn callback_transform_refs_are_exposed() {
 }
 
 #[test]
-fn utility_values_normalize_aliases_to_raw_values() {
+fn utility_values_resolve_shorthands_but_keep_the_value_map_key() {
     let utility = Utility::from_config(&utility_config(json!({
         "spacing": {
             "shorthand": "s",
@@ -89,14 +89,18 @@ fn utility_values_normalize_aliases_to_raw_values() {
         ("s".into(), Literal::String("md".into())),
     ]);
 
+    // The shorthand `s` resolves to `spacing` (so both entries collapse onto one
+    // key, last wins). The value-map key is NOT resolved to its CSS here: the
+    // runtime names the class from the author key (`s_md`), and the emit path
+    // resolves `md` -> `8px` when writing the declaration.
     assert_eq!(
         utility.normalize_style_object(&style),
-        Literal::Object(vec![("spacing".into(), Literal::String("8px".into()))]),
+        Literal::Object(vec![("spacing".into(), Literal::String("md".into()))]),
     );
 }
 
 #[test]
-fn utility_values_normalize_nested_conditions() {
+fn utility_values_normalize_nested_conditions_keep_the_value_map_key() {
     let utility = Utility::from_config(&utility_config(json!({
         "spacing": {
             "values": {
@@ -109,11 +113,14 @@ fn utility_values_normalize_nested_conditions() {
         Literal::Object(vec![("spacing".into(), Literal::String("sm".into()))]),
     )]);
 
+    // Nested conditions normalize structurally, but the value-map key `sm` is
+    // preserved (not resolved to `4px`) so cssgen's class name matches the
+    // runtime's. Resolution happens at emit time.
     assert_eq!(
         utility.normalize_style_object(&style),
         Literal::Object(vec![(
             "_hover".into(),
-            Literal::Object(vec![("spacing".into(), Literal::String("4px".into()))]),
+            Literal::Object(vec![("spacing".into(), Literal::String("sm".into()))]),
         )]),
     );
 }
@@ -1121,7 +1128,7 @@ fn resolve_values_value_passes_through_when_no_category_matches() {
 }
 
 #[test]
-fn class_name_value_uses_object_map_alias_not_resolved_css() {
+fn class_name_value_uses_the_authored_literal_not_a_token_alias() {
     let utility = Utility::from_config(&utility_config(json!({
         "marginBottom": {
             "className": "mb",
@@ -1129,11 +1136,16 @@ fn class_name_value_uses_object_map_alias_not_resolved_css() {
         }
     })));
 
+    // Authoring the token key keeps the key.
     assert_eq!(utility.class_name_value("marginBottom", "2"), "2");
-    assert_eq!(utility.class_name_value("marginBottom", "0.5rem"), "2");
+    // Authoring the resolved value keeps that value — it is NOT reverse-mapped
+    // back to the `2` alias. The runtime `css()` hashes the literal the author
+    // wrote, so cssgen must agree or it emits `.mb_2` for an element the runtime
+    // labelled `mb_0.5rem`. Legacy Panda named this `.mb_0\.5rem` too.
+    assert_eq!(utility.class_name_value("marginBottom", "0.5rem"), "0.5rem");
     assert_snapshot!(
         utility.transform_str("marginBottom", "0.5rem").class_name,
-        @"mb_2"
+        @"mb_0.5rem"
     );
 }
 

--- a/packages/compiler/__tests__/callbacks.test.ts
+++ b/packages/compiler/__tests__/callbacks.test.ts
@@ -358,16 +358,19 @@ describe('Compiler callbacks', () => {
        css({ space: '4', _hover: { space: 'compact' } })`,
     )
 
+    // Atoms carry the author's value-map key (`4`, `compact`), not the resolved
+    // CSS — the class name is hashed from this key to match the runtime, and the
+    // declaration value is resolved at emit time.
     expect(compiler.atoms()).toMatchInlineSnapshot(`
       [
         {
           "prop": "space",
-          "value": "var(--spacing-4)",
+          "value": 4,
           "conditions": [],
         },
         {
           "prop": "space",
-          "value": "2px",
+          "value": "compact",
           "conditions": [
             "_hover",
           ],
@@ -423,16 +426,19 @@ describe('Compiler callbacks', () => {
        css({ inset: 'full' })`,
     )
 
+    // Atoms carry the author's value-map key (`2`, `full`), not the resolved CSS
+    // (`var(--spacing-2)`, `100%`) — class names hash from the key to match the
+    // runtime; declaration values are resolved at emit time.
     expect(compiler.atoms()).toMatchInlineSnapshot(`
       [
         {
           "prop": "inset",
-          "value": "100%",
+          "value": 2,
           "conditions": [],
         },
         {
           "prop": "inset",
-          "value": "var(--spacing-2)",
+          "value": "full",
           "conditions": [],
         },
       ]


### PR DESCRIPTION
## Problem

The native (Rust) engine and the runtime `css()` disagree on the class **name** for object-map utility values, so cssgen writes a rule the runtime never matches and the style silently does nothing.

```ts
css({ minHeight: '100vh' })
// element gets class:  min-h_100vh   (runtime)
// stylesheet contains: .min-h_screen  (cssgen)  ← no .min-h_100vh rule → min-height never applies
```

This affects every utility whose `values` is an object map that maps an alias to a literal also writable directly — in `@pandacss/preset-base` that's `width`/`minWidth`/`maxWidth` and `height`/`minHeight`/`maxHeight` (their value maps include `screen: '100vw'` / `screen: '100vh'`), plus the general case:

| Authored | Element class (runtime) | cssgen rule (before) | Match |
| --- | --- | --- | --- |
| `minHeight: '100vh'` | `min-h_100vh` | `.min-h_screen` | ❌ |
| `width: '100vw'` | `w_100vw` | `.w_screen` | ❌ |
| `maxWidth: '100vw'` | `max-w_100vw` | `.max-w_screen` | ❌ |
| `marginBottom: '0.5rem'`¹ | `mb_0.5rem` | `.mb_2` | ❌ |
| `marginBottom: '2'` (the key) | `mb_2` | `.mb_2` | ✅ |
| `width: '100%'` | `w_100%` | `.w_100%` | ✅ ² |

¹ with `marginBottom.values = { '2': '0.5rem' }` &nbsp;&nbsp; ² only "worked" by luck — `full` resolves to `var(--sizes-full)`, not the literal `100%`, so it didn't match the reverse-map scan.

## Root cause

The runtime hashes the class name as `propKey + withoutSpace(value)` **verbatim** — it has no token dictionary and never reverse-maps. The native engine, however, did two things that lost the author's literal:

1. The encoder's `normalize_property_value_cow` substituted the **resolved CSS** onto the atom (`'2'` → `'0.5rem'`, `'sm'` → `'4px'`).
2. To compensate, `class_name_value` then scanned `values` and reverse-mapped a resolved value **back** to its alias when naming the class.

Step 2 was lossy and order-dependent: it correctly restored `mb_2` for `marginBottom: '0.5rem'`, but for `minHeight: '100vh'` it reverse-mapped the *authored* literal `100vh` to the `screen` alias, producing `.min-h_screen` for an element labelled `min-h_100vh`.

## Fix

Keep the author's value-map **key** on the atom and resolve it to CSS only at emit time (`raw_property_value` / `default_style` already look the key up in `values` when writing declarations). The class name is then the literal the author wrote — matching the runtime, and matching **legacy Panda**, which named these by the literal too (verified against `@pandacss/core@1.11.3`: `Utility.transform` → `getOrCreateClassName(key, withoutSpace(value))`, no reverse map).

- `class_name_value` no longer scans `values` (drops the dead `literal_matches_class_input` helper).
- `normalize_property_value_cow` no longer substitutes scalar value-map entries onto the atom.
- Authoring the token *key* is unchanged (`css({ marginBottom: '2' })` → `.mb_2`).
- `token()` calls are unaffected — they are evaluated to their CSS string before `css()` sees them, so both the runtime and cssgen name them by the resolved value (`c_oklch(…)`).

## Before / after (real `@pandacss/preset-base`, via `sandbox/codegen`)

```css
/* before */            /* after */
.min-h_screen { … }     .min-h_100vh { min-height: 100vh }
.w_screen { … }         .w_100vw, .w_screen { width: 100vw }   /* both classes now have a rule */
.max-w_screen { … }     .max-w_100vw { max-width: 100vw }
```

## Behavior note

`compiler.atoms()` (a tooling/introspection view) now reports the author's value-map key (`'sm'`, `'full'`, `2`) instead of the pre-resolved CSS. The resolved value is still emitted in declarations; only the introspection surface changed. Two `@pandacss/compiler` snapshots are updated accordingly.

## Tests

- New stylesheet repro `object_map_values_name_classes_by_literal_value` (asserts cssgen names by the authored literal for `marginBottom: '0.5rem'` and `minHeight: '100vh'`).
- Updated the unit/integration snapshots that asserted the old reverse-mapping / pre-resolution.
- `cargo nextest run --workspace` → **1263 passed**; `@pandacss/compiler` Vitest → **151 passed**; `sandbox/codegen` (react) → **89 passed**. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean on the touched crates.

Refs the class-name divergence discussed in #3599.
