### PR TITLE
fix(compiler): require jsxFramework for jsx extraction

### DIFF
--- a/.changeset/jsx-extract-requires-framework.md
+++ b/.changeset/jsx-extract-requires-framework.md
@@ -3,6 +3,6 @@
 '@pandacss/compiler-wasm': patch
 ---
 
-Stop generating dead CSS from non-Panda components when you haven't set `jsxFramework`.
+Only extract JSX style props when `jsxFramework` is configured.
 
-Before, a third-party tag like astro's `<Image width="900" height="800" />` was read as style props and emitted `.w_900` / `.h_800`. Now the "any uppercase component" rule only kicks in when `jsxFramework` is set, same as v1, which didn't extract JSX style props without a framework. Your real Panda components, and any project that sets `jsxFramework`, are unchanged. The fix covers `.tsx`, `.astro`, `.vue`, and `.svelte`.
+This prevents CSS from being generated for JSX components in projects that have not enabled JSX extraction. Function-call extraction is unchanged.

--- a/.changeset/jsx-extract-requires-framework.md
+++ b/.changeset/jsx-extract-requires-framework.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Stop generating dead CSS from non-Panda components when you haven't set `jsxFramework`.
+
+Before, a third-party tag like astro's `<Image width="900" height="800" />` was read as style props and emitted `.w_900` / `.h_800`. Now the "any uppercase component" rule only kicks in when `jsxFramework` is set, same as v1, which didn't extract JSX style props without a framework. Your real Panda components, and any project that sets `jsxFramework`, are unchanged. The fix covers `.tsx`, `.astro`, `.vue`, and `.svelte`.

