### PR TITLE
fix(compiler): mark important class names with a trailing `!` in the runtime

### DIFF
--- a/.changeset/fix-runtime-important-classname.md
+++ b/.changeset/fix-runtime-important-classname.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix the runtime `css()` naming `!important` classes differently from cssgen, so the rule never matched.
+
+`css({ padding: '0 !important' })` put `p_0_!important` on the element — the runtime hashed the whole string (`withoutSpace('0 !important')`) — but cssgen wrote `.p_0\!` (it strips `!important` and marks the class with a trailing `!`). The two never matched, so the `!important` declaration silently never applied. Same for `zIndex: '1002 !important'`, `whiteSpace: 'nowrap !important'`, `color: 'red.500 !important'`, etc.
+
+The generated runtime now mirrors legacy Panda (and the native emitter): it detects `!important`, strips it before hashing the value, and appends a trailing `!` to the final class — `p_0!`, `z_1002!`, `c_red.500!` — exactly the class cssgen emits (`.p_0\!`). Adds `isImportant` / `withoutImportant` runtime helpers (matching `@pandacss/shared`'s `/\s*!(important)?/i`) and wires them into `createCssRuntime`'s `serializeCss`, so both `css({})` and `css\`\`` are fixed in one place.

--- a/crates/pandacss_codegen/src/artifacts/helpers/css.rs
+++ b/crates/pandacss_codegen/src/artifacts/helpers/css.rs
@@ -71,10 +71,13 @@ pub(super) fn create_css_runtime() -> Item {
               const set = new Set<string>()
               walkObject(obj, (value: any, paths: string[]) => {
                 if (value == null) return
+                const important = isImportant(value)
                 const [prop, ...all] = c.shift(paths)
                 const cond = filterBaseConditions(all)
-                const res = u.transform(prop, withoutSpace(value))
-                set.add(toClass(cond, res.className))
+                const res = u.transform(prop, withoutSpace(withoutImportant(value)))
+                let name = toClass(cond, res.className)
+                if (important) name += "!"
+                set.add(name)
               })
               let out = ""
               for (const name of set) out += out ? " " + name : name

--- a/crates/pandacss_codegen/src/artifacts/helpers/misc.rs
+++ b/crates/pandacss_codegen/src/artifacts/helpers/misc.rs
@@ -133,6 +133,29 @@ pub(super) fn without_space() -> Item {
     )
 }
 
+pub(super) fn is_important() -> Item {
+    helper_function(
+        "isImportant",
+        vec![Param::typed("value", TsType::Ref("unknown".into()))],
+        TsType::Bool,
+        r#"return typeof value === "string" ? /\s*!(important)?/i.test(value) : false"#,
+        [],
+    )
+}
+
+pub(super) fn without_important() -> Item {
+    helper_function(
+        "withoutImportant",
+        vec![Param::typed("value", TsType::Ref("T".into()))],
+        TsType::Ref("T".into()),
+        indoc! {r#"
+            return (typeof value === "string" ? value.replace(/\s*!(important)?/i, "").trim() : value) as T
+        "#}
+        .trim(),
+        ["T extends string | number | boolean"],
+    )
+}
+
 pub(super) fn normalize_html_props() -> Item {
     Item::runtime(ItemNode::RawStmt(
         indoc! {r"

--- a/crates/pandacss_codegen/src/artifacts/helpers/mod.rs
+++ b/crates/pandacss_codegen/src/artifacts/helpers/mod.rs
@@ -42,6 +42,8 @@ pub fn module() -> Module {
         .with_item(misc::normalize_html_props_types())
         .with_item(misc::uniq())
         .with_item(misc::without_space())
+        .with_item(misc::is_important())
+        .with_item(misc::without_important())
 }
 
 #[must_use]

--- a/crates/pandacss_codegen/tests/helpers_artifact.rs
+++ b/crates/pandacss_codegen/tests/helpers_artifact.rs
@@ -682,10 +682,13 @@ fn emits_ts_source() {
         const set = new Set<string>()
         walkObject(obj, (value: any, paths: string[]) => {
           if (value == null) return
+          const important = isImportant(value)
           const [prop, ...all] = c.shift(paths)
           const cond = filterBaseConditions(all)
-          const res = u.transform(prop, withoutSpace(value))
-          set.add(toClass(cond, res.className))
+          const res = u.transform(prop, withoutSpace(withoutImportant(value)))
+          let name = toClass(cond, res.className)
+          if (important) name += "!"
+          set.add(name)
         })
         let out = ""
         for (const name of set) out += out ? " " + name : name
@@ -947,10 +950,13 @@ fn emits_js_runtime() {
         const set = new Set()
         walkObject(obj, (value, paths) => {
           if (value == null) return
+          const important = isImportant(value)
           const [prop, ...all] = c.shift(paths)
           const cond = filterBaseConditions(all)
-          const res = u.transform(prop, withoutSpace(value))
-          set.add(toClass(cond, res.className))
+          const res = u.transform(prop, withoutSpace(withoutImportant(value)))
+          let name = toClass(cond, res.className)
+          if (important) name += "!"
+          set.add(name)
         })
         let out = ""
         for (const name of set) out += out ? " " + name : name

--- a/sandbox/codegen/__tests__/css.test.ts
+++ b/sandbox/codegen/__tests__/css.test.ts
@@ -122,6 +122,22 @@ describe('css', () => {
 
     expect(className).toMatchInlineSnapshot(`"fs_12px bg-c_red.600"`)
   })
+
+  test('important value', () => {
+    // The runtime must strip `!important` before naming, then mark the class
+    // with a trailing `!` — matching the cssgen rule (`.p_0\!`). Hashing the raw
+    // string (`p_0_!important`) names a class cssgen never writes, so the
+    // `!important` declaration silently never applies.
+    const className = css({ padding: '0 !important' })
+
+    expect(className).toMatchInlineSnapshot('"p_0!"')
+  })
+
+  test('important value with token and condition', () => {
+    const className = css({ zIndex: '1002 !important', _hover: { color: 'red.500 !important' } })
+
+    expect(className).toMatchInlineSnapshot('"z_1002! hover:c_red.500!"')
+  })
 })
 
 describe('css.raw', () => {


### PR DESCRIPTION
## Problem

The runtime `css()` and the native cssgen disagree on the class **name** for `!important` values, so cssgen writes a rule the runtime never matches and the `!important` style silently does nothing.

```ts
css({ padding: '0 !important' })
// element gets class:  p_0_!important   (runtime — hashes the whole string)
// stylesheet contains: .p_0\!           (cssgen — strips !important, marks with `!`)
// → no .p_0_\!important rule → padding never applies
```

This affects every `!important` value, e.g. `zIndex: '1002 !important'` (`z_1002_!important` vs `.z_1002\!`), `whiteSpace: 'nowrap !important'`, `color: 'var(--x) !important'`, etc.

## Root cause

The native emitter (cssgen) handles `!important` the way legacy Panda always has: it strips the `!important` keyword from the value, names the class from the clean value, and appends a trailing `!` marker (`.p_0\!`, escaped). The generated **runtime**, however, dropped that handling during the v2 rewrite — `createCssRuntime`'s `serializeCss` just does `u.transform(prop, withoutSpace(value))`, hashing the raw string including ` !important`.

Legacy `@pandacss/shared`'s `createCss` (verified against `1.11.3`):

```js
const important = isImportant(value)
const transformed = utility.transform(prop, withoutImportant(sanitize(value)))
let className = hashFn(conditions, transformed.className)
if (important) className = `${className}!`
```

The v2 runtime lost the `isImportant` / `withoutImportant` / trailing-`!` steps.

## Fix

Restore the legacy handling in the one shared place — `createCssRuntime`'s `serializeCss` (used by both `css({})` and the `css\`\`` template variant):

```js
const important = isImportant(value)
const res = u.transform(prop, withoutSpace(withoutImportant(value)))
let name = toClass(cond, res.className)
if (important) name += "!"
```

Adds `isImportant` / `withoutImportant` runtime helpers using the same `/\s*!(important)?/i` regex as `@pandacss/shared` and as the native `pandacss_shared::important` splitter, so runtime and cssgen agree on the marker placement (after hashing/prefix, matching the emitter's `Target::Class` important suffix).

## Before / after

| Authored | Element class (before) | Element class (after) | cssgen rule |
| --- | --- | --- | --- |
| `padding: '0 !important'` | `p_0_!important` | `p_0!` | `.p_0\!` ✅ |
| `zIndex: '1002 !important'` | `z_1002_!important` | `z_1002!` | `.z_1002\!` ✅ |
| `whiteSpace: 'nowrap !important'` | `white-space_nowrap_!important` | `white-space_nowrap!` | `.white-space_nowrap\!` ✅ |
| `color: 'red.500 !important'` | `c_red.500_!important` | `c_red.500!` | `.c_red\.500\!` ✅ |

(Verified end-to-end against real `@pandacss/preset-base` via `sandbox/codegen`: runtime `css()` output now equals the cssgen selector for every case.)

## Tests

- New `sandbox/codegen/__tests__/css.test.ts` cases: `css({ padding: '0 !important' })` → `"p_0!"`, and `css({ zIndex: '1002 !important', _hover: { color: 'red.500 !important' } })` → `"z_1002! hover:c_red.500!"`.
- Updated the two `helpers_artifact` snapshots for the new `serializeCss` body.
- `cargo nextest run --workspace` → **1262 passed**; `@pandacss/compiler` Vitest → **151 passed**; `sandbox/codegen` (react) → **91 passed**. `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

Refs the class-name divergence discussed in #3599.
