### PR TITLE
test(static-css): align bleed snapshot with token-fallback parity

### DIFF
--- a/packages/compiler/__tests__/static-css-patterns.test.ts
+++ b/packages/compiler/__tests__/static-css-patterns.test.ts
@@ -138,10 +138,10 @@ describe('staticCss.patterns (preset-base parity)', () => {
     expect(utilitiesCss(compiler)).toMatchInlineSnapshot(`
       "@layer utilities {
         .\\--bleed-x_token\\(spacing\\.4\\,_4\\) {
-          --bleed-x: var(--spacing-4);
+          --bleed-x: var(--spacing-4, 4);
         }
         .\\--bleed-y_token\\(spacing\\.0\\,_0\\) {
-          --bleed-y: var(--spacing-0);
+          --bleed-y: var(--spacing-0, 0);
         }
         .mx_calc\\(var\\(--bleed-x\\,_0\\)_\\*_-1\\) {
           margin-inline: calc(var(--bleed-x, 0) * -1);


### PR DESCRIPTION
## what

update the `bleed` static-css snapshot to keep the `token()` fallback.

`token(spacing.4, 4)` resolves to `var(--spacing-4, 4)` — the fallback stays when the token resolves. the snapshot expected `var(--spacing-4)`.

## why

the resolver was changed to keep token fallbacks in `0202dba22` (align global css parity) — it's v1 behavior and is covered by the `pandacss_utility` token-ref tests (`token(colors.red.300, blue)` → `var(--colors-red-300, blue)`). the bleed snapshot was written before that change and never regenerated, so it failed on v2.

engine output is correct; only the stale snapshot needed fixing.

## test plan

- [x] `pnpm --filter @pandacss/compiler test` — 189 pass (was 188 + this one failing)
