### PR TITLE
feat(config): nested designSystem chains and smart include

### DIFF
--- a/.changeset/design-system-nested-chains.md
+++ b/.changeset/design-system-nested-chains.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/config': minor
+'@pandacss/compiler': minor
+---
+
+Compose design systems. A design system can now extend another by setting its own `designSystem` field, and you still
+write one line in your config — the parent comes along for free.
+
+Set `designSystem: '@acme/marketing'`, and if `@acme/marketing` was built on `@acme/foundations`, Panda walks the chain
+and merges both presets under your config: foundations first, then marketing, then you on top. Each parent resolves from
+where its child is installed, so it works in monorepos and Docker builds where the consumer only depends on the leaf.
+Each design system's pre-extracted styles hydrate under its own name. A cycle (`@a` → `@b` → `@a`) or a parent that
+isn't installed stops the build with a message that names the package and what to do.

--- a/.changeset/smart-include.md
+++ b/.changeset/smart-include.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/config': minor
+---
+
+Name a package in `include` and Panda scans it for you. A library that uses Panda but isn't a design system — say a charts package built on `@acme/ds` — can go straight in `include` as a bare specifier (or via `--include`); Panda resolves it and globs its source so its styles land in your CSS. No hand-written `./node_modules/...` glob, and the package's own dependencies are skipped.
+
+If you point `include` at an actual design system (a package shipping `panda.lib.json`), Panda stops and tells you to move it to `designSystem` — and reports every one at once, not one per run. Plain globs and local folder names work exactly as before.

--- a/design-notes/design-system-manifest.md
+++ b/design-notes/design-system-manifest.md
@@ -387,9 +387,14 @@ them**.
    components are never re-extracted. Diagnostics: not-found, version-mismatch, peer-range. Manifest/preset/build-info
    registered as build deps. _Deferred to later phases:_ build-info tree-shaking to app imports (optimization) and the
    stale-build-info `files` re-extract fallback (Phase 5).
-3. **Nested chains.** `resolveChain` over manifest values: ordered plan, resolve-against-manifest-dir, cycle guard. Host
-   reads the parent chain and feeds values in. Diagnostics: cycle, parent-not-found. Tested as in-memory arrays (depth-N,
-   diamond, cycle).
+3. **Nested chains. ✅ Complete.** A manifest's own `designSystem` field links to its parent. The host
+   (`packages/config` `loadDesignSystemChain`) walks that chain, resolving each parent against the **previous manifest's
+   directory** (not the consumer cwd, so transitive parents work in workspaces and Docker layers), guards cycles with a
+   visited set, and merges presets root → leaf (ancestors lowest, leaf and app override). The node driver
+   (`packages/compiler` `hydrateDesignSystem`) hydrates each level under its own name. Diagnostics: cycle,
+   parent-not-found. The engine `resolveChain` primitive (root-first order, diamond dedup, cycle path) lands with single
+   level and is tested as in-memory arrays (depth-N, diamond, cycle); the host walk is tested end-to-end (depth-2 merge
+   order, dual importMap roots, resolve-against-manifest-dir, cycle, parent-not-found).
 4. **Smart `include`.** Bare specifiers resolve via Node resolution: manifest present → redirect; no manifest → auto-glob +
    extract. Diagnostic: in-include (batched).
 5. **`panda lib` + propagation.** The command (+ `--watch`): glob `src/` → `create` → write manifest/buildinfo/preset → sync

