### PR TITLE
feat(compiler): design-system manifest value + engine gen/load

### DIFF
--- a/.changeset/design-system-manifest.md
+++ b/.changeset/design-system-manifest.md
@@ -4,7 +4,9 @@
 '@pandacss/compiler-shared': patch
 ---
 
-Add the `compiler.designSystem` namespace — `create` + `validate` for a design
-system's `panda.lib.json` manifest. The manifest records a library's preset,
-build info, import paths, and parent design system so a consumer adopts it with
-one `designSystem` field.
+Add the `compiler.designSystem` namespace — `create`, `validate`, and `load` for
+a design system's `panda.lib.json` manifest. The manifest records a library's
+preset, build info, import paths, and parent design system so a consumer adopts
+it with one `designSystem` field. `load` is the consumer side: it validates the
+manifest and hydrates the library's pre-extracted styles, tree-shaken to the
+consumer's imports.

--- a/.changeset/design-system-manifest.md
+++ b/.changeset/design-system-manifest.md
@@ -4,9 +4,13 @@
 '@pandacss/compiler-shared': patch
 ---
 
-Add the `compiler.designSystem` namespace — `create`, `validate`, and `load` for
-a design system's `panda.lib.json` manifest. The manifest records a library's
-preset, build info, import paths, and parent design system so a consumer adopts
-it with one `designSystem` field. `load` is the consumer side: it validates the
-manifest and hydrates the library's pre-extracted styles, tree-shaken to the
-consumer's imports.
+Add the `compiler.designSystem` namespace — `create`, `validate`, `load`, and
+`resolveChain` for a design system's `panda.lib.json` manifest. The manifest
+records a library's preset, build info, import paths, and parent design system so
+a consumer adopts it with one `designSystem` field.
+
+- `create` / `validate` — produce and schema-check a manifest.
+- `load` — the consumer side: validate, then hydrate the library's pre-extracted
+  styles, tree-shaken to the consumer's imports.
+- `resolveChain` — the composition case: order a chain of parent design systems
+  root-first, deduping shared ancestors and reporting cycles.

--- a/.changeset/design-system-manifest.md
+++ b/.changeset/design-system-manifest.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+'@pandacss/compiler-shared': patch
+---
+
+Add the `compiler.designSystem` namespace — `create` + `validate` for a design
+system's `panda.lib.json` manifest. The manifest records a library's preset,
+build info, import paths, and parent design system so a consumer adopts it with
+one `designSystem` field.

--- a/crates/pandacss_project/src/design_system.rs
+++ b/crates/pandacss_project/src/design_system.rs
@@ -1,0 +1,97 @@
+//! `panda.lib.json` — the manifest a library publishes so a consumer adopts it
+//! with one `designSystem: '@acme/ds'` field. Generation lives here (a
+//! [`Project`](crate::Project) method) so the schema version has one source of
+//! truth; the host owns fs + module resolution, this module only deals in
+//! values. See `design-notes/design-system-manifest.md`.
+
+use serde::{Deserialize, Serialize};
+
+/// Bumped when the wire shape changes; a version mismatch surfaces a diagnostic
+/// rather than mis-reading the manifest.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// The published `panda.lib.json` record. Paths are relative to the manifest's
+/// own directory (resolves the same from `node_modules`, a symlink, or Docker).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DesignSystemManifest {
+    pub schema_version: u32,
+    pub name: String,
+    /// Informational; powers the drift receipt, never enforced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Peer Panda range the consumer's Panda must satisfy.
+    pub panda: String,
+    pub preset: String,
+    pub build_info: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub import_map: Option<ManifestImportMap>,
+    /// This library's own parent design system — the chain link. Omitted at a root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub design_system: Option<String>,
+    /// Re-extract fallback globs when build info can't be hydrated (version skew).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+}
+
+/// Published import specifiers per category (plural keys, the author-facing wire
+/// form, not the engine's internal singular ones).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestImportMap {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub css: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipes: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub patterns: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jsx: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<String>,
+}
+
+/// Host-supplied manifest fields — everything but the engine-stamped
+/// `schemaVersion`. `importMap`/`designSystem` are optional so a later phase can
+/// source them from the resolved config without changing this shape.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestInput {
+    pub name: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    pub panda: String,
+    pub preset: String,
+    pub build_info: String,
+    #[serde(default)]
+    pub import_map: Option<ManifestImportMap>,
+    #[serde(default)]
+    pub design_system: Option<String>,
+    #[serde(default)]
+    pub files: Vec<String>,
+}
+
+impl super::Project {
+    /// Build a [`DesignSystemManifest`] from host-supplied fields, stamping
+    /// [`MANIFEST_SCHEMA_VERSION`]. Pure (no fs).
+    // PORT NOTE: a later phase fills `importMap`/parent `designSystem` from
+    // config when the input omits them, which is why this lives on `Project`.
+    #[must_use]
+    #[allow(
+        clippy::unused_self,
+        reason = "stays a Project method so the next phase can read config-derived fields here"
+    )]
+    pub fn design_system_manifest(&self, input: ManifestInput) -> DesignSystemManifest {
+        DesignSystemManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            name: input.name,
+            version: input.version,
+            panda: input.panda,
+            preset: input.preset,
+            build_info: input.build_info,
+            import_map: input.import_map,
+            design_system: input.design_system,
+            files: input.files,
+        }
+    }
+}

--- a/crates/pandacss_project/src/design_system.rs
+++ b/crates/pandacss_project/src/design_system.rs
@@ -4,6 +4,7 @@
 //! truth; the host owns fs + module resolution, this module only deals in
 //! values. See `design-notes/design-system-manifest.md`.
 
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 /// Bumped when the wire shape changes; a version mismatch surfaces a diagnostic
@@ -94,4 +95,91 @@ impl super::Project {
             files: input.files,
         }
     }
+}
+
+/// Outcome of [`resolve_chain`]: the order to merge presets + hydrate build
+/// info, or the cycle that makes the chain unresolvable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum ChainPlan {
+    /// Deduped, root-first order (ancestors before descendants), so a leaf and
+    /// the consumer override their parents — preset inheritance precedence.
+    Ordered { order: Vec<String> },
+    /// The chain revisits a package; `cycle` is the loop path for the diagnostic
+    /// (`@a → @b → @a`). A design system can't depend on itself.
+    Cycle { cycle: Vec<String> },
+}
+
+/// Order a set of already-read manifests by their `designSystem` parent links
+/// into a root-first hydrate/merge plan, deduping shared ancestors and catching
+/// cycles. Pure value logic (no fs, no module resolution) — the host reads each
+/// level's manifest and hands the collected values here, so the recursion is
+/// exercised in-memory. A parent absent from the set is a chain boundary (the
+/// host owns parent-not-found via module resolution).
+#[must_use]
+pub fn resolve_chain(manifests: &[DesignSystemManifest]) -> ChainPlan {
+    // name → parent link, deduped by name (first wins); `present` preserves input
+    // order so roots emit deterministically.
+    let mut parent_of: FxHashMap<&str, Option<&str>> = FxHashMap::default();
+    let mut present: Vec<&str> = Vec::new();
+    for manifest in manifests {
+        if parent_of
+            .insert(&manifest.name, manifest.design_system.as_deref())
+            .is_none()
+        {
+            present.push(&manifest.name);
+        }
+    }
+
+    let mut state: FxHashMap<&str, Mark> = FxHashMap::default();
+    let mut order: Vec<String> = Vec::new();
+    for name in present {
+        let mut path: Vec<&str> = Vec::new();
+        if let Err(cycle) = visit(name, &parent_of, &mut state, &mut order, &mut path) {
+            return ChainPlan::Cycle { cycle };
+        }
+    }
+    ChainPlan::Ordered { order }
+}
+
+/// DFS colour: `Gray` is on the current path (a back-edge to it is a cycle),
+/// `Black` is fully placed.
+#[derive(PartialEq, Eq)]
+enum Mark {
+    Gray,
+    Black,
+}
+
+/// Emit `name`'s present ancestors before `name` (post-order ⇒ root-first),
+/// erroring with the loop path on a back-edge to a node on the current path.
+fn visit<'a>(
+    name: &'a str,
+    parent_of: &FxHashMap<&'a str, Option<&'a str>>,
+    state: &mut FxHashMap<&'a str, Mark>,
+    order: &mut Vec<String>,
+    path: &mut Vec<&'a str>,
+) -> Result<(), Vec<String>> {
+    match state.get(name) {
+        Some(Mark::Black) => return Ok(()),
+        Some(Mark::Gray) => {
+            let start = path.iter().position(|&n| n == name).unwrap_or(0);
+            let mut cycle: Vec<String> = path[start..].iter().map(|&n| n.to_owned()).collect();
+            cycle.push(name.to_owned());
+            return Err(cycle);
+        }
+        None => {}
+    }
+
+    state.insert(name, Mark::Gray);
+    path.push(name);
+    // Only order against a parent that's present in the set.
+    if let Some(parent) = parent_of.get(name).copied().flatten()
+        && parent_of.contains_key(parent)
+    {
+        visit(parent, parent_of, state, order, path)?;
+    }
+    path.pop();
+    state.insert(name, Mark::Black);
+    order.push(name.to_owned());
+    Ok(())
 }

--- a/crates/pandacss_project/src/design_system.rs
+++ b/crates/pandacss_project/src/design_system.rs
@@ -1,8 +1,6 @@
 //! `panda.lib.json` — the manifest a library publishes so a consumer adopts it
