### PR TITLE
fix(compiler): treat source parse errors as warnings, not build failures

### DIFF
--- a/.changeset/parse-errors-non-fatal.md
+++ b/.changeset/parse-errors-non-fatal.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/compiler': patch
+---
+
+A file Panda can't parse no longer aborts the whole build. Parse errors are now warnings: Panda skips the unparseable file, reports the diagnostic, and continues. The bundler (astro/vite/tsc) still reports genuine syntax errors, and `--max-warnings 0` restores strict failure for callers that want it.

--- a/crates/pandacss_extractor/src/imports.rs
+++ b/crates/pandacss_extractor/src/imports.rs
@@ -131,8 +131,10 @@ pub(crate) fn collect_parser_diagnostics(
                 })
             });
             let location = span.map(|s| line_index.locate_range(s.start, s.end));
+            // A parse error warns rather than aborts the build; the bundler reports real
+            // syntax errors. `--max-warnings 0` restores strict failure.
             let mut diagnostic =
-                Diagnostic::error(diagnostic_codes::JS_PARSE_ERROR, error.message.to_string());
+                Diagnostic::warning(diagnostic_codes::JS_PARSE_ERROR, error.message.to_string());
             diagnostic.span = span;
             diagnostic.location = location;
             diagnostic

--- a/crates/pandacss_extractor/tests/extract.rs
+++ b/crates/pandacss_extractor/tests/extract.rs
@@ -278,7 +278,7 @@ fn parse_error_contract_diagnostics_and_partial_extractions() {
         !result.diagnostics.is_empty(),
         "parse error must surface as a diagnostic"
     );
-    assert_yaml_snapshot!(result.diagnostics[0].severity, @"error");
+    assert_yaml_snapshot!(result.diagnostics[0].severity, @"warning");
     // No assertion on `result.calls` — Oxc's recovery may or may not
     // expose the pre-error css() call depending on parser behaviour.
     // The point is that the API doesn't crash and surfaces the error.

--- a/crates/pandacss_extractor/tests/imports.rs
+++ b/crates/pandacss_extractor/tests/imports.rs
@@ -518,7 +518,7 @@ fn parse_error_is_reported() {
     let result = scan("import from 'broken';\n");
     assert!(result.imports.is_empty());
     assert_eq!(result.diagnostics.len(), 1);
-    assert_eq!(result.diagnostics[0].severity, DiagnosticSeverity::Error);
+    assert_eq!(result.diagnostics[0].severity, DiagnosticSeverity::Warning);
 }
 
 #[test]

--- a/crates/pandacss_project/tests/parsed_file.rs
+++ b/crates/pandacss_project/tests/parsed_file.rs
@@ -45,7 +45,7 @@ fn parsed_file_surfaces_diagnostics_per_file() {
         !report.diagnostics.is_empty(),
         "ParseFileReport carries the list"
     );
-    assert_eq!(report.diagnostics[0].severity, DiagnosticSeverity::Error);
+    assert_eq!(report.diagnostics[0].severity, DiagnosticSeverity::Warning);
 
     let view = project.get_file("broken.tsx").expect("file recorded");
     assert_eq!(
@@ -53,7 +53,7 @@ fn parsed_file_surfaces_diagnostics_per_file() {
         report.diagnostics.len(),
         "ParsedFile mirrors the ParseFileReport list"
     );
-    assert_eq!(view.diagnostics()[0].severity, DiagnosticSeverity::Error);
+    assert_eq!(view.diagnostics()[0].severity, DiagnosticSeverity::Warning);
 }
 
 #[test]

--- a/packages/cli/__tests__/build.test.ts
+++ b/packages/cli/__tests__/build.test.ts
@@ -64,7 +64,7 @@ describe('build command (default panda)', () => {
     expect(readFileSync(join(dir, 'panda.css'), 'utf8')).toContain('red')
   })
 