--- a/design-notes/design-system-manifest.md
+++ b/design-notes/design-system-manifest.md
@@ -399,8 +399,19 @@ them**.
    so the host orders it by reversing the walk and catches cycles by path — `resolveChain`'s topo-sort, diamond dedup, and
    second cycle pass would all be no-ops on linear input. The runtime wiring earns its place only with [plural
    parents](#why-singular), where a node gains two parents, the walk becomes a DAG, and diamonds can actually form.
-4. **Smart `include`.** Bare specifiers resolve via Node resolution: manifest present → redirect; no manifest → auto-glob +
-   extract. Diagnostic: in-include (batched).
+4. **Smart `include`. ✅ Complete.** Bare specifiers in `include` resolve via Node resolution (`packages/config`
+   `expandSmartInclude`, run during `resolveAuthoredPresets`). An entry is treated as a package only if it matches the npm
+   package-name grammar — globs (incl. extglob), relative/absolute paths, and multi-segment paths pass through untouched.
+   The package directory resolves exports-safely (`<spec>/package.json`, else the package entry walked up to its
+   `package.json`); a `panda.lib.json` is then detected **on disk** (immune to `exports`): present → it's a design system,
+   batched `design_system_in_include` error redirecting to `designSystem`; absent → auto-glob the package source
+   (`<pkg>/**/*.{…}` over `SMART_INCLUDE_EXTENSIONS`, relative under cwd / absolute when hoisted, POSIX-separated), emit a
+   matching `<pkg>/**/node_modules/**` exclude so the consumed package's own deps aren't scanned (pnpm symlink farms), and
+   register its `package.json` as a config dep. The CLI `--include` override flows through the same resolution
+   (`resolveSmartInclude`), so a bare specifier works there too. _Deferred:_ cross-package **source** watch (open item #4)
+   — re-running cssgen on edits inside the consumed package, beyond the config-dep invalidation wired here. The extension
+   list is a hand-maintained mirror of the engine's parseable set (config is binding-free); a future engine-side extension
+   gate would make it the single source of truth.
 5. **`panda lib` + propagation.** The command (+ `--watch`): glob `src/` → `create` → write manifest/buildinfo/preset → sync
    exports. Register resolved paths as build deps; drift receipt + persisted state; stale-buildinfo fallback; token-conflict
    warning. Remove `ship`/`emit-pkg` with a migration note.

--- a/design-notes/design-system-manifest.md
+++ b/design-notes/design-system-manifest.md
@@ -394,7 +394,11 @@ them**.
    (`packages/compiler` `hydrateDesignSystem`) hydrates each level under its own name. Diagnostics: cycle,
    parent-not-found. The engine `resolveChain` primitive (root-first order, diamond dedup, cycle path) lands with single
    level and is tested as in-memory arrays (depth-N, diamond, cycle); the host walk is tested end-to-end (depth-2 merge
-   order, dual importMap roots, resolve-against-manifest-dir, cycle, parent-not-found).
+   order, dual importMap roots, resolve-against-manifest-dir, cycle, parent-not-found). _Deferred:_ the runtime path does
+   **not** feed manifests through `resolveChain`. With a single `designSystem` parent the reachable chain is a strict line,
+   so the host orders it by reversing the walk and catches cycles by path — `resolveChain`'s topo-sort, diamond dedup, and
+   second cycle pass would all be no-ops on linear input. The runtime wiring earns its place only with [plural
+   parents](#why-singular), where a node gains two parents, the walk becomes a DAG, and diamonds can actually form.
 4. **Smart `include`.** Bare specifiers resolve via Node resolution: manifest present → redirect; no manifest → auto-glob +
    extract. Diagnostic: in-include (batched).
 5. **`panda lib` + propagation.** The command (+ `--watch`): glob `src/` → `create` → write manifest/buildinfo/preset → sync

--- a/packages/compiler/src/design-system.ts
+++ b/packages/compiler/src/design-system.ts
@@ -2,12 +2,15 @@ import { type BuildInfoArtifact, type Compiler } from '@pandacss/compiler-shared
 import { readPandaVersion, type LoadConfigResult } from '@pandacss/config'
 import { readFileSync } from 'node:fs'
 
-type ResolvedDesignSystem = NonNullable<NonNullable<LoadConfigResult['metadata']>['designSystem']>
+type ResolvedDesignSystem = NonNullable<NonNullable<LoadConfigResult['metadata']>['designSystem']>[number]
 
-export function hydrateDesignSystem(compiler: Compiler, ds: ResolvedDesignSystem | undefined): void {
-  if (!ds) return
-
+export function hydrateDesignSystem(compiler: Compiler, chain: ResolvedDesignSystem[] | undefined): void {
+  if (!chain || chain.length === 0) return
   const pandaVersion = readPandaVersion()
+  for (const ds of chain) hydrateLevel(compiler, ds, pandaVersion)
+}
+
+function hydrateLevel(compiler: Compiler, ds: ResolvedDesignSystem, pandaVersion: string | undefined): void {
   const compat = compiler.designSystem.validate(ds.manifest, { pandaVersion })
   if (!compat.ok) {
     throw incompatibleManifestError(compiler, ds, compat.reason, pandaVersion)

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -8,7 +8,14 @@ import {
   type Driver,
   type SourceChange,
 } from '@pandacss/compiler-shared'
-import { type HostHooks, type LoadConfigResult, diffConfig, loadConfig, resolveSmartInclude } from '@pandacss/config'
+import {
+  type HostHooks,
+  type LoadConfigResult,
+  diffConfig,
+  loadConfig,
+  mergeExcludes,
+  resolveSmartInclude,
+} from '@pandacss/config'
 import { hydrateDesignSystem } from './design-system'
 import { createCompilerFromSnapshot } from './index'
 
@@ -37,8 +44,8 @@ function applyIncludeOverride(loaded: LoadConfigResult, cwd: string, include: st
   const resolved = resolveSmartInclude(include, cwd, deps)
   loaded.config.include = resolved.include
   if (resolved.excludes.length > 0) {
-    const existing = Array.isArray(loaded.config.exclude) ? loaded.config.exclude : []
-    loaded.config.exclude = [...existing, ...resolved.excludes]
+    const existing = Array.isArray(loaded.config.exclude) ? loaded.config.exclude : undefined
+    loaded.config.exclude = mergeExcludes(existing, resolved.excludes)
   }
   loaded.dependencies = Array.from(deps)
 }

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -8,7 +8,7 @@ import {
   type Driver,
   type SourceChange,
 } from '@pandacss/compiler-shared'
-import { type HostHooks, type LoadConfigResult, diffConfig, loadConfig } from '@pandacss/config'
+import { type HostHooks, type LoadConfigResult, diffConfig, loadConfig, resolveSmartInclude } from '@pandacss/config'
 import { hydrateDesignSystem } from './design-system'
 import { createCompilerFromSnapshot } from './index'
 
@@ -28,8 +28,19 @@ type CodegenPrepareHooks = NonNullable<HostHooks['codegen:prepare']>
  */
 export async function createNodeDriver(options: NodeDriverOptions): Promise<Driver> {
   const loaded = await loadConfig({ cwd: options.cwd, file: options.configPath })
-  if (options.include?.length) loaded.config.include = options.include
+  if (options.include?.length) applyIncludeOverride(loaded, options.cwd, options.include)
   return new NodeDriver(options, loaded)
+}
+
+function applyIncludeOverride(loaded: LoadConfigResult, cwd: string, include: string[]): void {
+  const deps = new Set(loaded.dependencies)
+  const resolved = resolveSmartInclude(include, cwd, deps)
+  loaded.config.include = resolved.include
+  if (resolved.excludes.length > 0) {
+    const existing = Array.isArray(loaded.config.exclude) ? loaded.config.exclude : []
+    loaded.config.exclude = [...existing, ...resolved.excludes]
+  }
+  loaded.dependencies = Array.from(deps)
 }
 
 class NodeDriver extends BaseDriver {
@@ -57,7 +68,7 @@ class NodeDriver extends BaseDriver {
   async reload(): Promise<DiffConfigResult> {
     const next = await loadConfig({ cwd: this.#options.cwd, file: this.#options.configPath })
     // Re-apply before diffing so the override isn't seen as a config change.
-    if (this.#options.include?.length) next.config.include = this.#options.include
+    if (this.#options.include?.length) applyIncludeOverride(next, this.#options.cwd, this.#options.include)
     const diff = diffConfig(this.#loaded, next)
     if (diff.hasChanged) {
       this.#loaded = next

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -60,10 +60,10 @@ describe('resolveAuthoredPresets / designSystem', () => {
       },
       'styled-system',
     ])
-    expect(metadata?.designSystem?.name).toBe('@acme/ds')
-    expect(metadata?.designSystem?.manifest.name).toBe('@acme/ds')
-    expect(metadata?.designSystem?.buildInfoPath).toMatch(/panda\.buildinfo\.json$/)
-    expect(metadata?.designSystem?.files).toEqual(['./dist/**/*.mjs'])
+    expect(metadata?.designSystem?.map((ds) => ds.name)).toEqual(['@acme/ds'])
+    expect(metadata?.designSystem?.[0]?.manifest.name).toBe('@acme/ds')
+    expect(metadata?.designSystem?.[0]?.buildInfoPath).toMatch(/panda\.buildinfo\.json$/)
+    expect(metadata?.designSystem?.[0]?.files).toEqual(['./dist/**/*.mjs'])
   })
 
   test('respects a custom outdir basename in the wired importMap', async () => {
@@ -111,7 +111,7 @@ describe('resolveAuthoredPresets / designSystem', () => {
     writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
 
     const { metadata } = await resolveAuthoredPresets({ designSystem: '@acme/future' } as any, cwd)
-    expect(metadata?.designSystem?.buildInfoPath).toMatch(/b\.json$/)
+    expect(metadata?.designSystem?.[0]?.buildInfoPath).toMatch(/b\.json$/)
   })
 
   test('rejects a manifest missing a buildInfo entry', async () => {
@@ -128,30 +128,126 @@ describe('resolveAuthoredPresets / designSystem', () => {
     )
   })
 
-  test('rejects parent design systems in the single-level loader', async () => {
-    const pkg = join(cwd, 'node_modules', '@acme', 'child')
-    mkdirSync(pkg, { recursive: true })
-    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ name: '@acme/child' }))
-    writeFileSync(
-      join(pkg, 'panda.lib.json'),
-      JSON.stringify({
-        schemaVersion: 1,
-        name: '@acme/child',
-        panda: '^2.0.0',
-        preset: './p.mjs',
-        buildInfo: './b.json',
-        designSystem: '@acme/base',
-      }),
-    )
-    writeFileSync(join(pkg, 'p.mjs'), 'export default {}')
-    await expect(resolveAuthoredPresets({ designSystem: '@acme/child' } as any, cwd)).rejects.toThrow(
-      /nested design systems are not supported yet/,
-    )
-  })
-
   test('errors with guidance when the package does not resolve', async () => {
     await expect(resolveAuthoredPresets({ designSystem: '@acme/missing' } as any, cwd)).rejects.toThrow(
       /designSystem "@acme\/missing" could not be resolved/,
     )
+  })
+})
+
+describe('resolveAuthoredPresets / designSystem nested chains', () => {
+  let cwd: string
+
+  const writeManifest = (dir: string, manifest: Record<string, unknown>, preset: string) => {
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: manifest.name }))
+    writeFileSync(join(dir, 'panda.lib.json'), JSON.stringify({ schemaVersion: 1, panda: '^2.0.0', ...manifest }))
+    writeFileSync(join(dir, 'preset.mjs'), preset)
+  }
+
+  beforeAll(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'panda-ds-chain-'))
+    const mods = join(cwd, 'node_modules')
+
+    writeManifest(
+      join(mods, '@acme', 'marketing'),
+      {
+        name: '@acme/marketing',
+        preset: './preset.mjs',
+        buildInfo: './bi.json',
+        designSystem: '@acme/foundations',
+        importMap: { css: '@acme/marketing/css' },
+      },
+      `export default { name: '@acme/marketing', theme: { tokens: { colors: { brand: { value: 'mk' }, mkOnly: { value: 'mk' } } } } }`,
+    )
+    writeManifest(
+      join(mods, '@acme', 'marketing', 'node_modules', '@acme', 'foundations'),
+      { name: '@acme/foundations', preset: './preset.mjs', buildInfo: './bi.json' },
+      `export default { name: '@acme/foundations', theme: { tokens: { colors: { brand: { value: 'fd' }, fdOnly: { value: 'fd' } } } } }`,
+    )
+
+    writeManifest(
+      join(mods, '@acme', 'loop-a'),
+      { name: '@acme/loop-a', preset: './preset.mjs', buildInfo: './bi.json', designSystem: '@acme/loop-b' },
+      `export default { name: '@acme/loop-a' }`,
+    )
+    writeManifest(
+      join(mods, '@acme', 'loop-b'),
+      { name: '@acme/loop-b', preset: './preset.mjs', buildInfo: './bi.json', designSystem: '@acme/loop-a' },
+      `export default { name: '@acme/loop-b' }`,
+    )
+
+    writeManifest(
+      join(mods, '@acme', 'orphan'),
+      { name: '@acme/orphan', preset: './preset.mjs', buildInfo: './bi.json', designSystem: '@acme/ghost' },
+      `export default { name: '@acme/orphan' }`,
+    )
+
+    writeManifest(
+      join(mods, '@acme', 'skinned'),
+      { name: '@acme/skinned', preset: './preset.mjs', buildInfo: './bi.json', designSystem: '@acme/raw' },
+      `export default { name: '@acme/skinned', theme: { tokens: { colors: { brand: { value: 'skin' }, skinOnly: { value: 'skin' } } } } }`,
+    )
+    writeManifest(
+      join(mods, '@acme', 'raw'),
+      { name: '@acme/raw-identity', preset: './preset.mjs', buildInfo: './bi.json' },
+      `export default { name: '@acme/raw-identity', theme: { tokens: { colors: { brand: { value: 'raw' }, rawOnly: { value: 'raw' } } } } }`,
+    )
+  })
+
+  afterAll(() => rmSync(cwd, { recursive: true, force: true }))
+
+  test('merges ancestors root-first so the leaf and the app override the root', async () => {
+    const { config } = await resolveAuthoredPresets(
+      { designSystem: '@acme/marketing', theme: { tokens: { colors: { brand: { value: 'app' } } } } } as any,
+      cwd,
+    )
+    const colors = config.theme?.tokens?.colors
+    if (!colors) throw new Error('expected resolved color tokens')
+    expect(colors.brand.value).toBe('app')
+    expect(colors.mkOnly.value).toBe('mk')
+    expect(colors.fdOnly.value).toBe('fd')
+  })
+
+  test('records the resolved chain root-first in metadata', async () => {
+    const { metadata } = await resolveAuthoredPresets({ designSystem: '@acme/marketing' } as any, cwd)
+    expect(metadata?.designSystem?.map((ds) => ds.name)).toEqual(['@acme/foundations', '@acme/marketing'])
+  })
+
+  test('wires one importMap root per design system, root-first, then the local outdir', async () => {
+    const { config } = await resolveAuthoredPresets({ designSystem: '@acme/marketing' } as any, cwd)
+    expect(config.importMap).toEqual([
+      '@acme/foundations',
+      {
+        css: '@acme/marketing/css',
+        recipes: '@acme/marketing/recipes',
+        patterns: '@acme/marketing/patterns',
+        jsx: '@acme/marketing/jsx',
+        tokens: '@acme/marketing/tokens',
+      },
+      'styled-system',
+    ])
+  })
+
+  test('reports a cycle in the parent chain', async () => {
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/loop-a' } as any, cwd)).rejects.toThrow(
+      /Design-system cycle: @acme\/loop-a → @acme\/loop-b → @acme\/loop-a/,
+    )
+  })
+
+  test('reports a parent that is not installed alongside its declaring library', async () => {
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/orphan' } as any, cwd)).rejects.toThrow(
+      /designSystem "@acme\/orphan" extends "@acme\/ghost"/,
+    )
+  })
+
+  test('links the chain by specifier, so a parent whose manifest name differs still merges as the root', async () => {
+    const { config, metadata } = await resolveAuthoredPresets({ designSystem: '@acme/skinned' } as any, cwd)
+    const colors = config.theme?.tokens?.colors
+    if (!colors) throw new Error('expected resolved color tokens')
+    expect(colors.brand.value).toBe('skin')
+    expect(colors.rawOnly.value).toBe('raw')
+    expect(colors.skinOnly.value).toBe('skin')
+    expect(metadata?.designSystem?.map((ds) => ds.name)).toEqual(['@acme/raw-identity', '@acme/skinned'])
   })
 })

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -133,6 +133,19 @@ describe('resolveAuthoredPresets / designSystem', () => {
       /designSystem "@acme\/missing" could not be resolved/,
     )
   })