--- a/crates/pandacss_extractor/src/calls.rs
+++ b/crates/pandacss_extractor/src/calls.rs
@@ -192,6 +192,9 @@ impl Extractor<'_, '_, '_> {
         match callee {
             Expression::Identifier(ident) => {
                 let matched = self.ctx.aliases.get(ident.name.as_str())?;
+                if matched.category == MatchCategory::Jsx && !self.ctx.config.has_jsx_framework {
+                    return None;
+                }
                 // `p({...})` where `p` is a namespace alias isn't a Panda call.
                 if matched.kind == ImportSpecifierKind::Namespace {
                     return None;
@@ -214,6 +217,9 @@ impl Extractor<'_, '_, '_> {
             Expression::StaticMemberExpression(_) => {
                 let (object, path) = flatten_static_member_path(callee)?;
                 let matched = self.ctx.aliases.get(object.name.as_str())?;
+                if matched.category == MatchCategory::Jsx && !self.ctx.config.has_jsx_framework {
+                    return None;
+                }
                 if let Some(resolver) = self.ctx.resolver
                     && !resolver.is_import_binding(object)
                 {

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -237,7 +237,7 @@ fn run_extract<'cb>(
     let ctx = VisitorContext::new(&matched, config).with_resolver(&resolver);
 
     let (calls, call_diagnostics, mut token_refs, mut style_source_refs) =
-        if should_collect_calls(&matched) {
+        if should_collect_calls(&matched, config) {
             let _span = tracing::trace_span!("visit_calls").entered();
             if verbose {
                 collect_calls_verbose(&parser_return.program, &ctx, &line_index)
@@ -249,7 +249,7 @@ fn run_extract<'cb>(
         } else {
             (Vec::new(), Vec::new(), Vec::new(), Vec::new())
         };
-    let mut jsx = if should_collect_jsx(&matched, config) {
+    let mut jsx = if should_collect_jsx(config) {
         let _span = tracing::trace_span!("visit_jsx").entered();
         if verbose {
             let (jsx, refs) = collect_jsx_verbose(&parser_return.program, &ctx);
@@ -261,7 +261,7 @@ fn run_extract<'cb>(
     } else {
         Vec::new()
     };
-    if should_collect_jsx(&matched, config) {
+    if should_collect_jsx(config) {
         let _span = tracing::trace_span!("visit_template_styles").entered();
         jsx.extend(crate::template_styles::collect_template_styles(
             raw_source, path, &matched, config,
@@ -285,20 +285,18 @@ fn run_extract<'cb>(
     }
 }
 
-fn should_collect_calls(matched: &[MatchedImport]) -> bool {
-    !matched.is_empty()
+fn should_collect_calls(matched: &[MatchedImport], config: &ExtractorConfig) -> bool {
+    matched
+        .iter()
+        .any(|import| import.category != MatchCategory::Jsx || config.has_jsx_framework)
 }
 
 fn should_skip_extraction(matched: &[MatchedImport], config: &ExtractorConfig) -> bool {
-    matched.is_empty() && !config.has_jsx_framework && !config.jsx.has_component_matchers()
+    !should_collect_calls(matched, config) && !should_collect_jsx(config)
 }
 
-fn should_collect_jsx(matched: &[MatchedImport], config: &ExtractorConfig) -> bool {
+fn should_collect_jsx(config: &ExtractorConfig) -> bool {
     config.has_jsx_framework
-        || config.jsx.has_component_matchers()
-        || matched
-            .iter()
-            .any(|import| import.category == MatchCategory::Jsx)
 }
 
 fn dedupe_token_refs(token_refs: Vec<TokenRef>) -> Vec<TokenRef> {

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -92,6 +92,10 @@ pub fn extract_jsx(
     matched: &[MatchedImport],
     config: &ExtractorConfig,
 ) -> ExtractedJsxResult {
+    if !config.has_jsx_framework {
+        return ExtractedJsxResult::default();
+    }
+
     let allocator = Allocator::default();
     let raw_source = source;
     let source = crate::adapt_source(source, path);

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -202,7 +202,13 @@ impl Extractor<'_, '_, '_> {
 
                 let tag_name = id.name.as_str();
                 let is_configured_component = self.ctx.config.jsx.is_component_tag(tag_name);
-                if !is_configured_component && !self.ctx.config.jsx.should_match_tag(tag_name) {
+                if !is_configured_component
+                    && !self
+                        .ctx
+                        .config
+                        .jsx
+                        .should_match_tag(tag_name, self.ctx.config.has_jsx_framework)
+                {
                     return None;
                 }
                 Some(ResolvedTag {
@@ -234,7 +240,13 @@ impl Extractor<'_, '_, '_> {
         let Some(matched) = self.ctx.aliases.get(root) else {
             let display = member_display(root, path);
             let is_configured_component = self.ctx.config.jsx.is_component_tag(&display);
-            if is_configured_component || self.ctx.config.jsx.should_match_tag(&display) {
+            if is_configured_component
+                || self
+                    .ctx
+                    .config
+                    .jsx
+                    .should_match_tag(&display, self.ctx.config.has_jsx_framework)
+            {
                 return Some(ResolvedTag {
                     category: MatchCategory::Jsx,
                     name: Cow::Owned(display),
@@ -339,7 +351,13 @@ impl Extractor<'_, '_, '_> {
 
                 let tag_name = id.name.as_str();
                 let is_configured_component = self.ctx.config.jsx.is_component_tag(tag_name);
-                if !is_configured_component && !self.ctx.config.jsx.should_match_tag(tag_name) {
+                if !is_configured_component
+                    && !self
+                        .ctx
+                        .config
+                        .jsx
+                        .should_match_tag(tag_name, self.ctx.config.has_jsx_framework)
+                {
                     return None;
                 }
                 Some(ResolvedTag {

--- a/crates/pandacss_extractor/src/matcher.rs
+++ b/crates/pandacss_extractor/src/matcher.rs
@@ -254,8 +254,9 @@ impl JsxExtractionConfig {
     }
 
     #[must_use]
-    pub fn should_match_tag(&self, tag_name: &str) -> bool {
-        self.is_component_tag(tag_name) || is_uppercase_component_tag(tag_name)
+    pub fn should_match_tag(&self, tag_name: &str, has_jsx_framework: bool) -> bool {
+        self.is_component_tag(tag_name)
+            || (has_jsx_framework && is_uppercase_component_tag(tag_name))
     }
 
     #[must_use]

--- a/crates/pandacss_extractor/src/template_styles.rs
+++ b/crates/pandacss_extractor/src/template_styles.rs
@@ -318,7 +318,10 @@ fn resolve_template_tag<'a>(
             _ => {}
         }
     }
-    if config.jsx.should_match_tag(tag_name) {
+    if config
+        .jsx
+        .should_match_tag(tag_name, config.has_jsx_framework)
+    {
         return Some(ResolvedTemplateTag {
             category: MatchCategory::Jsx,
             name: Cow::Borrowed(tag_name),

--- a/crates/pandacss_extractor/src/template_styles.rs
+++ b/crates/pandacss_extractor/src/template_styles.rs
@@ -43,6 +43,10 @@ pub(crate) fn collect_template_styles(
     matched: &[MatchedImport],
     config: &ExtractorConfig,
 ) -> Vec<ExtractedJsx> {
+    if !config.has_jsx_framework {
+        return Vec::new();
+    }
+
     let context_source = template_context_source(source, path);
     let context = TemplateContext {
         source: context_source.as_ref(),

--- a/crates/pandacss_extractor/tests/calls.rs
+++ b/crates/pandacss_extractor/tests/calls.rs
@@ -106,6 +106,19 @@ fn extract_with(
     )
 }
 
+fn extract_with_jsx(
+    source: &str,
+    matched: &[MatchedImport],
+    matchers: &Matchers,
+) -> ExtractedCallsResult {
+    extract_calls(
+        source,
+        "fixture.tsx",
+        matched,
+        &ExtractorConfig::new(matchers.clone()).with_jsx_framework(true),
+    )
+}
+
 fn extract_template(source: &str, matched: &[MatchedImport]) -> ExtractedCallsResult {
     extract_calls(
         source,
@@ -115,7 +128,7 @@ fn extract_template(source: &str, matched: &[MatchedImport]) -> ExtractedCallsRe
     )
 }
 
-fn extract_with_template(
+fn extract_with_template_jsx(
     source: &str,
     matched: &[MatchedImport],
     matchers: &Matchers,
@@ -124,7 +137,9 @@ fn extract_with_template(
         source,
         "fixture.tsx",
         matched,
-        &ExtractorConfig::new(matchers.clone()).with_syntax(CssSyntaxKind::TemplateLiteral),
+        &ExtractorConfig::new(matchers.clone())
+            .with_jsx_framework(true)
+            .with_syntax(CssSyntaxKind::TemplateLiteral),
     )
 }
 
@@ -767,7 +782,7 @@ fn parse_error_surfaces_diagnostic() {
 fn multi_arg_call_extracts_all_literal_args() {
     // styled('div', { base: { color: 'red' } }) — both args are literal.
     assert_yaml_snapshot!(
-        extract(
+        extract_with_jsx(
             "styled('div', { base: { color: 'red' } })",
             &[MatchedImport {
                 category: MatchCategory::Jsx,
@@ -776,6 +791,7 @@ fn multi_arg_call_extracts_all_literal_args() {
                 alias: "styled".into(),
                 kind: ImportSpecifierKind::Named,
             }],
+            &panda_matchers("@panda"),
         ),
         @"
     calls:
@@ -833,7 +849,7 @@ fn jsx_factory_property_call_extracts_recipe_config() {
     }
     matchers.jsx_factories = Some(vec!["panda".into()]);
 
-    let result = extract_with(
+    let result = extract_with_jsx(
         "panda.div({ base: { color: 'red' }, variants: { size: { sm: { fontSize: '12px' } } } })",
         &[jsx_factory("panda")],
         &matchers,
@@ -851,7 +867,7 @@ fn jsx_factory_property_call_extracts_recipe_config() {
 
 #[test]
 fn jsx_factory_call_tagged_template_extracts_as_css() {
-    let result = extract_with_template(
+    let result = extract_with_template_jsx(
         "styled('span')`color: red; padding: 4px;`",
         &[jsx_factory("styled")],
         &panda_matchers("@panda"),
@@ -876,7 +892,7 @@ fn jsx_factory_call_tagged_template_extracts_as_css() {
 fn bare_jsx_factory_tagged_template_does_not_extract() {
     // `styled` without an element has no target; only member
     // (`styled.div`) and call (`styled('div')`) tags extract.
-    let result = extract_with_template(
+    let result = extract_with_template_jsx(
         "styled`display: flex;`",
         &[jsx_factory("styled")],
         &panda_matchers("@panda"),
@@ -890,7 +906,7 @@ fn bare_jsx_factory_tagged_template_does_not_extract() {
 
 #[test]
 fn unmatched_member_tagged_template_does_not_extract() {
-    let result = extract_with_template(
+    let result = extract_with_template_jsx(
         "other.div`display: flex;`",
         &[jsx_factory("styled")],
         &panda_matchers("@panda"),
@@ -904,7 +920,7 @@ fn unmatched_member_tagged_template_does_not_extract() {
 
 #[test]
 fn jsx_factory_call_tagged_template_ignored_in_object_syntax() {
-    let result = extract_with(
+    let result = extract_with_jsx(
         "styled('span')`color: red; padding: 4px;`",
         &[jsx_factory("styled")],
         &panda_matchers("@panda"),

--- a/crates/pandacss_extractor/tests/common/mod.rs
+++ b/crates/pandacss_extractor/tests/common/mod.rs
@@ -36,6 +36,10 @@ pub fn panda_config() -> ExtractorConfig {
     ExtractorConfig::new(panda_matchers())
 }
 
+pub fn panda_jsx_config() -> ExtractorConfig {
+    panda_config().with_jsx_framework(true)
+}
+
 pub fn panda_config_with_jsx(jsx: JsxExtractionConfig) -> ExtractorConfig {
     panda_config().with_jsx(jsx)
 }

--- a/crates/pandacss_extractor/tests/conditional_output.rs
+++ b/crates/pandacss_extractor/tests/conditional_output.rs
@@ -6,13 +6,17 @@
 //! we emit both alternatives so the downstream encoder can generate
 //! atomic-CSS-style output.
 
-use crate::common::panda_config;
+use crate::common::{panda_config, panda_jsx_config};
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
 use pandacss_extractor::{ExtractUsage, extract};
 
 fn run(source: &str) -> ExtractUsage {
     extract(source, "fixture.tsx", &panda_config())
+}
+
+fn run_jsx(source: &str) -> ExtractUsage {
+    extract(source, "fixture.tsx", &panda_jsx_config())
 }
 
 // --- ternary ---
@@ -128,7 +132,7 @@ fn ternary_in_jsx_attribute_emits_conditional() {
         import { Box } from '@panda/jsx';
         const el = <Box color={isDark ? 'white' : 'black'} />;
     "};
-    assert_yaml_snapshot!(run(src).jsx, @"
+    assert_yaml_snapshot!(run_jsx(src).jsx, @"
     - category: jsx
       kind: component
       name: Box

--- a/crates/pandacss_extractor/tests/css_template.rs
+++ b/crates/pandacss_extractor/tests/css_template.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
 
-use crate::common::panda_config;
+use crate::common::{panda_config, panda_jsx_config};
 use pandacss_extractor::{CssSyntaxKind, ExtractUsage, extract};
 
 fn run(source: &str) -> ExtractUsage {
@@ -9,6 +9,14 @@ fn run(source: &str) -> ExtractUsage {
         source,
         "fixture.tsx",
         &panda_config().with_syntax(CssSyntaxKind::TemplateLiteral),
+    )
+}
+
+fn run_jsx(source: &str) -> ExtractUsage {
+    extract(
+        source,
+        "fixture.tsx",
+        &panda_jsx_config().with_syntax(CssSyntaxKind::TemplateLiteral),
     )
 }
 
@@ -25,7 +33,7 @@ fn css_tagged_template_media_query_matches_js_core_fixture() {
           }
         `
     "};
-    let result = run(source);
+    let result = run_jsx(source);
     assert_yaml_snapshot!(result.calls[0].data, @r#"
     - width: 500px
       height: 500px
@@ -54,7 +62,7 @@ fn css_tagged_template_native_nesting_matches_js_core_fixture() {
           }
         `
     "};
-    let result = run(source);
+    let result = run_jsx(source);
     assert_yaml_snapshot!(result.calls[0].data, @r#"
     - color: red
       "& p":
@@ -232,7 +240,7 @@ fn styled_tagged_template_uses_same_css_template_parser() {
           }
         `
     "};
-    let result = run(source);
+    let result = run_jsx(source);
     assert_yaml_snapshot!(result.jsx[0].data, @r#"
     "& figure":
       margin: "0"

--- a/crates/pandacss_extractor/tests/extract.rs
+++ b/crates/pandacss_extractor/tests/extract.rs
@@ -283,3 +283,34 @@ fn parse_error_contract_diagnostics_and_partial_extractions() {
     // expose the pre-error css() call depending on parser behaviour.
     // The point is that the API doesn't crash and surfaces the error.
 }
+
+#[test]
+fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+    let source = indoc! {r#"
+        import { Box } from "@panda/jsx"
+        import { Image } from "some-image-lib"
+        export const App = () => (
+          <>
+            <Box color="red" />
+            <Image width="900" height="800" />
+          </>
+        )
+    "#};
+    let result = extract(source, "app.tsx", &panda_config());
+    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
+    assert_eq!(names, ["Box"]);
+}
+
+#[test]
+fn uppercase_component_extracts_with_jsx_framework() {
+    let source = indoc! {r#"
+        import { css } from "@panda/css"
+        import { Image } from "some-image-lib"
+        const _ = css({ color: "red" })
+        export const App = () => <Image width="900" height="800" />
+    "#};
+    let result = extract(source, "app.tsx", &panda_config().with_jsx_framework(true));
+    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
+    assert_eq!(image.len(), 1);
+    assert_eq!(image[0].data.to_json()["width"], "900");
+}

--- a/crates/pandacss_extractor/tests/extract.rs
+++ b/crates/pandacss_extractor/tests/extract.rs
@@ -1,7 +1,7 @@
-use crate::common::{panda_config, panda_config_with_jsx};
+use crate::common::{panda_config, panda_config_with_jsx, panda_jsx_config};
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
-use pandacss_extractor::{JsxExtractionConfig, extract, extract_debug};
+use pandacss_extractor::{CssSyntaxKind, JsxExtractionConfig, extract, extract_debug};
 
 #[test]
 fn single_pass_extract_combines_calls_and_jsx() {
@@ -17,7 +17,7 @@ fn single_pass_extract_combines_calls_and_jsx() {
                 const el = <Box fontSize="lg" />
             "#},
             "fixture.tsx",
-            &panda_config(),
+            &panda_jsx_config(),
         ),
         @r#"
     imports:
@@ -215,15 +215,22 @@ fn extract_debug_skips_work_but_keeps_unmatched_imports() {
 }
 
 #[test]
-fn configured_jsx_components_still_extract_without_imports() {
+fn configured_jsx_components_require_jsx_framework() {
     let mut jsx = JsxExtractionConfig::default();
     jsx.component_names.insert("Card".into());
+
+    let result = extract(
+        "<Card color='red' onClick={handler} />",
+        "fixture.tsx",
+        &panda_config_with_jsx(jsx.clone()),
+    );
+    assert!(result.jsx.is_empty());
 
     assert_yaml_snapshot!(
         extract(
             "<Card color='red' onClick={handler} />",
             "fixture.tsx",
-            &panda_config_with_jsx(jsx),
+            &panda_config_with_jsx(jsx).with_jsx_framework(true),
         ),
         @"
     calls: []
@@ -285,7 +292,7 @@ fn parse_error_contract_diagnostics_and_partial_extractions() {
 }
 
 #[test]
-fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+fn jsx_extraction_requires_jsx_framework() {
     let source = indoc! {r#"
         import { Box } from "@panda/jsx"
         import { Image } from "some-image-lib"
@@ -298,7 +305,28 @@ fn non_panda_uppercase_component_ignored_without_jsx_framework() {
     "#};
     let result = extract(source, "app.tsx", &panda_config());
     let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert_eq!(names, ["Box"]);
+    assert!(names.is_empty());
+}
+
+#[test]
+fn jsx_factory_extraction_requires_jsx_framework() {
+    let source = indoc! {r#"
+        import { styled } from "@panda/jsx"
+
+        const Card = styled('div', { base: { color: 'red' } })
+        const Panel = styled.div`
+          padding: 4px;
+        `
+    "#};
+    let result = extract(
+        source,
+        "factory.tsx",
+        &panda_config().with_syntax(CssSyntaxKind::TemplateLiteral),
+    );
+
+    assert!(result.calls.is_empty(), "jsx factory calls must be gated");
+    assert!(result.jsx.is_empty(), "styled template usage must be gated");
+    assert!(result.diagnostics.is_empty());
 }
 
 #[test]
@@ -309,7 +337,7 @@ fn uppercase_component_extracts_with_jsx_framework() {
         const _ = css({ color: "red" })
         export const App = () => <Image width="900" height="800" />
     "#};
-    let result = extract(source, "app.tsx", &panda_config().with_jsx_framework(true));
+    let result = extract(source, "app.tsx", &panda_jsx_config());
     let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
     assert_eq!(image.len(), 1);
     assert_eq!(image[0].data.to_json()["width"], "900");

--- a/crates/pandacss_extractor/tests/extract.rs
+++ b/crates/pandacss_extractor/tests/extract.rs
@@ -1,4 +1,4 @@
-use crate::common::{panda_config, panda_config_with_jsx, panda_jsx_config};
+use crate::common::{extract_shape, panda_config, panda_config_with_jsx, panda_jsx_config};
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
 use pandacss_extractor::{CssSyntaxKind, JsxExtractionConfig, extract, extract_debug};
@@ -224,7 +224,10 @@ fn configured_jsx_components_require_jsx_framework() {
         "fixture.tsx",
         &panda_config_with_jsx(jsx.clone()),
     );
-    assert!(result.jsx.is_empty());
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls: []
+    jsx: []
+    ");
 
     assert_yaml_snapshot!(
         extract(
@@ -304,8 +307,10 @@ fn jsx_extraction_requires_jsx_framework() {
         )
     "#};
     let result = extract(source, "app.tsx", &panda_config());
-    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert!(names.is_empty());
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls: []
+    jsx: []
+    ");
 }
 
 #[test]
@@ -324,8 +329,10 @@ fn jsx_factory_extraction_requires_jsx_framework() {
         &panda_config().with_syntax(CssSyntaxKind::TemplateLiteral),
     );
 
-    assert!(result.calls.is_empty(), "jsx factory calls must be gated");
-    assert!(result.jsx.is_empty(), "styled template usage must be gated");
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls: []
+    jsx: []
+    ");
     assert!(result.diagnostics.is_empty());
 }
 
@@ -338,7 +345,15 @@ fn uppercase_component_extracts_with_jsx_framework() {
         export const App = () => <Image width="900" height="800" />
     "#};
     let result = extract(source, "app.tsx", &panda_jsx_config());
-    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
-    assert_eq!(image.len(), 1);
-    assert_eq!(image[0].data.to_json()["width"], "900");
+    assert_yaml_snapshot!(extract_shape(&result), @r#"
+    calls:
+      - name: css
+        data:
+          color: red
+    jsx:
+      - name: Image
+        data:
+          width: "900"
+          height: "800"
+    "#);
 }

--- a/crates/pandacss_extractor/tests/framework_astro.rs
+++ b/crates/pandacss_extractor/tests/framework_astro.rs
@@ -249,8 +249,10 @@ fn jsx_extraction_requires_jsx_framework() {
         <Image width="900" height="800" />
     "#};
     let result = extract(source, "page.astro", &panda_config());
-    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert!(names.is_empty(), "jsx extraction requires a jsxFramework");
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls: []
+    jsx: []
+    ");
 }
 
 #[test]
@@ -263,8 +265,12 @@ fn uppercase_component_extracts_with_jsx_framework() {
         <Image width="900" height="800" />
     "#};
     let result = extract(source, "page.astro", &panda_jsx_config());
-    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
-    assert_eq!(image.len(), 1);
-    assert_eq!(image[0].data.to_json()["width"], "900");
-    assert_eq!(image[0].data.to_json()["height"], "800");
+    assert_yaml_snapshot!(extract_shape(&result), @r#"
+    calls: []
+    jsx:
+      - name: Image
+        data:
+          width: "900"
+          height: "800"
+    "#);
 }

--- a/crates/pandacss_extractor/tests/framework_astro.rs
+++ b/crates/pandacss_extractor/tests/framework_astro.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use insta::{assert_snapshot, assert_yaml_snapshot};
 
-use crate::common::{extract_shape, import_shape, panda_config};
+use crate::common::{extract_shape, import_shape, panda_config, panda_jsx_config};
 use pandacss_extractor::{extract, scan_imports};
 
 #[test]
@@ -40,7 +40,7 @@ fn attribute_and_children_expressions_extract() {
         </p>
     "};
 
-    let result = extract(source, "page.astro", &panda_config());
+    let result = extract(source, "page.astro", &panda_jsx_config());
     assert!(result.diagnostics.is_empty());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
@@ -65,7 +65,7 @@ fn frontmatter_const_resolves_in_template() {
         <section class={css(panel)} />
     "};
 
-    let result = extract(source, "page.astro", &panda_config());
+    let result = extract(source, "page.astro", &panda_jsx_config());
     assert!(result.diagnostics.is_empty());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
@@ -87,7 +87,7 @@ fn jsx_style_props_extract_from_template() {
         <Box color="red" fontSize="2xl" />
     "#};
 
-    let result = extract(source, "page.astro", &panda_config());
+    let result = extract(source, "page.astro", &panda_jsx_config());
     assert!(result.diagnostics.is_empty());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
@@ -239,7 +239,7 @@ fn spans_point_into_the_original_astro_source() {
 }
 
 #[test]
-fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+fn jsx_extraction_requires_jsx_framework() {
     let source = indoc! {r#"
         ---
         import { Box } from '@panda/jsx';
@@ -250,11 +250,7 @@ fn non_panda_uppercase_component_ignored_without_jsx_framework() {
     "#};
     let result = extract(source, "page.astro", &panda_config());
     let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert_eq!(
-        names,
-        ["Box"],
-        "non-panda <Image> must not be extracted without a jsxFramework"
-    );
+    assert!(names.is_empty(), "jsx extraction requires a jsxFramework");
 }
 
 #[test]
@@ -266,11 +262,7 @@ fn uppercase_component_extracts_with_jsx_framework() {
         ---
         <Image width="900" height="800" />
     "#};
-    let result = extract(
-        source,
-        "page.astro",
-        &panda_config().with_jsx_framework(true),
-    );
+    let result = extract(source, "page.astro", &panda_jsx_config());
     let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
     assert_eq!(image.len(), 1);
     assert_eq!(image[0].data.to_json()["width"], "900");

--- a/crates/pandacss_extractor/tests/framework_astro.rs
+++ b/crates/pandacss_extractor/tests/framework_astro.rs
@@ -237,3 +237,42 @@ fn spans_point_into_the_original_astro_source() {
     let span = &result.calls[0].span;
     assert_snapshot!(&source[span.start as usize..span.end as usize], @"css({ color: 'red' })");
 }
+
+#[test]
+fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+    let source = indoc! {r#"
+        ---
+        import { Box } from '@panda/jsx';
+        import { Image } from 'astro:assets';
+        ---
+        <Box color="red" />
+        <Image width="900" height="800" />
+    "#};
+    let result = extract(source, "page.astro", &panda_config());
+    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["Box"],
+        "non-panda <Image> must not be extracted without a jsxFramework"
+    );
+}
+
+#[test]
+fn uppercase_component_extracts_with_jsx_framework() {
+    let source = indoc! {r#"
+        ---
+        import { css } from '@panda/css';
+        import { Image } from 'astro:assets';
+        ---
+        <Image width="900" height="800" />
+    "#};
+    let result = extract(
+        source,
+        "page.astro",
+        &panda_config().with_jsx_framework(true),
+    );
+    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
+    assert_eq!(image.len(), 1);
+    assert_eq!(image[0].data.to_json()["width"], "900");
+    assert_eq!(image[0].data.to_json()["height"], "800");
+}

--- a/crates/pandacss_extractor/tests/framework_svelte.rs
+++ b/crates/pandacss_extractor/tests/framework_svelte.rs
@@ -504,8 +504,10 @@ fn jsx_extraction_requires_jsx_framework() {
         <Image width="900" height="800" />
     "#};
     let result = extract(source, "Card.svelte", &panda_config());
-    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert!(names.is_empty());
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls: []
+    jsx: []
+    ");
 }
 
 #[test]
@@ -519,7 +521,15 @@ fn uppercase_component_extracts_with_jsx_framework() {
         <Image width="900" height="800" />
     "#};
     let result = extract(source, "Card.svelte", &panda_jsx_config());
-    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
-    assert_eq!(image.len(), 1);
-    assert_eq!(image[0].data.to_json()["width"], "900");
+    assert_yaml_snapshot!(extract_shape(&result), @r#"
+    calls:
+      - name: css
+        data:
+          color: red
+    jsx:
+      - name: Image
+        data:
+          width: "900"
+          height: "800"
+    "#);
 }

--- a/crates/pandacss_extractor/tests/framework_svelte.rs
+++ b/crates/pandacss_extractor/tests/framework_svelte.rs
@@ -492,3 +492,38 @@ fn spans_point_into_the_original_svelte_source() {
     let span = &result.calls[0].span;
     assert_snapshot!(&source[span.start as usize..span.end as usize], @"css({ color: 'red' })");
 }
+
+#[test]
+fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+    let source = indoc! {r#"
+        <script>
+          import { Box } from '@panda/jsx'
+          import Image from 'some-image-lib'
+        </script>
+        <Box color="red" />
+        <Image width="900" height="800" />
+    "#};
+    let result = extract(source, "Card.svelte", &panda_config());
+    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
+    assert_eq!(names, ["Box"]);
+}
+
+#[test]
+fn uppercase_component_extracts_with_jsx_framework() {
+    let source = indoc! {r#"
+        <script>
+          import { css } from '@panda/css'
+          import Image from 'some-image-lib'
+          const _ = css({ color: 'red' })
+        </script>
+        <Image width="900" height="800" />
+    "#};
+    let result = extract(
+        source,
+        "Card.svelte",
+        &panda_config().with_jsx_framework(true),
+    );
+    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
+    assert_eq!(image.len(), 1);
+    assert_eq!(image[0].data.to_json()["width"], "900");
+}

--- a/crates/pandacss_extractor/tests/framework_svelte.rs
+++ b/crates/pandacss_extractor/tests/framework_svelte.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use insta::{assert_snapshot, assert_yaml_snapshot};
 
-use crate::common::{extract_shape, import_shape, panda_config};
+use crate::common::{extract_shape, import_shape, panda_config, panda_jsx_config};
 use pandacss_extractor::{extract, extract_jsx, match_imports, scan_imports};
 
 #[test]
@@ -43,7 +43,7 @@ fn template_calls_and_style_props_extract_together() {
         <p class={css({ fontWeight: 'bold' })} />
     "#};
 
-    let result = extract(source, "Card.svelte", &panda_config());
+    let result = extract(source, "Card.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
       - name: css
@@ -69,7 +69,7 @@ fn native_tags_do_not_emit_template_style_props() {
         <div color="red" />
     "#};
 
-    let result = extract(source, "Native.svelte", &panda_config());
+    let result = extract(source, "Native.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx: []
@@ -86,7 +86,7 @@ fn staged_extract_jsx_includes_template_style_props() {
         <Box color="red" />
     "#};
 
-    let config = panda_config();
+    let config = panda_config().with_jsx_framework(true);
     let scan = scan_imports(source, "Card.svelte");
     let matched = match_imports(&scan, &config.matchers);
     let result = extract_jsx(source, "Card.svelte", &matched, &config);
@@ -131,7 +131,7 @@ fn module_and_instance_scripts_are_both_scanned() {
         <Box color="red" />
     "#};
 
-    let result = extract(source, "TwoScripts.svelte", &panda_config());
+    let result = extract(source, "TwoScripts.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls:
       - name: css
@@ -154,7 +154,7 @@ fn static_class_attrs_do_not_become_style_props() {
         <Box class="card" color="red" />
     "#};
 
-    let result = extract(source, "StaticClass.svelte", &panda_config());
+    let result = extract(source, "StaticClass.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -175,7 +175,7 @@ fn conditional_style_props_emit_conditional_literals() {
         <Box color={selected ? 'red' : 'blue'} />
     "};
 
-    let result = extract(source, "Conditional.svelte", &panda_config());
+    let result = extract(source, "Conditional.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -200,7 +200,7 @@ fn array_css_prop_from_script_constant_extracts() {
         <Box css={styles} />
     "};
 
-    let result = extract(source, "ArrayCss.svelte", &panda_config());
+    let result = extract(source, "ArrayCss.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -223,7 +223,7 @@ fn spread_filters_non_style_props() {
         <Box {...props} />
     "};
 
-    let result = extract(source, "SpreadFilter.svelte", &panda_config());
+    let result = extract(source, "SpreadFilter.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -244,7 +244,7 @@ fn namespace_component_style_props_extract() {
         <Panda.Box color="red" padding="4px" />
     "#};
 
-    let result = extract(source, "Namespace.svelte", &panda_config());
+    let result = extract(source, "Namespace.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -266,7 +266,7 @@ fn svelte_directive_attrs_are_ignored_but_static_siblings_extract() {
         <Box class:active={active} bind:this={ref} color="red" />
     "#};
 
-    let result = extract(source, "Directives.svelte", &panda_config());
+    let result = extract(source, "Directives.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -290,7 +290,7 @@ fn comments_inside_tags_are_ignored() {
         />
     "#};
 
-    let result = extract(source, "Comments.svelte", &panda_config());
+    let result = extract(source, "Comments.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -317,7 +317,7 @@ fn await_and_each_blocks_do_not_break_component_style_props() {
         {/await}
     "#};
 
-    let result = extract(source, "Blocks.svelte", &panda_config());
+    let result = extract(source, "Blocks.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -378,7 +378,7 @@ fn larger_svelte_file_mixes_scripts_blocks_calls_and_style_props() {
         </style>
     "#};
 
-    let result = extract(source, "Large.svelte", &panda_config());
+    let result = extract(source, "Large.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
       - name: css
@@ -437,7 +437,7 @@ fn snippets_render_and_key_blocks_are_tolerated() {
         {@render row(css({ margin: '8px' }))}
     "#};
 
-    let result = extract(source, "Snippets.svelte", &panda_config());
+    let result = extract(source, "Snippets.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls:
       - name: css
@@ -465,7 +465,7 @@ fn typescript_assertions_in_markup_style_props_fold() {
         <Box color={color as string} padding={spacing!} />
     "#};
 
-    let result = extract(source, "TypeScriptMarkup.svelte", &panda_config());
+    let result = extract(source, "TypeScriptMarkup.svelte", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
     jsx:
@@ -494,7 +494,7 @@ fn spans_point_into_the_original_svelte_source() {
 }
 
 #[test]
-fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+fn jsx_extraction_requires_jsx_framework() {
     let source = indoc! {r#"
         <script>
           import { Box } from '@panda/jsx'
@@ -505,7 +505,7 @@ fn non_panda_uppercase_component_ignored_without_jsx_framework() {
     "#};
     let result = extract(source, "Card.svelte", &panda_config());
     let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert_eq!(names, ["Box"]);
+    assert!(names.is_empty());
 }
 
 #[test]
@@ -518,11 +518,7 @@ fn uppercase_component_extracts_with_jsx_framework() {
         </script>
         <Image width="900" height="800" />
     "#};
-    let result = extract(
-        source,
-        "Card.svelte",
-        &panda_config().with_jsx_framework(true),
-    );
+    let result = extract(source, "Card.svelte", &panda_jsx_config());
     let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
     assert_eq!(image.len(), 1);
     assert_eq!(image[0].data.to_json()["width"], "900");

--- a/crates/pandacss_extractor/tests/framework_vue.rs
+++ b/crates/pandacss_extractor/tests/framework_vue.rs
@@ -719,3 +719,38 @@ fn kebab_case_tag_without_configured_component_is_ignored() {
     jsx: []
     ");
 }
+
+#[test]
+fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+    let source = indoc! {r#"
+        <template>
+          <Box color="red" />
+          <Image width="900" height="800" />
+        </template>
+        <script setup lang="ts">
+        import { Box } from '@panda/jsx'
+        import { Image } from 'some-image-lib'
+        </script>
+    "#};
+    let result = extract(source, "Card.vue", &panda_config());
+    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
+    assert_eq!(names, ["Box"]);
+}
+
+#[test]
+fn uppercase_component_extracts_with_jsx_framework() {
+    let source = indoc! {r#"
+        <template>
+          <Image width="900" height="800" />
+        </template>
+        <script setup lang="ts">
+        import { css } from '@panda/css'
+        import { Image } from 'some-image-lib'
+        const _ = css({ color: 'red' })
+        </script>
+    "#};
+    let result = extract(source, "Card.vue", &panda_config().with_jsx_framework(true));
+    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
+    assert_eq!(image.len(), 1);
+    assert_eq!(image[0].data.to_json()["width"], "900");
+}

--- a/crates/pandacss_extractor/tests/framework_vue.rs
+++ b/crates/pandacss_extractor/tests/framework_vue.rs
@@ -733,8 +733,10 @@ fn jsx_extraction_requires_jsx_framework() {
         </script>
     "#};
     let result = extract(source, "Card.vue", &panda_config());
-    let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert!(names.is_empty());
+    assert_yaml_snapshot!(extract_shape(&result), @"
+    calls: []
+    jsx: []
+    ");
 }
 
 #[test]
@@ -750,7 +752,15 @@ fn uppercase_component_extracts_with_jsx_framework() {
         </script>
     "#};
     let result = extract(source, "Card.vue", &panda_jsx_config());
-    let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
-    assert_eq!(image.len(), 1);
-    assert_eq!(image[0].data.to_json()["width"], "900");
+    assert_yaml_snapshot!(extract_shape(&result), @r#"
+    calls:
+      - name: css
+        data:
+          color: red
+    jsx:
+      - name: Image
+        data:
+          width: "900"
+          height: "800"
+    "#);
 }

--- a/crates/pandacss_extractor/tests/framework_vue.rs
+++ b/crates/pandacss_extractor/tests/framework_vue.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use insta::{assert_snapshot, assert_yaml_snapshot};
 
-use crate::common::{extract_shape, import_shape, panda_config};
+use crate::common::{extract_shape, import_shape, panda_config, panda_jsx_config};
 use pandacss_extractor::{JsxExtractionConfig, JsxKind};
 use pandacss_extractor::{extract, extract_jsx, match_imports, scan_imports};
 
@@ -46,7 +46,7 @@ fn template_calls_and_style_props_extract_together() {
         </script>
     "#};
 
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
       - name: css
@@ -80,7 +80,7 @@ fn nested_template_branches_emit_component_style_props() {
         </script>
     "#};
 
-    let result = extract(source, "Nested.vue", &panda_config());
+    let result = extract(source, "Nested.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -104,7 +104,7 @@ fn native_tags_do_not_emit_template_style_props() {
         </script>
     "#};
 
-    let result = extract(source, "Native.vue", &panda_config());
+    let result = extract(source, "Native.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx: []
@@ -122,7 +122,7 @@ fn staged_extract_jsx_includes_template_style_props() {
         </script>
     "#};
 
-    let config = panda_config();
+    let config = panda_config().with_jsx_framework(true);
     let scan = scan_imports(source, "Card.vue");
     let matched = match_imports(&scan, &config.matchers);
     let result = extract_jsx(source, "Card.vue", &matched, &config);
@@ -145,7 +145,7 @@ fn script_setup_aliases_and_template_calls_extract() {
         </script>
     "#};
 
-    let result = extract(source, "Alias.vue", &panda_config());
+    let result = extract(source, "Alias.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
       - name: css
@@ -172,7 +172,7 @@ fn script_and_script_setup_are_both_scanned() {
         </script>
     "#};
 
-    let result = extract(source, "TwoScripts.vue", &panda_config());
+    let result = extract(source, "TwoScripts.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls:
       - name: css
@@ -196,7 +196,7 @@ fn static_class_attrs_do_not_become_style_props() {
         </script>
     "#};
 
-    let result = extract(source, "StaticClass.vue", &panda_config());
+    let result = extract(source, "StaticClass.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -218,7 +218,7 @@ fn conditional_bound_style_props_emit_conditional_literals() {
         </script>
     "#};
 
-    let result = extract(source, "Conditional.vue", &panda_config());
+    let result = extract(source, "Conditional.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -244,7 +244,7 @@ fn array_css_prop_from_script_constant_extracts() {
         </script>
     "#};
 
-    let result = extract(source, "ArrayCss.vue", &panda_config());
+    let result = extract(source, "ArrayCss.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -267,7 +267,7 @@ fn v_bind_spread_filters_non_style_props() {
         </script>
     "#};
 
-    let result = extract(source, "SpreadFilter.vue", &panda_config());
+    let result = extract(source, "SpreadFilter.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -289,7 +289,7 @@ fn namespace_component_style_props_extract() {
         </script>
     "#};
 
-    let result = extract(source, "Namespace.vue", &panda_config());
+    let result = extract(source, "Namespace.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -312,7 +312,7 @@ fn dynamic_arg_style_props_are_skipped_but_static_siblings_extract() {
         </script>
     "#};
 
-    let result = extract(source, "DynamicArg.vue", &panda_config());
+    let result = extract(source, "DynamicArg.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx:
@@ -333,7 +333,7 @@ fn non_html_template_lang_is_skipped_for_template_attrs() {
         </script>
     "#};
 
-    let result = extract(source, "Pug.vue", &panda_config());
+    let result = extract(source, "Pug.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r"
     calls: []
     jsx: []
@@ -352,7 +352,7 @@ fn comments_and_tag_like_strings_do_not_break_template_extraction() {
         </script>
     "#};
 
-    let result = extract(source, "Comments.vue", &panda_config());
+    let result = extract(source, "Comments.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @r#"
     calls: []
     jsx:
@@ -412,7 +412,7 @@ fn larger_vue_sfc_mixes_scripts_templates_calls_and_style_props() {
         </style>
     "#};
 
-    let result = extract(source, "Large.vue", &panda_config());
+    let result = extract(source, "Large.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
       - name: css
@@ -466,7 +466,7 @@ fn slot_templates_and_v_memo_do_not_break_extraction() {
         </template>
     "#};
 
-    let result = extract(source, "Slots.vue", &panda_config());
+    let result = extract(source, "Slots.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls:
       - name: css
@@ -495,7 +495,7 @@ fn script_tag_attrs_with_gt_do_not_break_import_scan() {
         </template>
     "#};
 
-    let result = extract(source, "Generic.vue", &panda_config());
+    let result = extract(source, "Generic.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
     jsx:
@@ -540,7 +540,7 @@ fn bare_recipe_component_in_template_emits_usage() {
         </script>
     "#};
 
-    let mut config = panda_config();
+    let mut config = panda_jsx_config();
     config.matchers.jsx_kinds = [
         ("Custom.Root".to_owned(), JsxKind::Recipe),
         ("Custom.Label".to_owned(), JsxKind::Recipe),
@@ -578,7 +578,7 @@ fn bare_unconfigured_component_in_template_is_not_emitted() {
         import Sidebar from './Sidebar.vue'
         </script>
     "#};
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
     jsx: []
@@ -598,7 +598,7 @@ fn multi_statement_event_handler_does_not_break_the_parse() {
         import { Box } from '@panda/jsx';
         </script>
     "#};
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert!(result.diagnostics.is_empty());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
@@ -619,7 +619,7 @@ fn single_expression_event_handler_still_parses() {
         import { Box } from '@panda/jsx';
         </script>
     "#};
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert!(result.diagnostics.is_empty());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
@@ -644,7 +644,7 @@ fn same_name_shorthand_resolves_through_script_scope() {
         const fontSize = '12px'
         </script>
     "#};
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
     jsx:
@@ -667,7 +667,7 @@ fn same_name_shorthand_without_binding_is_dropped() {
         import { Box } from '@panda/jsx';
         </script>
     "#};
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
     jsx:
@@ -687,7 +687,7 @@ fn kebab_case_tag_resolves_to_configured_pascal_component() {
           <custom-root />
         </template>
     "};
-    let mut config = panda_config();
+    let mut config = panda_jsx_config();
     config.matchers.jsx_kinds = [("CustomRoot".to_owned(), JsxKind::Recipe)]
         .into_iter()
         .collect();
@@ -713,7 +713,7 @@ fn kebab_case_tag_without_configured_component_is_ignored() {
           <my-widget color="red" />
         </template>
     "#};
-    let result = extract(source, "Card.vue", &panda_config());
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     assert_yaml_snapshot!(extract_shape(&result), @"
     calls: []
     jsx: []
@@ -721,7 +721,7 @@ fn kebab_case_tag_without_configured_component_is_ignored() {
 }
 
 #[test]
-fn non_panda_uppercase_component_ignored_without_jsx_framework() {
+fn jsx_extraction_requires_jsx_framework() {
     let source = indoc! {r#"
         <template>
           <Box color="red" />
@@ -734,7 +734,7 @@ fn non_panda_uppercase_component_ignored_without_jsx_framework() {
     "#};
     let result = extract(source, "Card.vue", &panda_config());
     let names: Vec<&str> = result.jsx.iter().map(|j| j.name.as_str()).collect();
-    assert_eq!(names, ["Box"]);
+    assert!(names.is_empty());
 }
 
 #[test]
@@ -749,7 +749,7 @@ fn uppercase_component_extracts_with_jsx_framework() {
         const _ = css({ color: 'red' })
         </script>
     "#};
-    let result = extract(source, "Card.vue", &panda_config().with_jsx_framework(true));
+    let result = extract(source, "Card.vue", &panda_jsx_config());
     let image: Vec<_> = result.jsx.iter().filter(|j| j.name == "Image").collect();
     assert_eq!(image.len(), 1);
     assert_eq!(image[0].data.to_json()["width"], "900");

--- a/crates/pandacss_extractor/tests/jsx.rs
+++ b/crates/pandacss_extractor/tests/jsx.rs
@@ -44,7 +44,7 @@ fn extract(source: &str, matched: &[MatchedImport]) -> ExtractedJsxResult {
         source,
         "fixture.tsx",
         matched,
-        &jsx_config(["styled", "Box", "Stack", "Grid"]),
+        &jsx_config(["styled", "Box", "Stack", "Grid"]).with_jsx_framework(true),
     )
 }
 
@@ -66,7 +66,9 @@ fn extract_with_jsx_config(
         source,
         "fixture.tsx",
         matched,
-        &jsx_config(["styled", "Box", "Stack", "Grid"]).with_jsx(jsx),
+        &jsx_config(["styled", "Box", "Stack", "Grid"])
+            .with_jsx(jsx)
+            .with_jsx_framework(true),
     )
 }
 

--- a/crates/pandacss_extractor/tests/jsx.rs
+++ b/crates/pandacss_extractor/tests/jsx.rs
@@ -53,7 +53,9 @@ fn extract_template(source: &str, matched: &[MatchedImport]) -> ExtractedJsxResu
         source,
         "fixture.tsx",
         matched,
-        &jsx_config(["styled", "Box", "Stack", "Grid"]).with_syntax(CssSyntaxKind::TemplateLiteral),
+        &jsx_config(["styled", "Box", "Stack", "Grid"])
+            .with_syntax(CssSyntaxKind::TemplateLiteral)
+            .with_jsx_framework(true),
     )
 }
 
@@ -1869,7 +1871,8 @@ fn styled_factory_member_tag_is_classified_as_factory() {
 
 #[test]
 fn pattern_jsx_name_is_classified_as_pattern() {
-    let config = jsx_kind_config(["styled", "Stack"], &[("Stack", JsxKind::Pattern)]);
+    let config = jsx_kind_config(["styled", "Stack"], &[("Stack", JsxKind::Pattern)])
+        .with_jsx_framework(true);
     let result = extract_jsx(
         "<Stack gap='4' />",
         "fixture.tsx",
@@ -1883,7 +1886,8 @@ fn pattern_jsx_name_is_classified_as_pattern() {
 
 #[test]
 fn recipe_jsx_name_is_classified_as_recipe() {
-    let config = jsx_kind_config(["styled", "Button"], &[("Button", JsxKind::Recipe)]);
+    let config = jsx_kind_config(["styled", "Button"], &[("Button", JsxKind::Recipe)])
+        .with_jsx_framework(true);
     let result = extract_jsx(
         "<Button size='lg' />",
         "fixture.tsx",

--- a/crates/pandacss_extractor/tests/polish.rs
+++ b/crates/pandacss_extractor/tests/polish.rs
@@ -23,10 +23,22 @@ fn run(source: &str) -> ExtractUsage {
     extract(source, "fixture.tsx", &ExtractorConfig::new(matchers()))
 }
 
-fn run_with_factories(source: &str, factories: Vec<&str>) -> ExtractUsage {
+fn run_jsx(source: &str) -> ExtractUsage {
+    extract(
+        source,
+        "fixture.tsx",
+        &ExtractorConfig::new(matchers()).with_jsx_framework(true),
+    )
+}
+
+fn run_jsx_with_factories(source: &str, factories: Vec<&str>) -> ExtractUsage {
     let mut m = matchers();
     m.jsx_factories = Some(factories.into_iter().map(String::from).collect());
-    extract(source, "fixture.tsx", &ExtractorConfig::new(m))
+    extract(
+        source,
+        "fixture.tsx",
+        &ExtractorConfig::new(m).with_jsx_framework(true),
+    )
 }
 
 // --- TS enums ---
@@ -155,7 +167,7 @@ fn jsx_factory_names_are_explicitly_configured() {
         import { Panda } from '@panda/jsx';
         const a = <Panda.div color='red' />;
     "};
-    let jsx = run(src).jsx;
+    let jsx = run_jsx(src).jsx;
     assert!(
         jsx.is_empty(),
         "non-default factory `<Panda.x>` should not extract under defaults: {jsx:#?}"
@@ -169,7 +181,7 @@ fn custom_jsx_factory_extracts_member_chain() {
         import { Panda } from '@panda/jsx';
         const a = <Panda.div color='red' />;
     "};
-    assert_yaml_snapshot!(run_with_factories(src, vec!["Panda"]).jsx, @"
+    assert_yaml_snapshot!(run_jsx_with_factories(src, vec!["Panda"]).jsx, @"
     - category: jsx
       kind: factory
       name: Panda.div
@@ -190,7 +202,7 @@ fn custom_jsx_factory_excludes_default_styled() {
         import { styled } from '@panda/jsx';
         const a = <styled.div color='red' />;
     "};
-    let jsx = run_with_factories(src, vec!["Panda"]).jsx;
+    let jsx = run_jsx_with_factories(src, vec!["Panda"]).jsx;
     assert!(
         jsx.is_empty(),
         "`<styled.x>` should not extract when factories list is overridden to `['Panda']`: {jsx:#?}"

--- a/crates/pandacss_extractor/tests/scope.rs
+++ b/crates/pandacss_extractor/tests/scope.rs
@@ -5,13 +5,17 @@
 //! `oxc_semantic` integration. These tests use the combined `extract()`
 //! entrypoint so the resolver is always present.
 
-use crate::common::panda_config;
+use crate::common::{panda_config, panda_jsx_config};
 use indoc::indoc;
 use insta::{assert_snapshot, assert_yaml_snapshot};
 use pandacss_extractor::{ExtractUsage, extract};
 
 fn run(source: &str) -> ExtractUsage {
     extract(source, "fixture.tsx", &panda_config())
+}
+
+fn run_jsx(source: &str) -> ExtractUsage {
+    extract(source, "fixture.tsx", &panda_jsx_config())
 }
 
 // --- identifier reference resolution ---
@@ -761,7 +765,7 @@ fn jsx_attribute_resolves_identifier() {
         const w = '5px';
         const el = <Box width={w} />;
     "};
-    assert_yaml_snapshot!(run(src).jsx, @"
+    assert_yaml_snapshot!(run_jsx(src).jsx, @"
     - category: jsx
       kind: component
       name: Box
@@ -781,7 +785,7 @@ fn jsx_spread_of_local_identifier_resolves() {
         const base = { color: 'red' };
         const el = <Box {...base} padding='4px' />;
     "};
-    assert_yaml_snapshot!(run(src).jsx, @"
+    assert_yaml_snapshot!(run_jsx(src).jsx, @"
     - category: jsx
       kind: component
       name: Box
@@ -803,7 +807,7 @@ fn jsx_tag_shadowed_by_param_is_not_extracted() {
           return <Box color='red' />;
         }
     "};
-    let jsx = run(src).jsx;
+    let jsx = run_jsx(src).jsx;
     assert!(
         jsx.is_empty(),
         "shadowed JSX tag must not extract: {jsx:#?}"
@@ -955,7 +959,7 @@ fn inner_scope_shadows_outer_same_named_const() {
           return <Box color={color} />;
         }
     "};
-    let json = serde_json::to_value(&run(src).jsx[0].data).unwrap();
+    let json = serde_json::to_value(&run_jsx(src).jsx[0].data).unwrap();
     assert_eq!(
         json["color"], "orange.500",
         "inner scope's binding should win, not the module-level one",
@@ -974,7 +978,7 @@ fn closure_captures_outer_const() {
           return <Box color={color} />;
         }
     "};
-    let json = serde_json::to_value(&run(src).jsx[0].data).unwrap();
+    let json = serde_json::to_value(&run_jsx(src).jsx[0].data).unwrap();
     assert_eq!(json["color"], "orange.600");
 }
 

--- a/crates/pandacss_project/tests/build_info.rs
+++ b/crates/pandacss_project/tests/build_info.rs
@@ -256,6 +256,7 @@ fn build_info_serializes_recipes_with_per_module_provenance() {
 /// (`<Tabs.Root>`) — so we prove JSX usage feeds per-module recipe provenance.
 fn jsx_recipe_lib_project() -> pandacss_project::Project {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {
@@ -385,6 +386,7 @@ fn hydrate_with_module_filter_emits_only_imported_recipes() {
 #[test]
 fn build_info_maps_exports_of_recipe_consuming_components() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {
@@ -427,6 +429,7 @@ fn build_info_maps_exports_of_recipe_consuming_components() {
 #[test]
 fn build_info_tracks_named_specifier_exports() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": { "recipes": { "card": { "jsx": ["Card"], "base": { "padding": "4px" } } } }
     }));
     // `export { Local as Public }` — the exported (public) name is tracked.
@@ -448,6 +451,7 @@ fn build_info_tracks_named_specifier_exports() {
 
 fn jsx_button_project() -> pandacss_project::Project {
     create_project(json!({
+        "jsxFramework": "react",
         "theme": { "recipes": { "button": { "jsx": ["Button"], "base": { "display": "inline-flex" } } } }
     }))
 }
@@ -549,6 +553,7 @@ fn build_info_ignores_unresolved_or_cyclic_re_exports() {
 #[test]
 fn build_info_exports_round_trip_through_json() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": { "recipes": { "button": { "jsx": ["Button"], "base": { "display": "inline-flex" } } } }
     }));
     project.parse_file(
@@ -582,7 +587,9 @@ fn hydrate_rejects_incompatible_schema_version() {
 
 #[test]
 fn build_info_serializes_jsx_style_props_with_module_provenance() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     project.parse_file(
         "card.tsx",
         "import { Box } from '@panda/jsx'; export const Card = () => <Box color='red' padding='4px' />;",
@@ -606,7 +613,9 @@ fn build_info_serializes_jsx_style_props_with_module_provenance() {
 
 #[test]
 fn build_info_hydrates_jsx_style_props() {
-    let mut source = create_project(json!({}));
+    let mut source = create_project(json!({
+        "jsxFramework": "react"
+    }));
     source.parse_file(
         "card.tsx",
         "import { Box } from '@panda/jsx'; export const Card = () => <Box color='red' padding='4px' />;",
@@ -620,7 +629,9 @@ fn build_info_hydrates_jsx_style_props() {
 
 #[test]
 fn build_info_tree_shakes_jsx_style_props_by_module() {
-    let mut source = create_project(json!({}));
+    let mut source = create_project(json!({
+        "jsxFramework": "react"
+    }));
     source.parse_file(
         "card.tsx",
         "import { Box } from '@panda/jsx'; export const Card = () => <Box color='red' />;",
@@ -644,6 +655,7 @@ fn build_info_tree_shakes_jsx_style_props_by_module() {
 
 fn recipe_jsx_with_style_props_project() -> pandacss_project::Project {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {
@@ -696,6 +708,7 @@ fn build_info_hydrates_recipe_jsx_with_atomic_style_props() {
 #[test]
 fn build_info_serializes_pattern_jsx_with_module_provenance() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "none",
         "patterns": {
             "stack": {
@@ -724,6 +737,7 @@ fn build_info_serializes_pattern_jsx_with_module_provenance() {
 #[test]
 fn build_info_hydrates_pattern_jsx_atoms() {
     let mut source = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "none",
         "patterns": {
             "stack": {
@@ -755,7 +769,10 @@ fn build_info_hydrates_pattern_jsx_atoms() {
 
 #[test]
 fn build_info_serializes_jsx_factory_styles_with_module_provenance() {
-    let mut project = create_project(json!({ "jsxFactory": "panda" }));
+    let mut project = create_project(json!({
+        "jsxFramework": "react",
+        "jsxFactory": "panda"
+    }));
     project.parse_file(
         "notice.tsx",
         "import { panda } from '@panda/jsx'; export const Notice = panda('div', { color: 'red', padding: '4px' });",
@@ -772,7 +789,10 @@ fn build_info_serializes_jsx_factory_styles_with_module_provenance() {
 
 #[test]
 fn build_info_hydrates_jsx_factory_styles() {
-    let mut source = create_project(json!({ "jsxFactory": "panda" }));
+    let mut source = create_project(json!({
+        "jsxFramework": "react",
+        "jsxFactory": "panda"
+    }));
     source.parse_file(
         "notice.tsx",
         "import { panda } from '@panda/jsx'; export const Notice = panda('div', { color: 'red', padding: '4px' });",

--- a/crates/pandacss_project/tests/config.rs
+++ b/crates/pandacss_project/tests/config.rs
@@ -57,6 +57,7 @@ fn invalid_serialized_jsx_regex_returns_error() {
 #[test]
 fn jsx_names_include_patterns_and_recipes() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxFactory": "styled",
         "patterns": {
             "stack": {},
@@ -210,6 +211,7 @@ fn utility_values_normalize_aliases() {
 #[test]
 fn jsx_shorthands_are_normalized() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "utilities": {
             "padding": { "shorthand": "p" }
         }
@@ -234,6 +236,7 @@ fn jsx_shorthands_are_normalized() {
 #[test]
 fn all_jsx_props_filter_valid_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "utilities": {
             "padding": { "shorthand": "p" }
         }
@@ -261,6 +264,7 @@ fn all_jsx_props_filter_valid_props() {
 #[test]
 fn generated_color_palette_utility_is_a_valid_jsx_prop() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "tokens": {
                 "colors": {
@@ -294,6 +298,7 @@ fn generated_color_palette_utility_is_a_valid_jsx_prop() {
 #[test]
 fn disabled_color_palette_generation_omits_jsx_prop_support() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "colorPalette": {
                 "enabled": false
@@ -632,6 +637,7 @@ fn local_factory_alias_extracts_as_implicit_uppercase_component() {
 #[test]
 fn minimal_jsx_filters_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "minimal"
     }));
 
@@ -657,6 +663,7 @@ fn minimal_jsx_filters_style_props() {
 #[test]
 fn jsx_css_prop_arrays_are_processed_as_style_objects() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "minimal"
     }));
 
@@ -681,6 +688,7 @@ fn jsx_css_prop_arrays_are_processed_as_style_objects() {
 #[test]
 fn minimal_jsx_keeps_pattern_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "minimal",
         "patterns": {
             "stack": {
@@ -711,6 +719,7 @@ fn minimal_jsx_keeps_pattern_props() {
 #[test]
 fn none_jsx_keeps_component_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "none",
         "patterns": {
             "stack": {

--- a/crates/pandacss_project/tests/config.rs
+++ b/crates/pandacss_project/tests/config.rs
@@ -605,7 +605,8 @@ fn implicit_uppercase_jsx_components_follow_minimal_style_prop_mode() {
 #[test]
 fn local_factory_alias_extracts_as_implicit_uppercase_component() {
     let mut project = create_project(json!({
-        "jsxFactory": "panda"
+        "jsxFactory": "panda",
+        "jsxFramework": "react"
     }));
 
     let report = project.parse_file(

--- a/crates/pandacss_project/tests/config_recipes.rs
+++ b/crates/pandacss_project/tests/config_recipes.rs
@@ -88,6 +88,7 @@ fn tracks_and_encodes_config_recipes() {
 #[test]
 fn splits_recipe_component_variant_and_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {
@@ -173,6 +174,7 @@ fn splits_recipe_component_variant_and_style_props() {
 #[test]
 fn dotted_recipe_variant_values_do_not_emit_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {
@@ -1526,6 +1528,7 @@ fn recipe_compound_variants_combine_selected_conditions_with_smart_mode() {
 #[test]
 fn recipe_components_support_conditional_variants_and_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "breakpoints": {
                 "md": "768px"
@@ -1595,6 +1598,7 @@ fn recipe_components_support_conditional_variants_and_style_props() {
 #[test]
 fn recipe_components_can_drive_multiple_config_recipes() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "toneRecipe": {
@@ -1654,6 +1658,7 @@ fn recipe_components_can_drive_multiple_config_recipes() {
 #[test]
 fn recipe_jsx_regex_names_match_components() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {

--- a/crates/pandacss_project/tests/deprecation.rs
+++ b/crates/pandacss_project/tests/deprecation.rs
@@ -118,6 +118,7 @@ fn multiple_deprecated_props_in_one_call_each_emit_a_warning() {
 #[test]
 fn jsx_usage_emits_warning_at_element_span() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "utilities": {
             "color": { "className": "c", "deprecated": true }
         }

--- a/crates/pandacss_project/tests/extraction_pipeline.rs
+++ b/crates/pandacss_project/tests/extraction_pipeline.rs
@@ -138,7 +138,9 @@ fn cva_base_conditional_value_emits_both_branches() {
 #[test]
 fn jsx_style_props_feed_the_encoder() {
     // A JSX usage routes into the same encoder pipeline as css().
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     let report = project.parse_file(
         "a.tsx",
         indoc! {r"
@@ -161,6 +163,7 @@ fn jsx_style_props_feed_the_encoder() {
 #[test]
 fn jsx_condition_props_feed_conditioned_atoms() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "conditions": {
             "hover": "&:hover"
         },
@@ -196,6 +199,7 @@ fn jsx_condition_props_feed_conditioned_atoms() {
 #[test]
 fn jsx_factory_call_base_styles_feed_the_encoder() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxFactory": "panda"
     }));
 
@@ -235,6 +239,7 @@ fn jsx_factory_call_base_styles_feed_the_encoder() {
 #[test]
 fn jsx_factory_call_plain_style_object_stays_atomic_css() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxFactory": "panda"
     }));
 
@@ -270,6 +275,7 @@ fn jsx_factory_call_plain_style_object_stays_atomic_css() {
 #[test]
 fn jsx_factory_call_recipe_variants_feed_the_encoder() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxFactory": "panda"
     }));
 
@@ -339,6 +345,7 @@ fn jsx_factory_call_recipe_variants_feed_the_encoder() {
 #[test]
 fn jsx_factory_property_call_variants_without_base_feed_the_encoder() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxFactory": "panda"
     }));
 
@@ -387,6 +394,7 @@ fn jsx_factory_property_call_variants_without_base_feed_the_encoder() {
 #[test]
 fn jsx_factory_default_props_route_imported_recipe_usage() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": {
@@ -459,6 +467,7 @@ fn jsx_factory_default_props_route_imported_recipe_usage() {
 #[test]
 fn jsx_factory_call_tagged_template_feeds_atomic_css() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "syntax": "template-literal"
     }));
 
@@ -529,6 +538,7 @@ fn css_tagged_template_feeds_atomic_css() {
 #[test]
 fn styled_member_tagged_template_feeds_jsx_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "syntax": "template-literal"
     }));
 
@@ -787,6 +797,7 @@ fn tagged_template_token_function_interpolations_fold() {
 #[test]
 fn tagged_template_string_fragment_interpolations_fold() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "syntax": "template-literal"
     }));
 
@@ -969,6 +980,7 @@ fn bare_slot_recipe_component_in_vue_template_emits_recipe_css() {
     // inferred jsx names (`Custom.Root`, `Custom.Label`) plus the template
     // `emit_empty` rule must produce the recipe base CSS without any props.
     let mut project = create_project(json!({
+        "jsxFramework": "vue",
         "theme": {
             "slotRecipes": {
                 "custom": {
@@ -1036,6 +1048,7 @@ fn kebab_case_recipe_component_in_vue_template_selects_variants() {
     // Vue templates may reference the PascalCase binding as `<custom-root>`;
     // the inferred `CustomRoot` jsx name must match and route variants.
     let mut project = create_project(json!({
+        "jsxFramework": "vue",
         "theme": {
             "slotRecipes": {
                 "custom": {
@@ -1087,6 +1100,7 @@ fn same_name_shorthand_variant_in_vue_template_selects_variants() {
     // Vue 3.4 same-name shorthand: `:size` binds the script `size` constant,
     // so the variant resolves through the script scope.
     let mut project = create_project(json!({
+        "jsxFramework": "vue",
         "theme": {
             "slotRecipes": {
                 "custom": {
@@ -1140,6 +1154,7 @@ fn same_name_shorthand_variant_in_vue_template_selects_variants() {
 #[test]
 fn named_slot_recipe_member_tag_routes_recipe_and_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "slotRecipes": {
                 "tabs": {
@@ -1216,7 +1231,9 @@ fn named_slot_recipe_member_tag_routes_recipe_and_style_props() {
 fn jsx_css_prop_object_feeds_styles() {
     // The `css` prop's object value is treated as nested styles, not a flat
     // `css`-named atom.
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     project.parse_file(
         "a.tsx",
         indoc! {r"
@@ -1237,7 +1254,9 @@ fn jsx_css_prop_object_feeds_styles() {
 #[test]
 fn jsx_css_prop_array_merges_each_object() {
     // Array form `css={[{...}, {...}]}` — each entry contributes atoms.
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     project.parse_file(
         "a.tsx",
         indoc! {r"
@@ -1259,7 +1278,9 @@ fn jsx_css_prop_array_merges_each_object() {
 fn wildcard_css_prop_feeds_styles() {
     // `*Css` props (e.g. `inputCss`) are treated as nested style objects, the
     // same as the bare `css` prop.
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     project.parse_file(
         "a.tsx",
         indoc! {r"

--- a/crates/pandacss_project/tests/patterns.rs
+++ b/crates/pandacss_project/tests/patterns.rs
@@ -614,6 +614,7 @@ fn object_value<'a>(literal: &'a Literal, key: &str) -> Option<&'a Literal> {
 #[test]
 fn extracted_jsx_carries_kind_from_config() {
     let project = create_project(json!({
+        "jsxFramework": "react",
         "patterns": {
             "stack": { "jsxName": "Stack", "properties": { "gap": { "type": "string" } } }
         },

--- a/crates/pandacss_project/tests/patterns.rs
+++ b/crates/pandacss_project/tests/patterns.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 #[test]
 fn pattern_defaults_apply_before_transform() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "patterns": {
             "stack": {
                 "jsxName": "Stack",
@@ -257,6 +258,7 @@ fn inline_pattern_raw_spread_uses_transformed_styles_in_nested_css() {
 #[test]
 fn strict_pattern_components_only_extract_pattern_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "patterns": {
             "panel": {
                 "jsxName": "Panel",
@@ -292,6 +294,7 @@ fn strict_pattern_components_only_extract_pattern_props() {
 #[test]
 fn pattern_blocklist_filters_style_props() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "patterns": {
             "panel": {
                 "jsxName": "Panel",
@@ -419,6 +422,7 @@ fn pattern_local_import_alias_routes_to_export_pattern() {
 #[test]
 fn pattern_function_and_jsx_share_transform_with_default_values() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "patterns": {
             "stack": {
                 "jsxName": "Stack",

--- a/crates/pandacss_project/tests/svelte.rs
+++ b/crates/pandacss_project/tests/svelte.rs
@@ -182,7 +182,9 @@ fn event_action_class_and_special_tag_expressions_are_extracted() {
 
 #[test]
 fn component_style_props_are_extracted_from_markup_attrs() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     let report = project.parse_file(
         "StyleProps.svelte",
         indoc! {r#"
@@ -208,7 +210,9 @@ fn component_style_props_are_extracted_from_markup_attrs() {
 
 #[test]
 fn component_expression_style_props_and_spreads_are_extracted() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     let report = project.parse_file(
         "ExpressionStyleProps.svelte",
         indoc! {r#"
@@ -244,7 +248,9 @@ fn component_expression_style_props_and_spreads_are_extracted() {
 
 #[test]
 fn script_constants_resolve_in_markup_style_props() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     let report = project.parse_file(
         "ResolvedStyleProps.svelte",
         indoc! {r#"
@@ -330,7 +336,9 @@ fn module_reactive_await_and_special_tags_are_tolerated() {
 
 #[test]
 fn native_svelte_tags_do_not_extract_style_props() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     let report = project.parse_file(
         "Native.svelte",
         indoc! {r#"
@@ -350,6 +358,7 @@ fn native_svelte_tags_do_not_extract_style_props() {
 #[test]
 fn markup_style_props_follow_minimal_jsx_style_prop_mode() {
     let mut project = create_project(json!({
+        "jsxFramework": "react",
         "jsxStyleProps": "minimal"
     }));
     let report = project.parse_file(
@@ -374,7 +383,9 @@ fn markup_style_props_follow_minimal_jsx_style_prop_mode() {
 
 #[test]
 fn namespace_component_style_props_are_extracted() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "react"
+    }));
     let report = project.parse_file(
         "Namespace.svelte",
         indoc! {r#"

--- a/crates/pandacss_project/tests/usages.rs
+++ b/crates/pandacss_project/tests/usages.rs
@@ -41,6 +41,7 @@ fn span_text(source: &str, span: Option<Span>) -> &str {
 
 fn project() -> pandacss_project::Project {
     create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "tokens": {
                 "colors": { "red": { "300": { "value": "#f00" }, "500": { "value": "#e00" } } },
@@ -411,6 +412,7 @@ fn framework_template_style_entries_stay_report_only() {
 #[test]
 fn inspection_exposes_recipe_component_entries() {
     let result = create_project(json!({
+        "jsxFramework": "react",
         "theme": {
             "recipes": {
                 "button": { "jsx": ["Button"], "base": { "color": "red.500" } }

--- a/crates/pandacss_project/tests/vue_sfc.rs
+++ b/crates/pandacss_project/tests/vue_sfc.rs
@@ -211,7 +211,9 @@ fn complex_template_expressions_keep_delimiters_inside_strings() {
 
 #[test]
 fn component_style_props_are_extracted_from_template_attrs() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "vue"
+    }));
     let report = project.parse_file(
         "StyleProps.vue",
         indoc! {r#"
@@ -239,7 +241,9 @@ fn component_style_props_are_extracted_from_template_attrs() {
 
 #[test]
 fn component_bound_style_props_and_spreads_are_extracted() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "vue"
+    }));
     let report = project.parse_file(
         "BoundStyleProps.vue",
         indoc! {r#"
@@ -277,7 +281,9 @@ fn component_bound_style_props_and_spreads_are_extracted() {
 
 #[test]
 fn script_setup_constants_resolve_in_template_style_props() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "vue"
+    }));
     let report = project.parse_file(
         "ResolvedStyleProps.vue",
         indoc! {r#"
@@ -315,7 +321,9 @@ fn script_setup_constants_resolve_in_template_style_props() {
 
 #[test]
 fn nested_template_branches_extract_component_style_props() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "vue"
+    }));
     let report = project.parse_file(
         "NestedBranches.vue",
         indoc! {r#"
@@ -351,7 +359,9 @@ fn nested_template_branches_extract_component_style_props() {
 
 #[test]
 fn native_vue_tags_do_not_extract_style_props() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "vue"
+    }));
     let report = project.parse_file(
         "Native.vue",
         indoc! {r#"
@@ -373,6 +383,7 @@ fn native_vue_tags_do_not_extract_style_props() {
 #[test]
 fn template_style_props_follow_minimal_jsx_style_prop_mode() {
     let mut project = create_project(json!({
+        "jsxFramework": "vue",
         "jsxStyleProps": "minimal"
     }));
     let report = project.parse_file(
@@ -399,7 +410,9 @@ fn template_style_props_follow_minimal_jsx_style_prop_mode() {
 
 #[test]
 fn namespace_component_style_props_are_extracted() {
-    let mut project = create_project(json!({}));
+    let mut project = create_project(json!({
+        "jsxFramework": "vue"
+    }));
     let report = project.parse_file(
         "Namespace.vue",
         indoc! {r#"

--- a/design-notes/jsx-tag-matching.md
+++ b/design-notes/jsx-tag-matching.md
@@ -72,8 +72,12 @@ A rule must carry at least `from` or `tag` (config-validation error otherwise).
 
 ### Semantics
 
-- **Baseline + cascade.** Panda's own detection (importMap components + uppercase tags) is the baseline; user rules
-  cascade on top. For a given tag the **last matching rule wins** (`ignore` or include) — the `.gitignore` / ESLint /
+- **Baseline + cascade.** Panda's own detection is the baseline; user rules cascade on top. The baseline is importMap
+  components (always) plus the implicit "any uppercase component" heuristic — but the **uppercase heuristic only applies
+  when a `jsxFramework` is configured**, i.e. Panda is acting as a JSX styling system. Without one, a capitalized
+  non-Panda component (e.g. astro's `<Image width height>`) is not a style usage and must not be extracted (matching v1,
+  which did no JSX style-prop extraction at all without a framework). For a given tag the **last matching rule wins**
+  (`ignore` or include) — the `.gitignore` / ESLint /
   CSS-source-order model. Chosen over "ignore-always-wins" because it preserves v1's expressive power (ignore a whole
   package but re-include one component) without losing local readability, and over a specificity model because
   computed specificity is a known source of confusion. Convention: **order general rules first, specific refinements
@@ -88,8 +92,8 @@ A rule must carry at least `from` or `tag` (config-validation error otherwise).
   subpaths (`/^~\/components/`). Relative specifiers (`./button`) are position-dependent — prefer `tag` or an alias.
 - **Preset merge.** Rules concatenate in config-resolution order with the app's rules last, so an app naturally
   overrides preset-contributed rules — consistent with last-match-wins.
-- Local, non-imported uppercase tags keep the native default (`is_uppercase_component_tag`) unless a later `ignore`
-  rule removes them.
+- Local, non-imported uppercase tags keep the native default (`is_uppercase_component_tag`, gated on a configured
+  `jsxFramework`) unless a later `ignore` rule removes them.
 
 This one surface replaces all three v1 knobs: `matchTag` (include by name), `matchTagMode: 'override'` (`ignore`), and
 `matchTagProp` (`props` / `ignoreProps`).

--- a/design-notes/jsx-tag-matching.md
+++ b/design-notes/jsx-tag-matching.md
@@ -72,12 +72,12 @@ A rule must carry at least `from` or `tag` (config-validation error otherwise).
 
 ### Semantics
 
-- **Baseline + cascade.** Panda's own detection is the baseline; user rules cascade on top. The baseline is importMap
-  components (always) plus the implicit "any uppercase component" heuristic — but the **uppercase heuristic only applies
-  when a `jsxFramework` is configured**, i.e. Panda is acting as a JSX styling system. Without one, a capitalized
-  non-Panda component (e.g. astro's `<Image width height>`) is not a style usage and must not be extracted (matching v1,
-  which did no JSX style-prop extraction at all without a framework). For a given tag the **last matching rule wins**
-  (`ignore` or include) — the `.gitignore` / ESLint /
+- **Baseline + cascade.** JSX style-prop extraction is opt-in via `jsxFramework`. Without it, JSX tags never produce
+  style usages, even when they are imported from Panda JSX modules or matched by configured component names. This
+  matches v1, where the JSX parser callbacks were not enabled without a framework. When `jsxFramework` is configured,
+  Panda's own detection becomes the baseline: importMap components plus the implicit "any uppercase component"
+  heuristic. User rules cascade on top of that baseline. For a given tag the **last matching rule wins** (`ignore` or
+  include) — the `.gitignore` / ESLint /
   CSS-source-order model. Chosen over "ignore-always-wins" because it preserves v1's expressive power (ignore a whole
   package but re-include one component) without losing local readability, and over a specificity model because
   computed specificity is a known source of confusion. Convention: **order general rules first, specific refinements
@@ -92,8 +92,8 @@ A rule must carry at least `from` or `tag` (config-validation error otherwise).
   subpaths (`/^~\/components/`). Relative specifiers (`./button`) are position-dependent — prefer `tag` or an alias.
 - **Preset merge.** Rules concatenate in config-resolution order with the app's rules last, so an app naturally
   overrides preset-contributed rules — consistent with last-match-wins.
-- Local, non-imported uppercase tags keep the native default (`is_uppercase_component_tag`, gated on a configured
-  `jsxFramework`) unless a later `ignore` rule removes them.
+- Local, non-imported uppercase tags keep the native default (`is_uppercase_component_tag`) only after
+  `jsxFramework` enables JSX extraction, unless a later `ignore` rule removes them.
 
 This one surface replaces all three v1 knobs: `matchTag` (include by name), `matchTagMode: 'override'` (`ignore`), and
 `matchTagProp` (`props` / `ignoreProps`).

--- a/packages/cli/__tests__/buildinfo.test.ts
+++ b/packages/cli/__tests__/buildinfo.test.ts
@@ -92,6 +92,7 @@ describe('buildinfo command', () => {
       `export default {
         outdir: 'styled-system',
         include: ['**/*.tsx'],
+        jsxFramework: 'react',
         importMap: { css: ['@panda/css'], recipe: ['@panda/recipes'], pattern: ['@panda/patterns'], jsx: ['@panda/jsx'], tokens: ['@panda/tokens'] },
         theme: { recipes: { button: { jsx: ['Button'], base: { display: 'inline-flex' } } } },
       }`,


### PR DESCRIPTION
Stop generating dead CSS from non-Panda components when you haven't set `jsxFramework`.

## The bug

Without a `jsxFramework`, Panda still read style-prop-named attributes off any capitalized component. So astro's `<Image width="900" height="800" />` turned into `.w_900` and `.h_800` — dead atomic CSS you never asked for. v1 didn't do this: it extracted no JSX style props without a framework. Reported in [#3599](https://github.com/chakra-ui/panda/discussions/3599#discussioncomment-17432000).

## The fix

The "any uppercase component" rule now only applies when `jsxFramework` is set. Your real Panda components (imported from the styled-system) and any project that sets `jsxFramework` are unchanged. For the framework case, the opt-out is still `jsxMatchTag`.

One shared check covers every target: `.tsx`, `.astro`, `.vue`, `.svelte`.

## How it was checked

- new regression tests per framework: no framework → non-Panda `<Image>` ignored, Panda `<Box>` still extracted; with framework → `<Image>` extracted
- `cargo test --workspace` — green, CSS snapshots unchanged
- `pnpm --filter @pandacss/compiler test` — 189 pass