### PR TITLE
fix(compiler): emit narrower border shorthands after all-sides shorthands

### DIFF
--- a/.changeset/border-side-shorthand-cascade-order.md
+++ b/.changeset/border-side-shorthand-cascade-order.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix narrower border shorthands losing the cascade to the all-sides `borderColor`/`borderStyle`/`borderWidth` shorthands. Per-side shorthands (`borderInlineEnd`, `borderTop`, …) and axis-pair shorthands (`borderInlineColor`, `borderBlockWidth`, …) were emitted before the all-sides ones, which then re-applied the border — so `borderEnd: 0` could no longer remove that side. They now sort after the all-sides shorthands, so the narrower property wins, matching v1.

--- a/crates/pandacss_stylesheet/src/sort.rs
+++ b/crates/pandacss_stylesheet/src/sort.rs
@@ -779,6 +779,12 @@ fn property_priority(prop: &str) -> u16 {
     if is_longhand_logical(prop) {
         return 3000;
     }
+    if is_border_side_shorthand(prop) {
+        return 2500;
+    }
+    if is_border_axis_shorthand(prop) {
+        return 2200;
+    }
     if is_shorthand_of_longhands(prop) {
         return 2000;
     }
@@ -826,17 +832,6 @@ fn is_shorthand_of_longhands(prop: &str) -> bool {
             | "borderColor"
             | "borderStyle"
             | "borderWidth"
-            | "borderBlockStart"
-            | "borderTop"
-            | "borderBlockEnd"
-            | "borderBottom"
-            | "borderInlineColor"
-            | "borderInlineStyle"
-            | "borderInlineWidth"
-            | "borderInlineStart"
-            | "borderLeft"
-            | "borderInlineEnd"
-            | "borderRight"
             | "borderImage"
             | "borderRadius"
             | "caret"
@@ -877,6 +872,32 @@ fn is_shorthand_of_longhands(prop: &str) -> bool {
             | "textEmphasis"
             | "textWrap"
             | "transition"
+    )
+}
+
+fn is_border_side_shorthand(prop: &str) -> bool {
+    matches!(
+        prop,
+        "borderInlineStart"
+            | "borderInlineEnd"
+            | "borderBlockStart"
+            | "borderBlockEnd"
+            | "borderTop"
+            | "borderRight"
+            | "borderBottom"
+            | "borderLeft"
+    )
+}
+
+fn is_border_axis_shorthand(prop: &str) -> bool {
+    matches!(
+        prop,
+        "borderInlineColor"
+            | "borderInlineStyle"
+            | "borderInlineWidth"
+            | "borderBlockColor"
+            | "borderBlockStyle"
+            | "borderBlockWidth"
     )
 }
 
@@ -957,9 +978,6 @@ fn is_longhand_logical(prop: &str) -> bool {
             | "backgroundSize"
             | "backgroundPositionX"
             | "backgroundPositionY"
-            | "borderBlockColor"
-            | "borderBlockStyle"
-            | "borderBlockWidth"
             | "borderBlockStartColor"
             | "borderBlockStartStyle"
             | "borderBlockStartWidth"

--- a/crates/pandacss_stylesheet/tests/sort.rs
+++ b/crates/pandacss_stylesheet/tests/sort.rs
@@ -66,6 +66,78 @@ fn applies_every_part_of_block_form_conditions() {
 }
 
 #[test]
+fn emits_side_border_shorthand_after_all_sides_shorthands() {
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": {
+            "borderColor": { "className": "bd-c" },
+            "borderStyle": { "className": "border-style" },
+            "borderWidth": { "className": "bd-w" },
+            "borderInlineEnd": { "className": "bd-e" },
+            "borderEndStartRadius": { "className": "bdr-es" },
+            "borderStartStartRadius": { "className": "bdr-ss" }
+        }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ borderColor: 'purple', borderStyle: 'solid', borderWidth: '1px', borderInlineEnd: '0', borderEndStartRadius: '6px', borderStartStartRadius: '6px' })",
+        &[StylesheetLayer::Utilities],
+    );
+    assert_snapshot!(css, @r"
+@layer utilities {
+  .bd-c_purple {
+    border-color: purple;
+  }
+  .border-style_solid {
+    border-style: solid;
+  }
+  .bd-w_1px {
+    border-width: 1px;
+  }
+  .bd-e_0 {
+    border-inline-end: 0;
+  }
+  .bdr-es_6px {
+    border-end-start-radius: 6px;
+  }
+  .bdr-ss_6px {
+    border-start-start-radius: 6px;
+  }
+}
+");
+}
+
+#[test]
+fn emits_axis_border_shorthands_after_all_sides_shorthands() {
+    let config = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },
+        "utilities": {
+            "borderColor": { "className": "bd-c" },
+            "borderInlineColor": { "className": "bd-x-c" },
+            "borderBlockColor": { "className": "bd-y-c" }
+        }
+    }));
+    let css = compile_layer_css(
+        &config,
+        "import { css } from '@panda/css'; css({ borderColor: 'red', borderInlineColor: 'green', borderBlockColor: 'blue' })",
+        &[StylesheetLayer::Utilities],
+    );
+    assert_snapshot!(css, @r"
+@layer utilities {
+  .bd-c_red {
+    border-color: red;
+  }
+  .bd-x-c_green {
+    border-inline-color: green;
+  }
+  .bd-y-c_blue {
+    border-block-color: blue;
+  }
+}
+");
+}
+
+#[test]
 fn sorts_breakpoints_by_resolved_width() {
     let config = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },


### PR DESCRIPTION
## What

Narrower border shorthands now sort after the all-sides `borderColor` / `borderStyle` / `borderWidth`, so they win the cascade:

- per-side shorthands — `borderInlineEnd`, `borderTop`, …
- axis-pair shorthands — `borderInlineColor`, `borderBlockWidth`, …

## Why

`cx(base, override)` where `base` sets `borderWidth` / `borderStyle` and `override` sets `borderEnd: 0` rendered a closed box instead of an open bracket. The side-removal class was emitted first, then `border-style` / `border-width` re-applied the inline-end border:

```css
.bd-e_0        { border-inline-end: 0; }   /* emitted first */
.border-style_solid { border-style: solid; }
.bd-w_1px      { border-width: 1px; }       /* re-applies the side */
```

These shorthands shared the 2000 sort tier with the all-sides ones, and the axis tiebreaker (added in v2, not present in v1) floated the narrower inline-axis props ahead. v1 kept declaration order within the tier, so the override landed last and won.

## Notes

- Per-side shorthands go to tier 2500, axis-pair shorthands to tier 2200 — both above the all-sides 2000 tier and below longhands (3000). Ordered by specificity, so the result is deterministic regardless of extraction order rather than relying on v1's declaration-order behaviour.
- `borderBlockColor` / `borderBlockStyle` / `borderBlockWidth` move from the longhand tier (3000) into the new axis-pair tier so inline and block sides behave symmetrically. The inline pair was the one that hit the bug; the block pair already sorted after the all-sides shorthands, just at a different tier.

## Test plan

- [x] `cargo test -p pandacss_stylesheet` (307) — two new regression tests, no other snapshot drift
- [x] `cargo test -p pandacss_project` (261) — recipes share this sort, no drift
- [x] `cargo fmt -p pandacss_stylesheet -- --check`
- [x] `cargo clippy -p pandacss_stylesheet --all-targets -- -D warnings`
