### PR TITLE
fix(compiler): allow top-level return in .astro frontmatter

### DIFF
--- a/.changeset/astro-frontmatter-top-level-return.md
+++ b/.changeset/astro-frontmatter-top-level-return.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/compiler': patch
+---
+
+Parse `.astro` frontmatter where a top-level `return` is valid. Astro compiles frontmatter as the body of the component's render function, so a top-level `return` (e.g. an early `return null` guard) is legal Astro. The Oxc extractor parsed the masked frontmatter as a bare module and rejected it, aborting the whole build. Such files now extract cleanly.

--- a/crates/pandacss_extractor/src/adapter.rs
+++ b/crates/pandacss_extractor/src/adapter.rs
@@ -3,6 +3,18 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use oxc_parser::ParseOptions;
+
+/// Astro frontmatter is a render-function body, so a top-level `return` is valid
+/// there but a hard error in the bare module we mask it into. Allow it for `.astro`.
+#[must_use]
+pub(crate) fn parse_options_for(path: &str) -> ParseOptions {
+    ParseOptions {
+        allow_return_outside_function: has_extension(path, "astro"),
+        ..ParseOptions::default()
+    }
+}
+
 #[must_use]
 pub(crate) fn adapt_source<'a>(source: &'a str, path: &str) -> Cow<'a, str> {
     if has_extension(path, "vue") {

--- a/crates/pandacss_extractor/src/calls.rs
+++ b/crates/pandacss_extractor/src/calls.rs
@@ -71,7 +71,9 @@ pub fn extract_calls(
     let source = crate::adapt_source(source, path);
     let source = source.as_ref();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
-    let parser_return = Parser::new(&allocator, source, source_type).parse();
+    let parser_return = Parser::new(&allocator, source, source_type)
+        .with_options(crate::adapter::parse_options_for(path))
+        .parse();
 
     let resolver = crate::Resolver::build(
         &parser_return.program,

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -151,7 +151,9 @@ fn run_extract<'cb>(
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
     let parser_return = {
         let _span = tracing::trace_span!("oxc_parse", path = path).entered();
-        Parser::new(&allocator, source, source_type).parse()
+        Parser::new(&allocator, source, source_type)
+            .with_options(crate::adapter::parse_options_for(path))
+            .parse()
     };
     let mut diagnostics = collect_parser_diagnostics(&parser_return.errors, source);
     let imports = {

--- a/crates/pandacss_extractor/src/imports.rs
+++ b/crates/pandacss_extractor/src/imports.rs
@@ -71,7 +71,9 @@ pub fn scan_imports(source: &str, path: &str) -> ImportScanResult {
     let source = crate::adapt_source(source, path);
     let source = source.as_ref();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
-    let parser_return = Parser::new(&allocator, source, source_type).parse();
+    let parser_return = Parser::new(&allocator, source, source_type)
+        .with_options(crate::adapter::parse_options_for(path))
+        .parse();
 
     ImportScanResult {
         imports: collect_imports(&parser_return.program),

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -94,7 +94,9 @@ pub fn extract_jsx(
     let source = crate::adapt_source(source, path);
     let source = source.as_ref();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
-    let parser_return = Parser::new(&allocator, source, source_type).parse();
+    let parser_return = Parser::new(&allocator, source, source_type)
+        .with_options(crate::adapter::parse_options_for(path))
+        .parse();
 
     let resolver = crate::Resolver::build(
         &parser_return.program,

--- a/crates/pandacss_extractor/tests/framework_astro.rs
+++ b/crates/pandacss_extractor/tests/framework_astro.rs
@@ -200,6 +200,33 @@ fn astro_directives_and_control_flow_extract() {
 }
 
 #[test]
+fn top_level_return_in_frontmatter_is_valid_astro() {
+    // Frontmatter is a render-function body, so a top-level `return` is valid Astro.
+    // Without it allowed, Oxc errors on the masked module and aborts the build.
+    let source = indoc! {r"
+        ---
+        import { css } from '@panda/css';
+        const open = true;
+        if (open) {
+          return null;
+        }
+        ---
+
+        <div class={css({ color: 'red' })} />
+    "};
+
+    let result = extract(source, "Foo.astro", &panda_config());
+    assert!(result.diagnostics.is_empty());
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls:
+      - name: css
+        data:
+          color: red
+    jsx: []
+    ");
+}
+
+#[test]
 fn spans_point_into_the_original_astro_source() {
     // The mask is a same-length blank-and-copy, so a surviving token keeps its
     // original byte offset: the reported span slices the ORIGINAL source verbatim.


### PR DESCRIPTION
## what

a `.astro` component with a top-level `return` in its frontmatter aborts the whole v2 build. this allows it.

```astro
---
import { SOME_FLAG } from 'astro:env/client'
if (SOME_FLAG === '') {
  return null
}
---
<div />
```

```
error js_parse_error src/Foo.astro:3:2
A 'return' statement can only be used within a function body.
```

## why

astro compiles frontmatter as the body of the component's render function, so a top-level `return` is valid astro. the extractor masks frontmatter into module scope and parses it with oxc, where `return` outside a function is a hard syntax error — and through `@pandacss/postcss` one such file kills the entire `astro build`. v1's ts-morph extractor parsed it fine, so this is a v2 regression.

## notes

oxc's parser already exposes `ParseOptions::allow_return_outside_function` (babel/acorn's `allowReturnOutsideFunction`). a path-keyed `parse_options_for()` enables it only for `.astro`, wired into the four masked parse entrypoints (`extract`, `calls`, `jsx`, `imports`). no change for `.ts`/`.tsx`/`.vue`/`.svelte`.

out of scope: the reporter also asked for per-file parse errors to be non-fatal (skip + warn). that conflicts with the "diagnostics are authoritative" contract and would silently drop styles from genuinely broken files — worth its own discussion. the breakage here is resolved without it.

## test plan

- `top_level_return_in_frontmatter_is_valid_astro` reproduces the exact repro: emits a `js_parse_error` before the change, extracts cleanly after.
- `cargo test -p pandacss_extractor` — 411 pass; `cargo fmt`/`clippy` clean.

closes the regression in discussion #3599.
