### PR TITLE
fix(compiler): keep author order for chained nested `&` selectors (pseudo-relocation)

### DIFF
--- a/.changeset/fix-nested-selector-pseudo-relocation.md
+++ b/.changeset/fix-nested-selector-pseudo-relocation.md
@@ -1,0 +1,11 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix a structural pseudo being relocated off the parent onto a nested descendant in chained arbitrary `&` selectors.
+
+Two nested arbitrary-selector object keys form a parent→descendant chain, e.g. `css({ '&:last-child': { '& .divider': { display: 'none' } } })`. v1 (and the intended cascade) emits `.cls:last-child .divider` — the structural pseudo stays on the class-bearing parent. v2 emitted `.cls .divider:last-child`, relocating `:last-child` onto the descendant — a different selector that matches the wrong elements.
+
+The cause is the condition sort: it orders selector conditions by pseudo-class priority, which floats the relational `& .divider` (priority 0) ahead of the pseudo `&:last-child` (priority > 0), inverting the authored nesting. For *named* conditions (`_hover`, `_dark`, …) that ordering is correct and order-independent, but for **raw arbitrary `&` selectors authored as nested object keys** the order is structurally significant.
+
+The sort now preserves author order whenever either side is a raw nested-selector key that establishes a combinator relationship (descendant ` `, child `>`, sibling `+`/`~`). Named/breakpoint/container/theme conditions keep their existing cascade sort, and bare compounds like `&:last-child` still sort normally. The rule grouping/dedup key (`CssRuleKey`) is unaffected — only the apply order of nested arbitrary selectors changes.