-//! with one `designSystem: '@acme/ds'` field. Generation lives here (a
-//! [`Project`](crate::Project) method) so the schema version has one source of
-//! truth; the host owns fs + module resolution, this module only deals in
-//! values. See `design-notes/design-system-manifest.md`.
+//! with one `designSystem: '@acme/ds'` field. Values only; the host owns fs +
+//! module resolution. See `design-notes/design-system-manifest.md`.
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -74,9 +72,8 @@ pub struct ManifestInput {
 
 impl super::Project {
     /// Build a [`DesignSystemManifest`] from host-supplied fields, stamping
-    /// [`MANIFEST_SCHEMA_VERSION`]. Pure (no fs).
-    // PORT NOTE: a later phase fills `importMap`/parent `designSystem` from
-    // config when the input omits them, which is why this lives on `Project`.
+    /// [`MANIFEST_SCHEMA_VERSION`]. A `Project` method so a later phase can fill
+    /// `importMap`/parent `designSystem` from config. Pure (no fs).
     #[must_use]
     #[allow(
         clippy::unused_self,
@@ -102,20 +99,16 @@ impl super::Project {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum ChainPlan {
-    /// Deduped, root-first order (ancestors before descendants), so a leaf and
-    /// the consumer override their parents — preset inheritance precedence.
+    /// Deduped, root-first order (ancestors before descendants) — preset
+    /// inheritance precedence.
     Ordered { order: Vec<String> },
-    /// The chain revisits a package; `cycle` is the loop path for the diagnostic
-    /// (`@a → @b → @a`). A design system can't depend on itself.
+    /// The chain revisits a package; `cycle` is the loop path (`@a → @b → @a`).
     Cycle { cycle: Vec<String> },
 }
 
-/// Order a set of already-read manifests by their `designSystem` parent links
-/// into a root-first hydrate/merge plan, deduping shared ancestors and catching
-/// cycles. Pure value logic (no fs, no module resolution) — the host reads each
-/// level's manifest and hands the collected values here, so the recursion is
-/// exercised in-memory. A parent absent from the set is a chain boundary (the
-/// host owns parent-not-found via module resolution).
+/// Order already-read manifests by their `designSystem` parent links into a
+/// root-first merge/hydrate plan, deduping shared ancestors and catching cycles.
+/// A parent absent from the set is a chain boundary (the host resolves it).
 #[must_use]
 pub fn resolve_chain(manifests: &[DesignSystemManifest]) -> ChainPlan {
     // name → parent link, deduped by name (first wins); `present` preserves input

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -28,6 +28,7 @@
 mod build_info;
 mod codegen;
 mod config;
+mod design_system;
 mod error;
 mod hook_filter;
 mod inspection;
@@ -63,6 +64,9 @@ use pandacss_utility::{StyleNormalizer, Utility};
 pub type UtilityStyleKey = (Box<str>, AtomValue);
 
 pub use build_info::{BuildAtom, BuildInfo, BuildValue, ModuleEntry, SCHEMA_VERSION};
+pub use design_system::{
+    DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestImportMap, ManifestInput,
+};
 pub use error::{ConfigError, Result};
 pub use hook_filter::HookFilter;
 pub use inspection::{

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -65,7 +65,8 @@ pub type UtilityStyleKey = (Box<str>, AtomValue);
 
 pub use build_info::{BuildAtom, BuildInfo, BuildValue, ModuleEntry, SCHEMA_VERSION};
 pub use design_system::{
-    DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestImportMap, ManifestInput,
+    ChainPlan, DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestImportMap, ManifestInput,
+    resolve_chain,
 };
 pub use error::{ConfigError, Result};
 pub use hook_filter::HookFilter;

--- a/crates/pandacss_project/tests/design_system.rs
+++ b/crates/pandacss_project/tests/design_system.rs
@@ -1,0 +1,71 @@
+//! `Project::design_system_manifest` — produce a `panda.lib.json` value from
+//! host-supplied identity + paths, stamping the engine-owned schema version, and
+//! round-trip it through JSON. Pure (no fs).
+
+use crate::common::create_project;
+use pandacss_project::{DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestInput};
+use serde_json::{from_value, json, to_value};
+
+fn full_input() -> ManifestInput {
+    from_value(json!({
+        "name": "@acme/ds",
+        "version": "1.2.3",
+        "panda": "^2.0.0",
+        "preset": "./preset.mjs",
+        "buildInfo": "./panda.buildinfo.json",
+        "importMap": { "css": "@acme/ds/css", "recipes": "@acme/ds/recipes" },
+        "designSystem": "@acme/foundations",
+        "files": ["./dist/**/*.mjs"],
+    }))
+    .expect("deserialize manifest input")
+}
+
+#[test]
+fn stamps_schema_version_and_carries_input_fields() {
+    let project = create_project(json!({}));
+    let manifest = project.design_system_manifest(full_input());
+
+    assert_eq!(manifest.schema_version, MANIFEST_SCHEMA_VERSION);
+    assert_eq!(manifest.name, "@acme/ds");
+    assert_eq!(manifest.version.as_deref(), Some("1.2.3"));
+    assert_eq!(manifest.panda, "^2.0.0");
+    assert_eq!(manifest.design_system.as_deref(), Some("@acme/foundations"));
+    assert_eq!(
+        manifest.import_map.as_ref().and_then(|m| m.css.as_deref()),
+        Some("@acme/ds/css")
+    );
+    assert_eq!(manifest.files, ["./dist/**/*.mjs"]);
+}
+
+#[test]
+fn omits_optional_fields_when_absent() {
+    let project = create_project(json!({}));
+    let input: ManifestInput = from_value(json!({
+        "name": "@acme/ds",
+        "panda": "^2.0.0",
+        "preset": "./preset.mjs",
+        "buildInfo": "./panda.buildinfo.json",
+    }))
+    .expect("deserialize minimal input");
+
+    let manifest = project.design_system_manifest(input);
+    let json = to_value(&manifest).expect("serialize manifest");
+
+    // Engine stamps the version; absent optionals don't appear on the wire.
+    assert_eq!(json["schemaVersion"], MANIFEST_SCHEMA_VERSION);
+    assert!(json.get("version").is_none());
+    assert!(json.get("importMap").is_none());
+    assert!(json.get("designSystem").is_none());
+    assert!(json.get("files").is_none());
+}
+
+#[test]
+fn round_trips_through_json() {
+    let project = create_project(json!({}));
+    let manifest = project.design_system_manifest(full_input());
+
+    let json = serde_json::to_string(&manifest).expect("serialize manifest");
+    let restored: DesignSystemManifest = serde_json::from_str(&json).expect("deserialize manifest");
+
+    assert_eq!(manifest, restored);
+}

--- a/crates/pandacss_project/tests/design_system.rs
+++ b/crates/pandacss_project/tests/design_system.rs
@@ -3,7 +3,9 @@
 //! round-trip it through JSON. Pure (no fs).
 
 use crate::common::create_project;
-use pandacss_project::{DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestInput};
+use pandacss_project::{
+    ChainPlan, DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestInput, resolve_chain,
+};
 use serde_json::{from_value, json, to_value};
 
 fn full_input() -> ManifestInput {
@@ -68,4 +70,71 @@ fn round_trips_through_json() {
     let restored: DesignSystemManifest = serde_json::from_str(&json).expect("deserialize manifest");
 
     assert_eq!(manifest, restored);
+}
+
+/// A bare manifest with just a name and optional parent — chain resolution only
+/// reads those two fields.
+fn node(name: &str, parent: Option<&str>) -> DesignSystemManifest {
+    from_value(json!({
+        "schemaVersion": MANIFEST_SCHEMA_VERSION,
+        "name": name,
+        "panda": "^2.0.0",
+        "preset": "./preset.mjs",
+        "buildInfo": "./panda.buildinfo.json",
+        "designSystem": parent,
+    }))
+    .expect("deserialize node")
+}
+
+fn order(plan: ChainPlan) -> Vec<String> {
+    match plan {
+        ChainPlan::Ordered { order } => order,
+        ChainPlan::Cycle { cycle } => panic!("expected an ordered plan, got cycle {cycle:?}"),
+    }
+}
+
+#[test]
+fn resolve_chain_orders_a_depth_n_stack_root_first() {
+    // leaf → marketing → foundations; input in leaf-first order.
+    let plan = resolve_chain(&[
+        node("@acme/marketing", Some("@acme/foundations")),
+        node("@acme/foundations", None),
+    ]);
+    assert_eq!(order(plan), ["@acme/foundations", "@acme/marketing"]);
+}
+
+#[test]
+fn resolve_chain_dedupes_a_shared_parent() {
+    // Two libraries sharing one ancestor — the ancestor emits once, before both.
+    let plan = resolve_chain(&[
+        node("@acme/a", Some("@acme/base")),
+        node("@acme/b", Some("@acme/base")),
+        node("@acme/base", None),
+    ]);
+    assert_eq!(order(plan), ["@acme/base", "@acme/a", "@acme/b"]);
+}
+
+#[test]
+fn resolve_chain_treats_an_absent_parent_as_a_boundary() {
+    // The parent isn't in the set (host owns parent-not-found); the node still
+    // resolves as a root rather than erroring.
+    let plan = resolve_chain(&[node("@acme/leaf", Some("@acme/missing"))]);
+    assert_eq!(order(plan), ["@acme/leaf"]);
+}
+
+#[test]
+fn resolve_chain_reports_a_cycle_path() {
+    let plan = resolve_chain(&[
+        node("@acme/a", Some("@acme/b")),
+        node("@acme/b", Some("@acme/a")),
+    ]);
+    match plan {
+        ChainPlan::Cycle { cycle } => assert_eq!(cycle, ["@acme/a", "@acme/b", "@acme/a"]),
+        ChainPlan::Ordered { order } => panic!("expected a cycle, got order {order:?}"),
+    }
+}
+
+#[test]
+fn resolve_chain_handles_an_empty_set() {
+    assert_eq!(order(resolve_chain(&[])), Vec::<String>::new());
 }

--- a/crates/pandacss_project/tests/main.rs
+++ b/crates/pandacss_project/tests/main.rs
@@ -5,6 +5,7 @@ mod compositions;
 mod config;
 mod config_recipes;
 mod deprecation;
+mod design_system;
 mod diagnostics;
 mod extraction_pipeline;
 mod lifecycle;

--- a/design-notes/README.md
+++ b/design-notes/README.md
@@ -44,6 +44,9 @@ rolldown's [`meta/design/`](https://github.com/rolldown/rolldown/tree/main/meta/
 - [Build info](./build-info.md) — `panda.buildinfo.json`: the portable encoder state a design system ships, its
   condensed format, per-module tree-shaking + import resolution, stacked DS-on-DS consume sketch, the version guard, and
   the engine/JS/CLI layering.
+- [Design-system manifest](./design-system-manifest.md) — `designSystem: '@acme/ds'`: the `panda.lib.json` manifest, gen +
+  load as fs-free compiler methods (`compiler.designSystem.*`), the parent-chain walk for nested design systems, module/type
+  resolution, setup diagnostics, and the incremental PR breakdown.
 - [Virtual styled-system](./virtual-styled-system.md) — DS publishes canonical `styled-system/`; `designSystems` resolves
   manifest preset + dual importMap (DS + app overlay) + overlay codegen for app extensions that need JS/TS modules.
 - [Chakra UI design-system migration](./chakra-ui-design-system-migration.md) — Chakra-specific plan for replacing

--- a/design-notes/design-system-manifest.md
+++ b/design-notes/design-system-manifest.md
@@ -1,0 +1,410 @@
+---
+title: Design Systems (`designSystem`)
+status: draft
+scope:
+  - crates/pandacss_project
+  - crates/pandacss_config
+  - packages/compiler-shared
+  - packages/compiler
+  - packages/compiler-wasm
+  - packages/config
+  - packages/cli
+related:
+  - build-info.md
+  - virtual-styled-system.md
+  - config-loading-design.md
+  - compiler-diagnostics.md
+---
+
+# Design Systems (`designSystem`)
+
+## Summary
+
+A Panda design system (DS) is an npm package that ships components **and** the Panda configuration those components were
+built against. Today, adopting one is the single biggest paper-cut in Panda: every consuming app has to hand-coordinate
+four config knobs and re-extract every component it imports. This note specifies a first-class replacement — one config
+field for consumers (`designSystem: '@acme/ds'`) backed by a small **manifest** (`panda.lib.json`) the library publishes —
+and resolves the design decisions end to end so the path forward is unambiguous.
+
+The manifest ties together everything a consumer needs: the library's preset, its portable extraction cache, its import
+paths, and a pointer to its **own** parent design system. Resolving `designSystem` reads that manifest, merges the preset,
+wires `importMap`, hydrates the pre-extracted styles, and walks the parent chain. The library author produces all of it with
+one command, `panda lib`.
+
+The hard logic — generating the manifest, loading it, walking a chain of parents, and guarding versions — lives in the Rust
+engine as **pure functions over in-memory values**. The filesystem and Node module resolution stay in the TypeScript host.
+That boundary is the load-bearing decision of this design: it keeps the bug-prone logic unit-testable without writing or
+reading a single file.
+
+## The problem
+
+A design system today is three packages and a documentation burden:
+
+1. A **preset** package (tokens, recipes, conditions, utilities).
+2. A **components** package, plus instructions telling every app to add its glob to `include`.
+3. An **`importMap` override** so the shipped components import from the DS, not the consumer's local `styled-system`.
+4. A **`buildinfo`** path the consumer must wire by hand to avoid re-extracting.
+
+So a consumer's config looks like this, and every field is a chance to get it wrong:
+
+```ts
+import { acmePreset } from '@acme/ds/preset'
+
+export default defineConfig({
+  presets: ['@pandacss/dev/presets', acmePreset],
+  importMap: '@acme/ds',
+  include: ['./src/**/*.{ts,tsx}', './node_modules/@acme/ds/dist/panda.buildinfo.json'],
+})
+```
+
+On top of the coordination cost, **the consumer re-extracts every component it imports** — the library already did that
+work, and it's thrown away. The pain compounds in the shapes real users actually have:
+
+- **Monorepo with an internal UI package.** Which package gets a `panda.config.ts`? Both? Does the app re-generate the
+  library's CSS or reuse it? There is no clear answer today.
+- **Docker builds.** A `prepare` script runs `panda` during install, but config resolution is cwd-relative and only some
+  workspace files are copied into the build layer, so resolution fails.
+- **A shared config hidden inside a library** (e.g. font-face declarations). Every consuming app has a different layout, so
+  the fonts resolve in some and not others.
+- **Composed design systems.** A `marketing-ds` built on `foundations` has to bake `import { foundationsPreset }` into its
+  own source — the exact `node_modules` reach-in we want to eliminate.
+- **Distribution at scale.** Shipping a DS to npm breaks the per-package `styled-system` generation model; teams fall back
+  to bundler aliasing that is fragile and hard to explain.
+
+The goal is to make all of that one field for the consumer and one command for the author, and to make the engine reuse the
+library's extraction instead of repeating it.
+
+## Goals and non-goals
+
+**Goals**
+
+1. **One consumer field.** `designSystem: '@acme/ds'` replaces the four-knob coordination.
+2. **One author command.** `panda lib` produces every artifact the consumer needs and is idempotent.
+3. **No re-extraction.** The consumer hydrates the library's pre-extracted styles; it parses only its own source.
+4. **Composition without reach-in.** A DS declares only its own parent and its own additions — never imports a grandparent's
+   preset from source.
+5. **Resolves where users build.** Workspaces, symlinks, and Docker layers — resolution must not assume cwd equals the
+   package location.
+6. **Diagnoses setup mistakes.** Misconfiguration is the common failure; the compiler should say what's wrong and how to fix it.
+
+**Non-goals (for now)**
+
+- **Plural `designSystem`.** A single field; see [Why singular](#why-singular). Plural is a non-breaking future addition.
+- **Multiple competing token sources.** Two packages both defining `colors.brand` differently is a conflict, not a feature.
+- **Micro-frontend federation guidance** — version-namespaced output for many DS versions on one page. The content-addressed
+  hashing here makes identical versions dedupe naturally (see [Federation and versioning](#federation-and-versioning)), but
+  full MFE guidance is a separate effort.
+- **Runtime (non-build-time) manifest consumption**, registry integration, or auto-publishing.
+
+## The model: two fields, two questions
+
+`designSystem` and `include` answer different questions and stay distinct:
+
+- **`designSystem`** — *"What is my design language?"* A package that defines tokens/recipes/conditions and ships a
+  `panda.lib.json`. Its preset becomes part of the consumer's config; its styles arrive pre-extracted.
+- **`include`** — *"Which files use that design language?"* Globs, plus (with **smart `include`**) bare package specifiers
+  for libraries that *consume* a DS but aren't one themselves — e.g. a charts package built on `@acme/ds`.
+
+A package with a manifest belongs under `designSystem`. A package without one, named in `include`, is auto-globbed and
+re-extracted. Putting a manifest-bearing package in `include` is a setup error we diagnose and redirect — silently
+accepting it would re-extract a library that already shipped its extraction.
+
+### Why singular
+
+`designSystem` is `string`, not `string | string[]`. The cases that look plural are three different things:
+
+- App uses `@acme/ds` **and** `@acme/charts` — charts *consumes* a DS, it isn't one. → `include`.
+- App uses `@company/foundations` **and** `@company/marketing-ds` — marketing-ds extends foundations via **its own**
+  manifest entry. Composition happens at the library level; the consumer sees one entry. → [chains](#nested--recursive-design-systems).
+- Migrating `@acme/v1` → `@acme/v2` — set `designSystem: '@acme/v2'`, keep `@acme/v1` in `include` during the migration.
+
+The genuinely-plural case (two token sources both defining `colors.brand`) isn't a use case — supporting it forces
+decisions on token-conflict resolution, condition reconciliation, layer priority, and hash-space merging for ~zero real
+demand. Singular keeps the surface honest; plural can be added without breaking anyone if demand appears.
+
+## The manifest (`panda.lib.json`)
+
+The library publishes one JSON file. **Every path is relative to the manifest's own directory**, so it resolves identically
+whether read from `node_modules`, a workspace symlink, or a Docker layer:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "name": "@acme/ds",
+  "version": "1.2.3",            // informational; powers the drift receipt, never enforced
+  "panda": "^2.0.0",             // peer range — the version contract both sides agree on
+  "preset": "./preset.mjs",      // compiled preset module (the library ships no source .ts)
+  "buildInfo": "./panda.buildinfo.json",
+  "importMap": {
+    "css": "@acme/ds/css",
+    "recipes": "@acme/ds/recipes",
+    "patterns": "@acme/ds/patterns",
+    "jsx": "@acme/ds/jsx",
+    "tokens": "@acme/ds/tokens"
+  },
+  "designSystem": "@acme/foundations", // OPTIONAL — this library's OWN parent DS (recorded by `panda lib`)
+  "files": ["./dist/**/*.{js,mjs}"]    // re-extract fallback when build info can't be hydrated
+}
+```
+
+Why each field lives in the manifest rather than elsewhere:
+
+- **`preset`** — the configuration contract: token *definitions*, utilities, recipes, conditions, font faces. It is a
+  **compiled `.mjs`**, not source `.ts`: a consumer must never need a TypeScript toolchain to read a dependency, and presets
+  carry executable shape (callbacks, transforms) that can't be expressed in JSON. The font-resolution pain dissolves here —
+  the library's font-face config travels in its preset and merges into every consumer.
+- **`buildInfo`** — a path to the **portable encoder state** (the library's atoms/recipes from extracting its own source,
+  interned and tree-shakeable). The manifest *points at* it; it does not embed it, so the two regenerate independently. The
+  build-info wire format and tree-shaking model are detailed in [build-info.md](./build-info.md); for this note, what matters
+  is that it carries token *usage* (path + resolved value), not token *definitions* — definitions come from `preset`. That
+  split is what lets a consumer re-theme the same token paths.
+- **`importMap`** — so the library's compiled JSX keeps importing from `@acme/ds/css` rather than the consumer's local
+  `styled-system`. The host normalizes it and merges it with the consumer's own map.
+- **`designSystem`** — the **parent pointer**, and the mechanism that makes composition work without reach-in. Set only when
+  the library's own config declared a `designSystem`. See [Nested / recursive design systems](#nested--recursive-design-systems).
+- **`panda` + `schemaVersion`** — the version guard, and the answer to "dependency or peer dependency?": `@pandacss/dev` is a
+  **peer** dependency of a design system, and `panda` is the range a consumer's Panda must satisfy.
+- **`files`** — the consumer-side fallback. If the build info can't be hydrated (version skew, fingerprint drift), the
+  consumer re-extracts these globs instead of failing. Recommended in every published manifest.
+
+## Where this runs: Rust engine vs TypeScript host
+
+This is the design's spine. The manifest's **generation and consumption are pure functions over values**, exposed as a
+compiler namespace that mirrors the existing `compiler.buildInfo.*`:
+
+```ts
+compiler.designSystem.create({ panda })            // Project value → manifest value (producer)
+compiler.designSystem.validate(manifest)           // schema + peer range compatible? { ok } | { ok: false, reason }
+compiler.designSystem.load(manifest, { buildInfo }) // consumer: merge preset facts + hydrate → resolved layer
+compiler.designSystem.resolveChain(manifests)       // ordered manifest values → dedup'd, cycle-checked merge/hydrate plan
+```
+
+Every method takes and returns plain data. `resolveChain` in particular is handed the **already-read** manifest values — the
+host did the disk reads and Node resolution — and returns the order to merge and hydrate. So the recursion logic, the part
+most likely to harbor bugs, is exercised with hand-authored manifest arrays and **zero filesystem**.
+
+| Layer | Language | Owns | Touches fs? |
+| --- | --- | --- | --- |
+| Engine (`pandacss_project`, `pandacss_config`) | **Rust** | manifest value type, `create`, `validate`, `resolveChain`, hydrate wiring, version + cycle guards | no |
+| Bindings (`packages/compiler/crate`, `compiler-wasm/crate`) | **Rust** | mirror the flat primitives across native + browser | no |
+| JS namespace (`compiler-shared`) | **TS** | `compiler.designSystem.*`, manifest (de)serialization, importMap normalization | no |
+| Host (`packages/cli`, driver) | **TS** | Node module resolution, reading/writing `panda.lib.json` + `package.json` exports, `--watch` | **yes — all of it** |
+
+Only the bottom row touches disk. Everything above is values. So "does the chain walk handle a 7-deep stack, a shared-parent
+diamond, and a cycle?" is a set of in-memory Rust unit tests, not a tree of sandbox packages.
+
+## Generating the manifest (producer)
+
+`compiler.designSystem.create({ panda })` turns a built `Project` into a manifest value:
+
+1. The engine already holds the merged config, encoder state, and the `exports` map (export name → module). `create` reads
+   them; it does not re-extract.
+2. It stamps `name`/`version` from the supplied package identity, `panda` from the author-declared peer range, and
+   `schemaVersion` from the running binding.
+3. It records the producer's **own** `designSystem` parent (from the producer's resolved config), so the manifest carries the
+   chain link.
+4. It emits paths as placeholders relative to the eventual output root; the host fills concrete relative paths when it writes.
+
+`panda lib` is the only fs-aware part: glob `src/`, drive the engine to build the `Project`, call `create`, write
+`panda.lib.json` + `panda.buildinfo.json` + the compiled `preset.mjs`, and sync `package.json` exports. It reads from `src/`
+(not a bundler's `dist/`), so it is bundler-agnostic, and it is **idempotent** — running it twice produces no diff. It
+supersedes the older two-step `ship`/`emit-pkg` flow, which is removed (a documented breaking change). `panda lib --watch`
+rebuilds on `src/` changes via the same watcher the app dev mode uses.
+
+```jsonc
+// package.json — exports synced by `panda lib`
+{
+  "exports": {
+    "./panda.lib.json": "./dist/panda.lib.json",
+    "./preset":         "./dist/preset.mjs",
+    "./css":            "./dist/css/index.mjs",
+    "./recipes/*":      "./dist/recipes/*"
+  }
+}
+```
+
+## Loading the manifest (consumer)
+
+When the consumer's config has `designSystem: '@acme/ds'`:
+
+1. The host **resolves** `@acme/ds/panda.lib.json` via Node module resolution.
+2. It reads that manifest and any parent chain (next section), then calls `resolveChain([…])` for the ordered plan.
+3. For each manifest in the plan (root-first, so parents merge before children):
+   - **Merge preset** into the effective config, *under* the user's local config — user overrides win, the same override
+     semantics as any preset. The consumer does **not** also list the DS preset in `presets`.
+   - **Merge importMap** — prepend the DS roots, keep the app's local `outdir` (dual-root rules in [virtual-styled-system.md](./virtual-styled-system.md)).
+   - **`validate`** the build info against the resolved compiler (schema + peer range + config fingerprint). On mismatch,
+     re-extract the manifest's `files` for that layer and emit a warning.
+   - **Hydrate** the build info, tree-shaken to the consumer's actual imports (only the modules it uses).
+4. Extract the consumer's own `src/` as normal; its atoms merge into the same encoder. The library's components are never
+   re-extracted.
+
+The resolved manifest and build-info paths are registered as build dependencies, so watch mode and `pnpm update @acme/ds`
+both trigger regeneration.
+
+## Nested / recursive design systems
+
+A design system built on another is the hard case, and the manifest's `designSystem` field is the entire mechanism. Each
+library declares **only its own parent** and **only its own additions** — never an `import { parentPreset }` baked into
+source. That import is exactly the `node_modules` reach-in this feature removes.
+
+```ts
+// @acme/marketing-ds/panda.config.ts
+export default defineConfig({
+  designSystem: '@acme/foundations', // recorded into THIS library's manifest by `panda lib`
+  presets: [marketingPreset],        // marketing's own additions only
+})
+```
+
+The consumer lists only the leaf; `foundations` is pulled in transitively:
+
+```ts
+// app/panda.config.ts
+export default defineConfig({
+  designSystem: '@acme/marketing-ds',
+  include: ['./src/**/*.{ts,tsx}'],
+})
+```
+
+### The walk
+
+The host reads each level's manifest and hands the collected values to `resolveChain`. Two invariants make it correct, and
+both are tested in-memory:
+
+- **Resolve each parent against the previous manifest's directory, not the consumer's cwd.** `marketing-ds`'s parent
+  `foundations` is resolved relative to where `marketing-ds` is installed. This is what makes transitive parents work when
+  the consumer depends only on the immediate child — and it is the fix for the Docker case, where cwd-relative resolution
+  breaks because only part of the workspace exists in the build layer.
+- **Cycle guard.** `A → B → A` is caught by walking with a visited set and surfaced as a diagnostic, not a stack overflow.
+
+`resolveChain` returns the dedup'd, ordered list: root → leaf for preset merge (so leaf and app override ancestors), and each
+build info hydrated under its own name (re-hydrating one layer replaces just that layer). The governing rule: **preset chain
+= config inheritance; build info = per-package extraction cache.** Never merge build-info blobs across packages — merge only
+emit output and presets.
+
+## Module and type resolution
+
+Three resolution problems, three answers:
+
+- **"Where is the package?"** — Bare specifiers (`@acme/ds` in `designSystem`, bare names in smart `include`) resolve via the
+  host's Node resolution, trying `…/panda.lib.json` first, then `…/package.json`. This is a host concern; the engine never
+  resolves modules. The resolve-against-manifest-dir rule above keeps it working in workspaces and Docker layers.
+- **"Which import is a Panda import?"** — The manifest's `importMap` carries the DS roots so the library's compiled JSX
+  resolves to `@acme/ds/css`, not the app's local `styled-system`. The host merges DS roots with the app's `outdir` into a
+  dual-root map; the extractor matches by substring. [virtual-styled-system.md](./virtual-styled-system.md) is the authority
+  on normalization; this note only requires that the manifest is the *source* of the DS roots.
+- **"Does the IDE know about these tokens?"** — The DS ships its `styled-system/types` via `package.json` exports, and the
+  consumer's codegen emits a **merged** type surface (DS contract + app extensions) so `strictTokens` enforces against the
+  composed system.
+
+## CSS layering, tree-shaking, and federation
+
+**Tree-shaking.** A DS shipping 100 components shouldn't push 100 components' CSS into an app that imports 10. Build info is
+keyed per source module, and the consumer hydrates only the modules its imports reach (subpath imports resolve directly;
+barrel imports resolve through the `exports` map). Panda-native scanning over-includes safely; a future bundler plugin is the
+precise opt-in.
+
+**Layering.** Each design system's hydrated CSS is emitted under a named cascade layer, `@layer ds-{name}`, with a single
+ordering statement declaring root-before-leaf-before-app. So `foundations` sits under `marketing-ds` sits under the app, and
+override precedence matches preset inheritance.
+
+### Federation and versioning
+
+Several federated micro-frontends on one page can use the same DS at the same or different versions. Two mechanisms already
+cover the common case without new surface:
+
+- **Identical versions dedupe for free.** Atom class names are content-addressed (hash of property + resolved value), so two
+  MFEs on `@acme/ds@1.2.3` produce byte-identical classes that collapse on the page.
+- **Incompatible versions fail safe.** The `panda` peer range + `schemaVersion` + config-fingerprint guard catches a
+  cross-version hash collision (same atom, different class) at load time and falls back to re-extraction for that layer
+  rather than emitting conflicting output.
+
+Explicit version-namespaced output (one bundle per DS version, hash keyed by DS identity) is the genuinely federated case and
+is deferred — it needs a coordination story across independently built apps that this field doesn't own.
+
+## Diagnostics
+
+Setup is where this feature lives or dies — most failures are misconfiguration, and a diagnostic's job is to say what's wrong
+and how to fix it, not just refuse. These follow the shared `Diagnostic` model and the `code`/`severity` conventions in
+[compiler-diagnostics.md](./compiler-diagnostics.md). Proposed stable codes:
+
+| Code | Severity | When | Guidance |
+| --- | --- | --- | --- |
+| `design_system_manifest_not_found` | error | `designSystem` set but no `panda.lib.json` resolves | "Install `@acme/ds`, or — if it isn't a Panda design system — build it with `panda lib`." |
+| `design_system_in_include` | error | a manifest-bearing package appears in `include` | "Move `@acme/ds` to `designSystem`; `include` is for files, not design systems." Batched, so every offender reports at once. |
+| `design_system_version_mismatch` | error | manifest `schemaVersion` ≠ running binding | Directional: consumer newer → "rebuild the lib with `panda lib`"; consumer older → "upgrade `@pandacss/dev` here, or rebuild the lib." |
+| `design_system_peer_range_unsatisfied` | error | consumer Panda outside manifest `panda` range | "This project's Panda doesn't satisfy `@acme/ds`'s `panda: ^2.0.0`." |
+| `design_system_cycle` | error | the chain revisits a package | "Design-system cycle: `@a` → `@b` → `@a`. A design system can't depend on itself." |
+| `design_system_parent_not_found` | error | a manifest's parent doesn't resolve from that manifest's dir | "`@acme/marketing-ds` declares parent `@acme/foundations`, not installed alongside it." |
+| `design_system_buildinfo_stale` | warning | build info fails `validate`; re-extract fallback used | "Re-extracting `@acme/ds` source; rebuild it with `panda lib` to restore the fast path." |
+| `design_system_token_conflict` | warning | DS and consumer both define the same token path | "`colors.brand` is defined by both `@acme/ds` and this config; the local value wins." |
+| `design_system_version_changed` | info | manifest `version` differs from persisted state between runs | Backward-looking receipt: `[designSystem] @acme/ds: 1.0.0 → 1.1.0`. No network, never enforced. |
+
+The split is deliberate: anything that breaks resolution is an `error`; drift and conflict with a defined fallback are
+`warning`; the version receipt is `info`. The engine owns chain/version/conflict diagnostics (it holds the resolved state);
+the host owns not-found/peer-range (it owns module resolution). Panda never makes a registry call, never nudges to upgrade,
+and never checks versions against anything but the consumer's own lockfile — staying on `@acme/ds@1.0.0` forever is fully
+supported.
+
+## Delivery in phases
+
+The feature is too large to land safely at once. Each phase is independently mergeable, is a no-op for existing users until
+the field is wired, and is ordered so the **fs-free engine primitives land and are tested before any host wiring depends on
+them**.
+
+1. **Manifest value + engine gen/load (no user-facing change).** `DesignSystemManifest` type; `create` + `validate` over a
+   `Project` value; (de)serialization. Unit-tested in-memory at Rust + native + wasm levels. No config field, no CLI.
+2. **`designSystem`, single level.** The config field; host resolves one manifest, merges preset, derives importMap,
+   validates + hydrates build info. Diagnostics: not-found, version-mismatch, peer-range. One-lib-→-one-app fixture.
+3. **Nested chains.** `resolveChain` over manifest values: ordered plan, resolve-against-manifest-dir, cycle guard. Host
+   reads the parent chain and feeds values in. Diagnostics: cycle, parent-not-found. Tested as in-memory arrays (depth-N,
+   diamond, cycle).
+4. **Smart `include`.** Bare specifiers resolve via Node resolution: manifest present → redirect; no manifest → auto-glob +
+   extract. Diagnostic: in-include (batched).
+5. **`panda lib` + propagation.** The command (+ `--watch`): glob `src/` → `create` → write manifest/buildinfo/preset → sync
+   exports. Register resolved paths as build deps; drift receipt + persisted state; stale-buildinfo fallback; token-conflict
+   warning. Remove `ship`/`emit-pkg` with a migration note.
+6. **Overlay codegen / virtual styled-system.** The app emits only its delta; per-package layer ordering; merged type
+   surface. Tracked in [virtual-styled-system.md](./virtual-styled-system.md).
+
+Phases 1–3 carry the technically hard logic and are all proven without touching disk. Phases 4–6 are host and ergonomics
+wiring on top.
+
+## Decisions
+
+These were open; resolving them is the point of the note. Each is a recommendation with rationale, not a deferral.
+
+- **Manifest location → standalone `panda.lib.json`.** Not a `package.json` field. It is explicit, discoverable, listed in
+  `exports`, and can be generated/gitignored without churning `package.json`. The cost (one more file) is worth the clarity.
+- **Stale build-info → re-extract that layer, warn, don't fail.** If the manifest ships `files`, hydrate failure falls back
+  to re-extracting that one library's source and emits `design_system_buildinfo_stale`. Fail closed only when no `files`
+  fallback exists. This keeps a version skew from breaking the whole build. `files` should be in every published manifest.
+- **Token conflict → local wins, warn.** Consistent with preset override semantics: the consumer's config beats the DS. Emit
+  `design_system_token_conflict` so the override is visible, not silent.
+- **Conditions → name-keyed, consumer wins.** A library's `_dark` selector and the consumer's are reconciled by name; the
+  consumer's definition wins on conflict. A library that needs a bespoke dark selector should name its condition distinctly
+  rather than redefining `_dark`.
+- **`staticCss` → travels automatically, no manifest field.** A library's `staticCss` rules are extracted into its build info
+  at `panda lib` time like any other usage, so they hydrate into the consumer with everything else. No separate opt-in field;
+  no separate CSS blob.
+- **CSS layer ordering → `@layer ds-{name}`, root-first.** A single layer-order statement declares ancestors before
+  descendants before the app, matching preset inheritance precedence.
+- **Public/private token visibility → out of scope here.** Stripping raw/component tokens from a consumer's IntelliSense while
+  keeping them usable inside the DS is a real need, but it is a preset/type-surface concern orthogonal to the manifest. Track
+  it separately.
+
+## Unresolved questions
+
+- **TS path generation.** Does the consumer need generated `tsconfig` `paths` for the DS styled-system, or do `package.json`
+  exports suffice across all bundlers? Leaning on exports; revisit if a bundler can't resolve the dual-root map.
+- **Workspace protocol resolution.** `designSystem: '@acme/ds'` where the dependency is `workspace:*` — confirm the
+  resolve-against-manifest-dir walk handles the symlink without special-casing.
+- **Versioned federation output.** One CSS bundle per DS version for independently built micro-frontends — the deferred
+  federated case; needs a cross-app coordination story before it's worth building.
+
+## Related notes
+
+- [Build info](./build-info.md) — the portable extraction cache the manifest points at; wire format, hydrate, tree-shaking.
+- [Virtual styled-system](./virtual-styled-system.md) — consume-side styled-system delivery, dual-root importMap, overlay codegen.
+- [Config loading](./config-loading-design.md) — preset resolution and the config snapshot the host merges into.
+- [Compiler diagnostics](./compiler-diagnostics.md) — the `Diagnostic` model and code/severity conventions these follow.

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -1,6 +1,8 @@
 import type {
   BuildInfoApi,
   DesignSystemApi,
+  DesignSystemChainPlan,
+  DesignSystemChainResult,
   DesignSystemLoadOptions,
   DesignSystemLoadResult,
   DesignSystemManifest,
@@ -13,6 +15,7 @@ import type {
 export interface DesignSystemNative {
   createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
   designSystemManifestSchemaVersion(): number
+  resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
 /** Build the `compiler.designSystem` namespace over a binding's primitives.
@@ -43,6 +46,13 @@ export function makeDesignSystemApi(native: DesignSystemNative, buildInfo: Build
       if (!result.ok) return { ok: false, reason: result.reason, modules: [] }
 
       return { ok: true, name: manifest.name, modules: result.modules }
+    },
+
+    resolveChain: (manifests: DesignSystemManifest[]): DesignSystemChainResult => {
+      const plan = native.resolveDesignSystemChain(manifests)
+      return plan.status === 'ordered'
+        ? { ok: true, order: plan.order }
+        : { ok: false, reason: 'cycle', cycle: plan.cycle }
     },
   }
 }

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -8,6 +8,7 @@ import type {
   DesignSystemManifest,
   DesignSystemManifestCompatibility,
   DesignSystemManifestInput,
+  DesignSystemValidateOptions,
 } from './types'
 
 /** The flat manifest primitives every binding (native / wasm) exposes; the
@@ -18,15 +19,33 @@ export interface DesignSystemNative {
   resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
+/** Major from a version or range (`^2.1.0` → `2`); `NaN` when no number is found
+ *  so an unreadable value fails the major check rather than passing silently. */
+const major = (value: string): number => {
+  const match = value.match(/\d+/)
+  return match ? Number(match[0]) : NaN
+}
+
 /** Build the `compiler.designSystem` namespace over a binding's primitives.
- *  `validate` checks `schemaVersion`; the peer-range check is host-layered.
- *  `load` reuses the `buildInfo` namespace to resolve + hydrate the library's
- *  pre-extracted styles, keeping that logic in one place. */
+ *  `validate` checks the wire-format `schemaVersion` and — given the consumer's
+ *  running `pandaVersion` — that its major matches the manifest's `panda` range.
+ *  Panda releases in lockstep, so the major boundary is the whole peer contract;
+ *  finer skew is already caught by `schemaVersion` + the build-info fingerprint.
+ *  `load` reuses the `buildInfo` namespace to hydrate the library's styles. */
 export function makeDesignSystemApi(native: DesignSystemNative, buildInfo: BuildInfoApi): DesignSystemApi {
   const schemaVersion = native.designSystemManifestSchemaVersion()
 
-  const validate = (manifest: DesignSystemManifest): DesignSystemManifestCompatibility =>
-    manifest.schemaVersion === schemaVersion ? { ok: true } : { ok: false, reason: 'schemaVersion' }
+  const validate = (
+    manifest: DesignSystemManifest,
+    options?: DesignSystemValidateOptions,
+  ): DesignSystemManifestCompatibility => {
+    if (manifest.schemaVersion !== schemaVersion) return { ok: false, reason: 'schemaVersion' }
+    const running = options?.pandaVersion
+    if (running !== undefined && major(running) !== major(manifest.panda)) {
+      return { ok: false, reason: 'pandaRange' }
+    }
+    return { ok: true }
+  }
 
   return {
     schemaVersion,
@@ -36,7 +55,7 @@ export function makeDesignSystemApi(native: DesignSystemNative, buildInfo: Build
     validate,
 
     load: (manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult => {
-      const compat = validate(manifest)
+      const compat = validate(manifest, { pandaVersion: options.pandaVersion })
       if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
 
       // `imports` omitted → hydrate every module (namespace import); otherwise

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -1,5 +1,8 @@
 import type {
+  BuildInfoApi,
   DesignSystemApi,
+  DesignSystemLoadOptions,
+  DesignSystemLoadResult,
   DesignSystemManifest,
   DesignSystemManifestCompatibility,
   DesignSystemManifestInput,
@@ -13,16 +16,33 @@ export interface DesignSystemNative {
 }
 
 /** Build the `compiler.designSystem` namespace over a binding's primitives.
- *  `validate` checks `schemaVersion`; the peer-range check is host-layered. */
-export function makeDesignSystemApi(native: DesignSystemNative): DesignSystemApi {
+ *  `validate` checks `schemaVersion`; the peer-range check is host-layered.
+ *  `load` reuses the `buildInfo` namespace to resolve + hydrate the library's
+ *  pre-extracted styles, keeping that logic in one place. */
+export function makeDesignSystemApi(native: DesignSystemNative, buildInfo: BuildInfoApi): DesignSystemApi {
   const schemaVersion = native.designSystemManifestSchemaVersion()
+
+  const validate = (manifest: DesignSystemManifest): DesignSystemManifestCompatibility =>
+    manifest.schemaVersion === schemaVersion ? { ok: true } : { ok: false, reason: 'schemaVersion' }
 
   return {
     schemaVersion,
 
     create: (input: DesignSystemManifestInput) => native.createDesignSystemManifest(input),
 
-    validate: (manifest: DesignSystemManifest): DesignSystemManifestCompatibility =>
-      manifest.schemaVersion === schemaVersion ? { ok: true } : { ok: false, reason: 'schemaVersion' },
+    validate,
+
+    load: (manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult => {
+      const compat = validate(manifest)
+      if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
+
+      // `imports` omitted → hydrate every module (namespace import); otherwise
+      // resolve the touched modules so only their CSS emits (tree-shaking).
+      const only = options.imports !== undefined ? buildInfo.modulesFor(options.buildInfo, options.imports) : undefined
+      const result = buildInfo.hydrate(options.buildInfo, { name: manifest.name, only })
+      if (!result.ok) return { ok: false, reason: result.reason, modules: [] }
+
+      return { ok: true, name: manifest.name, modules: result.modules }
+    },
   }
 }

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -1,0 +1,28 @@
+import type {
+  DesignSystemApi,
+  DesignSystemManifest,
+  DesignSystemManifestCompatibility,
+  DesignSystemManifestInput,
+} from './types'
+
+/** The flat manifest primitives every binding (native / wasm) exposes; the
+ *  `compiler.designSystem` namespace is built over these. */
+export interface DesignSystemNative {
+  createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
+  designSystemManifestSchemaVersion(): number
+}
+
+/** Build the `compiler.designSystem` namespace over a binding's primitives.
+ *  `validate` checks `schemaVersion`; the peer-range check is host-layered. */
+export function makeDesignSystemApi(native: DesignSystemNative): DesignSystemApi {
+  const schemaVersion = native.designSystemManifestSchemaVersion()
+
+  return {
+    schemaVersion,
+
+    create: (input: DesignSystemManifestInput) => native.createDesignSystemManifest(input),
+
+    validate: (manifest: DesignSystemManifest): DesignSystemManifestCompatibility =>
+      manifest.schemaVersion === schemaVersion ? { ok: true } : { ok: false, reason: 'schemaVersion' },
+  }
+}

--- a/packages/compiler-shared/src/index.ts
+++ b/packages/compiler-shared/src/index.ts
@@ -6,6 +6,7 @@
  * This module is a barrel; the surface is split by concern:
  * - `./types`      — data-shape contract (the serialized `Compiler` surface)
  * - `./build-info` — the `buildInfo` namespace factory over binding primitives
+ * - `./design-system` — the `designSystem` namespace factory (`panda.lib.json`)
  * - `./callbacks`  — the JS-callback runtime (`utility.transform`, …)
  * - `./introspect` — the `introspect(spec)` query/sort helper
  * - `./driver`     — the host orchestration layer (`Driver`, `BaseDriver`)
@@ -13,6 +14,7 @@
 
 export * from './types'
 export * from './build-info'
+export * from './design-system'
 export * from './callbacks'
 export * from './defaults'
 export * from './import-map'

--- a/packages/compiler-shared/src/types.ts
+++ b/packages/compiler-shared/src/types.ts
@@ -863,7 +863,28 @@ export type DesignSystemManifestCompatibility =
   | { ok: true }
   | { ok: false; reason: DesignSystemManifestIncompatibility }
 
-/** Produce + validate `panda.lib.json`. Accessed as `compiler.designSystem`. */
+/** Inputs to `load` — the library's already-read build info plus the consumer's
+ *  imports from the design system, for tree-shaking. */
+export interface DesignSystemLoadOptions {
+  /** The library's portable encoder state (its `panda.buildinfo.json`), already
+   *  read off disk by the host. */
+  buildInfo: BuildInfo
+  /** Export names the consumer imports from the design system; resolved to
+   *  modules via the build info's `exports` so only their CSS emits. Omit to
+   *  hydrate every module (e.g. a namespace import). */
+  imports?: string[]
+}
+
+/** Outcome of `load`. On success, `modules` is the hydrated set keyed under the
+ *  manifest name. On failure, `reason` is why — a manifest wire mismatch or an
+ *  incompatible build info — and the host falls back to re-extracting the
+ *  manifest's `files`. */
+export type DesignSystemLoadResult =
+  | { ok: true; name: string; modules: string[] }
+  | { ok: false; reason: DesignSystemManifestIncompatibility | BuildInfoIncompatibility; modules: [] }
+
+/** Produce, validate, and load `panda.lib.json`. Accessed as
+ *  `compiler.designSystem`. */
 export interface DesignSystemApi {
   /** The manifest wire-format version this compiler reads/writes. */
   readonly schemaVersion: number
@@ -875,6 +896,13 @@ export interface DesignSystemApi {
   /** Check a manifest's `schemaVersion` against this compiler; the peer-range
    *  verdict is layered on by the host. */
   validate(manifest: DesignSystemManifest): DesignSystemManifestCompatibility
+
+  /** Consumer side (`designSystem: '@acme/ds'`): validate the manifest, resolve
+   *  which library modules the consumer's imports touch, and hydrate them under
+   *  the manifest name as a layer. Covers the build-info half — preset and
+   *  `importMap` merge into the consumer config at build time, in the host,
+   *  since the engine value layer can't execute the preset module. */
+  load(manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult
 }
 
 /** A configured, long-lived compiler: built once from a serialized config, fed

--- a/packages/compiler-shared/src/types.ts
+++ b/packages/compiler-shared/src/types.ts
@@ -863,6 +863,15 @@ export type DesignSystemManifestCompatibility =
   | { ok: true }
   | { ok: false; reason: DesignSystemManifestIncompatibility }
 
+/** Raw chain plan the binding returns — a status-tagged value the namespace
+ *  reshapes into {@link DesignSystemChainResult}. */
+export type DesignSystemChainPlan = { status: 'ordered'; order: string[] } | { status: 'cycle'; cycle: string[] }
+
+/** Outcome of `resolveChain`. On success, `order` is the deduped root-first
+ *  sequence to merge presets + hydrate build info. On a cycle, `cycle` is the
+ *  loop path for the diagnostic. */
+export type DesignSystemChainResult = { ok: true; order: string[] } | { ok: false; reason: 'cycle'; cycle: string[] }
+
 /** Inputs to `load` — the library's already-read build info plus the consumer's
  *  imports from the design system, for tree-shaking. */
 export interface DesignSystemLoadOptions {
@@ -903,6 +912,12 @@ export interface DesignSystemApi {
    *  `importMap` merge into the consumer config at build time, in the host,
    *  since the engine value layer can't execute the preset module. */
   load(manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult
+
+  /** Order a set of already-read manifests by their parent (`designSystem`)
+   *  links into a deduped, root-first plan — the composition case (a design
+   *  system built on another). The host reads each level off disk and hands the
+   *  values here; this catches cycles and returns the merge/hydrate order. */
+  resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainResult
 }
 
 /** A configured, long-lived compiler: built once from a serialized config, fed

--- a/packages/compiler-shared/src/types.ts
+++ b/packages/compiler-shared/src/types.ts
@@ -809,6 +809,74 @@ export interface BuildInfoApi {
   hydrate(buildInfo: BuildInfo, options: BuildInfoHydrateOptions): BuildInfoHydrateResult
 }
 
+// ---------------------------------------------------------------------------
+// Design-system manifest — `panda.lib.json` (the `designSystem` field)
+// ---------------------------------------------------------------------------
+
+/** Published import specifiers per category, so a library's compiled JSX keeps
+ *  importing from the DS (`@acme/ds/css`), not the consumer's `styled-system`. */
+export interface DesignSystemManifestImportMap {
+  css?: string
+  recipes?: string
+  patterns?: string
+  jsx?: string
+  tokens?: string
+}
+
+/** `panda.lib.json` — the manifest a library publishes for the `designSystem`
+ *  field. Paths are relative to the manifest's own directory. */
+export interface DesignSystemManifest {
+  schemaVersion: number
+  name: string
+  /** Informational; powers the drift receipt, never enforced. */
+  version?: string
+  /** Peer Panda range the consumer's Panda must satisfy. */
+  panda: string
+  preset: string
+  buildInfo: string
+  importMap?: DesignSystemManifestImportMap
+  /** This library's own parent design system — the chain link. Absent at a root. */
+  designSystem?: string
+  /** Re-extract fallback globs when build info can't be hydrated (version skew). */
+  files?: string[]
+}
+
+/** Host-supplied manifest fields — everything but the engine-stamped
+ *  `schemaVersion`. */
+export interface DesignSystemManifestInput {
+  name: string
+  version?: string
+  panda: string
+  preset: string
+  buildInfo: string
+  importMap?: DesignSystemManifestImportMap
+  designSystem?: string
+  files?: string[]
+}
+
+/** Why a manifest is incompatible. `schemaVersion` is the engine's verdict;
+ *  `pandaRange` is layered on by the host (it knows the running version). */
+export type DesignSystemManifestIncompatibility = 'schemaVersion' | 'pandaRange'
+
+/** Discriminated result so `ok: true` narrows away `reason`. */
+export type DesignSystemManifestCompatibility =
+  | { ok: true }
+  | { ok: false; reason: DesignSystemManifestIncompatibility }
+
+/** Produce + validate `panda.lib.json`. Accessed as `compiler.designSystem`. */
+export interface DesignSystemApi {
+  /** The manifest wire-format version this compiler reads/writes. */
+  readonly schemaVersion: number
+
+  /** Build a manifest from host-supplied fields, stamping the schema version —
+   *  the producer side (`panda lib`). */
+  create(input: DesignSystemManifestInput): DesignSystemManifest
+
+  /** Check a manifest's `schemaVersion` against this compiler; the peer-range
+   *  verdict is layered on by the host. */
+  validate(manifest: DesignSystemManifest): DesignSystemManifestCompatibility
+}
+
 /** A configured, long-lived compiler: built once from a serialized config, fed
  *  source files, drained to CSS via `compile()`. Identical on native and wasm —
  *  only construction differs (native sync; wasm async + populates `fs`). */
@@ -880,6 +948,10 @@ export interface Compiler {
   /** Build-info distribution — produce, validate, and hydrate a design system's
    *  serialized encoder state. See {@link BuildInfoApi}. */
   readonly buildInfo: BuildInfoApi
+
+  /** Design-system manifest — produce + validate `panda.lib.json`. See
+   *  {@link DesignSystemApi}. */
+  readonly designSystem: DesignSystemApi
 
   // Codegen artifacts
   /** Generate + write artifacts under `outdir` via the platform fs (disk on

--- a/packages/compiler-shared/src/types.ts
+++ b/packages/compiler-shared/src/types.ts
@@ -823,10 +823,9 @@ export interface DesignSystemManifestImportMap {
   tokens?: string
 }
 
-/** `panda.lib.json` — the manifest a library publishes for the `designSystem`
- *  field. Paths are relative to the manifest's own directory. */
-export interface DesignSystemManifest {
-  schemaVersion: number
+/** Host-supplied manifest fields — everything but the engine-stamped
+ *  `schemaVersion`. Paths are relative to the manifest's own directory. */
+export interface DesignSystemManifestInput {
   name: string
   /** Informational; powers the drift receipt, never enforced. */
   version?: string
@@ -841,21 +840,14 @@ export interface DesignSystemManifest {
   files?: string[]
 }
 
-/** Host-supplied manifest fields — everything but the engine-stamped
+/** `panda.lib.json` — the published manifest: host input plus the engine-stamped
  *  `schemaVersion`. */
-export interface DesignSystemManifestInput {
-  name: string
-  version?: string
-  panda: string
-  preset: string
-  buildInfo: string
-  importMap?: DesignSystemManifestImportMap
-  designSystem?: string
-  files?: string[]
+export interface DesignSystemManifest extends DesignSystemManifestInput {
+  schemaVersion: number
 }
 
-/** Why a manifest is incompatible. `schemaVersion` is the engine's verdict;
- *  `pandaRange` is layered on by the host (it knows the running version). */
+/** Why a manifest is incompatible: a `schemaVersion` wire mismatch, or the
+ *  consumer's Panda major outside the manifest's `panda` range (`pandaRange`). */
 export type DesignSystemManifestIncompatibility = 'schemaVersion' | 'pandaRange'
 
 /** Discriminated result so `ok: true` narrows away `reason`. */
@@ -863,13 +855,20 @@ export type DesignSystemManifestCompatibility =
   | { ok: true }
   | { ok: false; reason: DesignSystemManifestIncompatibility }
 
+/** Options for {@link DesignSystemApi.validate}. */
+export interface DesignSystemValidateOptions {
+  /** The consumer's running Panda version. When given, `validate` also checks
+   *  its major against the manifest's `panda` range — a `pandaRange` failure on
+   *  mismatch. Omit to check `schemaVersion` only. */
+  pandaVersion?: string
+}
+
 /** Raw chain plan the binding returns — a status-tagged value the namespace
  *  reshapes into {@link DesignSystemChainResult}. */
 export type DesignSystemChainPlan = { status: 'ordered'; order: string[] } | { status: 'cycle'; cycle: string[] }
 
-/** Outcome of `resolveChain`. On success, `order` is the deduped root-first
- *  sequence to merge presets + hydrate build info. On a cycle, `cycle` is the
- *  loop path for the diagnostic. */
+/** Outcome of `resolveChain`: the deduped root-first merge/hydrate `order`, or
+ *  the `cycle` loop path on failure. */
 export type DesignSystemChainResult = { ok: true; order: string[] } | { ok: false; reason: 'cycle'; cycle: string[] }
 
 /** Inputs to `load` — the library's already-read build info plus the consumer's
@@ -882,12 +881,14 @@ export interface DesignSystemLoadOptions {
    *  modules via the build info's `exports` so only their CSS emits. Omit to
    *  hydrate every module (e.g. a namespace import). */
   imports?: string[]
+  /** The consumer's running Panda version, forwarded to `validate` so `load`
+   *  also gates on the `panda` range. See {@link DesignSystemValidateOptions}. */
+  pandaVersion?: string
 }
 
-/** Outcome of `load`. On success, `modules` is the hydrated set keyed under the
- *  manifest name. On failure, `reason` is why — a manifest wire mismatch or an
- *  incompatible build info — and the host falls back to re-extracting the
- *  manifest's `files`. */
+/** Outcome of `load`: the hydrated `modules` keyed under the manifest name, or a
+ *  `reason` (wire mismatch / incompatible build info) the host falls back on by
+ *  re-extracting the manifest's `files`. */
 export type DesignSystemLoadResult =
   | { ok: true; name: string; modules: string[] }
   | { ok: false; reason: DesignSystemManifestIncompatibility | BuildInfoIncompatibility; modules: [] }
@@ -902,21 +903,18 @@ export interface DesignSystemApi {
    *  the producer side (`panda lib`). */
   create(input: DesignSystemManifestInput): DesignSystemManifest
 
-  /** Check a manifest's `schemaVersion` against this compiler; the peer-range
-   *  verdict is layered on by the host. */
-  validate(manifest: DesignSystemManifest): DesignSystemManifestCompatibility
+  /** Check a manifest's `schemaVersion` against this compiler, plus the `panda`
+   *  major against `options.pandaVersion` when supplied — so `ok: true` means
+   *  safe to use, not just a matching wire version. */
+  validate(manifest: DesignSystemManifest, options?: DesignSystemValidateOptions): DesignSystemManifestCompatibility
 
-  /** Consumer side (`designSystem: '@acme/ds'`): validate the manifest, resolve
-   *  which library modules the consumer's imports touch, and hydrate them under
-   *  the manifest name as a layer. Covers the build-info half — preset and
-   *  `importMap` merge into the consumer config at build time, in the host,
-   *  since the engine value layer can't execute the preset module. */
+  /** Consumer side (`designSystem: '@acme/ds'`): validate the manifest and
+   *  hydrate the modules the consumer's imports touch, under the manifest name.
+   *  The build-info half only — preset + `importMap` merge in the host. */
   load(manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult
 
-  /** Order a set of already-read manifests by their parent (`designSystem`)
-   *  links into a deduped, root-first plan — the composition case (a design
-   *  system built on another). The host reads each level off disk and hands the
-   *  values here; this catches cycles and returns the merge/hydrate order. */
+  /** Order already-read manifests by their parent (`designSystem`) links into a
+   *  deduped, root-first plan — the composition case. Catches cycles. */
   resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainResult
 }
 

--- a/packages/compiler-wasm/__tests__/design-system.test.ts
+++ b/packages/compiler-wasm/__tests__/design-system.test.ts
@@ -80,6 +80,12 @@ describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
     expect(app.designSystem.validate(manifest)).toEqual({ ok: false, reason: 'schemaVersion' })
   })
 
+  it('validate() rejects when the running Panda major is outside the manifest range', async () => {
+    const app = await createCompiler(baseConfig)
+    const manifest = app.designSystem.create(fullInput)
+    expect(app.designSystem.validate(manifest, { pandaVersion: '1.9.0' })).toEqual({ ok: false, reason: 'pandaRange' })
+  })
+
   // load(): produce a manifest + build info on a lib, then load into a fresh
   // consumer across the wasm boundary — the full consumer round-trip.
   it('load() validates + tree-shakes the library build info to imported modules', async () => {

--- a/packages/compiler-wasm/__tests__/design-system.test.ts
+++ b/packages/compiler-wasm/__tests__/design-system.test.ts
@@ -124,6 +124,29 @@ describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
       modules: [],
     })
   })
+
+  // resolveChain across the boundary: ordered plan and cycle detection.
+  it('resolveChain() orders a chain root-first and reports cycles', async () => {
+    const app = await createCompiler(baseConfig)
+    const node = (name: string, parent?: string) =>
+      app.designSystem.create({
+        name,
+        panda: '^2.0.0',
+        preset: './preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+        designSystem: parent,
+      })
+
+    expect(
+      app.designSystem.resolveChain([node('@acme/marketing', '@acme/foundations'), node('@acme/foundations')]),
+    ).toEqual({ ok: true, order: ['@acme/foundations', '@acme/marketing'] })
+
+    expect(app.designSystem.resolveChain([node('@acme/a', '@acme/b'), node('@acme/b', '@acme/a')])).toEqual({
+      ok: false,
+      reason: 'cycle',
+      cycle: ['@acme/a', '@acme/b', '@acme/a'],
+    })
+  })
 })
 
 describeMissingWasm()

--- a/packages/compiler-wasm/__tests__/design-system.test.ts
+++ b/packages/compiler-wasm/__tests__/design-system.test.ts
@@ -79,6 +79,51 @@ describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
     }
     expect(app.designSystem.validate(manifest)).toEqual({ ok: false, reason: 'schemaVersion' })
   })
+
+  // load(): produce a manifest + build info on a lib, then load into a fresh
+  // consumer across the wasm boundary — the full consumer round-trip.
+  it('load() validates + tree-shakes the library build info to imported modules', async () => {
+    const lib = await createCompiler(baseConfig)
+    lib.parseFileSource('button.tsx', "import { css } from '@panda/css'\nexport const Button = css({ color: 'red' })")
+    lib.parseFileSource('card.tsx', "import { css } from '@panda/css'\nexport const Card = css({ background: 'blue' })")
+
+    const buildInfo = {
+      ...lib.buildInfo.create({ panda: '^2.0.0' }),
+      exports: { Button: 'button.tsx', Card: 'card.tsx' },
+    }
+    const manifest = lib.designSystem.create(fullInput)
+
+    const app = await createCompiler(baseConfig)
+    expect(app.designSystem.load(manifest, { buildInfo, imports: ['Button'] })).toEqual({
+      ok: true,
+      name: '@acme/ds',
+      modules: ['button.tsx'],
+    })
+
+    // card's `background: blue` should not hydrate.
+    expect(app.getLayerCss({ layers: ['utilities'] }).css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .color_red {
+          color: red;
+        }
+      }
+      "
+    `)
+  })
+
+  it('load() bails on an incompatible build info', async () => {
+    const lib = await createCompiler(baseConfig)
+    lib.parseFileSource('button.tsx', "import { css } from '@panda/css'\nexport const Button = css({ color: 'red' })")
+    const buildInfo = lib.buildInfo.create({ panda: '^2.0.0' })
+    const stale = { ...buildInfo, schemaVersion: buildInfo.schemaVersion + 1 }
+
+    const app = await createCompiler(baseConfig)
+    expect(app.designSystem.load(app.designSystem.create(fullInput), { buildInfo: stale })).toEqual({
+      ok: false,
+      reason: 'schemaVersion',
+      modules: [],
+    })
+  })
 })
 
 describeMissingWasm()

--- a/packages/compiler-wasm/__tests__/design-system.test.ts
+++ b/packages/compiler-wasm/__tests__/design-system.test.ts
@@ -1,8 +1,8 @@
 import type { DesignSystemManifest, DesignSystemManifestInput } from '@pandacss/compiler-shared'
-import { describe, expect, it } from 'vitest'
-import { createProject } from './test-utils'
+import { expect, it } from 'vitest'
 
-const project = () => createProject({})
+import { baseConfig, describeIfBuilt, describeMissingWasm } from './helpers'
+import { createCompiler } from '../src'
 
 const fullInput: DesignSystemManifestInput = {
   name: '@acme/ds',
@@ -15,9 +15,9 @@ const fullInput: DesignSystemManifestInput = {
   files: ['./dist/**/*.mjs'],
 }
 
-describe('compiler.designSystem', () => {
-  it('create() stamps the engine schema version and carries input fields', () => {
-    const app = project()
+describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
+  it('create() stamps the engine schema version and carries input fields', async () => {
+    const app = await createCompiler(baseConfig)
     const manifest = app.designSystem.create(fullInput)
 
     expect(manifest.schemaVersion).toBe(app.designSystem.schemaVersion)
@@ -33,8 +33,19 @@ describe('compiler.designSystem', () => {
     })
   })
 
-  it('create() omits absent optionals on the wire', () => {
-    const manifest = project().designSystem.create({
+  // serde_wasm_bindgen serializes maps as objects — importMap must be a plain
+  // object across the boundary, not a Map (parity with the native binding).
+  it('create() returns importMap as a plain object', async () => {
+    const app = await createCompiler(baseConfig)
+    const { importMap } = app.designSystem.create(fullInput)
+
+    expect(importMap).not.toBeInstanceOf(Map)
+    expect(Object.getPrototypeOf(importMap)).toBe(Object.prototype)
+  })
+
+  it('create() omits absent optionals on the wire', async () => {
+    const app = await createCompiler(baseConfig)
+    const manifest = app.designSystem.create({
       name: '@acme/ds',
       panda: '^2.0.0',
       preset: './preset.mjs',
@@ -47,44 +58,21 @@ describe('compiler.designSystem', () => {
     expect('files' in manifest).toBe(false)
   })
 
-  it('create() throws when a required field is missing', () => {
-    const app = project()
+  it('create() throws when a required field is missing', async () => {
+    const app = await createCompiler(baseConfig)
     expect(() =>
       // @ts-expect-error - missing required `panda`
       app.designSystem.create({ name: '@acme/ds', preset: './preset.mjs', buildInfo: './panda.buildinfo.json' }),
     ).toThrow()
   })
 
-  it('create() ignores unknown input fields', () => {
-    const manifest = project().designSystem.create({
-      name: '@acme/ds',
-      panda: '^2.0.0',
-      preset: './preset.mjs',
-      buildInfo: './panda.buildinfo.json',
-      // @ts-expect-error - unknown field is dropped, not surfaced
-      bogus: 'ignored',
-    })
-    expect('bogus' in manifest).toBe(false)
-  })
-
-  it('create() collapses an empty files array to absent', () => {
-    const manifest = project().designSystem.create({
-      name: '@acme/ds',
-      panda: '^2.0.0',
-      preset: './preset.mjs',
-      buildInfo: './panda.buildinfo.json',
-      files: [],
-    })
-    expect('files' in manifest).toBe(false)
-  })
-
-  it('validate() accepts a manifest with a matching schemaVersion', () => {
-    const app = project()
+  it('validate() accepts a manifest with a matching schemaVersion', async () => {
+    const app = await createCompiler(baseConfig)
     expect(app.designSystem.validate(app.designSystem.create(fullInput))).toEqual({ ok: true })
   })
 
-  it('validate() rejects an unsupported schemaVersion', () => {
-    const app = project()
+  it('validate() rejects an unsupported schemaVersion', async () => {
+    const app = await createCompiler(baseConfig)
     const manifest: DesignSystemManifest = {
       ...app.designSystem.create(fullInput),
       schemaVersion: app.designSystem.schemaVersion + 1,
@@ -92,3 +80,5 @@ describe('compiler.designSystem', () => {
     expect(app.designSystem.validate(manifest)).toEqual({ ok: false, reason: 'schemaVersion' })
   })
 })
+
+describeMissingWasm()

--- a/packages/compiler-wasm/crate/src/project.rs
+++ b/packages/compiler-wasm/crate/src/project.rs
@@ -769,6 +769,23 @@ impl WasmCompiler {
             .map_err(|err| JsValue::from_str(&err.to_string()))
     }
 
+    /// Order already-read manifests by their `designSystem` parent links into a
+    /// root-first hydrate/merge plan (or report a cycle). Backs the
+    /// `designSystem.resolveChain` JS namespace. Pure — the host did the reads.
+    ///
+    /// # Errors
+    /// Returns a JS error if `manifests` is invalid or the plan fails to serialize.
+    #[wasm_bindgen(js_name = resolveDesignSystemChain)]
+    pub fn resolve_design_system_chain(&self, manifests: JsValue) -> Result<JsValue, JsValue> {
+        let manifests: Vec<pandacss_project::DesignSystemManifest> =
+            serde_wasm_bindgen::from_value(manifests)
+                .map_err(|err| JsValue::from_str(&err.to_string()))?;
+        let plan = pandacss_project::resolve_chain(&manifests);
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        plan.serialize(&serializer)
+            .map_err(|err| JsValue::from_str(&err.to_string()))
+    }
+
     /// The manifest wire-format version this binding reads/writes.
     #[wasm_bindgen(js_name = designSystemManifestSchemaVersion)]
     #[must_use]

--- a/packages/compiler-wasm/crate/src/project.rs
+++ b/packages/compiler-wasm/crate/src/project.rs
@@ -753,6 +753,29 @@ impl WasmCompiler {
         pandacss_project::SCHEMA_VERSION
     }
 
+    /// Build a `panda.lib.json` value from host-supplied fields, stamping the
+    /// engine-owned schema version. Backs the `designSystem.create` JS namespace.
+    ///
+    /// # Errors
+    /// Returns a JS error if `input` is invalid or the manifest fails to serialize.
+    #[wasm_bindgen(js_name = createDesignSystemManifest)]
+    pub fn create_design_system_manifest(&self, input: JsValue) -> Result<JsValue, JsValue> {
+        let input: pandacss_project::ManifestInput = serde_wasm_bindgen::from_value(input)
+            .map_err(|err| JsValue::from_str(&err.to_string()))?;
+        let manifest = self.inner.design_system_manifest(input);
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        manifest
+            .serialize(&serializer)
+            .map_err(|err| JsValue::from_str(&err.to_string()))
+    }
+
+    /// The manifest wire-format version this binding reads/writes.
+    #[wasm_bindgen(js_name = designSystemManifestSchemaVersion)]
+    #[must_use]
+    pub fn design_system_manifest_schema_version(&self) -> u32 {
+        pandacss_project::MANIFEST_SCHEMA_VERSION
+    }
+
     /// Engine-owned fingerprint of the resolved config's output-affecting fields,
     /// stamped into build info as `configFingerprint`.
     #[wasm_bindgen(js_name = configFingerprint)]

--- a/packages/compiler-wasm/src/types.ts
+++ b/packages/compiler-wasm/src/types.ts
@@ -13,6 +13,8 @@
 import type {
   Atom,
   BuildInfo,
+  DesignSystemManifest,
+  DesignSystemManifestInput,
   CodegenArtifact,
   CodegenArtifactId,
   CodegenDependency,
@@ -158,4 +160,8 @@ export declare class WasmCompiler {
   applyBuildInfo(name: string, buildInfo: BuildInfo, only?: string[]): boolean
   buildInfoSchemaVersion(): number
   configFingerprint(): string
+  // Flat design-system manifest primitives (the `makeDesignSystemApi` namespace
+  // is built over these in `web.ts`, mirroring the native binding).
+  createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
+  designSystemManifestSchemaVersion(): number
 }

--- a/packages/compiler-wasm/src/web.ts
+++ b/packages/compiler-wasm/src/web.ts
@@ -22,6 +22,7 @@ import {
   assertProjectHooks,
   getTokenCategoryValues,
   makeBuildInfoApi,
+  makeDesignSystemApi,
   mergeCallbacks,
   prepareCompilerConfig,
 } from '@pandacss/compiler-shared'
@@ -29,6 +30,7 @@ import type {
   BuildInfoNative,
   Compiler,
   CompilerOptions,
+  DesignSystemNative,
   ProjectCallbacks,
   ProjectHooks,
   SerializedConfig,
@@ -100,10 +102,15 @@ export function build(
   // Expose the shared FS as a field so the return shape matches native.
   ;(compiler as unknown as { fs: WasmFileSystem }).fs = fs
 
-  // Wire the ergonomic `compiler.buildInfo` namespace over the wasm primitives,
-  // mirroring the native binding. Non-enumerable so it stays off snapshots.
+  // Wire the ergonomic `compiler.buildInfo` / `compiler.designSystem` namespaces
+  // over the wasm primitives, mirroring the native binding. Non-enumerable so
+  // they stay off snapshots.
   Object.defineProperty(compiler, 'buildInfo', {
     value: makeBuildInfoApi(compiler as unknown as BuildInfoNative),
+    enumerable: false,
+  })
+  Object.defineProperty(compiler, 'designSystem', {
+    value: makeDesignSystemApi(compiler as unknown as DesignSystemNative),
     enumerable: false,
   })
 

--- a/packages/compiler-wasm/src/web.ts
+++ b/packages/compiler-wasm/src/web.ts
@@ -105,12 +105,11 @@ export function build(
   // Wire the ergonomic `compiler.buildInfo` / `compiler.designSystem` namespaces
   // over the wasm primitives, mirroring the native binding. Non-enumerable so
   // they stay off snapshots.
-  Object.defineProperty(compiler, 'buildInfo', {
-    value: makeBuildInfoApi(compiler as unknown as BuildInfoNative),
-    enumerable: false,
-  })
+  const buildInfo = makeBuildInfoApi(compiler as unknown as BuildInfoNative)
+  Object.defineProperty(compiler, 'buildInfo', { value: buildInfo, enumerable: false })
   Object.defineProperty(compiler, 'designSystem', {
-    value: makeDesignSystemApi(compiler as unknown as DesignSystemNative),
+    // `load` reuses the `buildInfo` namespace just wired above.
+    value: makeDesignSystemApi(compiler as unknown as DesignSystemNative, buildInfo),
     enumerable: false,
   })
 

--- a/packages/compiler/__tests__/design-system.test.ts
+++ b/packages/compiler/__tests__/design-system.test.ts
@@ -1,0 +1,63 @@
+import type { DesignSystemManifest, DesignSystemManifestInput } from '@pandacss/compiler-shared'
+import { describe, expect, it } from 'vitest'
+import { createProject } from './test-utils'
+
+const project = () => createProject({})
+
+const fullInput: DesignSystemManifestInput = {
+  name: '@acme/ds',
+  version: '1.2.3',
+  panda: '^2.0.0',
+  preset: './preset.mjs',
+  buildInfo: './panda.buildinfo.json',
+  importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes' },
+  designSystem: '@acme/foundations',
+  files: ['./dist/**/*.mjs'],
+}
+
+describe('compiler.designSystem', () => {
+  it('create() stamps the engine schema version and carries input fields', () => {
+    const app = project()
+    const manifest = app.designSystem.create(fullInput)
+
+    expect(manifest.schemaVersion).toBe(app.designSystem.schemaVersion)
+    expect(manifest).toMatchObject({
+      name: '@acme/ds',
+      version: '1.2.3',
+      panda: '^2.0.0',
+      preset: './preset.mjs',
+      buildInfo: './panda.buildinfo.json',
+      importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes' },
+      designSystem: '@acme/foundations',
+      files: ['./dist/**/*.mjs'],
+    })
+  })
+
+  it('create() omits absent optionals on the wire', () => {
+    const manifest = project().designSystem.create({
+      name: '@acme/ds',
+      panda: '^2.0.0',
+      preset: './preset.mjs',
+      buildInfo: './panda.buildinfo.json',
+    })
+
+    expect(manifest.version).toBeUndefined()
+    expect(manifest.importMap).toBeUndefined()
+    expect(manifest.designSystem).toBeUndefined()
+    expect('files' in manifest).toBe(false)
+  })
+
+  it('validate() accepts a manifest with a matching schemaVersion', () => {
+    const app = project()
+    expect(app.designSystem.validate(app.designSystem.create(fullInput))).toEqual({ ok: true })
+  })
+
+  it('validate() rejects an unsupported schemaVersion', () => {
+    const app = project()
+    const manifest: DesignSystemManifest = {
+      ...app.designSystem.create(fullInput),
+      schemaVersion: app.designSystem.schemaVersion + 1,
+    }
+    expect(app.designSystem.validate(manifest)).toEqual({ ok: false, reason: 'schemaVersion' })
+  })
+})

--- a/packages/compiler/__tests__/design-system.test.ts
+++ b/packages/compiler/__tests__/design-system.test.ts
@@ -176,4 +176,39 @@ describe('compiler.designSystem', () => {
       modules: [],
     })
   })
+
+  // --- resolveChain(): composition — order a chain of parent design systems ---
+
+  // A bare manifest with just identity + parent; resolveChain reads only those.
+  const node = (name: string, parent?: string): DesignSystemManifest =>
+    project().designSystem.create({
+      name,
+      panda: '^2.0.0',
+      preset: './preset.mjs',
+      buildInfo: './panda.buildinfo.json',
+      designSystem: parent,
+    })
+
+  it('resolveChain() orders a chain root-first', () => {
+    const app = project()
+    expect(
+      app.designSystem.resolveChain([node('@acme/marketing', '@acme/foundations'), node('@acme/foundations')]),
+    ).toEqual({ ok: true, order: ['@acme/foundations', '@acme/marketing'] })
+  })
+
+  it('resolveChain() dedupes a shared parent', () => {
+    const app = project()
+    expect(
+      app.designSystem.resolveChain([node('@acme/a', '@acme/base'), node('@acme/b', '@acme/base'), node('@acme/base')]),
+    ).toEqual({ ok: true, order: ['@acme/base', '@acme/a', '@acme/b'] })
+  })
+
+  it('resolveChain() reports a cycle path', () => {
+    const app = project()
+    expect(app.designSystem.resolveChain([node('@acme/a', '@acme/b'), node('@acme/b', '@acme/a')])).toEqual({
+      ok: false,
+      reason: 'cycle',
+      cycle: ['@acme/a', '@acme/b', '@acme/a'],
+    })
+  })
 })

--- a/packages/compiler/__tests__/design-system.test.ts
+++ b/packages/compiler/__tests__/design-system.test.ts
@@ -91,4 +91,89 @@ describe('compiler.designSystem', () => {
     }
     expect(app.designSystem.validate(manifest)).toEqual({ ok: false, reason: 'schemaVersion' })
   })
+
+  // --- load(): consumer side — validate + hydrate the library's build info ---
+
+  // A library publishing two styled modules, plus the manifest pointing at it.
+  const lib = () => {
+    const ds = createProject({ utilities: { padding: { className: 'p' }, margin: { className: 'm' } } })
+    ds.parseFileSource(
+      'button.tsx',
+      "import { css } from '@panda/css'\nexport const Button = css({ color: 'red', padding: '4px' })",
+    )
+    ds.parseFileSource(
+      'card.tsx',
+      "import { css } from '@panda/css'\nexport const Card = css({ color: 'red', margin: '8px' })",
+    )
+    const buildInfo = {
+      ...ds.buildInfo.create({ panda: '^2.0.0' }),
+      exports: { Button: 'button.tsx', Card: 'card.tsx' },
+    }
+    const manifest = ds.designSystem.create({ ...fullInput, importMap: undefined })
+    return { manifest, buildInfo }
+  }
+
+  it('load() hydrates every module when imports are omitted', () => {
+    const app = project()
+    const { manifest, buildInfo } = lib()
+
+    expect(app.designSystem.load(manifest, { buildInfo })).toEqual({
+      ok: true,
+      name: '@acme/ds',
+      modules: ['button.tsx', 'card.tsx'],
+    })
+  })
+
+  it('load() tree-shakes to the modules the consumer imports', () => {
+    const app = project()
+    const { manifest, buildInfo } = lib()
+
+    expect(app.designSystem.load(manifest, { buildInfo, imports: ['Button'] })).toEqual({
+      ok: true,
+      name: '@acme/ds',
+      modules: ['button.tsx'],
+    })
+    expect(app.getLayerCss({ layers: ['utilities'] }).css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .padding_4px {
+          padding: 4px;
+        }
+        .color_red {
+          color: red;
+        }
+      }
+      "
+    `)
+  })
+
+  it('load() with empty imports hydrates nothing', () => {
+    const app = project()
+    const { manifest, buildInfo } = lib()
+
+    expect(app.designSystem.load(manifest, { buildInfo, imports: [] })).toEqual({
+      ok: true,
+      name: '@acme/ds',
+      modules: [],
+    })
+  })
+
+  it('load() bails on a manifest schemaVersion mismatch — host re-extracts files', () => {
+    const app = project()
+    const { manifest, buildInfo } = lib()
+    const stale: DesignSystemManifest = { ...manifest, schemaVersion: manifest.schemaVersion + 1 }
+
+    expect(app.designSystem.load(stale, { buildInfo })).toEqual({ ok: false, reason: 'schemaVersion', modules: [] })
+  })
+
+  it('load() bails on an incompatible build info', () => {
+    const app = project()
+    const { manifest, buildInfo } = lib()
+    const stale = { ...buildInfo, schemaVersion: buildInfo.schemaVersion + 1 }
+
+    expect(app.designSystem.load(manifest, { buildInfo: stale })).toEqual({
+      ok: false,
+      reason: 'schemaVersion',
+      modules: [],
+    })
+  })
 })

--- a/packages/compiler/__tests__/design-system.test.ts
+++ b/packages/compiler/__tests__/design-system.test.ts
@@ -92,6 +92,18 @@ describe('compiler.designSystem', () => {
     expect(app.designSystem.validate(manifest)).toEqual({ ok: false, reason: 'schemaVersion' })
   })
 
+  it('validate() accepts when the running Panda major matches the manifest range', () => {
+    const app = project()
+    const manifest = app.designSystem.create(fullInput)
+    expect(app.designSystem.validate(manifest, { pandaVersion: '2.5.1' })).toEqual({ ok: true })
+  })
+
+  it('validate() rejects when the running Panda major is outside the manifest range', () => {
+    const app = project()
+    const manifest = app.designSystem.create(fullInput)
+    expect(app.designSystem.validate(manifest, { pandaVersion: '1.9.0' })).toEqual({ ok: false, reason: 'pandaRange' })
+  })
+
   // --- load(): consumer side — validate + hydrate the library's build info ---
 
   // A library publishing two styled modules, plus the manifest pointing at it.
@@ -163,6 +175,17 @@ describe('compiler.designSystem', () => {
     const stale: DesignSystemManifest = { ...manifest, schemaVersion: manifest.schemaVersion + 1 }
 
     expect(app.designSystem.load(stale, { buildInfo })).toEqual({ ok: false, reason: 'schemaVersion', modules: [] })
+  })
+
+  it('load() bails when the running Panda major is outside the range — host re-extracts files', () => {
+    const app = project()
+    const { manifest, buildInfo } = lib()
+
+    expect(app.designSystem.load(manifest, { buildInfo, pandaVersion: '1.0.0' })).toEqual({
+      ok: false,
+      reason: 'pandaRange',
+      modules: [],
+    })
   })
 
   it('load() bails on an incompatible build info', () => {

--- a/packages/compiler/crate/src/project.rs
+++ b/packages/compiler/crate/src/project.rs
@@ -428,6 +428,34 @@ impl Compiler {
         pandacss_project::SCHEMA_VERSION
     }
 
+    /// Build a `panda.lib.json` value from host-supplied fields, stamping the
+    /// engine-owned schema version. Backs the `designSystem.create` JS namespace.
+    ///
+    /// # Errors
+    /// Returns an error if `input` is invalid or the manifest fails to serialize.
+    #[napi(js_name = createDesignSystemManifest)]
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "NAPI requires owned arguments"
+    )]
+    pub fn create_design_system_manifest(
+        &self,
+        input: serde_json::Value,
+    ) -> napi::Result<serde_json::Value> {
+        let input: pandacss_project::ManifestInput = serde_json::from_value(input)
+            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+        let manifest = self.inner.design_system_manifest(input);
+        serde_json::to_value(&manifest).map_err(|err| napi::Error::from_reason(err.to_string()))
+    }
+
+    /// The manifest wire-format version this binding reads/writes. The JS
+    /// `designSystem.validate` compares a manifest's `schemaVersion` against it.
+    #[napi(js_name = designSystemManifestSchemaVersion)]
+    #[must_use]
+    pub fn design_system_manifest_schema_version(&self) -> u32 {
+        pandacss_project::MANIFEST_SCHEMA_VERSION
+    }
+
     /// Stateless source inspection for tooling (reporting, lint, IDE). Returns
     /// classified Panda usage sites plus file-local extraction diagnostics.
     ///

--- a/packages/compiler/crate/src/project.rs
+++ b/packages/compiler/crate/src/project.rs
@@ -456,6 +456,29 @@ impl Compiler {
         pandacss_project::MANIFEST_SCHEMA_VERSION
     }
 
+    /// Order already-read manifests by their `designSystem` parent links into a
+    /// root-first hydrate/merge plan (or report a cycle). Backs the
+    /// `designSystem.resolveChain` JS namespace. Pure — the host did the reads.
+    ///
+    /// # Errors
+    /// Returns an error if `manifests` isn't a valid manifest array or the plan
+    /// fails to serialize.
+    #[napi(js_name = resolveDesignSystemChain)]
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "NAPI requires owned arguments"
+    )]
+    pub fn resolve_design_system_chain(
+        &self,
+        manifests: serde_json::Value,
+    ) -> napi::Result<serde_json::Value> {
+        let manifests: Vec<pandacss_project::DesignSystemManifest> =
+            serde_json::from_value(manifests)
+                .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+        let plan = pandacss_project::resolve_chain(&manifests);
+        serde_json::to_value(&plan).map_err(|err| napi::Error::from_reason(err.to_string()))
+    }
+
     /// Stateless source inspection for tooling (reporting, lint, IDE). Returns
     /// classified Panda usage sites plus file-local extraction diagnostics.
     ///

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -16,6 +16,22 @@ import type {
 import { makeBuildInfoApi, makeDesignSystemApi } from '@pandacss/compiler-shared'
 import type { CompilerConstructor, ExtractorSession, ExtractorSessionConstructor, NativeBinding } from './types'
 
+/** No-op build-info primitives so the fallback compiler still satisfies the
+ *  `Compiler.buildInfo` surface; `validate`/`hydrate` always report incompatible. */
+const fallbackBuildInfo = makeBuildInfoApi({
+  serializeBuildInfo: () => ({
+    schemaVersion: -1,
+    panda: '',
+    configFingerprint: '',
+    strings: [],
+    atoms: [],
+    modules: {},
+  }),
+  applyBuildInfo: () => false,
+  buildInfoSchemaVersion: () => -1,
+  configFingerprint: () => '',
+})
+
 /** No-op design-system primitives; `validate` always reports incompatible
  *  (`schemaVersion` is `-1`). */
 const fallbackDesignSystem = makeDesignSystemApi(
@@ -220,22 +236,6 @@ export const fallback: NativeBinding = {
   Extractor: FallbackExtractor as unknown as ExtractorSessionConstructor,
   Compiler: FallbackCompiler as unknown as CompilerConstructor,
 }
-
-/** No-op build-info primitives so the fallback compiler still satisfies the
- *  `Compiler.buildInfo` surface; `validate`/`hydrate` always report incompatible. */
-const fallbackBuildInfo = makeBuildInfoApi({
-  serializeBuildInfo: () => ({
-    schemaVersion: -1,
-    panda: '',
-    configFingerprint: '',
-    strings: [],
-    atoms: [],
-    modules: {},
-  }),
-  applyBuildInfo: () => false,
-  buildInfoSchemaVersion: () => -1,
-  configFingerprint: () => '',
-})
 
 function emptyCompileOutput(): CompileOutput {
   return {

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -22,6 +22,7 @@ const fallbackDesignSystem = makeDesignSystemApi(
   {
     createDesignSystemManifest: (input: DesignSystemManifestInput) => ({ ...input, schemaVersion: -1 }),
     designSystemManifestSchemaVersion: () => -1,
+    resolveDesignSystemChain: () => ({ status: 'ordered', order: [] }),
   },
   fallbackBuildInfo,
 )

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -2,6 +2,7 @@ import type {
   Atom,
   CompileOutput,
   Compiler,
+  DesignSystemManifestInput,
   Diagnostic,
   LayerCssOptions,
   SplitCssOptions,
@@ -12,8 +13,15 @@ import type {
   WriteLayerCssOptions,
   WriteSplitCssOptions,
 } from '@pandacss/compiler-shared'
-import { makeBuildInfoApi } from '@pandacss/compiler-shared'
+import { makeBuildInfoApi, makeDesignSystemApi } from '@pandacss/compiler-shared'
 import type { CompilerConstructor, ExtractorSession, ExtractorSessionConstructor, NativeBinding } from './types'
+
+/** No-op design-system primitives; `validate` always reports incompatible
+ *  (`schemaVersion` is `-1`). */
+const fallbackDesignSystem = makeDesignSystemApi({
+  createDesignSystemManifest: (input: DesignSystemManifestInput) => ({ ...input, schemaVersion: -1 }),
+  designSystemManifestSchemaVersion: () => -1,
+})
 
 class FallbackExtractor implements ExtractorSession {
   extract() {
@@ -156,6 +164,7 @@ class FallbackCompiler implements Compiler {
     return []
   }
   readonly buildInfo = fallbackBuildInfo
+  readonly designSystem = fallbackDesignSystem
   generateArtifacts() {
     return []
   }

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -18,10 +18,13 @@ import type { CompilerConstructor, ExtractorSession, ExtractorSessionConstructor
 
 /** No-op design-system primitives; `validate` always reports incompatible
  *  (`schemaVersion` is `-1`). */
-const fallbackDesignSystem = makeDesignSystemApi({
-  createDesignSystemManifest: (input: DesignSystemManifestInput) => ({ ...input, schemaVersion: -1 }),
-  designSystemManifestSchemaVersion: () => -1,
-})
+const fallbackDesignSystem = makeDesignSystemApi(
+  {
+    createDesignSystemManifest: (input: DesignSystemManifestInput) => ({ ...input, schemaVersion: -1 }),
+    designSystemManifestSchemaVersion: () => -1,
+  },
+  fallbackBuildInfo,
+)
 
 class FallbackExtractor implements ExtractorSession {
   extract() {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -91,7 +91,8 @@ function build(config: SerializedConfig, callbacks: ProjectCallbacks, options?: 
 }
 
 /** Wire the ergonomic `compiler.buildInfo` namespace over the native primitives.
- *  Non-enumerable so it doesn't surface in snapshots of the native instance. */
+ *  Non-enumerable so it doesn't surface in snapshots of the native instance, and
+ *  lazy — the API is built on first access, then cached in place. */
 function attachBuildInfo(compiler: Compiler): void {
   Object.defineProperty(compiler, 'buildInfo', {
     enumerable: false,
@@ -108,12 +109,22 @@ function attachBuildInfo(compiler: Compiler): void {
   })
 }
 
-/** Wire `compiler.designSystem` over the native primitives; non-enumerable,
- *  mirroring `buildInfo`. */
+/** Wire `compiler.designSystem` over the native primitives; non-enumerable and
+ *  lazy, mirroring `buildInfo`. `designSystem.load` reuses the `buildInfo`
+ *  namespace (accessing it here triggers its own lazy build). */
 function attachDesignSystem(compiler: Compiler): void {
   Object.defineProperty(compiler, 'designSystem', {
-    value: makeDesignSystemApi(compiler as unknown as DesignSystemNative),
     enumerable: false,
+    configurable: true,
+    get() {
+      const api = makeDesignSystemApi(compiler as unknown as DesignSystemNative, compiler.buildInfo)
+      Object.defineProperty(compiler, 'designSystem', {
+        value: api,
+        enumerable: false,
+        configurable: true,
+      })
+      return api
+    },
   })
 }
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -4,6 +4,7 @@ import type {
   CompileOutput,
   CompilerOptions,
   ConfigSnapshot,
+  DesignSystemNative,
   ProjectCallbacks,
   SerializedConfig,
 } from '@pandacss/compiler-shared'
@@ -12,6 +13,7 @@ import {
   assertProjectCallbacks,
   getTokenCategoryValues,
   makeBuildInfoApi,
+  makeDesignSystemApi,
   mergeCallbacks,
   mergeHooks,
   prepareCompilerConfig,
@@ -83,6 +85,7 @@ function build(config: SerializedConfig, callbacks: ProjectCallbacks, options?: 
   const compiler = nativeCompilerFromConfig(prepared, toNativeOptions(options), createUtilityValuesCallbacks(callbacks))
   registerCallbacks(compiler, callbacks, options?.hooks, compiler.token_dictionary?.())
   attachBuildInfo(compiler)
+  attachDesignSystem(compiler)
 
   return compiler
 }
@@ -102,6 +105,15 @@ function attachBuildInfo(compiler: Compiler): void {
       })
       return api
     },
+  })
+}
+
+/** Wire `compiler.designSystem` over the native primitives; non-enumerable,
+ *  mirroring `buildInfo`. */
+function attachDesignSystem(compiler: Compiler): void {
+  Object.defineProperty(compiler, 'designSystem', {
+    value: makeDesignSystemApi(compiler as unknown as DesignSystemNative),
+    enumerable: false,
   })
 }
 


### PR DESCRIPTION
## what

introduce first-class design systems, starting with the manifest.

- a design note for the whole feature: `designSystem: '@acme/ds'` backed by a `panda.lib.json` manifest that ties a library's preset, build info, import paths, and its own parent design system into one resolvable unit.
- the engine primitives over that manifest, exposed as `compiler.designSystem` across the native and wasm bindings:
  - `create` — produce a manifest from a built project (`panda lib`, later).
  - `validate` — schema check.
  - `load` — the consumer side: validate the manifest, then hydrate the library's pre-extracted styles, tree-shaken to the consumer's imports.
  - `resolveChain` — the composition case: order a chain of parent design systems root-first, deduping shared ancestors and reporting cycles.

## why

adopting a design system today means hand-wiring `presets` + `importMap` + `include` + a `buildinfo` path, and re-extracting every imported component in every app. the manifest collapses that to one field.

the hard logic — generation, consumption, and the parent-chain walk — is pure compiler methods over in-memory values. the engine owns it, the host owns fs + module resolution. so the bug-prone parts (version guard, resolve + hydrate, and the cycle guard in the chain walk) are testable without touching disk.

## notes

- engine primitives only. no `designSystem` config field, no `panda lib` CLI yet. the config field, host module resolution, smart `include`, and `panda lib` are later phases — laid out in the design note.
- `load` covers the build-info half of consumption. the preset + `importMap` merge into the consumer config is the host's job: the value layer can't execute the preset module. on any incompatibility `load` returns `{ ok: false, reason }` so the host falls back to re-extracting the manifest's `files`.
- `resolveChain` takes the manifests the host already read and returns the root-first merge/hydrate order (or a cycle path). a parent absent from the set is a chain boundary — the host owns parent-not-found via module resolution.
- `create` stamps the schema version and carries host-supplied fields today; `importMap` and the parent `designSystem` come from resolved config in phase 2. the input shape already allows them, so that lands without a signature change.
- the design note resolves the prior open questions as decisions (manifest location, stale-buildinfo fallback, token conflict, condition reconciliation, `staticCss`, layer ordering). three genuinely-open items remain.

## test plan

- [x] `cargo test -p pandacss_project --test integration design_system` — manifest value (stamp + carry, optional omission, json round-trip) + chain resolution (depth-n order, shared-parent dedup, absent-parent boundary, cycle path, empty set)
- [x] native vitest `design-system` (15: create/validate, load hydrate + tree-shake + mismatch, resolveChain order/dedup/cycle) + `build-info` (17, no regression)
- [x] wasm vitest `design-system` (9: create/validate + load + resolveChain over the boundary) + `build-info` (3)
- [x] `pnpm typecheck`
- [x] `cargo fmt --all --check`; clippy on `pandacss_project`, `compiler_napi`, `compiler_wasm`
- [x] rebuilt `compiler.node` + wasm bundle so the binding tests ran against the new methods
