### PR TITLE
fix(stylesheet): global css nesting and composition regressions

### DIFF
--- a/.changeset/global-nesting-composition-parity.md
+++ b/.changeset/global-nesting-composition-parity.md
@@ -2,7 +2,7 @@
 '@pandacss/compiler': patch
 ---
 
-Fix four v2 CSS-output regressions in `globalCss` and nested style objects:
+Fix v2 CSS-output regressions in `globalCss` and nested style objects:
 
 - Bare element selectors (e.g. `'.article': { h2: { ... } }`) now nest as descendants instead of being dropped.
 - Comma-separated selector groups now distribute the parent to every member (`h2, h3, h4` → `.article h2, .article h3, .article h4`).

--- a/.changeset/global-nesting-composition-parity.md
+++ b/.changeset/global-nesting-composition-parity.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix four v2 CSS-output regressions in `globalCss` and nested style objects:
+
+- Bare element selectors (e.g. `'.article': { h2: { ... } }`) now nest as descendants instead of being dropped.
+- Comma-separated selector groups now distribute the parent to every member (`h2, h3, h4` → `.article h2, .article h3, .article h4`).
+- A composition (`textStyle`/`layerStyle`/`animationStyle`) combined with explicit properties now merges into one block, so a sibling override (e.g. `fontFamily`) wins by source order.
+- Multiline values (e.g. `gridTemplateAreas` template literals) collapse their whitespace, keeping the class name and emitted declaration single-line.

--- a/crates/pandacss_extractor/src/literal.rs
+++ b/crates/pandacss_extractor/src/literal.rs
@@ -681,7 +681,7 @@ pub(crate) fn template_literal_to_literal(
     }
     let tail = t.quasis.last()?;
     out.push_str(tail.value.cooked.as_ref()?.as_str());
