### PR TITLE
fix(compiler): keep the leading dash on vendor-prefixed property class names

### DIFF
--- a/.changeset/fix-classname-vendor-prefix.md
+++ b/.changeset/fix-classname-vendor-prefix.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix cssgen dropping the leading dash on vendor-prefixed property names, so the class (and the CSS property) never matched the runtime.
+
+A vendor-prefixed property is authored PascalCase — `WebkitBackgroundClip`, `WebkitTextFillColor`, `MozAppearance`. The runtime `css()` hyphenates these with `property.replace(/[A-Z]/g, "-$&").toLowerCase()`, which prepends a dash to *every* uppercase including the first → `-webkit-background-clip`, and names the class `-webkit-background-clip_text`. The native engine's `hyphenate_property` suppressed the dash on the first letter (`index > 0`), producing `webkit-background-clip` — so cssgen wrote `.webkit-background-clip_text { webkit-background-clip: text }`, a class the runtime never emits *and* an invalid (de-prefixed) CSS property. The gradient-text pattern (`WebkitBackgroundClip: 'text'` + `WebkitTextFillColor: 'transparent'`) silently did nothing.
+
+`hyphenate_property` now prepends the dash to every uppercase letter (matching the runtime and legacy Panda's `wordRegex`/`/[A-Z]/g`), so `WebkitBackgroundClip` → `-webkit-background-clip` and `MozAppearance` → `-moz-appearance`. camelCase props are unchanged (`backgroundColor` → `background-color`), and the `msTransform` → `-ms-transform` special case is preserved.

--- a/crates/pandacss_stylesheet/tests/atomic.rs
+++ b/crates/pandacss_stylesheet/tests/atomic.rs
@@ -30,6 +30,44 @@ fn emits_dynamic_atomic_css() {
 }
 
 #[test]
+fn vendor_prefixed_property_keeps_leading_dash_in_class_name() {
+    // A vendor-prefixed property (PascalCase, capital first letter) hyphenates
+    // to a leading-dash CSS property — `WebkitBackgroundClip` ->
+    // `-webkit-background-clip`. The runtime `css()` (and legacy Panda) name the
+    // class from that leading-dash form (`-webkit-background-clip_text`), so
+    // cssgen must keep the dash too. Dropping it named `.webkit-background-clip_text`,
+    // a class the runtime never emits, so the declaration silently never applied
+    // (e.g. the gradient-text `WebkitBackgroundClip:'text'` +
+    // `WebkitTextFillColor:'transparent'` recipe).
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": {
+            "WebkitBackgroundClip": {},
+            "WebkitTextFillColor": {},
+            "MozAppearance": {}
+        }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent', MozAppearance: 'none' })",
+        &[StylesheetLayer::Utilities],
+    );
+    assert_snapshot!(css, @r"
+@layer utilities {
+  .\-moz-appearance_none {
+    -moz-appearance: none;
+  }
+  .\-webkit-background-clip_text {
+    -webkit-background-clip: text;
+  }
+  .\-webkit-text-fill-color_transparent {
+    -webkit-text-fill-color: transparent;
+  }
+}
+");
+}
+
+#[test]
 fn emits_dynamic_atomic_css_with_configured_separator() {
     let config = config(serde_json::json!({
         "separator": "__",

--- a/crates/pandacss_utility/src/lib.rs
+++ b/crates/pandacss_utility/src/lib.rs
@@ -1029,20 +1029,27 @@ pub fn hyphenate_property(property: &str) -> String {
         return property.to_owned();
     }
 
+    // Mirror the runtime/legacy `property.replace(/[A-Z]/g, "-$&").toLowerCase()`:
+    // a dash precedes EVERY uppercase letter, including the first. A leading
+    // uppercase only occurs for vendor-prefixed PascalCase props
+    // (`WebkitBackgroundClip` -> `-webkit-background-clip`, `MozAppearance` ->
+    // `-moz-appearance`); camelCase props start lowercase so they get no leading
+    // dash (`backgroundColor` -> `background-color`). The runtime `css()` names
+    // the class from this leading-dash form, so cssgen must produce the same or
+    // it emits a class — and a CSS property — the runtime never matches.
     let mut out = String::with_capacity(property.len() + 4);
-    for (index, ch) in property.char_indices() {
+    for ch in property.chars() {
         if ch.is_ascii_uppercase() {
-            if index > 0 {
-                out.push('-');
-            }
+            out.push('-');
             out.push(ch.to_ascii_lowercase());
         } else {
             out.push(ch);
         }
     }
 
-    // `msTransform` hyphenates to `ms-transform`, but the vendor prefix needs
-    // a leading dash: `-ms-transform`.
+    // `msTransform` starts lowercase, so the loop yields `ms-transform`; the
+    // vendor prefix needs a leading dash: `-ms-transform` (matches the legacy
+    // `.replace(/^ms-/, "-ms-")`).
     if let Some(rest) = out.strip_prefix("ms-") {
         let mut prefixed = String::with_capacity(out.len() + 1);
         prefixed.push_str("-ms-");


### PR DESCRIPTION
## Problem

The native (Rust) engine and the runtime `css()` disagree on the class **name** — and the emitted CSS **property** — for vendor-prefixed properties, so cssgen writes a rule the runtime never matches and the style silently does nothing.

```ts
css({ WebkitBackgroundClip: 'text' })
// element gets class:  -webkit-background-clip_text   (runtime — leading dash)
// stylesheet contains: .webkit-background-clip_text { webkit-background-clip: text }  (cssgen — NO dash)
// → no .-webkit-background-clip_text rule, and the property itself is de-prefixed → nothing applies
```

Also affects `WebkitTextFillColor`, `MozAppearance`, `MozBackgroundClip`, etc. Real-world impact: the **gradient-text** pattern (`WebkitBackgroundClip: 'text'` + `WebkitTextFillColor: 'transparent'`) renders unstyled.

## Root cause

The runtime hyphenates a property with `property.replace(/[A-Z]/g, "-$&").toLowerCase()` — a dash precedes **every** uppercase letter, including the first. A leading uppercase only occurs for vendor-prefixed PascalCase props, so they get a leading dash (`WebkitBackgroundClip` → `-webkit-background-clip`); camelCase props start lowercase and don't (`backgroundColor` → `background-color`).

The native `hyphenate_property` suppressed the dash on the first letter with an `if index > 0` guard, so vendor-prefixed props lost the leading dash. That broke the class name **and** the emitted CSS property (`webkit-background-clip` is not a real property).

Verified against legacy Panda `@pandacss/shared@1.11.3` — its `hypenateProperty` uses `wordRegex = /([A-Z])/g` → `.replace(wordRegex, "-$1")`, i.e. it keeps the leading dash too (`-webkit-background-clip`, `-moz-appearance`, `-ms-transform`). So both the runtime and legacy keep the dash; only the v2 cssgen dropped it.

## Fix

`hyphenate_property` now prepends the dash to every uppercase letter (matching the runtime / legacy regex). camelCase props are unaffected (`backgroundColor` → `background-color`), and the `msTransform` → `-ms-transform` special case (the prop starts lowercase `m`) is preserved.

## Before / after (real `@pandacss/preset-base`, via `sandbox/codegen`)

```css
/* before */                              /* after */
.webkit-background-clip_text {            .\-webkit-background-clip_text {
  webkit-background-clip: text;             -webkit-background-clip: text;
}                                         }
```

Runtime `css({ WebkitBackgroundClip: 'text' })` → `-webkit-background-clip_text` now has a matching cssgen rule. `WebkitTextFillColor` (which has an explicit `className: 'wktf-c'` in preset-base) is unaffected — it never used hyphenation — and `backgroundColor` → `.bg-c_red.500` confirms no regression to camelCase props.

## Tests

- New stylesheet repro `vendor_prefixed_property_keeps_leading_dash_in_class_name` (asserts `WebkitBackgroundClip`/`WebkitTextFillColor`/`MozAppearance` keep the leading dash in both the class name and the property).
- `cargo nextest run --workspace` → **1263 passed** (no regression — no existing test relied on the dropped dash). `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

Third class-name divergence in the family of #3601 / #3602; refs #3599.