--- a/crates/pandacss_stylesheet/src/sort.rs
+++ b/crates/pandacss_stylesheet/src/sort.rs
@@ -401,6 +401,17 @@ impl PartialOrd for SelectorKey {
 }
 
 fn compare_condition_names(config: &UserConfig, a: &str, b: &str) -> Ordering {
+    // Two nested-selector conditions that establish a descendant/child/sibling
+    // relationship are ORDER-SIGNIFICANT: `&:last-child` then `& .divider` must
+    // compose as `.cls:last-child .divider`, never `.cls .divider:last-child`.
+    // The pseudo-rank sort below would float the relational `& .divider`
+    // (rank 0) ahead of the pseudo `&:last-child` (rank > 0), relocating the
+    // pseudo onto the descendant. Keep author order (stable sort) whenever
+    // either side carries a relational combinator so the nesting can't invert.
+    if condition_is_relational(config, a) || condition_is_relational(config, b) {
+        return Ordering::Equal;
+    }
+
     let mut a_at_rules = Vec::new();
     let mut a_selectors = Vec::new();
     collect_condition_parts(config, a, &mut a_at_rules, &mut a_selectors);
@@ -415,6 +426,76 @@ fn compare_condition_names(config: &UserConfig, a: &str, b: &str) -> Ordering {
 
     compare_condition_apply_parts(&a_at_rules, &a_selectors, &b_at_rules, &b_selectors)
         .then_with(|| a.cmp(b))
+}
+
+/// True when `condition` is a RAW nested arbitrary selector authored as an
+/// object key (not a registered breakpoint / container / named / theme
+/// condition) that nests its subject under a combinator (descendant ` `, child
+/// `>`, adjacent `+`, general sibling `~`) relative to `&`. Such keys form an
+/// authored parent→descendant chain, so reordering one past another would
+/// change the ancestor chain. A bare compound like `&:last-child` is NOT
+/// relational (the pseudo sits on the subject) and still sorts normally; named
+/// conditions (`_dark`, `_ltr`, …) keep their existing cascade sort.
+fn condition_is_relational(config: &UserConfig, condition: &str) -> bool {
+    if !condition_is_raw_selector(config, condition) {
+        return false;
+    }
+    let mut at_rules = Vec::new();
+    let mut selectors = Vec::new();
+    collect_condition_parts(config, condition, &mut at_rules, &mut selectors);
+    selectors
+        .iter()
+        .any(|selector| selector_has_top_level_combinator(&selector.raw))
+}
+
+/// A condition that resolves to its own literal text — i.e. it is NOT a
+/// breakpoint, container, registered, or theme condition. These are the raw
+/// arbitrary selectors authored directly as nested object keys (`&:last-child`,
+/// `& .divider`), whose author order is structurally significant.
+fn condition_is_raw_selector(config: &UserConfig, condition: &str) -> bool {
+    if config.breakpoint_condition(condition).is_some()
+        || config.container_condition(condition).is_some()
+        || config.theme_condition(condition).is_some()
+    {
+        return false;
+    }
+    let key = condition.trim_start_matches('_');
+    if config.conditions.contains_key(condition) || config.conditions.contains_key(key) {
+        return false;
+    }
+    condition.contains('&')
+}
+
+/// Scan for a combinator at bracket/paren depth zero. ` `/`>`/`+`/`~` separating
+/// two compound selectors makes the selector relational; combinators inside
+/// `:is(...)`, `[...]`, etc. don't count.
+fn selector_has_top_level_combinator(selector: &str) -> bool {
+    let mut depth = 0i32;
+    let mut escaped = false;
+    let mut seen_subject = false;
+
+    for ch in selector.chars() {
+        if escaped {
+            escaped = false;
+            seen_subject = true;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth = depth.saturating_sub(1),
+            ' ' | '>' | '+' | '~' if depth == 0 => {
+                // A combinator only relates two compounds once a subject precedes
+                // it; leading whitespace / a leading combinator is not relational.
+                if seen_subject {
+                    return true;
+                }
+            }
+            _ if depth == 0 => seen_subject = true,
+            _ => {}
+        }
+    }
+    false
 }
 
 fn compare_condition_apply_parts(

--- a/crates/pandacss_stylesheet/tests/atomic.rs
+++ b/crates/pandacss_stylesheet/tests/atomic.rs
@@ -500,6 +500,33 @@ fn escapes_nested_selector_keys_into_valid_class_names() {
 }
 
 #[test]
+fn nested_pseudo_then_descendant_keeps_the_pseudo_on_the_parent() {
+    // Two nested arbitrary `&` selectors form a parent->descendant chain:
+    // `&:last-child` (outer) then `& .divider` (inner) must compose as
+    // `.cls:last-child .divider` — the pseudo stays on the class-bearing parent.
+    // The condition sort floated the relational `& .divider` (pseudo-rank 0)
+    // ahead of the pseudo `&:last-child` (rank > 0), relocating the pseudo onto
+    // the descendant (`.cls .divider:last-child`) — a different, wrong selector.
+    // Author order of raw nested-selector keys must be preserved. Matches v1.
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": { "display": { "className": "d" } }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ '&:last-child': { '& .divider': { display: 'none' } } })",
+        &[StylesheetLayer::Utilities],
+    );
+    assert_snapshot!(css, @r"
+@layer utilities {
+  .\[\&\:last-child\]\:\[\&_\.divider\]\:d_none:last-child .divider {
+    display: none;
+  }
+}
+");
+}
+
+#[test]
 fn escapes_leading_double_dash_class_names() {
     let config = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },


### PR DESCRIPTION
## Problem

When two nested arbitrary `&` selectors form a parent→descendant chain, v2 relocates a structural pseudo-class off the parent and onto the descendant, producing a selector that matches the wrong elements.

```ts
css({ '&:last-child': { '& .divider': { display: 'none' } } })
```

- **v1 (correct):** `.cls:last-child .divider { display: none }` — `:last-child` qualifies the class-bearing parent; `.divider` is its descendant.
- **v2 (broken):** `.cls .divider:last-child { display: none }` — `:last-child` was relocated onto `.divider`.

Found across ~9 real call sites (e.g. `&:last-child` + `& .requirements-divider`). Same family as the comma-member scope leak (#3607), distinct mechanism.

## Root cause

The cascade sort (`crates/pandacss_stylesheet/src/sort.rs`, `compare_condition_names`) orders selector conditions by pseudo-class priority. For the chain `['&:last-child', '& .divider']` it floats the relational `& .divider` (pseudo-rank 0) ahead of the pseudo `&:last-child` (rank > 0), so the inner descendant is applied first and the pseudo lands on it.

For **named** conditions (`_hover`, `_dark`, …) priority ordering is correct and order-independent. But **raw arbitrary `&` selectors authored as nested object keys** form an authored parent→descendant chain whose order is structurally significant — reordering them changes the ancestor chain.

Verified against legacy `@pandacss/node@1.11.3` (drove its real generator): v1 emits `.cls:last-child .divider`, preserving author order.

## Fix

`compare_condition_names` now returns `Equal` (deferring to the stable sort's author order) when *either* condition is a raw nested-selector key (not a registered breakpoint / container / named / theme condition) that establishes a top-level combinator relationship (descendant ` `, child `>`, adjacent `+`, general sibling `~`). Named conditions keep their existing cascade sort; bare compounds like `&:last-child` still sort normally; the rule grouping/dedup key (`CssRuleKey`, which canonicalizes parts independently) is untouched — only the apply order of nested arbitrary selectors changes.

## Before / after (real `@pandacss/preset-base`, via `sandbox/codegen`)

```css
/* before */ .cls .requirements-divider:last-child { display: none }
/* after  */ .cls:last-child .requirements-divider { display: none }
```

## Tests

- New stylesheet repro `nested_pseudo_then_descendant_keeps_the_pseudo_on_the_parent` asserting `.cls:last-child .divider`.
- Existing `nested_child_selector_stacks_theme_and_direction_conditions` (mixed `& > p` + named theme/direction/hover conditions) is unchanged — confirms named-condition ordering is preserved.
- `cargo nextest run --workspace` → **1263 passed**. `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.

Sibling to #3607 (comma-member scope leak) in the nested-arbitrary-selector family; refs #3599.