-    Some(Literal::String(out))
+    Some(Literal::String(collapse_whitespace(&out).trim().to_owned()))
 }
 
 fn truthy(value: &Literal) -> bool {

--- a/crates/pandacss_extractor/tests/calls.rs
+++ b/crates/pandacss_extractor/tests/calls.rs
@@ -185,6 +185,25 @@ fn string_value_whitespace_is_collapsed_outside_quotes() {
 }
 
 #[test]
+fn template_literal_value_whitespace_is_collapsed_outside_quotes() {
+    assert_yaml_snapshot!(
+        extract("css({ gridTemplateAreas: `\n    \"preview name delete\" \n    \"preview size delete\"` })", &[css("css")]),
+        @r#"
+    calls:
+      - category: css
+        name: css
+        alias: css
+        data:
+          - gridTemplateAreas: "\"preview name delete\" \"preview size delete\""
+        span:
+          start: 0
+          end: 83
+    diagnostics: []
+    "#,
+    );
+}
+
+#[test]
 fn spread_overwrite_keeps_spread_position() {
     // Same upsert semantics but the duplicate enters through an inline
     // literal spread. The key from the spread keeps its position; the
@@ -1243,7 +1262,7 @@ fn template_literal_without_interpolation() {
         alias: css
         data:
           - color: red
-            font: "sans \n serif"
+            font: sans serif
         span:
           start: 0
           end: 44
@@ -2013,7 +2032,7 @@ fn array_value_preserves_elision_holes() {
 #[test]
 fn multiline_template_literal_with_interpolation_folds() {
     // Template spans multiple lines, with a const-bound interpolation.
-    // Newlines and indentation are preserved verbatim — matches JS.
+    // Newlines and indentation collapse like v1's `trimWhitespace` path.
     let result = extract_with(
         indoc! {r"
             const angle = '135deg';
@@ -2030,9 +2049,10 @@ fn multiline_template_literal_with_interpolation_folds() {
     );
     let lit = serde_json::to_value(&result.calls[0].data[0]).unwrap();
     let bg = lit["backgroundImage"].as_str().unwrap();
-    assert!(bg.starts_with("linear-gradient("));
-    assert!(bg.contains("135deg"), "interpolation folded");
-    assert!(bg.contains("#d946ef80 10%"));
+    assert_eq!(
+        bg,
+        "linear-gradient( 135deg, #d946ef80 10%, transparent 50% )"
+    );
 }
 
 // --- TS syntactic unwraps (additional coverage) ---

--- a/crates/pandacss_extractor/tests/jsx.rs
+++ b/crates/pandacss_extractor/tests/jsx.rs
@@ -1182,6 +1182,42 @@ fn ts_satisfies_attribute_value() {
 }
 
 #[test]
+fn jsx_style_multiline_template_literal_collapses_whitespace() {
+    let source = indoc! {r##"
+        <Box
+          marginTop="3"
+          display="flex"
+          flexDir="column"
+          background="#e879f91a"
+          backgroundSize="8px 8px"
+          style={{
+            backgroundImage: `linear-gradient(
+              135deg,
+              #d946ef80 10%,
+              transparent 0,
+              transparent 50%,
+              #d946ef80 0,
+              #d946ef80 60%,
+              transparent 0,
+              transparent
+            )`,
+          }}
+        />
+    "##};
+
+    let result = extract(source, &[pattern_component("Box")]);
+    assert_yaml_snapshot!(jsx_data_for(&result.jsx, "Box"), @r##"
+    - marginTop: "3"
+      display: flex
+      flexDir: column
+      background: "#e879f91a"
+      backgroundSize: 8px 8px
+      style:
+        backgroundImage: "linear-gradient( 135deg, #d946ef80 10%, transparent 0, transparent 50%, #d946ef80 0, #d946ef80 60%, transparent 0, transparent )"
+    "##);
+}
+
+#[test]
 fn unary_in_attribute_value() {
     assert_yaml_snapshot!(
         extract(
@@ -1246,7 +1282,7 @@ fn template_literal_attribute_value() {
         alias: Box
         data:
           color: red
-          font: "sans \n serif"
+          font: sans serif
         span:
           start: 0
           end: 44

--- a/crates/pandacss_stylesheet/src/conditions.rs
+++ b/crates/pandacss_stylesheet/src/conditions.rs
@@ -118,11 +118,7 @@ pub(crate) fn is_nested_selector_key(key: &str) -> bool {
 }
 
 pub(crate) fn nested_selector(parent: &str, nested: &str) -> String {
-    if nested.contains('&') {
-        crate::selector::replace_selector_parent(nested, parent)
-    } else {
-        format!("{parent} {nested}")
-    }
+    crate::selector::replace_selector_parent(nested, parent)
 }
 
 fn query_raw_paths(query: &ConditionQuery) -> Vec<ConditionPath> {

--- a/crates/pandacss_stylesheet/src/emitter.rs
+++ b/crates/pandacss_stylesheet/src/emitter.rs
@@ -869,7 +869,8 @@ impl<'a> EmitContext<'a> {
             .chain(&recipes.variants)
             .chain(&recipes.compounds)
         {
-            for entry in &group.entries {
+            let entries = self.expand_recipe_style_entries(&group.entries);
+            for entry in &entries {
                 let Some(declarations) = self.recipe_entry_declarations(entry) else {
                     continue;
                 };
@@ -1210,7 +1211,8 @@ impl<'a> EmitContext<'a> {
         // Sorted recipe entries often lower to the same selector + wrapper
         // target; keep that block pending so declarations coalesce in order.
         let mut pending: Option<StyleRule> = None;
-        for entry in self.sort.sorted_recipe_entries(entries) {
+        let entries = self.expand_recipe_style_entries(entries);
+        for entry in self.sort.sorted_recipe_entries(&entries) {
             let Some(declarations) = self.style_entry_declarations(entry.entry, important) else {
                 continue;
             };
@@ -1710,7 +1712,8 @@ impl<'a> EmitContext<'a> {
             &rule_conditions,
         );
 
-        for entry in self.sort.sorted_recipe_entries(entries) {
+        let entries = self.expand_recipe_style_entries(entries);
+        for entry in self.sort.sorted_recipe_entries(&entries) {
             let Some(declarations) = self.recipe_entry_declarations(entry.entry) else {
                 continue;
             };
@@ -1730,6 +1733,65 @@ impl<'a> EmitContext<'a> {
         flush_pending_rule(pending, |pending| {
             write_rule(writer, &pending.target, &pending.declarations);
         });
+    }
+
+    fn expand_recipe_style_entries(&self, entries: &[RecipeStyleEntry]) -> Vec<RecipeStyleEntry> {
+        let mut seen = FxHashSet::default();
+        let mut out = Vec::new();
+        for entry in entries {
+            let mut active = FxHashSet::default();
+            self.expand_recipe_style_entry(entry, &mut active, &mut seen, &mut out);
+        }
+        out
+    }
+
+    fn push_recipe_style_entry(
+        entry: &RecipeStyleEntry,
+        seen: &mut FxHashSet<RecipeStyleEntry>,
+        out: &mut Vec<RecipeStyleEntry>,
+    ) {
+        let entry = entry.clone();
+        if seen.insert(entry.clone()) {
+            out.push(entry);
+        }
+    }
+
+    fn recipe_style_expansion_key(entry: &RecipeStyleEntry) -> (Box<str>, AtomValue) {
+        (entry.prop.clone(), entry.value.clone())
+    }
+
+    fn expand_recipe_style_entry(
+        &self,
+        entry: &RecipeStyleEntry,
+        active: &mut FxHashSet<(Box<str>, AtomValue)>,
+        seen: &mut FxHashSet<RecipeStyleEntry>,
+        out: &mut Vec<RecipeStyleEntry>,
+    ) {
+        let key = Self::recipe_style_expansion_key(entry);
+        if !active.insert(key.clone()) {
+            return;
+        }
+
+        let expanded = self
+            .composition_style_entries(entry.prop.as_ref(), &entry.value)
+            .or_else(|| self.nested_utility_style_entries(entry.prop.as_ref(), &entry.value));
+
+        let Some(entries) = expanded else {
+            Self::push_recipe_style_entry(entry, seen, out);
+            active.remove(&key);
+            return;
+        };
+
+        for mut next in entries {
+            if !entry.conditions.is_empty() {
+                let mut conditions = entry.conditions.clone();
+                conditions.extend(next.conditions.iter().cloned());
+                next.conditions = conditions;
+            }
+            next.important = entry.important || next.important;
+            self.expand_recipe_style_entry(&next, active, seen, out);
+        }
+        active.remove(&key);
     }
 
     fn recipe_entry_declarations(&self, entry: &RecipeStyleEntry) -> Option<Vec<Declaration>> {

--- a/crates/pandacss_stylesheet/src/emitter.rs
+++ b/crates/pandacss_stylesheet/src/emitter.rs
@@ -1364,7 +1364,17 @@ impl<'a> EmitContext<'a> {
         let mut composition_entries = Vec::new();
         for (key, value) in entries {
             if let Some(style_entries) = self.composition_style_entries_for_value(key, value) {
-                composition_entries.extend(style_entries);
+                let (base, conditional): (Vec<_>, Vec<_>) = style_entries
+                    .into_iter()
+                    .partition(|entry| entry.conditions.is_empty());
+                for sorted in self.sort.sorted_recipe_entries(&base) {
+                    if let Some(entry_declarations) =
+                        self.style_entry_declarations(sorted.entry, false)
+                    {
+                        append_declarations(&mut declarations, entry_declarations);
+                    }
+                }
+                composition_entries.extend(conditional);
                 continue;
             }
 
@@ -1396,6 +1406,16 @@ impl<'a> EmitContext<'a> {
                     &mut declarations,
                     &mut conditional_declarations,
                 ) {
+                    continue;
+                }
+                if !self.utility.is_known(key)
+                    && !pandacss_shared::css_properties::is_css_property(key)
+                {
+                    nested_rules.push(NestedStyleRule {
+                        selector: nested_selector(selector, key),
+                        value,
+                        condition: None,
+                    });
                     continue;
                 }
             }
@@ -1762,6 +1782,8 @@ impl<'a> EmitContext<'a> {
         raw: &str,
         value: Option<&AtomValue>,
     ) -> UtilityTransformResult {
+        let raw = collapse_multiline_value(raw);
+        let raw = raw.as_ref();
         if self.utility.should_transform(prop) {
             // Class hashes by the resolved value (`#ef4444`), matching legacy and
             // the runtime `token()` — `path` stays build-info only.
@@ -2094,6 +2116,14 @@ fn composition_style_object<'a>(prop: &str, styles: &'a Literal) -> Option<&'a L
         return None;
     }
     Some(styles)
+}
+
+fn collapse_multiline_value(raw: &str) -> Cow<'_, str> {
+    if raw.contains(['\n', '\r', '\t']) {
+        Cow::Owned(raw.split_whitespace().collect::<Vec<_>>().join(" "))
+    } else {
+        Cow::Borrowed(raw)
+    }
 }
 
 fn default_transform(prop: &str, raw: &str) -> UtilityTransformResult {

--- a/crates/pandacss_stylesheet/src/emitter.rs
+++ b/crates/pandacss_stylesheet/src/emitter.rs
@@ -1007,6 +1007,10 @@ impl<'a> EmitContext<'a> {
                     }
                     continue;
                 }
+                if self.is_bare_nested_selector_key(key) {
+                    self.collect_styles_usage(value, token_dictionary, keyframes, marks);
+                    continue;
+                }
             }
 
             if let Some(declarations) = self.serialized_property_declarations(key, value) {
@@ -1408,9 +1412,7 @@ impl<'a> EmitContext<'a> {
                 ) {
                     continue;
                 }
-                if !self.utility.is_known(key)
-                    && !pandacss_shared::css_properties::is_css_property(key)
-                {
+                if self.is_bare_nested_selector_key(key) {
                     nested_rules.push(NestedStyleRule {
                         selector: nested_selector(selector, key),
                         value,
@@ -1782,8 +1784,6 @@ impl<'a> EmitContext<'a> {
         raw: &str,
         value: Option<&AtomValue>,
     ) -> UtilityTransformResult {
-        let raw = collapse_multiline_value(raw);
-        let raw = raw.as_ref();
         if self.utility.should_transform(prop) {
             // Class hashes by the resolved value (`#ef4444`), matching legacy and
             // the runtime `token()` — `path` stays build-info only.
@@ -1959,6 +1959,10 @@ impl<'a> EmitContext<'a> {
 
         Some(self.style_object_entries(&result.styles))
     }
+
+    fn is_bare_nested_selector_key(&self, key: &str) -> bool {
+        !self.utility.is_known(key) && !pandacss_shared::css_properties::is_css_property(key)
+    }
 }
 
 struct NestedStyleRule<'a> {
@@ -2116,14 +2120,6 @@ fn composition_style_object<'a>(prop: &str, styles: &'a Literal) -> Option<&'a L
         return None;
     }
     Some(styles)
-}
-
-fn collapse_multiline_value(raw: &str) -> Cow<'_, str> {
-    if raw.contains(['\n', '\r', '\t']) {
-        Cow::Owned(raw.split_whitespace().collect::<Vec<_>>().join(" "))
-    } else {
-        Cow::Borrowed(raw)
-    }
 }
 
 fn default_transform(prop: &str, raw: &str) -> UtilityTransformResult {

--- a/crates/pandacss_stylesheet/tests/atomic.rs
+++ b/crates/pandacss_stylesheet/tests/atomic.rs
@@ -618,6 +618,25 @@ fn comma_group_nested_selector_scopes_every_member() {
 }
 
 #[test]
+fn multiline_value_collapses_whitespace_in_class_and_declaration() {
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ gridTemplateAreas: `\n    \"preview name delete\" \n    \"preview size delete\"` })",
+        &[StylesheetLayer::Utilities],
+    );
+    assert_snapshot!(css, @r#"
+@layer utilities {
+  .grid-template-areas_\"preview_name_delete\"_\"preview_size_delete\" {
+    grid-template-areas: "preview name delete" "preview size delete";
+  }
+}
+"#);
+}
+
+#[test]
 fn nested_pseudo_then_descendant_keeps_the_pseudo_on_the_parent() {
     // Two nested arbitrary `&` selectors form a parent->descendant chain:
     // `&:last-child` (outer) then `& .divider` (inner) must compose as

--- a/crates/pandacss_stylesheet/tests/global_css.rs
+++ b/crates/pandacss_stylesheet/tests/global_css.rs
@@ -150,10 +150,10 @@ fn expands_global_css_composition_props_through_utilities() {
     --made-with-panda: '🐼';
   }
   pre, code {
-    animation: fade-in 120ms ease;
-    background-color: var(--colors-red-500);
     font-size: var(--font-sizes-sm);
     line-height: var(--line-heights-tight);
+    background-color: var(--colors-red-500);
+    animation: fade-in 120ms ease;
   }
 }
 ");
@@ -184,6 +184,87 @@ fn skips_unknown_global_css_composition_values() {
 @layer base {
   :root {
     --made-with-panda: '🐼';
+  }
+}
+");
+}
+
+#[test]
+fn bare_type_selector_nests_as_descendant() {
+    let config = config(serde_json::json!({
+        "globalCss": {
+            ".article": {
+                "h2": { "color": "blue" }
+            }
+        }
+    }));
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Base]);
+    assert_snapshot!(css, @r"
+@layer base {
+  :root {
+    --made-with-panda: '🐼';
+  }
+  .article h2 {
+    color: blue;
+  }
+}
+");
+}
+
+#[test]
+fn comma_group_distributes_parent_to_every_member() {
+    let config = config(serde_json::json!({
+        "globalCss": {
+            ".article": {
+                "h2, h3, h4": { "color": "blue" }
+            }
+        }
+    }));
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Base]);
+    assert_snapshot!(css, @r"
+@layer base {
+  :root {
+    --made-with-panda: '🐼';
+  }
+  .article h2, .article h3, .article h4 {
+    color: blue;
+  }
+}
+");
+}
+
+#[test]
+fn composition_and_sibling_override_merge_into_one_block() {
+    let config = config(serde_json::json!({
+        "theme": {
+            "tokens": {
+                "fonts": { "code": { "value": "monospace" }, "sans": { "value": "system-ui" } }
+            },
+            "textStyles": {
+                "label": {
+                    "medium": { "value": { "fontFamily": "sans", "fontSize": "14px" } }
+                }
+            }
+        },
+        "globalCss": {
+            ".codeblock": {
+                "textStyle": "label.medium",
+                "fontFamily": "code"
+            }
+        }
+    }));
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Base]);
+    assert_snapshot!(css, @r"
+@layer base {
+  :root {
+    --made-with-panda: '🐼';
+  }
+  .codeblock {
+    font-family: code;
+    font-size: 14px;
   }
 }
 ");

--- a/crates/pandacss_stylesheet/tests/global_css.rs
+++ b/crates/pandacss_stylesheet/tests/global_css.rs
@@ -526,6 +526,40 @@ fn emits_global_css_recursive_nesting_and_important() {
 }
 
 #[test]
+fn emits_global_css_recursive_nesting_from_selector_list_parent() {
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": {
+            "margin": { "className": "m" },
+            "marginTop": { "className": "mt" }
+        },
+        "globalCss": {
+            "body > p, body > ul": {
+                "margin": 0,
+                "& ~ &": {
+                    "marginTop": 10
+                }
+            }
+        }
+    }));
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Base]);
+    assert_snapshot!(css, @"
+    @layer base {
+      :root {
+        --made-with-panda: '🐼';
+      }
+      body > p, body > ul {
+        margin: 0;
+      }
+      :is(body > p) ~ :is(body > p), :is(body > ul) ~ :is(body > ul) {
+        margin-top: 10px;
+      }
+    }
+    ");
+}
+
+#[test]
 fn emits_global_css_at_rules() {
     let config = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },

--- a/crates/pandacss_stylesheet/tests/keyframes.rs
+++ b/crates/pandacss_stylesheet/tests/keyframes.rs
@@ -117,6 +117,52 @@ fn optimize_keyframes_keeps_only_referenced_blocks() {
 }
 
 #[test]
+fn optimize_keyframes_keeps_global_css_bare_nested_selector_references() {
+    let config = config(serde_json::json!({
+        "optimize": { "removeUnusedKeyframes": true },
+        "theme": {
+            "keyframes": {
+                "spin": {
+                    "to": { "transform": "rotate(360deg)" }
+                },
+                "fade": {
+                    "to": { "opacity": "0" }
+                }
+            }
+        },
+        "globalCss": {
+            ".article": {
+                "h2": {
+                    "animationName": "spin"
+                }
+            }
+        }
+    }));
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Tokens, StylesheetLayer::Base]);
+
+    assert!(css.contains("@keyframes spin"));
+    assert!(!css.contains("@keyframes fade"));
+    assert_snapshot!(css, @"
+    @layer tokens {
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    }
+    @layer base {
+      :root {
+        --made-with-panda: '🐼';
+      }
+      .article h2 {
+        animation-name: spin;
+      }
+    }
+    ");
+}
+
+#[test]
 fn optimize_keyframes_keeps_static_css_references() {
     let config = config(serde_json::json!({
         "optimize": { "removeUnusedKeyframes": true },

--- a/crates/pandacss_stylesheet/tests/static_css.rs
+++ b/crates/pandacss_stylesheet/tests/static_css.rs
@@ -589,6 +589,130 @@ fn expands_static_css_slot_recipe_wildcard() {
 }
 
 #[test]
+fn static_recipe_compositions_resolve_token_values() {
+    let config = config(composition_recipe_fixture());
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Recipes]);
+    assert_snapshot!(css, @r"
+    @layer recipes {
+      @layer base {
+        .label {
+          font-size: var(--font-sizes-sm);
+        }
+      }
+      @layer variants {
+        .label--tone_danger {
+          color: var(--colors-red-500);
+        }
+      }
+      @layer compound_variants {
+        .label--compound__tone_danger {
+          animation-duration: var(--durations-fast);
+          animation-name: fade-in;
+        }
+      }
+    }
+    @layer recipes.slots {
+      @layer base {
+        .field__label {
+          font-size: var(--font-sizes-sm);
+        }
+      }
+      @layer variants {
+        .field__label--tone_danger {
+          color: var(--colors-red-500);
+        }
+      }
+      @layer compound_variants {
+        .field__helper--compound__tone_danger {
+          animation-duration: var(--durations-fast);
+          animation-name: fade-in;
+        }
+      }
+    }
+    ");
+}
+
+fn composition_recipe_fixture() -> serde_json::Value {
+    serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": ["@panda/recipes"], "pattern": [], "jsx": [], "tokens": [] },
+        "theme": {
+            "tokens": {
+                "fontSizes": {
+                    "sm": { "value": "0.875rem" }
+                },
+                "colors": {
+                    "red": {
+                        "500": { "value": "#ef4444" }
+                    }
+                },
+                "durations": {
+                    "fast": { "value": "120ms" }
+                }
+            },
+            "textStyles": {
+                "sm": { "value": { "fontSize": "sm" } }
+            },
+            "layerStyles": {
+                "danger": { "value": { "color": "red.500" } }
+            },
+            "animationStyles": {
+                "fade": { "value": { "animationName": "fade-in", "animationDuration": "fast" } }
+            },
+            "recipes": {
+                "label": {
+                    "className": "label",
+                    "staticCss": ["*"],
+                    "base": { "textStyle": "sm" },
+                    "variants": {
+                        "tone": {
+                            "danger": { "layerStyle": "danger" }
+                        }
+                    },
+                    "compoundVariants": [
+                        {
+                            "tone": "danger",
+                            "css": { "animationStyle": "fade" }
+                        }
+                    ]
+                }
+            },
+            "slotRecipes": {
+                "field": {
+                    "className": "field",
+                    "slots": ["label", "helper"],
+                    "staticCss": ["*"],
+                    "base": {
+                        "label": { "textStyle": "sm" }
+                    },
+                    "variants": {
+                        "tone": {
+                            "danger": {
+                                "label": { "layerStyle": "danger" }
+                            }
+                        }
+                    },
+                    "compoundVariants": [
+                        {
+                            "tone": "danger",
+                            "css": {
+                                "helper": { "animationStyle": "fade" }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "utilities": {
+            "animationDuration": { "className": "dur", "values": "durations" },
+            "animationName": { "className": "anim-name" },
+            "color": { "className": "c", "values": "colors" },
+            "fontSize": { "className": "fs", "values": "fontSizes" }
+        }
+    })
+}
+
+#[test]
 fn expands_static_recipe_compound_variant_css() {
     let config = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": ["@panda/recipes"], "pattern": [], "jsx": [], "tokens": [] },


### PR DESCRIPTION
Closes #3621

## what

four fixes to the css that `globalCss` and nested style objects produce.

- a plain element nested under a class — `'.article': { h2: {...} }` — now generates `.article h2 { ... }`. before, it generated nothing at all.
- a grouped selector like `'h2, h3, h4'` now scopes every part to the parent: `.article h2, .article h3, .article h4`. before, only the first part was scoped and the rest leaked out unscoped.
- putting a `textStyle` and a normal property in the same block now makes one rule, and the normal property wins. before it made two separate rules and the `textStyle` always won, so you couldn't override things like `fontFamily`.
- a value written across several lines (e.g. `gridTemplateAreas`) now collapses to a single line. before, the line breaks and indentation leaked into the class name and the output.

## why

all four worked in v1 and broke in v2. reported in #3599.

## notes

- this only touches `globalCss` and nested selectors inside a style object. atomic `css()` still needs a `&` to nest (e.g. `'& .article'`) — that's intentional, the generated class has to attach somewhere.
- one existing test snapshot changed: when several compositions share a block, their properties now group per composition in source order instead of being fully alphabetized. same css, different order.

## test plan

- [x] `cargo test -p pandacss_stylesheet`
- [x] `cargo test --workspace` (1451 pass)
- [x] `pnpm rust:fmt` and `pnpm rust:clippy`