+
+  test('throws when manifest resolution fails for an unexpected reason', async () => {
+    const pkg = join(cwd, 'node_modules', '@acme', 'broken-resolve')
+    mkdirSync(pkg, { recursive: true })
+    writeFileSync(
+      join(pkg, 'package.json'),
+      JSON.stringify({ name: '@acme/broken-resolve', exports: { './panda.lib.json': 42 } }),
+    )
+
+    await expect(resolveAuthoredPresets({ designSystem: '@acme/broken-resolve' } as any, cwd)).rejects.toThrow(
+      /Failed to resolve designSystem "@acme\/broken-resolve"/,
+    )
+  })
 })
 
 describe('resolveAuthoredPresets / designSystem nested chains', () => {

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -249,5 +249,6 @@ describe('resolveAuthoredPresets / designSystem nested chains', () => {
     expect(colors.rawOnly.value).toBe('raw')
     expect(colors.skinOnly.value).toBe('skin')
     expect(metadata?.designSystem?.map((ds) => ds.name)).toEqual(['@acme/raw-identity', '@acme/skinned'])
+    expect(config.importMap).toEqual(['@acme/raw', '@acme/skinned', 'styled-system'])
   })
 })

--- a/packages/config/__tests__/smart-include.test.ts
+++ b/packages/config/__tests__/smart-include.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { resolveAuthoredPresets } from '../src/preset'
+import { resolveSmartInclude, SMART_INCLUDE_EXTENSIONS } from '../src/smart-include'
+
+const EXT = SMART_INCLUDE_EXTENSIONS.join(',')
+
+describe('resolveAuthoredPresets / smart include', () => {
+  let cwd: string
+
+  const pkg = (name: string, files: Record<string, string>, extra: Record<string, unknown> = {}) => {
+    const dir = join(cwd, 'node_modules', ...name.split('/'))
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, ...extra }))
+    for (const [file, content] of Object.entries(files)) {
+      mkdirSync(join(dir, ...file.split('/').slice(0, -1)), { recursive: true })
+      writeFileSync(join(dir, file), content)
+    }
+  }
+
+  const manifest = (name: string) =>
+    JSON.stringify({ schemaVersion: 1, name, panda: '^2.0.0', preset: './p.mjs', buildInfo: './b.json' })
+
+  beforeAll(() => {
+    cwd = realpathSync(mkdtempSync(join(tmpdir(), 'panda-include-')))
+
+    pkg('@acme/charts', { 'index.js': 'export const Chart = () => {}' })
+    pkg('widgets', { 'index.js': 'export const Widget = () => {}' })
+
+    pkg('@acme/sealed', { 'dist/index.js': 'export const Sealed = () => {}' }, { exports: { '.': './dist/index.js' } })
+
+    pkg('@acme/ds', { 'panda.lib.json': manifest('@acme/ds') })
+    pkg('@acme/ds2', { 'panda.lib.json': manifest('@acme/ds2') })
+
+    pkg(
+      '@acme/sealed-ds',
+      { 'dist/index.js': 'export default {}', 'panda.lib.json': manifest('@acme/sealed-ds') },
+      { exports: { '.': './dist/index.js' } },
+    )
+
+    mkdirSync(join(cwd, 'components'), { recursive: true })
+  })
+
+  afterAll(() => rmSync(cwd, { recursive: true, force: true }))
+
+  test('auto-globs a consumed package that ships no manifest (scoped and unscoped)', async () => {
+    const { config, dependencies } = await resolveAuthoredPresets(
+      { include: ['./src/**/*.tsx', '@acme/charts', 'widgets'] } as any,
+      cwd,
+    )
+    expect(config.include).toEqual([
+      './src/**/*.tsx',
+      `node_modules/@acme/charts/**/*.{${EXT}}`,
+      `node_modules/widgets/**/*.{${EXT}}`,
+    ])
+    expect(config.exclude).toEqual([
+      '**/*.d.ts',
+      'node_modules/@acme/charts/**/node_modules/**',
+      'node_modules/widgets/**/node_modules/**',
+    ])
+    expect(dependencies.some((d) => d.endsWith(join('@acme', 'charts', 'package.json')))).toBe(true)
+    expect(dependencies.some((d) => d.endsWith(join('widgets', 'package.json')))).toBe(true)
+  })
+
+  test("appends the nested node_modules guard to the user's existing excludes", async () => {
+    const { config } = await resolveAuthoredPresets(
+      { include: ['@acme/charts'], exclude: ['**/*.stories.tsx'] } as any,
+      cwd,
+    )
+    expect(config.exclude).toEqual(['**/*.stories.tsx', 'node_modules/@acme/charts/**/node_modules/**'])
+  })
+
+  test('resolveSmartInclude returns the rewritten include, nested-node_modules excludes, and a dep', () => {
+    const deps = new Set<string>()
+    const result = resolveSmartInclude(['@acme/charts', './src/**/*.ts'], cwd, deps)
+    expect(result.changed).toBe(true)
+    expect(result.include).toEqual([`node_modules/@acme/charts/**/*.{${EXT}}`, './src/**/*.ts'])
+    expect(result.excludes).toEqual(['node_modules/@acme/charts/**/node_modules/**'])
+    expect([...deps].some((d) => d.endsWith(join('@acme', 'charts', 'package.json')))).toBe(true)
+  })
+
+  test('resolveSmartInclude leaves a glob-only list unchanged', () => {
+    const result = resolveSmartInclude(['**/*.tsx', './app/**'], cwd, new Set())
+    expect(result.changed).toBe(false)
+    expect(result.excludes).toEqual([])
+  })
+
+  test('resolves a package whose exports hide ./package.json via its entry', async () => {
+    const { config } = await resolveAuthoredPresets({ include: ['@acme/sealed'] } as any, cwd)
+    expect(config.include).toEqual([`node_modules/@acme/sealed/**/*.{${EXT}}`])
+  })
+
+  test('redirects a manifest-bearing package to designSystem', async () => {
+    await expect(resolveAuthoredPresets({ include: ['@acme/ds'] } as any, cwd)).rejects.toThrow(
+      /Design system in `include`: "@acme\/ds".*it belongs in `designSystem`/s,
+    )
+  })
+
+  test('detects a manifest on disk even when exports would hide it', async () => {
+    await expect(resolveAuthoredPresets({ include: ['@acme/sealed-ds'] } as any, cwd)).rejects.toThrow(
+      /Design system in `include`: "@acme\/sealed-ds"/,
+    )
+  })
+
+  test('batches every manifest-bearing offender into one error, skipping consumers', async () => {
+    await expect(
+      resolveAuthoredPresets({ include: ['@acme/ds', '@acme/charts', '@acme/ds2'] } as any, cwd),
+    ).rejects.toThrow(/Design systems in `include`: "@acme\/ds", "@acme\/ds2"/)
+  })
+
+  test('leaves globs, paths, and local directory names untouched', async () => {
+    const include = [
+      '**/*.tsx',
+      './app/**/*.ts',
+      '../shared/**/*.ts',
+      'src/components/**',
+      '+(a|b).ts',
+      '@(x).ts',
+      '[abc].ts',
+      '{a,b}.ts',
+      'components',
+      '@acme/not-installed',
+    ]
+    const { config } = await resolveAuthoredPresets({ include } as any, cwd)
+    expect(config.include).toEqual(include)
+  })
+
+  test('is a no-op when there is no include', async () => {
+    const { config } = await resolveAuthoredPresets({} as any, cwd)
+    expect(config.include).toBeUndefined()
+  })
+})