-  it('surfaces parse diagnostics from the css pass', async () => {
+  it('surfaces a parse error as a warning without failing the build', async () => {
     dir = createFixture()
     writeSyntaxError(dir)
 
@@ -76,13 +76,23 @@ describe('build command (default panda)', () => {
         {
           "code": "js_parse_error",
           "file": "App.tsx",
-          "severity": "error",
+          "severity": "warning",
         },
       ]
     `)
+    expect(result.ok).toBe(true)
+    expect(result.exitCode).toBe(0)
+    expect(normalizeOutput(logs.join('\n'), dir)).toContain('warning js_parse_error')
+  })
+
+  it('still fails the build on a parse error under --max-warnings 0', async () => {
+    dir = createFixture()
+    writeSyntaxError(dir)
+
+    const result = await runBuild({ cwd: dir, logLevel: 'silent', maxWarnings: 0 })
+
     expect(result.ok).toBe(false)
     expect(result.exitCode).toBe(1)
-    expect(normalizeOutput(logs.join('\n'), dir)).toContain('error js_parse_error')
   })
 
   it('--check passes after a clean build', async () => {

--- a/packages/cli/__tests__/cssgen.test.ts
+++ b/packages/cli/__tests__/cssgen.test.ts
@@ -61,7 +61,7 @@ describe('cssgen command', () => {
         {
           "code": "js_parse_error",
           "file": "App.tsx",
-          "severity": "error",
+          "severity": "warning",
         },
       ]
     `)
@@ -84,7 +84,7 @@ describe('cssgen command', () => {
         {
           "code": "js_parse_error",
           "file": "App.tsx",
-          "severity": "error",
+          "severity": "warning",
         },
       ]
     `)
@@ -103,7 +103,7 @@ describe('cssgen command', () => {
 
     expect(normalizeOutput(logs.join('\n'), dir)).toMatchInlineSnapshot(`
       "cssgen: parsed 1 files, wrote 274 bytes to <cwd>/styled-system/styles.css, diagnostics: 1
-      error js_parse_error: Unexpected token
+      warning js_parse_error: Unexpected token
         ┌─ App.tsx:1:48
         │
       1 │ import { css } from '@panda/css'; css({ color: 
@@ -123,7 +123,7 @@ describe('cssgen command', () => {
     )
 
     expect(logs.join('\n')).toMatchInlineSnapshot(
-      `"::error file=App.tsx,line=1,col=48,title=js_parse_error::Unexpected token"`,
+      `"::warning file=App.tsx,line=1,col=48,title=js_parse_error::Unexpected token"`,
     )
   })
 

--- a/packages/cli/__tests__/debug.test.ts
+++ b/packages/cli/__tests__/debug.test.ts
@@ -102,11 +102,11 @@ describe('debug command', () => {
         {
           "code": "js_parse_error",
           "file": "App.tsx",
-          "severity": "error",
+          "severity": "warning",
         },
       ]
     `)
-    expect(result.ok).toBe(false)
-    expect(result.exitCode).toBe(1)
+    expect(result.ok).toBe(true)
+    expect(result.exitCode).toBe(0)
   })
 })

--- a/packages/postcss/__tests__/postcss.test.ts
+++ b/packages/postcss/__tests__/postcss.test.ts
@@ -132,12 +132,30 @@ describe('@pandacss/postcss', () => {
       css: '',
       manifest: { files: [], tokens: [] },
       layerRanges: {},
-      diagnostics: [{ severity: 'error', code: 'js_parse_error', message: 'Unexpected token' }],
+      diagnostics: [{ severity: 'error', code: 'config_load_error', message: 'bad config' }],
     })
 
     await expect(run(INPUT)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[CssSyntaxError: pandacss: /project/styles.css:1:1: error js_parse_error Unexpected token]`,
+      `[CssSyntaxError: pandacss: /project/styles.css:1:1: error config_load_error bad config]`,
     )
+  })
+
+  it('warns on a parse error instead of failing the build', async () => {
+    const { driver, run } = await setup()
+    driver.cssgen.mockReturnValueOnce({
+      css: '.text_red { color: red }',
+      manifest: { files: [], tokens: [] },
+      layerRanges: {},
+      diagnostics: [{ severity: 'warning', code: 'js_parse_error', message: 'Unexpected token' }],
+    })
+
+    const result = await run(INPUT)
+
+    expect(result.warnings().map((warning) => warning.text)).toMatchInlineSnapshot(`
+      [
+        "warning js_parse_error Unexpected token",
+      ]
+    `)
   })
 
   it('uses dependency messages for source directories in Rollup watch mode', async () => {

--- a/packages/vite/__tests__/plugin.test.ts
+++ b/packages/vite/__tests__/plugin.test.ts
@@ -146,7 +146,7 @@ describe('@pandacss/vite', () => {
     const warning = await waitForWarning(warnings, 'while parsing')
     expect(warning.replaceAll(dir, '<root>')).toMatchInlineSnapshot(`
       "panda: 1 diagnostic(s) while parsing <root>/App.tsx
-      error js_parse_error <root>/App.tsx:3:55 Unexpected token"
+      warning js_parse_error <root>/App.tsx:3:55 Unexpected token"
     `)
 
     writeFileSync(appFile, APP(`{ color: 'blue' }`))


### PR DESCRIPTION
## what

a single file Panda can't parse no longer takes down the whole build. parse errors are now warnings — Panda skips the file, reports the diagnostic, and keeps going.

before, one unparseable file (e.g. a `.astro` with a top-level `return`, or anything Panda's framework masking doesn't yet cover) made `panda cssgen` exit 1 and, through `@pandacss/postcss`, failed the entire `astro build`.

## why

Panda isn't the user's syntax checker — the bundler (astro/vite/tsc) already reports genuine syntax errors. a file Panda can't parse should surface a visible warning and let extraction continue best-effort, not abort everyone's build. v1's ts-morph extractor recovered per file; v2's fail-fast was a regression.

## notes

`js_parse_error` drops from `error` to `warning` severity in the extractor. that flows through every consumer without special-casing:

- the postcss plugin only throws on `error`-severity diagnostics, so it now `result.warn`s instead
- the cli's `diagnosticsPass` ignores warnings, so `cssgen`/`build` exit 0
- the vite plugin already only warned

genuine fatal diagnostics (config load, token build) still throw. `--max-warnings 0` restores strict failure for CI that wants it.

## test plan

- extractor/project: parse-error diagnostics now assert `warning` severity (`cargo test -p pandacss_extractor -p pandacss_project`)
- postcss: a parse-error diagnostic warns instead of throwing; genuine errors still throw
- cli `build`/`cssgen`/`debug`: a syntax-error file yields a `warning` + `exitCode 0`; a new test asserts `--max-warnings 0` still fails it
- vite: diagnostic renders as `warning js_parse_error`

addresses the second ask in discussion #3599.
