### PR TITLE
feat(config): adopt a design system with the designSystem field

### DIFF
--- a/.changeset/design-system-single-level.md
+++ b/.changeset/design-system-single-level.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/compiler-shared': minor
+'@pandacss/compiler': minor
+'@pandacss/config': minor
+'@pandacss/types': minor
+---
+
+Adopt a published design system with one config field: `designSystem: '@acme/ds'`.
+
+Panda reads the library's `panda.lib.json`, merges its preset under your config (your overrides win), points its components at the design system's own styled-system, and reuses its pre-extracted styles instead of re-extracting them. If your Panda is a different major than the design system needs (say a v2 design system on Panda v1), you get a clear error instead of broken output.

--- a/design-notes/design-system-manifest.md
+++ b/design-notes/design-system-manifest.md
@@ -74,6 +74,31 @@ work, and it's thrown away. The pain compounds in the shapes real users actually
 The goal is to make all of that one field for the consumer and one command for the author, and to make the engine reuse the
 library's extraction instead of repeating it.
 
+## Field report: questions from real consumers
+
+These are the questions library authors actually hit when shipping a component library on Panda — gathered so the design is
+validated against real pain, not a hypothetical. Each maps to a part of this design; three are already answered, two are
+open action items tracked below.
+
+| # | The question | Answer | Where |
+| - | ------------ | ------ | ----- |
+| 1 | *I split my library into a preset package and a components package, and the components import from the preset's `styled-system`. Now every consumer has to point their `outdir` at my package's path. How do I ship this cleanly?* | The preset package is the **design system** — it ships `panda.lib.json`, and the consumer writes one field, `designSystem`. The components package *consumes* that DS but isn't one itself, so it belongs in the consumer's smart **`include`**. The manifest's `importMap` keeps the shipped components importing from the DS's own styled-system, so **no consumer ever aliases `outdir`** — that's the whole point of decoupling the styled-system from the components. | [`importMap`](#the-manifest-pandalibjson), [smart `include`](#the-model-two-fields-two-questions) |
+| 2 | *My bundler pulls too much into the type declarations — Panda's generated types "aren't exported by styled-system/…", and my component's exported type collapses to `undefined`. Why?* | **A bundler-external problem, not a codegen gap.** Panda's generated types *are* exported; the DTS pass is re-resolving the local `styled-system` folder as a bundle input and failing. The DS model fixes the root cause: the styled-system becomes a **real package export** the bundler can resolve and externalize. Authoring guidance: mark the styled-system specifiers `external` so type builds reference the published declarations instead of inlining them. **Open: author-side bundling guidance** (below). | [Module/type resolution](#module-and-type-resolution) + open item |
+| 3 | *If my library and the consuming app each have their own `styled-system`, what actually goes wrong?* | Three things, worst first: (a) **broken runtime identity** — two copies of the JSX runtime mean two React contexts, so a library's slot-recipe provider and the app don't share state; (b) **duplicated CSS** for identical atoms; (c) **`cx`/`cva` divergence** across the copies. Sharing one styled-system via the DS manifest is what lets a library and an app share runtime code — the promise made real. | [CSS layering/dedup](#css-layering-tree-shaking-and-federation) |
+| 4 | *In a monorepo, editing a component in a workspace package refreshes the DOM but the CSS doesn't update until I fully restart. How do I fix it?* | The bundler's HMR re-runs the component's JS, but Panda's cssgen never fired — the edited package's source isn't a tracked build dependency. DS/`include` resolution must register **cross-package source globs as watched build deps** and re-run cssgen on change, independent of the bundler. **Open: cross-package watch dependency** (below). | [Loading the manifest](#loading-the-manifest-consumer) + open item |
+| 5 | *Should Panda's dev package be a `dependency` or a `peerDependency` of my library?* | **Peer.** A design system declares it as a peer; the manifest's `panda` field is the range a consumer's Panda must satisfy. One Panda per install, no version-doubling. | [`panda` + `schemaVersion`](#the-manifest-pandalibjson) |
+
+### Open action items
+
+- **Author-side bundling guidance (from #2).** `panda lib` ships the styled-system as package exports, but DS authors still
+  run their own bundler over component source. Document — and have `panda lib` scaffold/validate — that the styled-system
+  specifiers are marked `external` so DTS builds reference the published types rather than re-resolving a local folder. This
+  is docs + a setup check, not engine code.
+- **Cross-package watch dependency (from #4).** Resolving `designSystem`/smart-`include` must register the consumed package's
+  source globs (and `buildInfo` path) as cssgen build dependencies so a watch run regenerates CSS on a dependency-source
+  edit, not just on `panda.lib.json`/lockfile changes. Today only the manifest paths are registered (see
+  [Loading the manifest](#loading-the-manifest-consumer)); the source-glob case is the gap.
+
 ## Goals and non-goals
 
 **Goals**
@@ -354,8 +379,14 @@ them**.
 
 1. **Manifest value + engine gen/load (no user-facing change).** `DesignSystemManifest` type; `create` + `validate` over a
    `Project` value; (de)serialization. Unit-tested in-memory at Rust + native + wasm levels. No config field, no CLI.
-2. **`designSystem`, single level.** The config field; host resolves one manifest, merges preset, derives importMap,
-   validates + hydrates build info. Diagnostics: not-found, version-mismatch, peer-range. One-lib-→-one-app fixture.
+2. **`designSystem`, single level. ✅ Complete.** Public `designSystem` config field; host
+   (`packages/config` `loadDesignSystemPreset`) resolves the manifest, merges its preset as the lowest layer (user wins),
+   auto-wires the dual-root importMap (DS roots + local outdir), and validates the manifest's `schemaVersion` + Panda
+   peer-range before loading — a consumer outside the DS's major (e.g. Panda <2 against a `^2.0.0` DS) is rejected.
+   The node driver (`packages/compiler` `hydrateDesignSystem`) hydrates the library's build info, keyed by DS name, so its
+   components are never re-extracted. Diagnostics: not-found, version-mismatch, peer-range. Manifest/preset/build-info
+   registered as build deps. _Deferred to later phases:_ build-info tree-shaking to app imports (optimization) and the
+   stale-build-info `files` re-extract fallback (Phase 5).
 3. **Nested chains.** `resolveChain` over manifest values: ordered plan, resolve-against-manifest-dir, cycle guard. Host
    reads the parent chain and feeds values in. Diagnostics: cycle, parent-not-found. Tested as in-memory arrays (depth-N,
    diamond, cycle).

--- a/packages/cli/__tests__/buildinfo.test.ts
+++ b/packages/cli/__tests__/buildinfo.test.ts
@@ -1,4 +1,4 @@
-import { createNodeDriver, type BuildInfo } from '@pandacss/compiler'
+import { createNodeDriver, type BuildInfoArtifact } from '@pandacss/compiler'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -15,7 +15,7 @@ function createLibFixture() {
   return dir
 }
 
-function readBuildInfo(dir: string, outfile = 'styled-system/panda.buildinfo.json'): BuildInfo {
+function readBuildInfo(dir: string, outfile = 'styled-system/panda.buildinfo.json'): BuildInfoArtifact {
   return JSON.parse(readFileSync(join(dir, outfile), 'utf8'))
 }
 

--- a/packages/cli/src/commands/buildinfo.ts
+++ b/packages/cli/src/commands/buildinfo.ts
@@ -1,4 +1,4 @@
-import { type BuildInfo, type Driver } from '@pandacss/compiler'
+import { type Driver } from '@pandacss/compiler'
 import { defineCommand } from 'citty'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, isAbsolute, relative } from 'node:path'
@@ -55,7 +55,7 @@ export async function runBuildinfo(
         phase: 'buildinfo',
         run: () => {
           const info = driver.compiler.buildInfo.create({ panda: flags.panda ?? '*' })
-          return normalizeBuildInfo(info, cwd)
+          return driver.compiler.buildInfo.normalize(info, { mapModuleKey: (key) => toRelativeKey(key, cwd) })
         },
       })
 
@@ -104,27 +104,6 @@ export async function runBuildinfo(
 
 function defaultOutfile(driver: Driver): string {
   return driver.compiler.joinPath([driver.paths().root, 'panda.buildinfo.json'])
-}
-
-/** Rewrite module keys (engine scan paths) to `cwd`-relative POSIX paths so the
- *  artifact is portable across machines — both the `modules` keys and the
- *  `exports` values, which reference the same module ids. */
-function normalizeBuildInfo(info: BuildInfo, cwd: string): BuildInfo {
-  const modules: BuildInfo['modules'] = {}
-
-  for (const [key, entry] of Object.entries(info.modules)) {
-    modules[toRelativeKey(key, cwd)] = entry
-  }
-
-  if (!info.exports) return { ...info, modules }
-
-  const exports: Record<string, string> = {}
-
-  for (const [name, key] of Object.entries(info.exports)) {
-    exports[name] = toRelativeKey(key, cwd)
-  }
-
-  return { ...info, modules, exports }
 }
 
 function toRelativeKey(key: string, cwd: string): string {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1,4 +1,4 @@
-import type { BuildInfo, Driver, ParseFileReport, TraceOptions } from '@pandacss/compiler'
+import type { BuildInfoArtifact, Driver, ParseFileReport, TraceOptions } from '@pandacss/compiler'
 import type { OutputSink } from './output'
 import type { CliResult } from './result'
 import { z } from 'zod'
@@ -107,7 +107,7 @@ export type DebugFlags = z.infer<typeof debugFlagsSchema>
 
 export interface BuildinfoResult extends CommandResult {
   outfile?: string
-  buildInfo?: BuildInfo
+  buildInfo?: BuildInfoArtifact
   moduleCount: number
   atomCount: number
   recipeCount: number

--- a/packages/compiler-shared/src/build-info.ts
+++ b/packages/compiler-shared/src/build-info.ts
@@ -1,75 +1,84 @@
 import type {
-  BuildInfo,
-  BuildInfoApi,
   BuildInfoCompatibility,
   BuildInfoCreateOptions,
+  BuildInfoArtifact,
   BuildInfoHydrateOptions,
   BuildInfoHydrateResult,
+  BuildInfoNormalizeOptions,
 } from './types'
 
-/** The flat build-info primitives every binding (native / wasm) exposes. The
- *  ergonomic `compiler.buildInfo` namespace is built over these. The engine owns
- *  the config fingerprint (stamped as `configFingerprint`), so the producer only
- *  supplies the published `panda` range. */
+/**
+ * The flat build-info primitives every binding (native / wasm) exposes. The
+ * ergonomic `compiler.buildInfo` namespace is built over these. The engine owns
+ * the config fingerprint (stamped as `configFingerprint`), so the producer only
+ * supplies the published `panda` range.
+ */
 export interface BuildInfoNative {
-  serializeBuildInfo(panda: string): BuildInfo
-  applyBuildInfo(name: string, buildInfo: BuildInfo, only?: string[]): boolean
-  buildInfoSchemaVersion?(): number
+  serializeBuildInfo(panda: string): BuildInfoArtifact
+  applyBuildInfo(name: string, buildInfo: BuildInfoArtifact, only?: string[]): boolean
+  buildInfoSchemaVersion(): number
   configFingerprint(): string
 }
 
-/** Build the `compiler.buildInfo` namespace over a binding's primitives.
- *
- *  `validate` authoritatively checks the wire-format `schemaVersion` against
- *  what this binding reads; the Panda peer-range / config-hash checks are
- *  layered on by the host (it knows the running version) and surface through the
- *  same `reason` union. */
-export function makeBuildInfoApi(native: BuildInfoNative): BuildInfoApi {
-  const schemaVersion = resolveSchemaVersion(native)
+export class BuildInfo {
+  readonly #native: BuildInfoNative
+  readonly #schemaVersion: number
+  readonly configFingerprint: string
 
-  const validate = (info: BuildInfo): BuildInfoCompatibility =>
-    info.schemaVersion === schemaVersion ? { ok: true } : { ok: false, reason: 'schemaVersion' }
-
-  return {
-    configFingerprint: native.configFingerprint(),
-
-    create: (options: BuildInfoCreateOptions) => native.serializeBuildInfo(options.panda),
-
-    validate,
-
-    modulesFor: (info: BuildInfo, exportNames: string[]): string[] => {
-      const exports = info.exports ?? {}
-      const modules = new Set<string>()
-
-      for (const name of exportNames) {
-        const module = exports[name]
-        if (module !== undefined) modules.add(module)
-      }
-
-      return [...modules]
-    },
-
-    hydrate: (info: BuildInfo, options: BuildInfoHydrateOptions): BuildInfoHydrateResult => {
-      const compat = validate(info)
-      if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
-
-      native.applyBuildInfo(options.name, info, options.only)
-
-      // The engine hydrates only modules that exist; report that exact set so the
-      // result never claims to have hydrated an unknown `only` key.
-      const modules = options.only ? options.only.filter((key) => key in info.modules) : Object.keys(info.modules)
-
-      return { ok: true, modules }
-    },
+  constructor(native: BuildInfoNative) {
+    this.#native = native
+    this.#schemaVersion = native.buildInfoSchemaVersion()
+    this.configFingerprint = native.configFingerprint()
   }
-}
 
-function resolveSchemaVersion(native: BuildInfoNative): number {
-  const schemaVersion = native.buildInfoSchemaVersion?.()
-  if (typeof schemaVersion === 'number') return schemaVersion
+  create(options: BuildInfoCreateOptions): BuildInfoArtifact {
+    return this.#native.serializeBuildInfo(options.panda)
+  }
 
-  // Some native bindings expose the serialized build-info shape but omit the
-  // direct schema-version accessor. The serializer still stamps the version, so
-  // derive it once and keep the public JS contract stable.
-  return native.serializeBuildInfo('0.0.0').schemaVersion
+  validate(info: BuildInfoArtifact): BuildInfoCompatibility {
+    return info.schemaVersion === this.#schemaVersion ? { ok: true } : { ok: false, reason: 'schemaVersion' }
+  }
+
+  modulesFor(info: BuildInfoArtifact, exportNames: string[]): string[] {
+    const exports = info.exports ?? {}
+    const modules = new Set<string>()
+
+    for (const name of exportNames) {
+      const module = exports[name]
+      if (module !== undefined) modules.add(module)
+    }
+
+    return [...modules]
+  }
+
+  normalize(info: BuildInfoArtifact, options: BuildInfoNormalizeOptions): BuildInfoArtifact {
+    const modules: BuildInfoArtifact['modules'] = {}
+
+    for (const [key, entry] of Object.entries(info.modules)) {
+      modules[options.mapModuleKey(key)] = entry
+    }
+
+    if (!info.exports) return { ...info, modules }
+
+    const exports: Record<string, string> = {}
+
+    for (const [name, key] of Object.entries(info.exports)) {
+      exports[name] = options.mapModuleKey(key)
+    }
+
+    return { ...info, modules, exports }
+  }
+
+  hydrate(info: BuildInfoArtifact, options: BuildInfoHydrateOptions): BuildInfoHydrateResult {
+    const compat = this.validate(info)
+    if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
+
+    this.#native.applyBuildInfo(options.name, info, options.only)
+
+    // The engine hydrates only modules that exist; report that exact set so the
+    // result never claims to have hydrated an unknown `only` key.
+    const modules = options.only ? options.only.filter((key) => key in info.modules) : Object.keys(info.modules)
+
+    return { ok: true, modules }
+  }
 }

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -11,13 +11,13 @@ import type {
 } from './types'
 
 /**
- * The flat manifest primitives every binding (native / wasm) exposes; the
- * `compiler.designSystem` namespace is built over these.
+ * Minimal primitives `DesignSystem` needs; native and wasm adapters can map
+ * their flat binding names into this smaller shape.
  */
-export interface DesignSystemNative {
-  createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
-  designSystemManifestSchemaVersion(): number
-  resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
+export interface DesignSystemBinding {
+  createManifest(input: DesignSystemManifestInput): DesignSystemManifest
+  manifestSchemaVersion(): number
+  resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
 /**
@@ -30,18 +30,18 @@ const major = (value: string): number => {
 }
 
 export class DesignSystem {
-  readonly #native: DesignSystemNative
+  readonly #binding: DesignSystemBinding
   readonly #buildInfo: BuildInfo
   readonly schemaVersion: number
 
-  constructor(native: DesignSystemNative, buildInfo: BuildInfo) {
-    this.#native = native
+  constructor(binding: DesignSystemBinding, buildInfo: BuildInfo) {
+    this.#binding = binding
     this.#buildInfo = buildInfo
-    this.schemaVersion = native.designSystemManifestSchemaVersion()
+    this.schemaVersion = binding.manifestSchemaVersion()
   }
 
   create(input: DesignSystemManifestInput): DesignSystemManifest {
-    return this.#native.createDesignSystemManifest(input)
+    return this.#binding.createManifest(input)
   }
 
   validate(manifest: DesignSystemManifest, options?: DesignSystemValidateOptions): DesignSystemManifestCompatibility {
@@ -70,7 +70,7 @@ export class DesignSystem {
   }
 
   resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainResult {
-    const plan = this.#native.resolveDesignSystemChain(manifests)
+    const plan = this.#binding.resolveChain(manifests)
     return plan.status === 'ordered'
       ? { ok: true, order: plan.order }
       : { ok: false, reason: 'cycle', cycle: plan.cycle }

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -19,11 +19,25 @@ export interface DesignSystemNative {
   resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
+export const DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION = 1
+
 /** Major from a version or range (`^2.1.0` → `2`); `NaN` when no number is found
  *  so an unreadable value fails the major check rather than passing silently. */
 const major = (value: string): number => {
   const match = value.match(/\d+/)
   return match ? Number(match[0]) : NaN
+}
+
+export function checkManifestCompatibility(
+  manifest: DesignSystemManifest,
+  options: { schemaVersion: number; pandaVersion?: string },
+): DesignSystemManifestCompatibility {
+  if (manifest.schemaVersion !== options.schemaVersion) return { ok: false, reason: 'schemaVersion' }
+  const running = options.pandaVersion
+  if (running !== undefined && major(running) !== major(manifest.panda)) {
+    return { ok: false, reason: 'pandaRange' }
+  }
+  return { ok: true }
 }
 
 /** Build the `compiler.designSystem` namespace over a binding's primitives.
@@ -38,14 +52,8 @@ export function makeDesignSystemApi(native: DesignSystemNative, buildInfo: Build
   const validate = (
     manifest: DesignSystemManifest,
     options?: DesignSystemValidateOptions,
-  ): DesignSystemManifestCompatibility => {
-    if (manifest.schemaVersion !== schemaVersion) return { ok: false, reason: 'schemaVersion' }
-    const running = options?.pandaVersion
-    if (running !== undefined && major(running) !== major(manifest.panda)) {
-      return { ok: false, reason: 'pandaRange' }
-    }
-    return { ok: true }
-  }
+  ): DesignSystemManifestCompatibility =>
+    checkManifestCompatibility(manifest, { schemaVersion, pandaVersion: options?.pandaVersion })
 
   return {
     schemaVersion,

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -1,6 +1,5 @@
+import type { BuildInfo } from './build-info'
 import type {
-  BuildInfoApi,
-  DesignSystemApi,
   DesignSystemChainPlan,
   DesignSystemChainResult,
   DesignSystemLoadOptions,
@@ -11,75 +10,69 @@ import type {
   DesignSystemValidateOptions,
 } from './types'
 
-/** The flat manifest primitives every binding (native / wasm) exposes; the
- *  `compiler.designSystem` namespace is built over these. */
+/**
+ * The flat manifest primitives every binding (native / wasm) exposes; the
+ * `compiler.designSystem` namespace is built over these.
+ */
 export interface DesignSystemNative {
   createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
   designSystemManifestSchemaVersion(): number
   resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
-export const DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION = 1
-
-/** Major from a version or range (`^2.1.0` → `2`); `NaN` when no number is found
- *  so an unreadable value fails the major check rather than passing silently. */
+/**
+ * Major from a version or range (`^2.1.0` -> `2`); `NaN` when no number is found
+ * so an unreadable value fails the major check rather than passing silently.
+ */
 const major = (value: string): number => {
   const match = value.match(/\d+/)
   return match ? Number(match[0]) : NaN
 }
 
-export function checkManifestCompatibility(
-  manifest: DesignSystemManifest,
-  options: { schemaVersion: number; pandaVersion?: string },
-): DesignSystemManifestCompatibility {
-  if (manifest.schemaVersion !== options.schemaVersion) return { ok: false, reason: 'schemaVersion' }
-  const running = options.pandaVersion
-  if (running !== undefined && major(running) !== major(manifest.panda)) {
-    return { ok: false, reason: 'pandaRange' }
+export class DesignSystem {
+  readonly #native: DesignSystemNative
+  readonly #buildInfo: BuildInfo
+  readonly schemaVersion: number
+
+  constructor(native: DesignSystemNative, buildInfo: BuildInfo) {
+    this.#native = native
+    this.#buildInfo = buildInfo
+    this.schemaVersion = native.designSystemManifestSchemaVersion()
   }
-  return { ok: true }
-}
 
-/** Build the `compiler.designSystem` namespace over a binding's primitives.
- *  `validate` checks the wire-format `schemaVersion` and — given the consumer's
- *  running `pandaVersion` — that its major matches the manifest's `panda` range.
- *  Panda releases in lockstep, so the major boundary is the whole peer contract;
- *  finer skew is already caught by `schemaVersion` + the build-info fingerprint.
- *  `load` reuses the `buildInfo` namespace to hydrate the library's styles. */
-export function makeDesignSystemApi(native: DesignSystemNative, buildInfo: BuildInfoApi): DesignSystemApi {
-  const schemaVersion = native.designSystemManifestSchemaVersion()
+  create(input: DesignSystemManifestInput): DesignSystemManifest {
+    return this.#native.createDesignSystemManifest(input)
+  }
 
-  const validate = (
-    manifest: DesignSystemManifest,
-    options?: DesignSystemValidateOptions,
-  ): DesignSystemManifestCompatibility =>
-    checkManifestCompatibility(manifest, { schemaVersion, pandaVersion: options?.pandaVersion })
+  validate(manifest: DesignSystemManifest, options?: DesignSystemValidateOptions): DesignSystemManifestCompatibility {
+    if (manifest.schemaVersion !== this.schemaVersion) return { ok: false, reason: 'schemaVersion' }
 
-  return {
-    schemaVersion,
+    const running = options?.pandaVersion
+    if (running !== undefined && major(running) !== major(manifest.panda)) {
+      return { ok: false, reason: 'pandaRange' }
+    }
 
-    create: (input: DesignSystemManifestInput) => native.createDesignSystemManifest(input),
+    return { ok: true }
+  }
 
-    validate,
+  load(manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult {
+    const compat = this.validate(manifest, { pandaVersion: options.pandaVersion })
+    if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
 
-    load: (manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult => {
-      const compat = validate(manifest, { pandaVersion: options.pandaVersion })
-      if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
+    // `imports` omitted -> hydrate every module (namespace import); otherwise
+    // resolve the touched modules so only their CSS emits (tree-shaking).
+    const only =
+      options.imports !== undefined ? this.#buildInfo.modulesFor(options.buildInfo, options.imports) : undefined
+    const result = this.#buildInfo.hydrate(options.buildInfo, { name: manifest.name, only })
+    if (!result.ok) return { ok: false, reason: result.reason, modules: [] }
 
-      // `imports` omitted → hydrate every module (namespace import); otherwise
-      // resolve the touched modules so only their CSS emits (tree-shaking).
-      const only = options.imports !== undefined ? buildInfo.modulesFor(options.buildInfo, options.imports) : undefined
-      const result = buildInfo.hydrate(options.buildInfo, { name: manifest.name, only })
-      if (!result.ok) return { ok: false, reason: result.reason, modules: [] }
+    return { ok: true, name: manifest.name, modules: result.modules }
+  }
 
-      return { ok: true, name: manifest.name, modules: result.modules }
-    },
-
-    resolveChain: (manifests: DesignSystemManifest[]): DesignSystemChainResult => {
-      const plan = native.resolveDesignSystemChain(manifests)
-      return plan.status === 'ordered'
-        ? { ok: true, order: plan.order }
-        : { ok: false, reason: 'cycle', cycle: plan.cycle }
-    },
+  resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainResult {
+    const plan = this.#native.resolveDesignSystemChain(manifests)
+    return plan.status === 'ordered'
+      ? { ok: true, order: plan.order }
+      : { ok: false, reason: 'cycle', cycle: plan.cycle }
   }
 }

--- a/packages/compiler-shared/src/import-map.ts
+++ b/packages/compiler-shared/src/import-map.ts
@@ -61,7 +61,7 @@ function importMapFromRoot(root: string): ImportMapOutput {
   }
 }
 
-function outdirBasename(outdir: string): string {
+export function outdirBasename(outdir: string): string {
   const parts = outdir.split('/').filter(Boolean)
   return parts.at(-1) ?? outdir
 }

--- a/packages/compiler-shared/src/index.ts
+++ b/packages/compiler-shared/src/index.ts
@@ -5,8 +5,8 @@
  *
  * This module is a barrel; the surface is split by concern:
  * - `./types`      — data-shape contract (the serialized `Compiler` surface)
- * - `./build-info` — the `buildInfo` namespace factory over binding primitives
- * - `./design-system` — the `designSystem` namespace factory (`panda.lib.json`)
+ * - `./build-info` — the `buildInfo` namespace over binding primitives
+ * - `./design-system` — the `designSystem` namespace (`panda.lib.json`)
  * - `./callbacks`  — the JS-callback runtime (`utility.transform`, …)
  * - `./introspect` — the `introspect(spec)` query/sort helper
  * - `./driver`     — the host orchestration layer (`Driver`, `BaseDriver`)

--- a/packages/compiler-shared/src/types/compiler.ts
+++ b/packages/compiler-shared/src/types/compiler.ts
@@ -1,3 +1,5 @@
+import type { BuildInfo } from '../build-info'
+import type { DesignSystem } from '../design-system'
 import type { SerializedConfig } from './config'
 import type { Diagnostic } from './diagnostics'
 import type {
@@ -88,9 +90,9 @@ export interface BuildModuleEntry {
 }
 
 /**
- * Serialized encoder state that lets consumers hydrate CSS without re-extracting a library.
+ * Portable encoder artifact that lets consumers hydrate CSS without re-extracting a library.
  */
-export interface BuildInfo {
+export interface BuildInfoArtifact {
   schemaVersion: number
   panda: string
   configFingerprint: string
@@ -109,6 +111,13 @@ export interface BuildInfoCreateOptions {
   panda: string
 }
 
+export interface BuildInfoNormalizeOptions {
+  /**
+   * Rewrite a module key while preserving build-info cross references.
+   */
+  mapModuleKey(key: string): string
+}
+
 export interface BuildInfoHydrateOptions {
   /**
    * Stable source design-system name. Later hydrates of the same name replace cleanly.
@@ -123,17 +132,6 @@ export interface BuildInfoHydrateOptions {
 export type BuildInfoHydrateResult =
   | { ok: true; modules: string[] }
   | { ok: false; reason: BuildInfoIncompatibility; modules: [] }
-
-export interface BuildInfoApi {
-  readonly configFingerprint: string
-  create(options: BuildInfoCreateOptions): BuildInfo
-  validate(buildInfo: BuildInfo): BuildInfoCompatibility
-  /**
-   * Resolve barrel export names to module keys using `BuildInfo.exports`.
-   */
-  modulesFor(buildInfo: BuildInfo, exportNames: string[]): string[]
-  hydrate(buildInfo: BuildInfo, options: BuildInfoHydrateOptions): BuildInfoHydrateResult
-}
 
 /**
  * Design-system manifest (`panda.lib.json`).
@@ -188,7 +186,7 @@ export type DesignSystemChainPlan = { status: 'ordered'; order: string[] } | { s
 export type DesignSystemChainResult = { ok: true; order: string[] } | { ok: false; reason: 'cycle'; cycle: string[] }
 
 export interface DesignSystemLoadOptions {
-  buildInfo: BuildInfo
+  buildInfo: BuildInfoArtifact
   /**
    * Export names imported by the consumer; omit for namespace/all-module hydration.
    */
@@ -199,17 +197,6 @@ export interface DesignSystemLoadOptions {
 export type DesignSystemLoadResult =
   | { ok: true; name: string; modules: string[] }
   | { ok: false; reason: DesignSystemManifestIncompatibility | BuildInfoIncompatibility; modules: [] }
-
-export interface DesignSystemApi {
-  readonly schemaVersion: number
-  create(input: DesignSystemManifestInput): DesignSystemManifest
-  validate(manifest: DesignSystemManifest, options?: DesignSystemValidateOptions): DesignSystemManifestCompatibility
-  load(manifest: DesignSystemManifest, options: DesignSystemLoadOptions): DesignSystemLoadResult
-  /**
-   * Order manifests by parent links into a root-first plan, or report a cycle.
-   */
-  resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainResult
-}
 
 /**
  * Configured compiler surface shared by native and wasm bindings.
@@ -251,8 +238,8 @@ export interface Compiler {
   getLayerCss(options: LayerCssOptions): CompileOutput
   getSplitCss(options?: SplitCssOptions): CssFile[]
 
-  readonly buildInfo: BuildInfoApi
-  readonly designSystem: DesignSystemApi
+  readonly buildInfo: BuildInfo
+  readonly designSystem: DesignSystem
 
   /**
    * Codegen artifacts.

--- a/packages/compiler-wasm/src/types.ts
+++ b/packages/compiler-wasm/src/types.ts
@@ -12,7 +12,7 @@
 
 import type {
   Atom,
-  BuildInfo,
+  BuildInfoArtifact,
   DesignSystemManifest,
   DesignSystemManifestInput,
   CodegenArtifact,
@@ -154,14 +154,14 @@ export declare class WasmCompiler {
   /** Per-file view, or `null` when `path` isn't known. */
   getFile(path: string): ParsedFileView | null
   staticPatternAtoms(): StaticPatternResult
-  // Flat build-info primitives (the `makeBuildInfoApi` namespace is built over
-  // these in `web.ts`, mirroring the native binding).
-  serializeBuildInfo(panda: string): BuildInfo
-  applyBuildInfo(name: string, buildInfo: BuildInfo, only?: string[]): boolean
+  // Flat build-info primitives (the `BuildInfo` namespace is built over these
+  // in `web.ts`, mirroring the native binding).
+  serializeBuildInfo(panda: string): BuildInfoArtifact
+  applyBuildInfo(name: string, buildInfo: BuildInfoArtifact, only?: string[]): boolean
   buildInfoSchemaVersion(): number
   configFingerprint(): string
-  // Flat design-system manifest primitives (the `makeDesignSystemApi` namespace
-  // is built over these in `web.ts`, mirroring the native binding).
+  // Flat design-system manifest primitives (the `DesignSystem` namespace is
+  // built over these in `web.ts`, mirroring the native binding).
   createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
   designSystemManifestSchemaVersion(): number
 }

--- a/packages/compiler-wasm/src/types.ts
+++ b/packages/compiler-wasm/src/types.ts
@@ -13,6 +13,7 @@
 import type {
   Atom,
   BuildInfoArtifact,
+  DesignSystemChainPlan,
   DesignSystemManifest,
   DesignSystemManifestInput,
   CodegenArtifact,
@@ -160,8 +161,9 @@ export declare class WasmCompiler {
   applyBuildInfo(name: string, buildInfo: BuildInfoArtifact, only?: string[]): boolean
   buildInfoSchemaVersion(): number
   configFingerprint(): string
-  // Flat design-system manifest primitives (the `DesignSystem` namespace is
-  // built over these in `web.ts`, mirroring the native binding).
+  // Raw design-system binding methods. `web.ts` adapts these into the smaller
+  // `DesignSystemBinding` contract used by the public namespace.
   createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
   designSystemManifestSchemaVersion(): number
+  resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }

--- a/packages/compiler-wasm/src/web.ts
+++ b/packages/compiler-wasm/src/web.ts
@@ -20,9 +20,9 @@
 import {
   assertProjectCallbacks,
   assertProjectHooks,
+  BuildInfo,
+  DesignSystem,
   getTokenCategoryValues,
-  makeBuildInfoApi,
-  makeDesignSystemApi,
   mergeCallbacks,
   prepareCompilerConfig,
 } from '@pandacss/compiler-shared'
@@ -50,18 +50,24 @@ export type {
 // Re-export the shared contract so consumers get one import surface.
 export type * from '@pandacss/compiler-shared'
 
-/** `configCallbacks` carry construction-time `utility.values` resolvers. */
+/**
+ * `configCallbacks` carry construction-time `utility.values` resolvers.
+ */
 interface WasmFromConfigOptions {
   configCallbacks?: {
     utilityValues?: Record<string, (tokenDictionary: TokenDictionaryInput | undefined) => unknown>
   }
 }
 
-/** The raw wasm instance — superset of {@link Compiler} carrying the internal
- *  `token_dictionary` the facade hides. */
+/**
+ * The raw wasm instance - superset of {@link Compiler} carrying the internal
+ * `token_dictionary` the facade hides.
+ */
 interface RawWasmCompiler extends WasmCompiler {
   token_dictionary?(): TokenDictionaryInput | undefined
 }
+
+type RuntimeWasmCompiler = RawWasmCompiler & Compiler & BuildInfoNative & DesignSystemNative & { fs: WasmFileSystem }
 
 export interface WasmModule {
   WasmFileSystem: new () => WasmFileSystem
@@ -96,24 +102,24 @@ export function build(
   assertProjectHooks(hooks, callbacks)
 
   const prepared = prepareCompilerConfig(config)
-  const compiler = mod.WasmCompiler.fromConfig(fs, prepared, buildFromConfigOptions(callbacks))
+  const compiler = mod.WasmCompiler.fromConfig(fs, prepared, buildFromConfigOptions(callbacks)) as RuntimeWasmCompiler
   registerCallbacks(compiler, callbacks, hooks, compiler.token_dictionary?.())
 
   // Expose the shared FS as a field so the return shape matches native.
-  ;(compiler as unknown as { fs: WasmFileSystem }).fs = fs
+  compiler.fs = fs
 
   // Wire the ergonomic `compiler.buildInfo` / `compiler.designSystem` namespaces
   // over the wasm primitives, mirroring the native binding. Non-enumerable so
   // they stay off snapshots.
-  const buildInfo = makeBuildInfoApi(compiler as unknown as BuildInfoNative)
+  const buildInfo = new BuildInfo(compiler)
   Object.defineProperty(compiler, 'buildInfo', { value: buildInfo, enumerable: false })
   Object.defineProperty(compiler, 'designSystem', {
     // `load` reuses the `buildInfo` namespace just wired above.
-    value: makeDesignSystemApi(compiler as unknown as DesignSystemNative, buildInfo),
+    value: new DesignSystem(compiler, buildInfo),
     enumerable: false,
   })
 
-  return compiler as unknown as Compiler
+  return compiler
 }
 
 export function buildFromConfigOptions(callbacks: ProjectCallbacks): WasmFromConfigOptions | undefined {

--- a/packages/compiler-wasm/src/web.ts
+++ b/packages/compiler-wasm/src/web.ts
@@ -30,7 +30,7 @@ import type {
   BuildInfoNative,
   Compiler,
   CompilerOptions,
-  DesignSystemNative,
+  DesignSystemBinding,
   ProjectCallbacks,
   ProjectHooks,
   SerializedConfig,
@@ -67,7 +67,7 @@ interface RawWasmCompiler extends WasmCompiler {
   token_dictionary?(): TokenDictionaryInput | undefined
 }
 
-type RuntimeWasmCompiler = RawWasmCompiler & Compiler & BuildInfoNative & DesignSystemNative & { fs: WasmFileSystem }
+type RuntimeWasmCompiler = RawWasmCompiler & Compiler & BuildInfoNative & { fs: WasmFileSystem }
 
 export interface WasmModule {
   WasmFileSystem: new () => WasmFileSystem
@@ -115,11 +115,19 @@ export function build(
   Object.defineProperty(compiler, 'buildInfo', { value: buildInfo, enumerable: false })
   Object.defineProperty(compiler, 'designSystem', {
     // `load` reuses the `buildInfo` namespace just wired above.
-    value: new DesignSystem(compiler, buildInfo),
+    value: new DesignSystem(toDesignSystemBinding(compiler), buildInfo),
     enumerable: false,
   })
 
   return compiler
+}
+
+function toDesignSystemBinding(compiler: RuntimeWasmCompiler): DesignSystemBinding {
+  return {
+    createManifest: (input) => compiler.createDesignSystemManifest(input),
+    manifestSchemaVersion: () => compiler.designSystemManifestSchemaVersion(),
+    resolveChain: (manifests) => compiler.resolveDesignSystemChain(manifests),
+  }
 }
 
 export function buildFromConfigOptions(callbacks: ProjectCallbacks): WasmFromConfigOptions | undefined {

--- a/packages/compiler/__tests__/build-info.test.ts
+++ b/packages/compiler/__tests__/build-info.test.ts
@@ -1,9 +1,9 @@
-import type { BuildInfo } from '@pandacss/compiler-shared'
+import type { BuildInfoArtifact } from '@pandacss/compiler-shared'
 import { describe, expect, it } from 'vitest'
 import { createProject } from './test-utils'
 
 // A "library" project that extracts two component modules.
-function libBuildInfo(): BuildInfo {
+function libBuildInfo(): BuildInfoArtifact {
   const lib = createProject({
     utilities: { padding: { className: 'p' }, margin: { className: 'm' } },
   })
@@ -12,7 +12,7 @@ function libBuildInfo(): BuildInfo {
   return lib.buildInfo.create({ panda: '^2.0.0' })
 }
 
-function withUnsupportedSchemaVersion(buildInfo: BuildInfo): BuildInfo {
+function withUnsupportedSchemaVersion(buildInfo: BuildInfoArtifact): BuildInfoArtifact {
   // One version ahead of the running binding — guaranteed incompatible.
   return {
     ...buildInfo,
@@ -222,6 +222,26 @@ describe('compiler.buildInfo', () => {
     `)
   })
 
+  it('normalize() rewrites module keys and export references together', () => {
+    const app = consumer()
+    const source = libBuildInfo()
+    const info = {
+      ...source,
+      modules: Object.fromEntries(Object.entries(source.modules).map(([key, entry]) => [`/repo/lib/${key}`, entry])),
+      exports: { Button: '/repo/lib/button.tsx', Card: '/repo/lib/card.tsx' },
+    }
+
+    const normalized = app.buildInfo.normalize(info, {
+      mapModuleKey: (key) => key.replace('/repo/lib/', ''),
+    })
+
+    expect(normalized.modules).toEqual({
+      'button.tsx': { atoms: [0, 2] },
+      'card.tsx': { atoms: [0, 1] },
+    })
+    expect(normalized.exports).toEqual({ Button: 'button.tsx', Card: 'card.tsx' })
+  })
+
   it('emits exports for recipe-consuming components, resolvable by name to recipe CSS', () => {
     // A design-system module whose exported component consumes a config recipe.
     const lib = createProject({
@@ -394,7 +414,7 @@ describe('compiler.buildInfo', () => {
 
   // A library shipping two recipes, each used from a distinct module so recipe
   // provenance is per-file (and thus tree-shakeable).
-  function recipeLibBuildInfo(): BuildInfo {
+  function recipeLibBuildInfo(): BuildInfoArtifact {
     const lib = createProject({
       theme: {
         recipes: {

--- a/packages/compiler/__tests__/node-driver.test.ts
+++ b/packages/compiler/__tests__/node-driver.test.ts
@@ -1,8 +1,18 @@
-import { mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createNodeDriver } from '../src'
+import { createProject } from './test-utils'
 
 const CONFIG = `import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -316,6 +326,130 @@ describe('createNodeDriver isConfigFile (symlinks)', () => {
 
     rmSync(parent, { recursive: true, force: true }) // unlinks the `proj` symlink
     rmSync(real, { recursive: true, force: true })
+  })
+})
+
+describe('createNodeDriver designSystem', () => {
+  it('loads a package manifest, hydrates build info, and tracks design-system dependencies', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'panda-driver-ds-'))
+    const pkg = join(dir, 'node_modules', '@acme', 'ds')
+    mkdirSync(pkg, { recursive: true })
+
+    const lib = createProject()
+    lib.parseFileSource('button.tsx', "import { css } from '@panda/css'\nexport const Button = css({ color: 'red' })")
+
+    writeFileSync(join(dir, 'panda.config.ts'), "export default { designSystem: '@acme/ds', include: ['App.tsx'] }")
+    writeFileSync(join(dir, 'App.tsx'), '')
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/ds', version: '1.0.0' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: '@acme/ds',
+        panda: '^2.0.0',
+        preset: './preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+        importMap: { css: '@acme/ds/css' },
+      }),
+    )
+    writeFileSync(join(pkg, 'preset.mjs'), 'export default { name: "@acme/ds" }')
+    writeFileSync(join(pkg, 'panda.buildinfo.json'), JSON.stringify(lib.buildInfo.create({ panda: '^2.0.0' })))
+
+    try {
+      const driver = await createNodeDriver({ cwd: dir })
+      const css = driver.cssgen().css
+
+      expect(css).toContain('color: red')
+      expect(driver.isConfigFile(join(pkg, 'panda.lib.json'))).toBe(true)
+      expect(driver.isConfigFile(join(pkg, 'preset.mjs'))).toBe(true)
+      expect(driver.isConfigFile(join(pkg, 'panda.buildinfo.json'))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails clearly when the manifest build info cannot be read', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'panda-driver-ds-missing-'))
+    const pkg = join(dir, 'node_modules', '@acme', 'ds')
+    mkdirSync(pkg, { recursive: true })
+
+    writeFileSync(join(dir, 'panda.config.ts'), "export default { designSystem: '@acme/ds' }")
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/ds', version: '1.0.0' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: '@acme/ds',
+        panda: '^2.0.0',
+        preset: './preset.mjs',
+        buildInfo: './missing.buildinfo.json',
+      }),
+    )
+    writeFileSync(join(pkg, 'preset.mjs'), 'export default { name: "@acme/ds" }')
+
+    try {
+      await expect(createNodeDriver({ cwd: dir })).rejects.toThrow(/Failed to hydrate designSystem "@acme\/ds"/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails clearly when the manifest schema is incompatible', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'panda-driver-ds-schema-'))
+    const pkg = join(dir, 'node_modules', '@acme', 'ds')
+    mkdirSync(pkg, { recursive: true })
+
+    const lib = createProject()
+
+    writeFileSync(join(dir, 'panda.config.ts'), "export default { designSystem: '@acme/ds' }")
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/ds', version: '1.0.0' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 999,
+        name: '@acme/ds',
+        panda: '^2.0.0',
+        preset: './preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+      }),
+    )
+    writeFileSync(join(pkg, 'preset.mjs'), 'export default { name: "@acme/ds" }')
+    writeFileSync(join(pkg, 'panda.buildinfo.json'), JSON.stringify(lib.buildInfo.create({ panda: '^2.0.0' })))
+
+    try {
+      await expect(createNodeDriver({ cwd: dir })).rejects.toThrow(/manifest schemaVersion 999 is incompatible/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails clearly when the manifest Panda range is incompatible', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'panda-driver-ds-range-'))
+    const pkg = join(dir, 'node_modules', '@acme', 'ds')
+    mkdirSync(pkg, { recursive: true })
+
+    const lib = createProject()
+
+    writeFileSync(join(dir, 'panda.config.ts'), "export default { designSystem: '@acme/ds' }")
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/ds', version: '1.0.0' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: '@acme/ds',
+        panda: '^999.0.0',
+        preset: './preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+      }),
+    )
+    writeFileSync(join(pkg, 'preset.mjs'), 'export default { name: "@acme/ds" }')
+    writeFileSync(join(pkg, 'panda.buildinfo.json'), JSON.stringify(lib.buildInfo.create({ panda: '^2.0.0' })))
+
+    try {
+      await expect(createNodeDriver({ cwd: dir })).rejects.toThrow(/manifest requires Panda \^999\.0\.0/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/compiler/src/design-system.ts
+++ b/packages/compiler/src/design-system.ts
@@ -1,24 +1,53 @@
-import { type BuildInfo, type Compiler } from '@pandacss/compiler-shared'
-import type { LoadConfigResult } from '@pandacss/config'
+import { type BuildInfoArtifact, type Compiler } from '@pandacss/compiler-shared'
+import { readPandaVersion, type LoadConfigResult } from '@pandacss/config'
 import { readFileSync } from 'node:fs'
 
-type ResolvedDesignSystem = NonNullable<LoadConfigResult['metadata']>['designSystem']
+type ResolvedDesignSystem = NonNullable<NonNullable<LoadConfigResult['metadata']>['designSystem']>
 
-export function hydrateDesignSystem(compiler: Compiler, ds: ResolvedDesignSystem): void {
+export function hydrateDesignSystem(compiler: Compiler, ds: ResolvedDesignSystem | undefined): void {
   if (!ds) return
-  let buildInfo: BuildInfo
+
+  const pandaVersion = readPandaVersion()
+  const compat = compiler.designSystem.validate(ds.manifest, { pandaVersion })
+  if (!compat.ok) {
+    throw incompatibleManifestError(compiler, ds, compat.reason, pandaVersion)
+  }
+
+  let buildInfo: BuildInfoArtifact
   try {
-    buildInfo = JSON.parse(readFileSync(ds.buildInfoPath, 'utf8')) as BuildInfo
-  } catch {
-    console.warn(
-      `[panda] designSystem "${ds.name}": could not read build info at ${ds.buildInfoPath}; its components will not be hydrated and their styles may be missing.`,
+    buildInfo = JSON.parse(readFileSync(ds.buildInfoPath, 'utf8')) as BuildInfoArtifact
+  } catch (error) {
+    throw new Error(
+      `Failed to hydrate designSystem ${JSON.stringify(ds.name)} from ${JSON.stringify(ds.buildInfoPath)}: ${errorMessage(error)}`,
     )
-    return
   }
-  const result = compiler.buildInfo.hydrate(buildInfo, { name: ds.name })
+
+  const result = compiler.designSystem.load(ds.manifest, { buildInfo, pandaVersion })
   if (!result.ok) {
-    console.warn(
-      `[panda] designSystem "${ds.name}": build info at ${ds.buildInfoPath} is incompatible (${result.reason}); its components will not be hydrated and their styles may be missing.`,
+    throw new Error(
+      `Failed to hydrate designSystem ${JSON.stringify(ds.name)} from ${JSON.stringify(ds.buildInfoPath)}: incompatible buildInfo ${result.reason}.`,
     )
   }
+}
+
+function incompatibleManifestError(
+  compiler: Compiler,
+  ds: ResolvedDesignSystem,
+  reason: 'schemaVersion' | 'pandaRange',
+  pandaVersion?: string,
+): Error {
+  if (reason === 'schemaVersion') {
+    return new Error(
+      `Failed to hydrate designSystem ${JSON.stringify(ds.name)} from ${JSON.stringify(ds.manifestPath)}: manifest schemaVersion ${ds.manifest.schemaVersion} is incompatible with this compiler (expected ${compiler.designSystem.schemaVersion}).`,
+    )
+  }
+
+  const running = pandaVersion ? ` (you are on ${pandaVersion})` : ''
+  return new Error(
+    `Failed to hydrate designSystem ${JSON.stringify(ds.name)}: manifest requires Panda ${ds.manifest.panda}${running}.`,
+  )
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/compiler/src/design-system.ts
+++ b/packages/compiler/src/design-system.ts
@@ -15,5 +15,10 @@ export function hydrateDesignSystem(compiler: Compiler, ds: ResolvedDesignSystem
     )
     return
   }
-  compiler.buildInfo.hydrate(buildInfo, { name: ds.name })
+  const result = compiler.buildInfo.hydrate(buildInfo, { name: ds.name })
+  if (!result.ok) {
+    console.warn(
+      `[panda] designSystem "${ds.name}": build info at ${ds.buildInfoPath} is incompatible (${result.reason}); its components will not be hydrated and their styles may be missing.`,
+    )
+  }
 }

--- a/packages/compiler/src/design-system.ts
+++ b/packages/compiler/src/design-system.ts
@@ -1,0 +1,16 @@
+import { type BuildInfo, type Compiler } from '@pandacss/compiler-shared'
+import type { LoadConfigResult } from '@pandacss/config'
+import { readFileSync } from 'node:fs'
+
+type ResolvedDesignSystem = NonNullable<LoadConfigResult['metadata']>['designSystem']
+
+export function hydrateDesignSystem(compiler: Compiler, ds: ResolvedDesignSystem): void {
+  if (!ds) return
+  let buildInfo: BuildInfo
+  try {
+    buildInfo = JSON.parse(readFileSync(ds.buildInfoPath, 'utf8')) as BuildInfo
+  } catch {
+    return
+  }
+  compiler.buildInfo.hydrate(buildInfo, { name: ds.name })
+}

--- a/packages/compiler/src/design-system.ts
+++ b/packages/compiler/src/design-system.ts
@@ -10,6 +10,9 @@ export function hydrateDesignSystem(compiler: Compiler, ds: ResolvedDesignSystem
   try {
     buildInfo = JSON.parse(readFileSync(ds.buildInfoPath, 'utf8')) as BuildInfo
   } catch {
+    console.warn(
+      `[panda] designSystem "${ds.name}": could not read build info at ${ds.buildInfoPath}; its components will not be hydrated and their styles may be missing.`,
+    )
     return
   }
   compiler.buildInfo.hydrate(buildInfo, { name: ds.name })

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -9,6 +9,7 @@ import {
   type SourceChange,
 } from '@pandacss/compiler-shared'
 import { type HostHooks, type LoadConfigResult, diffConfig, loadConfig } from '@pandacss/config'
+import { hydrateDesignSystem } from './design-system'
 import { createCompilerFromSnapshot } from './index'
 
 export interface NodeDriverOptions {
@@ -177,7 +178,13 @@ function resolveHookHandler(value: unknown, name: string): HookHandler {
 }
 
 function buildFromConfig(loaded: LoadConfigResult): Compiler {
-  return createCompilerFromSnapshot({ config: loaded.config, callbacks: loaded.callbacks, hooks: loaded.hooks })
+  const compiler = createCompilerFromSnapshot({
+    config: loaded.config,
+    callbacks: loaded.callbacks,
+    hooks: loaded.hooks,
+  })
+  hydrateDesignSystem(compiler, loaded.metadata?.designSystem)
+  return compiler
 }
 
 function toGenerateArtifactOptions(options: CodegenOptions | undefined): GenerateArtifactOptions | undefined {

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -36,9 +36,9 @@ const fallbackBuildInfo = new BuildInfo({
  *  (`schemaVersion` is `-1`). */
 const fallbackDesignSystem = new DesignSystem(
   {
-    createDesignSystemManifest: (input: DesignSystemManifestInput) => ({ ...input, schemaVersion: -1 }),
-    designSystemManifestSchemaVersion: () => -1,
-    resolveDesignSystemChain: () => ({ status: 'ordered', order: [] }),
+    createManifest: (input) => ({ ...input, schemaVersion: -1 }),
+    manifestSchemaVersion: () => -1,
+    resolveChain: () => ({ status: 'ordered', order: [] }),
   },
   fallbackBuildInfo,
 )

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -13,12 +13,12 @@ import type {
   WriteLayerCssOptions,
   WriteSplitCssOptions,
 } from '@pandacss/compiler-shared'
-import { makeBuildInfoApi, makeDesignSystemApi } from '@pandacss/compiler-shared'
+import { BuildInfo, DesignSystem } from '@pandacss/compiler-shared'
 import type { CompilerConstructor, ExtractorSession, ExtractorSessionConstructor, NativeBinding } from './types'
 
 /** No-op build-info primitives so the fallback compiler still satisfies the
  *  `Compiler.buildInfo` surface; `validate`/`hydrate` always report incompatible. */
-const fallbackBuildInfo = makeBuildInfoApi({
+const fallbackBuildInfo = new BuildInfo({
   serializeBuildInfo: () => ({
     schemaVersion: -1,
     panda: '',
@@ -34,7 +34,7 @@ const fallbackBuildInfo = makeBuildInfoApi({
 
 /** No-op design-system primitives; `validate` always reports incompatible
  *  (`schemaVersion` is `-1`). */
-const fallbackDesignSystem = makeDesignSystemApi(
+const fallbackDesignSystem = new DesignSystem(
   {
     createDesignSystemManifest: (input: DesignSystemManifestInput) => ({ ...input, schemaVersion: -1 }),
     designSystemManifestSchemaVersion: () => -1,
@@ -58,6 +58,27 @@ class FallbackExtractor implements ExtractorSession {
 class FallbackCompiler implements Compiler {
   static fromConfig() {
     return new FallbackCompiler()
+  }
+  serializeBuildInfo() {
+    return fallbackBuildInfo.create({ panda: '' })
+  }
+  applyBuildInfo() {
+    return false
+  }
+  buildInfoSchemaVersion() {
+    return -1
+  }
+  configFingerprint() {
+    return ''
+  }
+  createDesignSystemManifest(input: DesignSystemManifestInput) {
+    return { ...input, schemaVersion: -1 }
+  }
+  designSystemManifestSchemaVersion() {
+    return -1
+  }
+  resolveDesignSystemChain() {
+    return { status: 'ordered', order: [] } as const
   }
   config() {
     return {}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,19 +1,17 @@
 import type {
-  BuildInfoNative,
   Compiler,
   CompileOutput,
   CompilerOptions,
   ConfigSnapshot,
-  DesignSystemNative,
   ProjectCallbacks,
   SerializedConfig,
 } from '@pandacss/compiler-shared'
 import {
   assertProjectHooks,
   assertProjectCallbacks,
+  BuildInfo,
+  DesignSystem,
   getTokenCategoryValues,
-  makeBuildInfoApi,
-  makeDesignSystemApi,
   mergeCallbacks,
   mergeHooks,
   prepareCompilerConfig,
@@ -35,10 +33,12 @@ const nativeCompilerFromConfig =
     ? binding.Compiler.fromConfig.bind(binding.Compiler)
     : undefined
 
-/** One-shot stateless compile: build a compiler from `config`, parse every
- *  input file, and emit the stylesheet. Callback-bearing configs
- *  (`utilities.*.transform`, `patterns.*.transform`) are *not* supported here —
- *  use [`createCompiler`] + `options.callbacks` for those. */
+/**
+ * One-shot stateless compile: build a compiler from `config`, parse every
+ * input file, and emit the stylesheet. Callback-bearing configs
+ * (`utilities.*.transform`, `patterns.*.transform`) are *not* supported here -
+ * use [`createCompiler`] + `options.callbacks` for those.
+ */
 export function compile(input?: CompileInput): CompileOutput {
   return binding.compile(input)
 }
@@ -59,8 +59,10 @@ export function createCompiler(config: SerializedConfig, options?: CompilerOptio
   return build(config, options?.callbacks ?? {}, options)
 }
 
-/** Like {@link createCompiler}, but takes a snapshot; its callbacks merge under
- *  any in `options.callbacks`. */
+/**
+ * Like {@link createCompiler}, but takes a snapshot; its callbacks merge under
+ * any in `options.callbacks`.
+ */
 export function createCompilerFromSnapshot(snapshot: ConfigSnapshot, options?: CompilerOptions): Compiler {
   const callbacks = mergeCallbacks(snapshot.callbacks, options?.callbacks)
   const hooks = mergeHooks(snapshot.hooks, options?.hooks)
@@ -90,15 +92,17 @@ function build(config: SerializedConfig, callbacks: ProjectCallbacks, options?: 
   return compiler
 }
 
-/** Wire the ergonomic `compiler.buildInfo` namespace over the native primitives.
- *  Non-enumerable so it doesn't surface in snapshots of the native instance, and
- *  lazy — the API is built on first access, then cached in place. */
-function attachBuildInfo(compiler: Compiler): void {
+/**
+ * Wire the ergonomic `compiler.buildInfo` namespace over the native primitives.
+ * Non-enumerable so it doesn't surface in snapshots of the native instance, and
+ * lazy - the API is built on first access, then cached in place.
+ */
+function attachBuildInfo(compiler: ReturnType<NonNullable<typeof nativeCompilerFromConfig>>): void {
   Object.defineProperty(compiler, 'buildInfo', {
     enumerable: false,
     configurable: true,
     get() {
-      const api = makeBuildInfoApi(compiler as unknown as BuildInfoNative)
+      const api = new BuildInfo(compiler)
       Object.defineProperty(compiler, 'buildInfo', {
         value: api,
         enumerable: false,
@@ -109,15 +113,17 @@ function attachBuildInfo(compiler: Compiler): void {
   })
 }
 
-/** Wire `compiler.designSystem` over the native primitives; non-enumerable and
- *  lazy, mirroring `buildInfo`. `designSystem.load` reuses the `buildInfo`
- *  namespace (accessing it here triggers its own lazy build). */
-function attachDesignSystem(compiler: Compiler): void {
+/**
+ * Wire `compiler.designSystem` over the native primitives; non-enumerable and
+ * lazy, mirroring `buildInfo`. `designSystem.load` reuses the `buildInfo`
+ * namespace (accessing it here triggers its own lazy build).
+ */
+function attachDesignSystem(compiler: ReturnType<NonNullable<typeof nativeCompilerFromConfig>>): void {
   Object.defineProperty(compiler, 'designSystem', {
     enumerable: false,
     configurable: true,
     get() {
-      const api = makeDesignSystemApi(compiler as unknown as DesignSystemNative, compiler.buildInfo)
+      const api = new DesignSystem(compiler, compiler.buildInfo)
       Object.defineProperty(compiler, 'designSystem', {
         value: api,
         enumerable: false,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -3,6 +3,7 @@ import type {
   CompileOutput,
   CompilerOptions,
   ConfigSnapshot,
+  DesignSystemBinding,
   ProjectCallbacks,
   SerializedConfig,
 } from '@pandacss/compiler-shared'
@@ -123,7 +124,7 @@ function attachDesignSystem(compiler: ReturnType<NonNullable<typeof nativeCompil
     enumerable: false,
     configurable: true,
     get() {
-      const api = new DesignSystem(compiler, compiler.buildInfo)
+      const api = new DesignSystem(toDesignSystemBinding(compiler), compiler.buildInfo)
       Object.defineProperty(compiler, 'designSystem', {
         value: api,
         enumerable: false,
@@ -132,6 +133,16 @@ function attachDesignSystem(compiler: ReturnType<NonNullable<typeof nativeCompil
       return api
     },
   })
+}
+
+function toDesignSystemBinding(
+  compiler: ReturnType<NonNullable<typeof nativeCompilerFromConfig>>,
+): DesignSystemBinding {
+  return {
+    createManifest: (input) => compiler.createDesignSystemManifest(input),
+    manifestSchemaVersion: () => compiler.designSystemManifestSchemaVersion(),
+    resolveChain: (manifests) => compiler.resolveDesignSystemChain(manifests),
+  }
 }
 
 function toNativeOptions(options: CompilerOptions | undefined): NativeCompilerOptions | undefined {

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -1,6 +1,8 @@
 import type {
+  BuildInfoNative,
   Compiler,
   CompileOutput,
+  DesignSystemNative,
   Diagnostic,
   ExtractedCall,
   ExtractedJsx,
@@ -133,7 +135,7 @@ export interface NativeCompilerOptions {
 
 /** The raw native instance — superset of {@link Compiler} carrying the internal
  *  methods the facade hides. */
-export interface RawCompiler extends Compiler {
+export interface RawCompiler extends Compiler, BuildInfoNative, DesignSystemNative {
   token_dictionary?(): TokenDictionary | undefined
   registerUtilityTransform?(id: string, callback: (resolved: unknown, original: unknown) => unknown): void
   registerPatternTransform?(id: string, callback: (props: unknown, helpers: Record<string, unknown>) => unknown): void

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -2,7 +2,9 @@ import type {
   BuildInfoNative,
   Compiler,
   CompileOutput,
-  DesignSystemNative,
+  DesignSystemChainPlan,
+  DesignSystemManifest,
+  DesignSystemManifestInput,
   Diagnostic,
   ExtractedCall,
   ExtractedJsx,
@@ -133,9 +135,15 @@ export interface NativeCompilerOptions {
   crossFile?: boolean
 }
 
+interface RawDesignSystemBinding {
+  createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
+  designSystemManifestSchemaVersion(): number
+  resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
+}
+
 /** The raw native instance — superset of {@link Compiler} carrying the internal
  *  methods the facade hides. */
-export interface RawCompiler extends Compiler, BuildInfoNative, DesignSystemNative {
+export interface RawCompiler extends Compiler, BuildInfoNative, RawDesignSystemBinding {
   token_dictionary?(): TokenDictionary | undefined
   registerUtilityTransform?(id: string, callback: (resolved: unknown, original: unknown) => unknown): void
   registerPatternTransform?(id: string, callback: (props: unknown, helpers: Record<string, unknown>) => unknown): void

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -78,6 +78,13 @@ describe('resolveAuthoredPresets / designSystem', () => {
     ])
   })
 
+  test('keeps the design-system root first when the consumer already has an importMap', async () => {
+    const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds', importMap: '@my/aliases' } as any, cwd)
+    expect((config.importMap as any[])[0]).toMatchObject({ css: '@acme/ds/css' })
+    expect((config.importMap as any[])[1]).toBe('styled-system')
+    expect((config.importMap as any[])[2]).toBe('@my/aliases')
+  })
+
   test('fills importMap keys the manifest omits from the design-system root', async () => {
     const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd)
     const [dsRoot] = config.importMap as any[]

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -44,6 +44,7 @@ describe('resolveAuthoredPresets / designSystem', () => {
     expect(colors.dsOnly.value).toBe('ds')
     expect(dependencies.some((d) => d.endsWith('panda.lib.json'))).toBe(true)
     expect(dependencies.some((d) => d.endsWith('preset.mjs'))).toBe(true)
+    expect(dependencies.some((d) => d.endsWith('panda.buildinfo.json'))).toBe(true)
   })
 
   test('wires the dual-root importMap (DS roots + local outdir)', async () => {
@@ -60,6 +61,7 @@ describe('resolveAuthoredPresets / designSystem', () => {
       'styled-system',
     ])
     expect(metadata?.designSystem?.name).toBe('@acme/ds')
+    expect(metadata?.designSystem?.manifest.name).toBe('@acme/ds')
     expect(metadata?.designSystem?.buildInfoPath).toMatch(/panda\.buildinfo\.json$/)
     expect(metadata?.designSystem?.files).toEqual(['./dist/**/*.mjs'])
   })
@@ -92,20 +94,7 @@ describe('resolveAuthoredPresets / designSystem', () => {
     expect(dsRoot.tokens).toBe('@acme/ds/tokens')
   })
 
-  test('rejects a consumer whose Panda major is outside the manifest range', async () => {
-    await expect(
-      resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd, { pandaVersion: '1.9.0' }),
-    ).rejects.toThrow(/requires Panda \^2\.0\.0 \(you are on 1\.9\.0\)/)
-  })
-
-  test('accepts a matching Panda major', async () => {
-    const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd, { pandaVersion: '2.3.1' })
-    const colors = config.theme?.tokens?.colors
-    if (!colors) throw new Error('expected resolved color tokens')
-    expect(colors.dsOnly.value).toBe('ds')
-  })
-
-  test('rejects a manifest built for a different schema version', async () => {
+  test('defers manifest compatibility to compiler hydration', async () => {
     const pkg = join(cwd, 'node_modules', '@acme', 'future')
     mkdirSync(pkg, { recursive: true })
     writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/future' }))
@@ -120,9 +109,9 @@ describe('resolveAuthoredPresets / designSystem', () => {
       }),
     )
     writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
-    await expect(resolveAuthoredPresets({ designSystem: '@acme/future' } as any, cwd)).rejects.toThrow(
-      /different Panda manifest format/,
-    )
+
+    const { metadata } = await resolveAuthoredPresets({ designSystem: '@acme/future' } as any, cwd)
+    expect(metadata?.designSystem?.buildInfoPath).toMatch(/b\.json$/)
   })
 
   test('rejects a manifest missing a buildInfo entry', async () => {
@@ -136,6 +125,27 @@ describe('resolveAuthoredPresets / designSystem', () => {
     writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
     await expect(resolveAuthoredPresets({ designSystem: '@acme/no-buildinfo' } as any, cwd)).rejects.toThrow(
       /missing a "buildInfo" entry/,
+    )
+  })
+
+  test('rejects parent design systems in the single-level loader', async () => {
+    const pkg = join(cwd, 'node_modules', '@acme', 'child')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/child' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: '@acme/child',
+        panda: '^2.0.0',
+        preset: './p.mjs',
+        buildInfo: './b.json',
+        designSystem: '@acme/base',
+      }),
+    )
+    writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/child' } as any, cwd)).rejects.toThrow(
+      /nested design systems are not supported yet/,
     )
   })
 

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -50,7 +50,13 @@ describe('resolveAuthoredPresets / designSystem', () => {
     const { config, metadata } = await resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd)
 
     expect(config.importMap).toEqual([
-      { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+      {
+        css: '@acme/ds/css',
+        recipes: '@acme/ds/recipes',
+        patterns: '@acme/ds/patterns',
+        jsx: '@acme/ds/jsx',
+        tokens: '@acme/ds/tokens',
+      },
       'styled-system',
     ])
     expect(metadata?.designSystem?.name).toBe('@acme/ds')
@@ -61,9 +67,22 @@ describe('resolveAuthoredPresets / designSystem', () => {
   test('respects a custom outdir basename in the wired importMap', async () => {
     const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds', outdir: 'src/design' } as any, cwd)
     expect(config.importMap).toEqual([
-      { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+      {
+        css: '@acme/ds/css',
+        recipes: '@acme/ds/recipes',
+        patterns: '@acme/ds/patterns',
+        jsx: '@acme/ds/jsx',
+        tokens: '@acme/ds/tokens',
+      },
       'design',
     ])
+  })
+
+  test('fills importMap keys the manifest omits from the design-system root', async () => {
+    const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd)
+    const [dsRoot] = config.importMap as any[]
+    expect(dsRoot.patterns).toBe('@acme/ds/patterns')
+    expect(dsRoot.tokens).toBe('@acme/ds/tokens')
   })
 
   test('rejects a consumer whose Panda major is outside the manifest range', async () => {
@@ -96,6 +115,20 @@ describe('resolveAuthoredPresets / designSystem', () => {
     writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
     await expect(resolveAuthoredPresets({ designSystem: '@acme/future' } as any, cwd)).rejects.toThrow(
       /different Panda manifest format/,
+    )
+  })
+
+  test('rejects a manifest missing a buildInfo entry', async () => {
+    const pkg = join(cwd, 'node_modules', '@acme', 'no-buildinfo')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/no-buildinfo' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({ schemaVersion: 1, name: '@acme/no-buildinfo', panda: '^2.0.0', preset: './p.mjs' }),
+    )
+    writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/no-buildinfo' } as any, cwd)).rejects.toThrow(
+      /missing a "buildInfo" entry/,
     )
   })
 

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { resolveAuthoredPresets } from '../src/preset'
+
+describe('resolveAuthoredPresets / designSystem', () => {
+  let cwd: string
+
+  beforeAll(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'panda-ds-'))
+    const pkg = join(cwd, 'node_modules', '@acme', 'ds')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/ds', version: '1.0.0' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        name: '@acme/ds',
+        panda: '^2.0.0',
+        preset: './preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+        importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+        files: ['./dist/**/*.mjs'],
+      }),
+    )
+    writeFileSync(
+      join(pkg, 'preset.mjs'),
+      `export default { name: '@acme/ds', theme: { tokens: { colors: { brand: { value: 'ds' }, dsOnly: { value: 'ds' } } } } }`,
+    )
+  })
+
+  afterAll(() => rmSync(cwd, { recursive: true, force: true }))
+
+  test('merges the published preset under the consuming config', async () => {
+    const { config, dependencies } = await resolveAuthoredPresets(
+      { designSystem: '@acme/ds', theme: { tokens: { colors: { brand: { value: 'app' } } } } } as any,
+      cwd,
+    )
+
+    const colors = config.theme?.tokens?.colors
+    if (!colors) throw new Error('expected resolved color tokens')
+    expect(colors.brand.value).toBe('app')
+    expect(colors.dsOnly.value).toBe('ds')
+    expect(dependencies.some((d) => d.endsWith('panda.lib.json'))).toBe(true)
+    expect(dependencies.some((d) => d.endsWith('preset.mjs'))).toBe(true)
+  })
+
+  test('wires the dual-root importMap (DS roots + local outdir)', async () => {
+    const { config, metadata } = await resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd)
+
+    expect(config.importMap).toEqual([
+      { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+      'styled-system',
+    ])
+    expect(metadata?.designSystem?.name).toBe('@acme/ds')
+    expect(metadata?.designSystem?.buildInfoPath).toMatch(/panda\.buildinfo\.json$/)
+    expect(metadata?.designSystem?.files).toEqual(['./dist/**/*.mjs'])
+  })
+
+  test('respects a custom outdir basename in the wired importMap', async () => {
+    const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds', outdir: 'src/design' } as any, cwd)
+    expect(config.importMap).toEqual([
+      { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+      'design',
+    ])
+  })
+
+  test('rejects a consumer whose Panda major is outside the manifest range', async () => {
+    await expect(
+      resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd, { pandaVersion: '1.9.0' }),
+    ).rejects.toThrow(/requires Panda \^2\.0\.0 \(you are on 1\.9\.0\)/)
+  })
+
+  test('accepts a matching Panda major', async () => {
+    const { config } = await resolveAuthoredPresets({ designSystem: '@acme/ds' } as any, cwd, { pandaVersion: '2.3.1' })
+    const colors = config.theme?.tokens?.colors
+    if (!colors) throw new Error('expected resolved color tokens')
+    expect(colors.dsOnly.value).toBe('ds')
+  })
+
+  test('rejects a manifest built for a different schema version', async () => {
+    const pkg = join(cwd, 'node_modules', '@acme', 'future')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/future' }))
+    writeFileSync(
+      join(pkg, 'panda.lib.json'),
+      JSON.stringify({
+        schemaVersion: 999,
+        name: '@acme/future',
+        panda: '^2.0.0',
+        preset: './p.mjs',
+        buildInfo: './b.json',
+      }),
+    )
+    writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/future' } as any, cwd)).rejects.toThrow(
+      /different Panda manifest format/,
+    )
+  })
+
+  test('errors with guidance when the package does not resolve', async () => {
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/missing' } as any, cwd)).rejects.toThrow(
+      /designSystem "@acme\/missing" could not be resolved/,
+    )
+  })
+})

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -1,0 +1,114 @@
+import {
+  checkManifestCompatibility,
+  DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION,
+  type DesignSystemManifest,
+  type ImportMapOption,
+} from '@pandacss/compiler-shared'
+import type { UserConfig } from '@pandacss/types'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { PandaError } from './error'
+import { ensureConfigObject, errorMessage, type ExtendableConfig } from './shared'
+
+export interface ResolvedDesignSystem {
+  name: string
+  manifestPath: string
+  buildInfoPath: string
+  files: string[]
+  importMap?: DesignSystemManifest['importMap']
+}
+
+export async function loadDesignSystemPreset(
+  spec: string,
+  cwd: string,
+  deps: Set<string>,
+  options: { pandaVersion?: string },
+): Promise<{ preset: ExtendableConfig; info: ResolvedDesignSystem }> {
+  const require = createRequire(resolve(cwd, 'noop.js'))
+
+  let manifestPath: string
+  try {
+    manifestPath = require.resolve(`${spec}/panda.lib.json`, { paths: [cwd] })
+  } catch {
+    throw new PandaError(
+      'CONFIG_ERROR',
+      `💥 designSystem ${JSON.stringify(spec)} could not be resolved. Install it, or — if it isn't a Panda design system — build it with \`panda lib\`.`,
+    )
+  }
+  deps.add(manifestPath)
+
+  let manifest: DesignSystemManifest
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as DesignSystemManifest
+  } catch (error) {
+    throw new PandaError('CONFIG_ERROR', `💥 Failed to read ${JSON.stringify(manifestPath)}: ${errorMessage(error)}`)
+  }
+  if (typeof manifest.preset !== 'string') {
+    throw new PandaError('CONFIG_ERROR', `💥 ${JSON.stringify(spec)} manifest is missing a "preset" entry.`)
+  }
+
+  const compat = checkManifestCompatibility(manifest, {
+    schemaVersion: DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION,
+    pandaVersion: options.pandaVersion,
+  })
+  if (!compat.ok) throw incompatibleError(spec, manifest, compat.reason, options.pandaVersion)
+
+  const presetPath = resolve(dirname(manifestPath), manifest.preset)
+  deps.add(presetPath)
+
+  let preset: ExtendableConfig
+  try {
+    const mod = await import(pathToFileURL(presetPath).href)
+    preset = ensureConfigObject(mod.default ?? mod, manifest.name ?? spec)
+  } catch (error) {
+    if (error instanceof PandaError) throw error
+    throw new PandaError(
+      'CONFIG_ERROR',
+      `💥 Failed to load preset for designSystem ${JSON.stringify(spec)}: ${errorMessage(error)}`,
+    )
+  }
+
+  return {
+    preset,
+    info: {
+      name: manifest.name ?? spec,
+      manifestPath,
+      buildInfoPath: resolve(dirname(manifestPath), manifest.buildInfo),
+      files: manifest.files ?? [],
+      ...(manifest.importMap ? { importMap: manifest.importMap } : {}),
+    },
+  }
+}
+
+export function withDesignSystemImportMap(config: UserConfig, spec: string, info: ResolvedDesignSystem): UserConfig {
+  const existing: ImportMapOption[] =
+    config.importMap === undefined ? [] : Array.isArray(config.importMap) ? config.importMap : [config.importMap]
+  const dsRoot: ImportMapOption = info.importMap ?? spec
+  return { ...config, importMap: [dsRoot, outdirBasename(config.outdir), ...existing] }
+}
+
+function outdirBasename(outdir: string | undefined): string {
+  const parts = (outdir ?? 'styled-system').split('/').filter(Boolean)
+  return parts.at(-1) ?? 'styled-system'
+}
+
+function incompatibleError(
+  spec: string,
+  manifest: DesignSystemManifest,
+  reason: 'schemaVersion' | 'pandaRange',
+  pandaVersion?: string,
+): PandaError {
+  if (reason === 'schemaVersion') {
+    return new PandaError(
+      'CONFIG_ERROR',
+      `💥 designSystem ${JSON.stringify(spec)} was built for a different Panda manifest format (schemaVersion ${manifest.schemaVersion}, this Panda expects ${DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION}). Upgrade Panda here, or rebuild the library with \`panda lib\`.`,
+    )
+  }
+  const running = pandaVersion ? ` (you are on ${pandaVersion})` : ''
+  return new PandaError(
+    'CONFIG_ERROR',
+    `💥 designSystem ${JSON.stringify(spec)} requires Panda ${manifest.panda}${running}. This project's Panda doesn't satisfy that range.`,
+  )
+}

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -1,7 +1,9 @@
 import {
   checkManifestCompatibility,
   DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION,
+  outdirBasename,
   type DesignSystemManifest,
+  type ImportMapInput,
   type ImportMapOption,
 } from '@pandacss/compiler-shared'
 import type { UserConfig } from '@pandacss/types'
@@ -48,6 +50,9 @@ export async function loadDesignSystemPreset(
   if (typeof manifest.preset !== 'string') {
     throw new PandaError('CONFIG_ERROR', `💥 ${JSON.stringify(spec)} manifest is missing a "preset" entry.`)
   }
+  if (typeof manifest.buildInfo !== 'string') {
+    throw new PandaError('CONFIG_ERROR', `💥 ${JSON.stringify(spec)} manifest is missing a "buildInfo" entry.`)
+  }
 
   const compat = checkManifestCompatibility(manifest, {
     schemaVersion: DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION,
@@ -85,13 +90,18 @@ export async function loadDesignSystemPreset(
 export function withDesignSystemImportMap(config: UserConfig, spec: string, info: ResolvedDesignSystem): UserConfig {
   const existing: ImportMapOption[] =
     config.importMap === undefined ? [] : Array.isArray(config.importMap) ? config.importMap : [config.importMap]
-  const dsRoot: ImportMapOption = info.importMap ?? spec
-  return { ...config, importMap: [dsRoot, outdirBasename(config.outdir), ...existing] }
+  const dsRoot: ImportMapOption = info.importMap ? designSystemImportMap(info.importMap, spec) : spec
+  return { ...config, importMap: [dsRoot, outdirBasename(config.outdir ?? 'styled-system'), ...existing] }
 }
 
-function outdirBasename(outdir: string | undefined): string {
-  const parts = (outdir ?? 'styled-system').split('/').filter(Boolean)
-  return parts.at(-1) ?? 'styled-system'
+function designSystemImportMap(map: NonNullable<DesignSystemManifest['importMap']>, spec: string): ImportMapInput {
+  return {
+    css: map.css ?? `${spec}/css`,
+    recipes: map.recipes ?? `${spec}/recipes`,
+    patterns: map.patterns ?? `${spec}/patterns`,
+    jsx: map.jsx ?? `${spec}/jsx`,
+    tokens: map.tokens ?? `${spec}/tokens`,
+  }
 }
 
 function incompatibleError(

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -1,6 +1,4 @@
 import {
-  checkManifestCompatibility,
-  DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION,
   outdirBasename,
   type DesignSystemManifest,
   type ImportMapInput,
@@ -16,6 +14,7 @@ import { ensureConfigObject, errorMessage, type ExtendableConfig } from './share
 
 export interface ResolvedDesignSystem {
   name: string
+  manifest: DesignSystemManifest
   manifestPath: string
   buildInfoPath: string
   files: string[]
@@ -26,7 +25,6 @@ export async function loadDesignSystemPreset(
   spec: string,
   cwd: string,
   deps: Set<string>,
-  options: { pandaVersion?: string },
 ): Promise<{ preset: ExtendableConfig; info: ResolvedDesignSystem }> {
   const require = createRequire(resolve(cwd, 'noop.js'))
 
@@ -53,15 +51,17 @@ export async function loadDesignSystemPreset(
   if (typeof manifest.buildInfo !== 'string') {
     throw new PandaError('CONFIG_ERROR', `💥 ${JSON.stringify(spec)} manifest is missing a "buildInfo" entry.`)
   }
-
-  const compat = checkManifestCompatibility(manifest, {
-    schemaVersion: DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION,
-    pandaVersion: options.pandaVersion,
-  })
-  if (!compat.ok) throw incompatibleError(spec, manifest, compat.reason, options.pandaVersion)
+  if (typeof manifest.designSystem === 'string' && manifest.designSystem.length > 0) {
+    throw new PandaError(
+      'CONFIG_ERROR',
+      `💥 designSystem ${JSON.stringify(spec)} extends ${JSON.stringify(manifest.designSystem)}, but nested design systems are not supported yet.`,
+    )
+  }
 
   const presetPath = resolve(dirname(manifestPath), manifest.preset)
+  const buildInfoPath = resolve(dirname(manifestPath), manifest.buildInfo)
   deps.add(presetPath)
+  deps.add(buildInfoPath)
 
   let preset: ExtendableConfig
   try {
@@ -79,8 +79,9 @@ export async function loadDesignSystemPreset(
     preset,
     info: {
       name: manifest.name ?? spec,
+      manifest,
       manifestPath,
-      buildInfoPath: resolve(dirname(manifestPath), manifest.buildInfo),
+      buildInfoPath,
       files: manifest.files ?? [],
       ...(manifest.importMap ? { importMap: manifest.importMap } : {}),
     },
@@ -102,23 +103,4 @@ function designSystemImportMap(map: NonNullable<DesignSystemManifest['importMap'
     jsx: map.jsx ?? `${spec}/jsx`,
     tokens: map.tokens ?? `${spec}/tokens`,
   }
-}
-
-function incompatibleError(
-  spec: string,
-  manifest: DesignSystemManifest,
-  reason: 'schemaVersion' | 'pandaRange',
-  pandaVersion?: string,
-): PandaError {
-  if (reason === 'schemaVersion') {
-    return new PandaError(
-      'CONFIG_ERROR',
-      `💥 designSystem ${JSON.stringify(spec)} was built for a different Panda manifest format (schemaVersion ${manifest.schemaVersion}, this Panda expects ${DESIGN_SYSTEM_MANIFEST_SCHEMA_VERSION}). Upgrade Panda here, or rebuild the library with \`panda lib\`.`,
-    )
-  }
-  const running = pandaVersion ? ` (you are on ${pandaVersion})` : ''
-  return new PandaError(
-    'CONFIG_ERROR',
-    `💥 designSystem ${JSON.stringify(spec)} requires Panda ${manifest.panda}${running}. This project's Panda doesn't satisfy that range.`,
-  )
 }

--- a/packages/config/src/hook-utils.ts
+++ b/packages/config/src/hook-utils.ts
@@ -1,4 +1,5 @@
-import { isPlainObject } from './shared'
+import { PandaError } from './error'
+import { isPlainObject, type ExtendableConfig } from './shared'
 
 interface TraverseItem {
   value: unknown
@@ -142,4 +143,31 @@ function traverseValue(
 
 function joinPath(parent: string, key: string, separator: string) {
   return parent ? `${parent}${separator}${key}` : key
+}
+
+export function attachRuntimeHooks(config: ExtendableConfig, configs: ExtendableConfig[]): ExtendableConfig {
+  const plugins = configs.flatMap((item) => {
+    if ('hooks' in item && item.hooks != null) {
+      throw new PandaError(
+        'CONFIG_ERROR',
+        '💥 `config.hooks` was removed in v2. Use `plugins: [{ name: "local", hooks: { ... } }]` instead.',
+      )
+    }
+    return [...(item.plugins ?? []), ...(item.extend?.plugins ?? [])]
+  })
+
+  for (const plugin of plugins) {
+    if (!isPlainObject(plugin) || typeof plugin.name !== 'string' || plugin.name.length === 0) {
+      throw new PandaError(
+        'CONFIG_ERROR',
+        '💥 Every plugin in `config.plugins` must be an object with a non-empty `name`.',
+      )
+    }
+  }
+
+  if (plugins.length > 0) {
+    config.plugins = plugins
+  }
+
+  return config
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,6 +4,7 @@ export { diffConfig } from './diff'
 export { findConfig } from './find'
 export { bundleConfig } from './bundle'
 export { mergeConfigs } from './merge'
+export { readPandaVersion } from './version'
 
 export type { ConfigSnapshot } from './serialize'
 export type { DiffConfigResult } from './diff'

--- a/packages/config/src/preset.ts
+++ b/packages/config/src/preset.ts
@@ -8,7 +8,6 @@ import { collectPluginHookHandlers, normalizeHook, type PluginHookEntry } from '
 import type { ConfigSources } from './sources'
 import { mergeConfigs, mergeConfigsWithSources, type SourcedConfig } from './merge'
 import { ensureConfigObject, errorMessage, isPlainObject, type ExtendableConfig } from './shared'
-import { readPandaVersion } from './version'
 
 type PresetEntry = NonNullable<Config['presets']>[number]
 type ConfigSource = SourcedConfig['source']
@@ -34,7 +33,6 @@ export interface ResolveAuthoredPresetsOptions {
   trackSources?: boolean
   configFile?: string
   preserveRuntimeHooks?: boolean
-  pandaVersion?: string
 }
 
 export async function resolveAuthoredPresets(
@@ -56,9 +54,7 @@ export async function resolveAuthoredPresets(
   const designSystem = (config as UserConfig).designSystem
   let resolvedDesignSystem: { preset: ExtendableConfig; info: ResolvedDesignSystem } | undefined
   if (typeof designSystem === 'string' && designSystem.length > 0) {
-    resolvedDesignSystem = await loadDesignSystemPreset(designSystem, cwd, ctx.dependencies, {
-      pandaVersion: options.pandaVersion ?? readPandaVersion(),
-    })
+    resolvedDesignSystem = await loadDesignSystemPreset(designSystem, cwd, ctx.dependencies)
     await collectConfigs(resolvedDesignSystem.preset, { kind: 'preset', specifier: designSystem }, ctx, new WeakSet())
   }
 

--- a/packages/config/src/preset.ts
+++ b/packages/config/src/preset.ts
@@ -1,12 +1,14 @@
 import type { Config, UserConfig } from '@pandacss/types'
 import { normalize, relative } from 'node:path'
 import { bundleConfig } from './bundle'
+import { loadDesignSystemPreset, withDesignSystemImportMap, type ResolvedDesignSystem } from './design-system'
 import { PandaError } from './error'
-import { configResolvedUtils } from './hook-utils'
+import { attachRuntimeHooks, configResolvedUtils } from './hook-utils'
 import { collectPluginHookHandlers, normalizeHook, type PluginHookEntry } from './hooks'
 import type { ConfigSources } from './sources'
 import { mergeConfigs, mergeConfigsWithSources, type SourcedConfig } from './merge'
-import { isPlainObject, type ExtendableConfig } from './shared'
+import { ensureConfigObject, errorMessage, isPlainObject, type ExtendableConfig } from './shared'
+import { readPandaVersion } from './version'
 
 type PresetEntry = NonNullable<Config['presets']>[number]
 type ConfigSource = SourcedConfig['source']
@@ -24,6 +26,7 @@ export interface ResolveAuthoredPresetsResult {
   dependencies: string[]
   metadata?: {
     sources?: ConfigSources
+    designSystem?: ResolvedDesignSystem
   }
 }
 
@@ -31,6 +34,7 @@ export interface ResolveAuthoredPresetsOptions {
   trackSources?: boolean
   configFile?: string
   preserveRuntimeHooks?: boolean
+  pandaVersion?: string
 }
 
 export async function resolveAuthoredPresets(
@@ -49,51 +53,41 @@ export async function resolveAuthoredPresets(
   const rootSource: ConfigSource = { kind: 'config' }
   if (options.configFile) rootSource.file = normalize(relative(cwd, options.configFile))
 
+  const designSystem = (config as UserConfig).designSystem
+  let resolvedDesignSystem: { preset: ExtendableConfig; info: ResolvedDesignSystem } | undefined
+  if (typeof designSystem === 'string' && designSystem.length > 0) {
+    resolvedDesignSystem = await loadDesignSystemPreset(designSystem, cwd, ctx.dependencies, {
+      pandaVersion: options.pandaVersion ?? readPandaVersion(),
+    })
+    await collectConfigs(resolvedDesignSystem.preset, { kind: 'preset', specifier: designSystem }, ctx, new WeakSet())
+  }
+
   await collectConfigs(config, rootSource, ctx, new WeakSet())
+
+  const ds = resolvedDesignSystem
+  const finalize = (resolved: UserConfig): UserConfig =>
+    ds ? withDesignSystemImportMap(resolved, designSystem as string, ds.info) : resolved
+  const dsMetadata = ds ? { designSystem: ds.info } : undefined
 
   if (ctx.sourcedConfigs) {
     const merged = mergeConfigsWithSources(ctx.sourcedConfigs)
     if (options.preserveRuntimeHooks) attachRuntimeHooks(merged.config, ctx.configs)
     return {
-      config: merged.config as UserConfig,
+      config: finalize(merged.config as UserConfig),
       dependencies: Array.from(ctx.dependencies),
-      metadata: { sources: merged.sources },
+      metadata: { sources: merged.sources, ...dsMetadata },
     }
   }
 
   return {
-    config: (options.preserveRuntimeHooks
-      ? attachRuntimeHooks(mergeConfigs(ctx.configs), ctx.configs)
-      : mergeConfigs(ctx.configs)) as UserConfig,
+    config: finalize(
+      (options.preserveRuntimeHooks
+        ? attachRuntimeHooks(mergeConfigs(ctx.configs), ctx.configs)
+        : mergeConfigs(ctx.configs)) as UserConfig,
+    ),
     dependencies: Array.from(ctx.dependencies),
+    ...(dsMetadata ? { metadata: dsMetadata } : {}),
   }
-}
-
-function attachRuntimeHooks(config: ExtendableConfig, configs: ExtendableConfig[]): ExtendableConfig {
-  const plugins = configs.flatMap((item) => {
-    if ('hooks' in item && item.hooks != null) {
-      throw new PandaError(
-        'CONFIG_ERROR',
-        '💥 `config.hooks` was removed in v2. Use `plugins: [{ name: "local", hooks: { ... } }]` instead.',
-      )
-    }
-    return [...(item.plugins ?? []), ...(item.extend?.plugins ?? [])]
-  })
-
-  for (const plugin of plugins) {
-    if (!isPlainObject(plugin) || typeof plugin.name !== 'string' || plugin.name.length === 0) {
-      throw new PandaError(
-        'CONFIG_ERROR',
-        '💥 Every plugin in `config.plugins` must be an object with a non-empty `name`.',
-      )
-    }
-  }
-
-  if (plugins.length > 0) {
-    config.plugins = plugins
-  }
-
-  return config
 }
 
 async function collectConfigs(
@@ -177,11 +171,6 @@ async function resolvePreset(preset: PresetEntry, cwd: string) {
   }
 }
 
-function ensureConfigObject(config: unknown, name: string): ExtendableConfig {
-  if (isPlainObject(config)) return config as ExtendableConfig
-  throw new PandaError('CONFIG_ERROR', `💥 Preset ${JSON.stringify(name)} must resolve to an object.`)
-}
-
 function presetName(config: unknown) {
   return isPlainObject(config) && typeof config.name === 'string' ? config.name : undefined
 }
@@ -193,8 +182,4 @@ function presetSource(config: unknown, specifier?: string, file?: string): Confi
   if (specifier) source.specifier = specifier
   if (file) source.file = file
   return source
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/config/src/shared.ts
+++ b/packages/config/src/shared.ts
@@ -1,4 +1,5 @@
 import type { Config } from '@pandacss/types'
+import { PandaError } from './error'
 
 export type Dict = Record<string, any>
 export type Extendable<T> = T & { extend?: T }
@@ -24,4 +25,13 @@ export function clone<T>(value: T): T {
   }
 
   return value
+}
+
+export function ensureConfigObject(config: unknown, name: string): ExtendableConfig {
+  if (isPlainObject(config)) return config as ExtendableConfig
+  throw new PandaError('CONFIG_ERROR', `💥 Preset ${JSON.stringify(name)} must resolve to an object.`)
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,5 +1,6 @@
 import type { ProjectCallbacks, ProjectHooks, SerializedConfig } from '@pandacss/compiler-shared'
 import type { HostHooks } from './hooks'
+import type { ResolvedDesignSystem } from './design-system'
 import type { ConfigSources } from './sources'
 
 export interface LoadConfigOptions {
@@ -25,5 +26,6 @@ export interface LoadConfigResult {
   dependencies: string[]
   metadata?: {
     sources?: ConfigSources
+    designSystem?: ResolvedDesignSystem
   }
 }

--- a/packages/config/src/version.ts
+++ b/packages/config/src/version.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function readPandaVersion(): string | undefined {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '../package.json')
+    return (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string }).version
+  } catch {
+    return undefined
+  }
+}

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -219,6 +219,7 @@ interface FileSystemOptions {
    * ```
    */
   importMap?: ImportMapOption | Array<ImportMapOption>
+  designSystem?: string
   /**
    * List of files glob to watch for changes.
    * @default []


### PR DESCRIPTION
Adopt a published design system with one config field.

```ts
export default defineConfig({
  designSystem: '@acme/ds',
})
```

## What you get

Point `designSystem` at a package that ships a `panda.lib.json` manifest. Panda reads it and wires everything for you:

- merges the library's preset under your config — your overrides win
- points its components at the design system's own styled-system, so you never alias `outdir`
- reuses its pre-extracted styles instead of re-extracting every component you import

## Version guardrail

If your Panda is a different major than the design system needs — say a v2 design system on Panda v1 — you get a clear error instead of broken output.

## What's in scope

Single level for now. A design system built on another (the manifest's own parent) is the next phase; the engine `resolveChain` already landed in #3604, so this PR wires the single-level path. Build-info tree-shaking and the stale-build-info fallback are later work.

## How it was checked

- `pnpm test packages/config packages/compiler-shared` — 88 pass
- `pnpm --filter @pandacss/compiler test` — 189 pass (native rebuilt)
- `pnpm typecheck` — clean