--- a/packages/config/__tests__/smart-include.test.ts
+++ b/packages/config/__tests__/smart-include.test.ts
@@ -56,7 +56,6 @@ describe('resolveAuthoredPresets / smart include', () => {
       `node_modules/widgets/**/*.{${EXT}}`,
     ])
     expect(config.exclude).toEqual([
-      '**/*.d.ts',
       'node_modules/@acme/charts/**/node_modules/**',
       'node_modules/widgets/**/node_modules/**',
     ])

--- a/packages/config/__tests__/smart-include.test.ts
+++ b/packages/config/__tests__/smart-include.test.ts
@@ -28,6 +28,7 @@ describe('resolveAuthoredPresets / smart include', () => {
 
     pkg('@acme/charts', { 'index.js': 'export const Chart = () => {}' })
     pkg('widgets', { 'index.js': 'export const Widget = () => {}' })
+    pkg('components', { 'index.js': 'export const PackageComponent = () => {}' })
 
     pkg('@acme/sealed', { 'dist/index.js': 'export const Sealed = () => {}' }, { exports: { '.': './dist/index.js' } })
 
@@ -124,6 +125,12 @@ describe('resolveAuthoredPresets / smart include', () => {
     ]
     const { config } = await resolveAuthoredPresets({ include } as any, cwd)
     expect(config.include).toEqual(include)
+  })
+
+  test('prefers an existing local path over a package with the same name', async () => {
+    const { config } = await resolveAuthoredPresets({ include: ['components'] } as any, cwd)
+    expect(config.include).toEqual(['components'])
+    expect(config.exclude).toBeUndefined()
   })
 
   test('is a no-op when there is no include', async () => {

--- a/packages/config/__tests__/smart-include.test.ts
+++ b/packages/config/__tests__/smart-include.test.ts
@@ -31,6 +31,7 @@ describe('resolveAuthoredPresets / smart include', () => {
     pkg('components', { 'index.js': 'export const PackageComponent = () => {}' })
 
     pkg('@acme/sealed', { 'dist/index.js': 'export const Sealed = () => {}' }, { exports: { '.': './dist/index.js' } })
+    pkg('@acme/broken', { 'index.js': 'export const Broken = () => {}' }, { exports: { '.': 42 } })
 
     pkg('@acme/ds', { 'panda.lib.json': manifest('@acme/ds') })
     pkg('@acme/ds2', { 'panda.lib.json': manifest('@acme/ds2') })
@@ -90,6 +91,12 @@ describe('resolveAuthoredPresets / smart include', () => {
   test('resolves a package whose exports hide ./package.json via its entry', async () => {
     const { config } = await resolveAuthoredPresets({ include: ['@acme/sealed'] } as any, cwd)
     expect(config.include).toEqual([`node_modules/@acme/sealed/**/*.{${EXT}}`])
+  })
+
+  test('throws when package resolution fails for an unexpected reason', async () => {
+    await expect(resolveAuthoredPresets({ include: ['@acme/broken'] } as any, cwd)).rejects.toThrow(
+      /Failed to resolve include package "@acme\/broken"/,
+    )
   })
 
   test('redirects a manifest-bearing package to designSystem', async () => {

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -21,24 +21,69 @@ export interface ResolvedDesignSystem {
   importMap?: DesignSystemManifest['importMap']
 }
 
-export async function loadDesignSystemPreset(
+export interface DesignSystemLevel {
+  preset: ExtendableConfig
+  info: ResolvedDesignSystem
+}
+
+export async function loadDesignSystemChain(
   spec: string,
   cwd: string,
   deps: Set<string>,
-): Promise<{ preset: ExtendableConfig; info: ResolvedDesignSystem }> {
-  const require = createRequire(resolve(cwd, 'noop.js'))
+): Promise<DesignSystemLevel[]> {
+  const levels: DesignSystemLevel[] = []
+  const seenAt = new Map<string, number>()
 
-  let manifestPath: string
-  try {
-    manifestPath = require.resolve(`${spec}/panda.lib.json`, { paths: [cwd] })
-  } catch {
-    throw new PandaError(
-      'CONFIG_ERROR',
-      `💥 designSystem ${JSON.stringify(spec)} could not be resolved. Install it, or — if it isn't a Panda design system — build it with \`panda lib\`.`,
-    )
+  let currentSpec = spec
+  let fromDir = cwd
+  let declaredBy: string | undefined
+
+  for (;;) {
+    const manifestPath = resolveManifestPath(currentSpec, fromDir)
+    if (manifestPath === undefined) {
+      throw declaredBy === undefined ? notResolvedError(currentSpec) : parentNotResolvedError(declaredBy, currentSpec)
+    }
+    const seen = seenAt.get(manifestPath)
+    if (seen !== undefined) {
+      throw cycleError([...levels.slice(seen).map((level) => level.info.name), levels[seen].info.name])
+    }
+    seenAt.set(manifestPath, levels.length)
+    deps.add(manifestPath)
+
+    const { level, parent } = await loadManifestLevel(currentSpec, manifestPath, deps)
+    levels.push(level)
+
+    if (parent === undefined) break
+    declaredBy = level.info.name
+    fromDir = dirname(manifestPath)
+    currentSpec = parent
   }
-  deps.add(manifestPath)
 
+  return levels.reverse()
+}
+
+export function withDesignSystemImportMap(config: UserConfig, infos: ResolvedDesignSystem[]): UserConfig {
+  const existing: ImportMapOption[] =
+    config.importMap === undefined ? [] : Array.isArray(config.importMap) ? config.importMap : [config.importMap]
+  const roots: ImportMapOption[] = infos.map((info) =>
+    info.importMap ? designSystemImportMap(info.importMap, info.name) : info.name,
+  )
+  return { ...config, importMap: [...roots, outdirBasename(config.outdir ?? 'styled-system'), ...existing] }
+}
+
+function resolveManifestPath(spec: string, fromDir: string): string | undefined {
+  try {
+    return createRequire(resolve(fromDir, 'noop.js')).resolve(`${spec}/panda.lib.json`, { paths: [fromDir] })
+  } catch {
+    return undefined
+  }
+}
+
+async function loadManifestLevel(
+  spec: string,
+  manifestPath: string,
+  deps: Set<string>,
+): Promise<{ level: DesignSystemLevel; parent: string | undefined }> {
   let manifest: DesignSystemManifest
   try {
     manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as DesignSystemManifest
@@ -50,12 +95,6 @@ export async function loadDesignSystemPreset(
   }
   if (typeof manifest.buildInfo !== 'string') {
     throw new PandaError('CONFIG_ERROR', `💥 ${JSON.stringify(spec)} manifest is missing a "buildInfo" entry.`)
-  }
-  if (typeof manifest.designSystem === 'string' && manifest.designSystem.length > 0) {
-    throw new PandaError(
-      'CONFIG_ERROR',
-      `💥 designSystem ${JSON.stringify(spec)} extends ${JSON.stringify(manifest.designSystem)}, but nested design systems are not supported yet.`,
-    )
   }
 
   const presetPath = resolve(dirname(manifestPath), manifest.preset)
@@ -75,24 +114,23 @@ export async function loadDesignSystemPreset(
     )
   }
 
+  const parent =
+    typeof manifest.designSystem === 'string' && manifest.designSystem.length > 0 ? manifest.designSystem : undefined
+
   return {
-    preset,
-    info: {
-      name: manifest.name ?? spec,
-      manifest,
-      manifestPath,
-      buildInfoPath,
-      files: manifest.files ?? [],
-      ...(manifest.importMap ? { importMap: manifest.importMap } : {}),
+    parent,
+    level: {
+      preset,
+      info: {
+        name: manifest.name ?? spec,
+        manifest,
+        manifestPath,
+        buildInfoPath,
+        files: manifest.files ?? [],
+        ...(manifest.importMap ? { importMap: manifest.importMap } : {}),
+      },
     },
   }
-}
-
-export function withDesignSystemImportMap(config: UserConfig, spec: string, info: ResolvedDesignSystem): UserConfig {
-  const existing: ImportMapOption[] =
-    config.importMap === undefined ? [] : Array.isArray(config.importMap) ? config.importMap : [config.importMap]
-  const dsRoot: ImportMapOption = info.importMap ? designSystemImportMap(info.importMap, spec) : spec
-  return { ...config, importMap: [dsRoot, outdirBasename(config.outdir ?? 'styled-system'), ...existing] }
 }
 
 function designSystemImportMap(map: NonNullable<DesignSystemManifest['importMap']>, spec: string): ImportMapInput {
@@ -103,4 +141,25 @@ function designSystemImportMap(map: NonNullable<DesignSystemManifest['importMap'
     jsx: map.jsx ?? `${spec}/jsx`,
     tokens: map.tokens ?? `${spec}/tokens`,
   }
+}
+
+function notResolvedError(spec: string): PandaError {
+  return new PandaError(
+    'CONFIG_ERROR',
+    `💥 designSystem ${JSON.stringify(spec)} could not be resolved. Install it, or — if it isn't a Panda design system — build it with \`panda lib\`.`,
+  )
+}
+
+function parentNotResolvedError(child: string, parent: string): PandaError {
+  return new PandaError(
+    'CONFIG_ERROR',
+    `💥 designSystem ${JSON.stringify(child)} extends ${JSON.stringify(parent)}, which isn't installed alongside it. Install it where ${JSON.stringify(child)} can resolve it, or rebuild that library with \`panda lib\`.`,
+  )
+}
+
+function cycleError(cycle: string[]): PandaError {
+  return new PandaError(
+    'CONFIG_ERROR',
+    `💥 Design-system cycle: ${cycle.join(' → ')}. A design system can't depend on itself.`,
+  )
 }

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -6,10 +6,10 @@ import {
 } from '@pandacss/compiler-shared'
 import type { UserConfig } from '@pandacss/types'
 import { readFileSync } from 'node:fs'
-import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { PandaError } from './error'
+import { tryResolveFrom } from './resolve'
 import { ensureConfigObject, errorMessage, type ExtendableConfig } from './shared'
 
 export interface ResolvedDesignSystem {
@@ -74,9 +74,12 @@ export function withDesignSystemImportMap(config: UserConfig, infos: ResolvedDes
 
 function resolveManifestPath(spec: string, fromDir: string): string | undefined {
   try {
-    return createRequire(resolve(fromDir, 'noop.js')).resolve(`${spec}/panda.lib.json`, { paths: [fromDir] })
-  } catch {
-    return undefined
+    return tryResolveFrom(`${spec}/panda.lib.json`, fromDir)
+  } catch (error) {
+    throw new PandaError(
+      'CONFIG_ERROR',
+      `💥 Failed to resolve designSystem ${JSON.stringify(spec)} from ${JSON.stringify(fromDir)}: ${errorMessage(error)}`,
+    )
   }
 }
 

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -39,7 +39,7 @@ export async function loadDesignSystemChain(
   let fromDir = cwd
   let declaredBy: string | undefined
 
-  for (;;) {
+  while (true) {
     const manifestPath = resolveManifestPath(currentSpec, fromDir)
     if (manifestPath === undefined) {
       throw declaredBy === undefined ? notResolvedError(currentSpec) : parentNotResolvedError(declaredBy, currentSpec)

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -14,6 +14,7 @@ import { ensureConfigObject, errorMessage, type ExtendableConfig } from './share
 
 export interface ResolvedDesignSystem {
   name: string
+  specifier: string
   manifest: DesignSystemManifest
   manifestPath: string
   buildInfoPath: string
@@ -66,7 +67,7 @@ export function withDesignSystemImportMap(config: UserConfig, infos: ResolvedDes
   const existing: ImportMapOption[] =
     config.importMap === undefined ? [] : Array.isArray(config.importMap) ? config.importMap : [config.importMap]
   const roots: ImportMapOption[] = infos.map((info) =>
-    info.importMap ? designSystemImportMap(info.importMap, info.name) : info.name,
+    info.importMap ? designSystemImportMap(info.importMap, info.specifier) : info.specifier,
   )
   return { ...config, importMap: [...roots, outdirBasename(config.outdir ?? 'styled-system'), ...existing] }
 }
@@ -123,6 +124,7 @@ async function loadManifestLevel(
       preset,
       info: {
         name: manifest.name ?? spec,
+        specifier: spec,
         manifest,
         manifestPath,
         buildInfoPath,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,7 +4,7 @@ export { diffConfig } from './diff'
 export { findConfig } from './find'
 export { bundleConfig } from './bundle'
 export { mergeConfigs } from './merge'
-export { resolveSmartInclude } from './smart-include'
+export { resolveSmartInclude, mergeExcludes } from './smart-include'
 export { readPandaVersion } from './version'
 
 export type { ConfigSnapshot } from './serialize'

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,6 +4,7 @@ export { diffConfig } from './diff'
 export { findConfig } from './find'
 export { bundleConfig } from './bundle'
 export { mergeConfigs } from './merge'
+export { resolveSmartInclude } from './smart-include'
 export { readPandaVersion } from './version'
 
 export type { ConfigSnapshot } from './serialize'

--- a/packages/config/src/preset.ts
+++ b/packages/config/src/preset.ts
@@ -11,6 +11,7 @@ import { PandaError } from './error'
 import { attachRuntimeHooks, configResolvedUtils } from './hook-utils'
 import { collectPluginHookHandlers, normalizeHook, type PluginHookEntry } from './hooks'
 import type { ConfigSources } from './sources'
+import { expandSmartInclude } from './smart-include'
 import { mergeConfigs, mergeConfigsWithSources, type SourcedConfig } from './merge'
 import { ensureConfigObject, errorMessage, isPlainObject, type ExtendableConfig } from './shared'
 
@@ -68,8 +69,10 @@ export async function resolveAuthoredPresets(
   await collectConfigs(config, rootSource, ctx, new WeakSet())
 
   const dsInfos = dsChain.map((level) => level.info)
-  const finalize = (resolved: UserConfig): UserConfig =>
-    dsInfos.length > 0 ? withDesignSystemImportMap(resolved, dsInfos) : resolved
+  const finalize = (resolved: UserConfig): UserConfig => {
+    const withImportMap = dsInfos.length > 0 ? withDesignSystemImportMap(resolved, dsInfos) : resolved
+    return expandSmartInclude(withImportMap, cwd, ctx.dependencies)
+  }
   const dsMetadata = dsInfos.length > 0 ? { designSystem: dsInfos } : undefined
 
   if (ctx.sourcedConfigs) {

--- a/packages/config/src/preset.ts
+++ b/packages/config/src/preset.ts
@@ -1,7 +1,12 @@
 import type { Config, UserConfig } from '@pandacss/types'
 import { normalize, relative } from 'node:path'
 import { bundleConfig } from './bundle'
-import { loadDesignSystemPreset, withDesignSystemImportMap, type ResolvedDesignSystem } from './design-system'
+import {
+  loadDesignSystemChain,
+  withDesignSystemImportMap,
+  type DesignSystemLevel,
+  type ResolvedDesignSystem,
+} from './design-system'
 import { PandaError } from './error'
 import { attachRuntimeHooks, configResolvedUtils } from './hook-utils'
 import { collectPluginHookHandlers, normalizeHook, type PluginHookEntry } from './hooks'
@@ -25,7 +30,7 @@ export interface ResolveAuthoredPresetsResult {
   dependencies: string[]
   metadata?: {
     sources?: ConfigSources
-    designSystem?: ResolvedDesignSystem
+    designSystem?: ResolvedDesignSystem[]
   }
 }
 
@@ -52,18 +57,20 @@ export async function resolveAuthoredPresets(
   if (options.configFile) rootSource.file = normalize(relative(cwd, options.configFile))
 
   const designSystem = (config as UserConfig).designSystem
-  let resolvedDesignSystem: { preset: ExtendableConfig; info: ResolvedDesignSystem } | undefined
+  let dsChain: DesignSystemLevel[] = []
   if (typeof designSystem === 'string' && designSystem.length > 0) {
-    resolvedDesignSystem = await loadDesignSystemPreset(designSystem, cwd, ctx.dependencies)
-    await collectConfigs(resolvedDesignSystem.preset, { kind: 'preset', specifier: designSystem }, ctx, new WeakSet())
+    dsChain = await loadDesignSystemChain(designSystem, cwd, ctx.dependencies)
+    for (const level of dsChain) {
+      await collectConfigs(level.preset, { kind: 'preset', specifier: level.info.name }, ctx, new WeakSet())
+    }
   }
 
   await collectConfigs(config, rootSource, ctx, new WeakSet())
 
-  const ds = resolvedDesignSystem
+  const dsInfos = dsChain.map((level) => level.info)
   const finalize = (resolved: UserConfig): UserConfig =>
-    ds ? withDesignSystemImportMap(resolved, designSystem as string, ds.info) : resolved
-  const dsMetadata = ds ? { designSystem: ds.info } : undefined
+    dsInfos.length > 0 ? withDesignSystemImportMap(resolved, dsInfos) : resolved
+  const dsMetadata = dsInfos.length > 0 ? { designSystem: dsInfos } : undefined
 
   if (ctx.sourcedConfigs) {
     const merged = mergeConfigsWithSources(ctx.sourcedConfigs)

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -1,0 +1,17 @@
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+
+export function tryResolveFrom(request: string, fromDir: string): string | undefined {
+  try {
+    return createRequire(resolve(fromDir, 'noop.js')).resolve(request, { paths: [fromDir] })
+  } catch (error) {
+    if (isResolveMiss(error)) return undefined
+    throw error
+  }
+}
+
+export function isResolveMiss(error: unknown): boolean {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error ? (error as { code?: unknown }).code : undefined
+  return code === 'MODULE_NOT_FOUND' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+}

--- a/packages/config/src/smart-include.ts
+++ b/packages/config/src/smart-include.ts
@@ -1,7 +1,7 @@
 import type { UserConfig } from '@pandacss/types'
 import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { PandaError } from './error'
 
 export const SMART_INCLUDE_EXTENSIONS = ['js', 'mjs', 'cjs', 'jsx', 'ts', 'cts', 'mts', 'tsx', 'vue', 'svelte', 'astro']
@@ -23,6 +23,10 @@ export function resolveSmartInclude(include: string[], cwd: string, deps: Set<st
 
   for (const entry of include) {
     if (!PACKAGE_SPECIFIER.test(entry)) {
+      next.push(entry)
+      continue
+    }
+    if (isLocalPath(entry, cwd)) {
       next.push(entry)
       continue
     }
@@ -59,6 +63,10 @@ export function expandSmartInclude(config: UserConfig, cwd: string, deps: Set<st
 
 export function mergeExcludes(existing: string[] | undefined, additions: string[]): string[] {
   return [...(existing ?? []), ...additions]
+}
+
+function isLocalPath(entry: string, cwd: string): boolean {
+  return existsSync(isAbsolute(entry) ? entry : resolve(cwd, entry))
 }
 
 function resolvePackageDir(spec: string, cwd: string): string | undefined {

--- a/packages/config/src/smart-include.ts
+++ b/packages/config/src/smart-include.ts
@@ -1,13 +1,15 @@
 import type { UserConfig } from '@pandacss/types'
 import { existsSync } from 'node:fs'
-import { createRequire } from 'node:module'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { PandaError } from './error'
+import { tryResolveFrom } from './resolve'
+import { errorMessage } from './shared'
 
 export const SMART_INCLUDE_EXTENSIONS = ['js', 'mjs', 'cjs', 'jsx', 'ts', 'cts', 'mts', 'tsx', 'vue', 'svelte', 'astro']
 
 const MANIFEST = 'panda.lib.json'
 const PACKAGE_SPECIFIER = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/i
+const PATH_SEPARATOR = /[\\/]/
 
 export interface SmartIncludeResult {
   include: string[]
@@ -70,21 +72,28 @@ function isLocalPath(entry: string, cwd: string): boolean {
 }
 
 function resolvePackageDir(spec: string, cwd: string): string | undefined {
-  const require = createRequire(resolve(cwd, 'noop.js'))
-
-  const fromPackageJson = tryResolve(require, `${spec}/package.json`, cwd)
+  const fromPackageJson = tryResolve(`${spec}/package.json`, cwd)
   if (fromPackageJson !== undefined) return dirname(fromPackageJson)
 
-  const fromEntry = tryResolve(require, spec, cwd)
+  const fromEntry = tryResolve(spec, cwd)
   return fromEntry === undefined ? undefined : nearestPackageDir(fromEntry)
 }
 
-function tryResolve(require: ReturnType<typeof createRequire>, request: string, cwd: string): string | undefined {
+function tryResolve(request: string, cwd: string): string | undefined {
   try {
-    return require.resolve(request, { paths: [cwd] })
-  } catch {
-    return undefined
+    return tryResolveFrom(request, cwd)
+  } catch (error) {
+    throw new PandaError(
+      'CONFIG_ERROR',
+      `💥 Failed to resolve include package ${JSON.stringify(request)} from ${JSON.stringify(cwd)}: ${errorMessage(error)}`,
+    )
   }
+}
+
+function isInsideCwd(relativePath: string): boolean {
+  if (relativePath === '' || relativePath === '..') return false
+  if (isAbsolute(relativePath)) return false
+  return !relativePath.startsWith(`..${sep}`)
 }
 
 function nearestPackageDir(from: string): string | undefined {
@@ -99,12 +108,12 @@ function nearestPackageDir(from: string): string | undefined {
 
 function globBase(packageDir: string, cwd: string): string {
   const rel = relative(cwd, packageDir)
-  const base = rel !== '' && !rel.startsWith('..') ? rel : packageDir
+  const base = isInsideCwd(rel) ? rel : packageDir
   return toPosix(base)
 }
 
 function toPosix(path: string): string {
-  return path.split(/[\\/]/).join('/')
+  return path.split(PATH_SEPARATOR).join('/')
 }
 
 function inIncludeError(specs: string[]): PandaError {

--- a/packages/config/src/smart-include.ts
+++ b/packages/config/src/smart-include.ts
@@ -1,0 +1,110 @@
+import type { UserConfig } from '@pandacss/types'
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, relative, resolve } from 'node:path'
+import { PandaError } from './error'
+
+export const SMART_INCLUDE_EXTENSIONS = ['js', 'mjs', 'cjs', 'jsx', 'ts', 'cts', 'mts', 'tsx', 'vue', 'svelte', 'astro']
+
+const MANIFEST = 'panda.lib.json'
+const PACKAGE_SPECIFIER = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/i
+
+export interface SmartIncludeResult {
+  include: string[]
+  excludes: string[]
+  changed: boolean
+}
+
+export function resolveSmartInclude(include: string[], cwd: string, deps: Set<string>): SmartIncludeResult {
+  const offenders: string[] = []
+  const next: string[] = []
+  const excludes: string[] = []
+  let changed = false
+
+  for (const entry of include) {
+    if (!PACKAGE_SPECIFIER.test(entry)) {
+      next.push(entry)
+      continue
+    }
+
+    const packageDir = resolvePackageDir(entry, cwd)
+    if (packageDir === undefined) {
+      next.push(entry)
+      continue
+    }
+    if (existsSync(join(packageDir, MANIFEST))) {
+      offenders.push(entry)
+      continue
+    }
+
+    deps.add(join(packageDir, 'package.json'))
+    const base = globBase(packageDir, cwd)
+    next.push(`${base}/**/*.{${SMART_INCLUDE_EXTENSIONS.join(',')}}`)
+    excludes.push(`${base}/**/node_modules/**`)
+    changed = true
+  }
+
+  if (offenders.length > 0) throw inIncludeError(offenders)
+  return { include: changed ? next : include, excludes, changed }
+}
+
+export function expandSmartInclude(config: UserConfig, cwd: string, deps: Set<string>): UserConfig {
+  if (!config.include || config.include.length === 0) return config
+
+  const resolved = resolveSmartInclude(config.include, cwd, deps)
+  if (!resolved.changed) return config
+
+  return { ...config, include: resolved.include, exclude: mergeExcludes(config.exclude, resolved.excludes) }
+}
+
+function mergeExcludes(existing: string[] | undefined, additions: string[]): string[] {
+  const base = existing && existing.length > 0 ? existing : ['**/*.d.ts']
+  return [...base, ...additions]
+}
+
+function resolvePackageDir(spec: string, cwd: string): string | undefined {
+  const require = createRequire(resolve(cwd, 'noop.js'))
+
+  const fromPackageJson = tryResolve(require, `${spec}/package.json`, cwd)
+  if (fromPackageJson !== undefined) return dirname(fromPackageJson)
+
+  const fromEntry = tryResolve(require, spec, cwd)
+  return fromEntry === undefined ? undefined : nearestPackageDir(fromEntry)
+}
+
+function tryResolve(require: ReturnType<typeof createRequire>, request: string, cwd: string): string | undefined {
+  try {
+    return require.resolve(request, { paths: [cwd] })
+  } catch {
+    return undefined
+  }
+}
+
+function nearestPackageDir(from: string): string | undefined {
+  let dir = dirname(from)
+  for (;;) {
+    if (existsSync(join(dir, 'package.json'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) return undefined
+    dir = parent
+  }
+}
+
+function globBase(packageDir: string, cwd: string): string {
+  const rel = relative(cwd, packageDir)
+  const base = rel !== '' && !rel.startsWith('..') ? rel : packageDir
+  return toPosix(base)
+}
+
+function toPosix(path: string): string {
+  return path.split(/[\\/]/).join('/')
+}
+
+function inIncludeError(specs: string[]): PandaError {
+  const list = specs.map((spec) => JSON.stringify(spec)).join(', ')
+  const plural = specs.length > 1
+  return new PandaError(
+    'CONFIG_ERROR',
+    `💥 Design system${plural ? 's' : ''} in \`include\`: ${list}. ${plural ? 'They each ship' : 'It ships'} a ${MANIFEST}, so ${plural ? 'they belong' : 'it belongs'} in \`designSystem\`, not \`include\`. \`include\` is for files, not design systems.`,
+  )
+}

--- a/packages/config/src/smart-include.ts
+++ b/packages/config/src/smart-include.ts
@@ -57,9 +57,8 @@ export function expandSmartInclude(config: UserConfig, cwd: string, deps: Set<st
   return { ...config, include: resolved.include, exclude: mergeExcludes(config.exclude, resolved.excludes) }
 }
 
-function mergeExcludes(existing: string[] | undefined, additions: string[]): string[] {
-  const base = existing && existing.length > 0 ? existing : ['**/*.d.ts']
-  return [...base, ...additions]
+export function mergeExcludes(existing: string[] | undefined, additions: string[]): string[] {
+  return [...(existing ?? []), ...additions]
 }
 
 function resolvePackageDir(spec: string, cwd: string): string | undefined {

--- a/packages/config/src/smart-include.ts
+++ b/packages/config/src/smart-include.ts
@@ -89,7 +89,7 @@ function tryResolve(require: ReturnType<typeof createRequire>, request: string, 
 
 function nearestPackageDir(from: string): string | undefined {
   let dir = dirname(from)
-  for (;;) {
+  while (true) {
     if (existsSync(join(dir, 'package.json'))) return dir
     const parent = dirname(dir)
     if (parent === dir) return undefined

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -26,6 +26,6 @@ export interface LoadConfigResult {
   dependencies: string[]
   metadata?: {
     sources?: ConfigSources
-    designSystem?: ResolvedDesignSystem
+    designSystem?: ResolvedDesignSystem[]
   }
 }


### PR DESCRIPTION
Two related additions to how `designSystem` and `include` resolve. Both replace a hand-written `node_modules` path with a single named field, and they stay distinct: `designSystem` answers *"what is my design language?"*, `include` answers *"which files use it?"*.

## Nested designSystem chains

A design system can now build on another. You set `designSystem` once; if that design system was itself built on a parent, Panda pulls the parent in for you. No `import { parentPreset }`, no second entry in `presets`.

```ts
// @acme/marketing's panda.lib.json records its own parent
{ "name": "@acme/marketing", "designSystem": "@acme/foundations", ... }

// your app — one line, the whole chain comes with it
export default defineConfig({
  designSystem: '@acme/marketing',
})
```

This builds on the single-level `designSystem` field (#3627), which rejected nested chains with "not supported yet". The rejection is replaced with the walk.

**How it resolves.** `loadDesignSystemChain` (`packages/config`) walks the parent links on disk:

- Resolves each parent from where its child is installed, not the consumer's cwd. A transitive parent works when your app only depends on the leaf, and it survives Docker builds where only part of the workspace exists in the layer.
- Merges presets root → leaf. Ancestors sit lowest; the leaf and your own config override them.
- Guards cycles with a visited set keyed by resolved manifest path.

The node driver (`hydrateDesignSystem`) hydrates each level's pre-extracted styles under its own name, so no design system in the chain is re-extracted.

Diagnostics name the package and the fix:

- Cycle — `Design-system cycle: @a → @b → @a. A design system can't depend on itself.`
- Parent not installed — `designSystem "@acme/marketing" extends "@acme/foundations", which isn't installed alongside it.`

## Smart include

Name a package in `include` and Panda resolves it for you. A library that uses Panda but isn't a design system — say a charts package built on `@acme/ds` — goes straight in `include` as a bare specifier:

```ts
export default defineConfig({
  designSystem: '@acme/ds',     // the design language — merged, pre-extracted
  include: ['@acme/charts'],    // a consumer of it — globbed and scanned
})
```

Panda resolves the package, globs its source so its styles land in your CSS, and appends a `node_modules` exclude so the package's own dependencies aren't scanned. No hand-written `./node_modules/...` glob. Plain globs and local folder names pass through untouched. The CLI `--include` override flows through the same resolution.

If you point `include` at an actual design system (a package shipping `panda.lib.json`), Panda stops and tells you to move it to `designSystem` — reporting every offender at once, not one per run. The redirect is what keeps the two fields from blurring: manifest-bearing belongs in `designSystem`, everything else in `include`.

## Notes

- Smart include's extension list is a hand-maintained mirror of the engine's parseable set, since config stays binding-free. A future engine-side extension gate would make it the single source of truth.
- Deferred: cross-package source watch — re-running cssgen on edits inside a consumed package. The package's `package.json` is registered as a config dep today; live source watch is a separate open item.

## Tests

`packages/config/__tests__/design-system.test.ts` — depth-2 merge order, one importMap root per design system, resolve-against-manifest-dir, cycle + parent-not-found diagnostics, chain linked by specifier.

`packages/config/__tests__/smart-include.test.ts` — package vs glob vs path discrimination, `exports`-hidden `package.json` and on-disk manifest detection, manifest redirect (batched), auto-glob + nested-`node_modules` exclude, `resolveSmartInclude` (`--include` path), no-op when `include` is empty.

`pnpm typecheck`, `pnpm test packages/config`, and the compiler design-system/lifecycle suites pass.
