### PR TITLE
fix(compiler): scope every comma member of a nested `&` selector (page-blank fix)

### DIFF
--- a/.changeset/fix-comma-group-nested-selector-scope.md
+++ b/.changeset/fix-comma-group-nested-selector-scope.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix a comma member of a nested `&` selector losing its class scope, leaking a bare selector that could match `<html>` and blank the page.
+
+A nested-selector key may mix `&` and non-`&` comma members, e.g.
+`css({ '&:not(:first-child), :only-child': { … } })`. The engine substituted the parent into members that contain `&`, but left members **without** `&` untouched — so `:only-child` was emitted as a bare, unscoped selector. A bare `:only-child` matches `<html>` (the document's only element child); with `display: none` in the block that hid the entire app.
+
+`replace_selector_parent` now scopes every comma member: a member with `&` substitutes the parent (`.cls:not(:first-child)`), and a member without `&` becomes a descendant of the parent (`.cls :only-child`) — exactly how a whole `&`-free selector is already treated. This matches legacy Panda, which scopes each member.

--- a/crates/pandacss_stylesheet/src/conditions.rs
+++ b/crates/pandacss_stylesheet/src/conditions.rs
@@ -289,7 +289,18 @@ fn replace_selector_parent(raw: &str, parent: &str) -> String {
     let mut out = Vec::new();
     for parent in &parent_selectors {
         for raw in &raw_selectors {
-            out.push(raw.replace('&', parent));
+            // Each comma member is scoped independently: a member containing `&`
+            // substitutes the parent in place; a member WITHOUT `&` (e.g. the
+            // `:only-child` in `&:not(:first-child), :only-child`) is a
+            // descendant of the parent, exactly as `nested_selector` treats a
+            // whole `&`-free selector. Skipping the descendant prefix left such
+            // members unscoped — a bare `:only-child` matches <html> and the rule
+            // leaks to the whole document.
+            if raw.contains('&') {
+                out.push(raw.replace('&', parent));
+            } else {
+                out.push(format!("{parent} {raw}"));
+            }
         }
     }
     out.join(", ")

--- a/crates/pandacss_stylesheet/tests/atomic.rs
+++ b/crates/pandacss_stylesheet/tests/atomic.rs
@@ -500,6 +500,37 @@ fn escapes_nested_selector_keys_into_valid_class_names() {
 }
 
 #[test]
+fn comma_group_nested_selector_scopes_every_member() {
+    // A comma-separated nested-selector key where only SOME members contain `&`
+    // (`&:not(:first-child), :only-child`) must scope EVERY member to the atomic
+    // class: the `&` member substitutes the class, and the bare `:only-child`
+    // member becomes a descendant of the class. The bug left `:only-child`
+    // (no `&`) UNSCOPED, emitting a bare `:only-child { display: none }` — which
+    // matches <html> (the document's only element child) and blanks the page.
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": { "display": { "className": "d" } }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ '&:not(:first-child), :only-child': { display: 'none' } })",
+        &[StylesheetLayer::Utilities],
+    );
+    // Both comma members are scoped to the atomic class — the `&` member
+    // substitutes it (`.<class>:not(:first-child)`), the bare member becomes a
+    // descendant (`.<class> :only-child`). Crucially, the comma-joined list has
+    // NO bare leading-pseudo member; the previous output dropped the class scope
+    // on the second member, leaving a bare `:only-child` that matched <html>.
+    assert_snapshot!(css, @r"
+@layer utilities {
+  .\[\&\:not\(\:first-child\)\,_\:only-child\]\:d_none:not(:first-child), .\[\&\:not\(\:first-child\)\,_\:only-child\]\:d_none :only-child {
+    display: none;
+  }
+}
+");
+}
+
+#[test]
 fn escapes_leading_double_dash_class_names() {
     let config = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },


### PR DESCRIPTION
## Problem

A nested-selector key that mixes `&` and non-`&` comma members drops the class scope on the non-`&` members, emitting a **bare** selector. When that bare selector is a structural pseudo like `:only-child`, it matches `<html>` (the document's only element child) — and a `display: none` in the block **blanks the entire page**.

```ts
styled('div', { base: { '&:not(:first-child), :only-child': { '& .left-border': { display: 'none' } } } })
```

- **Expected** (legacy Panda): both comma members scoped to the atomic class —
  `.<cls>:not(:first-child) .left-border, .<cls> :only-child .left-border { display: none }`
- **v2 (broken):** the second member lost its class scope, emitting a bare `:only-child` → `… :only-child { display: none }` → `html { display: none }` → whole app blank. (Diagnosed via CDP as the page-blanking root cause in a real app.)

## Root cause

`replace_selector_parent` (in `crates/pandacss_stylesheet/src/conditions.rs`) splits the nested selector on top-level commas and, for each member, does `raw.replace('&', parent)`. A member **without** `&` (`:only-child`) has nothing to replace, so it passed through unscoped. The sibling helper `nested_selector` already handles a whole `&`-free selector by prefixing it as a descendant (`{parent} {nested}`) — but that descendant fallback wasn't applied per comma member.

## Fix

Scope every comma member independently: a member containing `&` substitutes the parent in place; a member without `&` becomes a descendant of the parent (`{parent} {member}`) — exactly how `nested_selector` treats a whole `&`-free selector, and matching legacy Panda (which scopes each member). camelCase/`&`-only selectors are unchanged.

## Before / after (real `@pandacss/preset-base`, via `sandbox/codegen`)

```css
/* before — bare :only-child leaks, matches <html> */
… :only-child { display: none }

/* after — both members scoped to the class */
.<cls> .left-border:not(:first-child), .<cls> .left-border :only-child { display: none }
```

No bare leading-pseudo member remains, so the rule can no longer match `<html>` — the page no longer blanks.

## Tests

- New stylesheet repro `comma_group_nested_selector_scopes_every_member` asserting both members of `&:not(:first-child), :only-child` are scoped to the class (no bare `:only-child`).
- `cargo nextest run --workspace` → **1263 passed** (no regression). `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

## Note (separate, lower-severity)

With *two* nesting levels (`{ outer: { inner: {...} } }`), the emitted member order can differ from legacy (`.<cls> .left-border:not(:first-child)` vs legacy's `.<cls>:not(:first-child) .left-border`) because the condition-sort reorders the two order-significant nested arbitrary selectors. That produces a still-**scoped** (non-page-blanking) but structurally different selector. It's a distinct cascade-ordering concern from this page-blank fix; happy to follow up separately if you'd like it addressed in the same PR.

This is a selector-emission bug, distinct from the class-naming divergences in #3601 / #3602 / #3603; refs #3599.

