### PR TITLE
fix(compiler): trim whitespace from non-important value class names

### DIFF
--- a/.changeset/fix-classname-whitespace-trim.md
+++ b/.changeset/fix-classname-whitespace-trim.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix cssgen keeping surrounding whitespace in the class name for non-`!important` values, so the class never matched the runtime.
+
+The runtime `css()` names the class from `withoutSpace(withoutImportant(value))`, and `withoutImportant` always `.trim()`s — so `css({ padding: '0 auto ' })` is labelled `p_0_auto`. The native engine's `class_name_value` only relied on `split_important`'s trim, which (unlike the runtime's unconditional `.trim()`, added in the `!important` fix) skips trimming when there is no `!important` marker. cssgen therefore wrote `.p_0_auto_` — a class the runtime never emits — and the style silently did nothing for any value with leading/trailing whitespace.
+
+`class_name_value` now trims before `withoutSpace`, matching the runtime and legacy Panda. `!important` values were already trimmed by the marker strip, so they are unaffected.

--- a/crates/pandacss_utility/src/lib.rs
+++ b/crates/pandacss_utility/src/lib.rs
@@ -362,7 +362,7 @@ impl Utility {
 
     #[must_use]
     pub fn class_name_value(&self, value: &str) -> String {
-        without_space(value)
+        without_space(value.trim())
     }
 
     #[must_use]
@@ -467,7 +467,8 @@ impl Utility {
         class_input: Option<&str>,
     ) -> UtilityTransformResult {
         let key = self.resolve_shorthand(prop);
-        let class_value = class_input.map_or_else(|| self.class_name_value(value), without_space);
+        let class_value =
+            class_input.map_or_else(|| self.class_name_value(value), |c| without_space(c.trim()));
         let style_value = self.expand_reference_in_value(&arbitrary_value(value));
         let style_prop = self
             .properties

--- a/crates/pandacss_utility/tests/utility.rs
+++ b/crates/pandacss_utility/tests/utility.rs
@@ -1133,6 +1133,10 @@ fn class_name_value_uses_authored_literal() {
 
     assert_eq!(utility.class_name_value("2"), "2");
     assert_eq!(utility.class_name_value("0.5rem"), "0.5rem");
+    // Surrounding whitespace is trimmed to match the runtime
+    // `withoutSpace(withoutImportant(value))`, which always `.trim()`s.
+    assert_eq!(utility.class_name_value("0 auto "), "0_auto");
+    assert_eq!(utility.class_name_value(" 0.5rem"), "0.5rem");
     assert_eq!(
         utility
             .value_alias_for_literal("marginBottom", "0.5rem")


### PR DESCRIPTION
## Problem

The runtime `css()` and the native cssgen disagree on the class **name** for any non-`!important` value with surrounding whitespace, so cssgen writes a rule the runtime never matches and the style silently does nothing.

```ts
css({ padding: '0 auto ' })   // trailing space, no !important
// element gets class:  p_0_auto    (runtime — trimmed)
// stylesheet contains: .p_0_auto_  (cssgen — trailing space → trailing _)
// → no .p_0_auto rule → padding never applies
```

## Root cause

The runtime names the class from `withoutSpace(withoutImportant(value))`, and `withoutImportant` ends in an unconditional `.trim()` — so a value with leading/trailing whitespace is trimmed before it reaches the class name.

The native side splits `!important` off with `pandacss_shared::without_important`, which only trims inside its marker branch and early-returns the value verbatim when there is no `!important`. `class_name_value` then ran `withoutSpace` on that untrimmed value, turning the surrounding space into a `_` (`0 auto ` → `0_auto_`) and naming the class `p_0_auto_`.

`!important` values were unaffected — the marker strip already trims them — which is why the divergence slipped past the `!important` fix.

## Fix

`class_name_value` now trims before `withoutSpace`, matching the runtime and legacy Panda (`@pandacss/core`'s `Utility.transform` names by `withoutSpace(value)` after the value has been trimmed). The token `class_input` path trims too, for the same parity.

```rust
// before
without_space(value)
// after
without_space(value.trim())
```

## Tests

- Extended `class_name_value_uses_authored_literal` with `'0 auto '` → `"0_auto"` and `' 0.5rem'` → `"0.5rem"`.
- `cargo test -p pandacss_utility -p pandacss_stylesheet -p pandacss_project -p pandacss_encoder` — all pass, **no snapshot changes** (nothing relied on the untrimmed class). `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

Same class-name divergence family as #3601 / #3602 / #3603.
