### PR TITLE
fix(compiler): resolve RecipeSelection to {} for variant-less recipes

### DIFF
--- a/.changeset/fix-recipe-selection-no-variants.md
+++ b/.changeset/fix-recipe-selection-no-variants.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix generated types when a recipe has no variants. `RecipeSelection` now resolves to `{}` instead of a `{ [x: string]: string }` index signature for variant-less recipes, which previously poisoned surrounding props.
+
+- `styled('div', { base }, { defaultProps: { 'aria-hidden': false } })` no longer errors on non-string `defaultProps`.
+- `createSlotRecipeContext` providers built from a no-variant `sva`/`cva` recipe no longer reject valid children.

--- a/crates/pandacss_codegen/src/artifacts/types/recipe_types.rs
+++ b/crates/pandacss_codegen/src/artifacts/types/recipe_types.rs
@@ -53,9 +53,11 @@ export type StringToBoolean<T> = T extends 'true' | 'false' ? boolean : T
 
 export type RecipeVariantRecord = Record<string, Record<string, SystemStyleObject>>
 
-export type RecipeSelection<T extends RecipeVariantRecord> = {
-  [K in keyof T]?: StringToBoolean<keyof T[K]>
-}
+export type RecipeSelection<T extends RecipeVariantRecord> = string extends keyof T
+  ? {}
+  : {
+      [K in keyof T]?: StringToBoolean<keyof T[K]>
+    }
 
 export type RecipeCompoundSelection<T> = {
   [K in keyof T]?: StringToBoolean<keyof T[K]> | Array<StringToBoolean<keyof T[K]>>

--- a/crates/pandacss_codegen/tests/types_artifact.rs
+++ b/crates/pandacss_codegen/tests/types_artifact.rs
@@ -372,9 +372,11 @@ fn emits_ts_source_types() {
 
     export type RecipeVariantRecord = Record<string, Record<string, SystemStyleObject>>
 
-    export type RecipeSelection<T extends RecipeVariantRecord> = {
-      [K in keyof T]?: StringToBoolean<keyof T[K]>
-    }
+    export type RecipeSelection<T extends RecipeVariantRecord> = string extends keyof T
+      ? {}
+      : {
+          [K in keyof T]?: StringToBoolean<keyof T[K]>
+        }
 
     export type RecipeCompoundSelection<T> = {
       [K in keyof T]?: StringToBoolean<keyof T[K]> | Array<StringToBoolean<keyof T[K]>>


### PR DESCRIPTION
## what

guard the generated `RecipeSelection` type so a recipe with no variants resolves to `{}` instead of a `{ [x: string]: string }` index signature.

## why

closes #3611, closes #3610.

a variant-less recipe widened to that index signature, which poisoned every prop it touched:

- #3611 — non-string `defaultProps` like `aria-hidden: false` were rejected ("type 'boolean' is not assignable to type 'string'").
- #3610 — slot recipe providers forced `children` to `string`, so valid jsx was rejected.

v1 had this guard; the v2 port dropped it.

## notes

- guard uses `string extends keyof T` rather than v1's `keyof any extends keyof T` — v2's constraint is keyed by `string`. real variant records have a literal-union `keyof`, so they keep narrowing.

## test plan

- [x] reproduced both errors against v2-generated types in `sandbox/vite-ts`, confirmed both clear after the change
- [x] confirmed a recipe with variants still narrows (valid selection passes, invalid value still errors)
- [x] `cargo test -p pandacss_codegen --test integration` — 78 passed
- [x] `cargo fmt -p pandacss_codegen --check`