### PR TITLE
feat(compiler): ship wasm32-wasi build for WebContainer/StackBlitz

### DIFF
--- a/.changeset/wasi-stackblitz.md
+++ b/.changeset/wasi-stackblitz.md
@@ -1,0 +1,12 @@
+---
+'@pandacss/compiler': patch
+---
+
+Ship a `wasm32-wasi` build of the compiler so Panda runs in WebContainer-based
+environments like StackBlitz, where the native binary can't load. The loader
+already falls back to `@pandacss/compiler-wasm32-wasi` when no native binding is
+present.
+
+The cdylib is now linked as a WASI reactor (it exports `_initialize`) so the
+WebAssembly runtime is initialized before use — without it the module hangs on
+load under the emnapi loader.

--- a/.changeset/wasi-stackblitz.md
+++ b/.changeset/wasi-stackblitz.md
@@ -2,11 +2,4 @@
 '@pandacss/compiler': patch
 ---
 
-Ship a `wasm32-wasi` build of the compiler so Panda runs in WebContainer-based
-environments like StackBlitz, where the native binary can't load. The loader
-already falls back to `@pandacss/compiler-wasm32-wasi` when no native binding is
-present.
-
-The cdylib is now linked as a WASI reactor (it exports `_initialize`) so the
-WebAssembly runtime is initialized before use — without it the module hangs on
-load under the emnapi loader.
+Add a WASI compiler fallback so Panda can run in WebContainer-based environments like StackBlitz.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,44 @@ jobs:
             packages/compiler-wasm/pkg-web
           if-no-files-found: error
 
+  build-wasi:
+    name: Build wasi artifact
+    if: ${{ github.repository == 'chakra-ui/panda' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        uses: ./.github/composite-actions/install
+        with:
+          ignore-scripts: 'true'
+
+      - name: Add wasi Rust target
+        run: rustup target add wasm32-wasip1-threads
+
+      - name: Build wasi binding
+        working-directory: packages/compiler
+        run: pnpm exec napi build --platform --release --manifest-path crate/Cargo.toml --output-dir . --js binding.cjs --dts native.d.ts --target wasm32-wasip1-threads
+
+      - name: Upload wasi artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: bindings-wasm32-wasi
+          path: |
+            packages/compiler/compiler.wasm32-wasi.wasm
+            packages/compiler/compiler.wasi.cjs
+            packages/compiler/compiler.wasi-browser.js
+            packages/compiler/wasi-worker.mjs
+            packages/compiler/wasi-worker-browser.mjs
+          if-no-files-found: error
+
   release:
     name: Release
     needs:
       - build-native
       - build-wasm
+      - build-wasi
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -185,6 +218,8 @@ jobs:
         run: |
           find packages/compiler/npm -name '*.node'
           test "$(find packages/compiler/npm -name '*.node' | wc -l)" -eq 8
+          test -f packages/compiler/npm/wasm32-wasi/compiler.wasm32-wasi.wasm
+          test -f packages/compiler/npm/wasm32-wasi/compiler.wasi.cjs
           test -f packages/compiler-wasm/pkg-node/compiler_wasm_bg.wasm
           test -f packages/compiler-wasm/pkg-web/compiler_wasm_bg.wasm
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,10 @@ jobs:
           name: compiler-wasm
           path: packages/compiler-wasm
 
+      - name: Stage wasi loader files at package root
+        working-directory: packages/compiler
+        run: mv artifacts/compiler.wasi.cjs artifacts/compiler.wasi-browser.js artifacts/wasi-worker.mjs artifacts/wasi-worker-browser.mjs .
+
       - name: Stage platform npm packages
         working-directory: packages/compiler
         run: pnpm exec napi artifacts --output-dir artifacts --npm-dir npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,9 @@ jobs:
       # Use napi directly so per-target flags are not lost behind pnpm's separator.
       - name: Build native binding
         working-directory: packages/compiler
-        run: pnpm exec napi build --platform --release --manifest-path crate/Cargo.toml --output-dir . --js binding.cjs --dts native.d.ts --target ${{ matrix.target }} ${{ matrix.args }}
+        run: >-
+          pnpm exec napi build --platform --release --manifest-path crate/Cargo.toml --output-dir . --js binding.cjs
+          --dts native.d.ts --target ${{ matrix.target }} ${{ matrix.args }}
 
       - name: Upload native binary
         uses: actions/upload-artifact@v7
@@ -145,7 +147,9 @@ jobs:
 
       - name: Build wasi binding
         working-directory: packages/compiler
-        run: pnpm exec napi build --platform --release --manifest-path crate/Cargo.toml --output-dir . --js binding.cjs --dts native.d.ts --target wasm32-wasip1-threads
+        run: >-
+          pnpm exec napi build --platform --release --manifest-path crate/Cargo.toml --output-dir . --js binding.cjs
+          --dts native.d.ts --target wasm32-wasip1-threads
 
       - name: Upload wasi artifact
         uses: actions/upload-artifact@v7
@@ -202,11 +206,27 @@ jobs:
 
       - name: Stage wasi loader files at package root
         working-directory: packages/compiler
-        run: mv artifacts/compiler.wasi.cjs artifacts/compiler.wasi-browser.js artifacts/wasi-worker.mjs artifacts/wasi-worker-browser.mjs .
+        run: >-
+          mv artifacts/compiler.wasi.cjs artifacts/compiler.wasi-browser.js artifacts/wasi-worker.mjs
+          artifacts/wasi-worker-browser.mjs .
 
       - name: Stage platform npm packages
         working-directory: packages/compiler
         run: pnpm exec napi artifacts --output-dir artifacts --npm-dir npm
+
+      - name: Verify wasi binding loads
+        run: |
+          cleanup() {
+            rm -f packages/compiler/node_modules/@pandacss/compiler-wasm32-wasi
+            if [ -f packages/compiler/compiler.wasi.cjs.smoke ]; then
+              mv packages/compiler/compiler.wasi.cjs.smoke packages/compiler/compiler.wasi.cjs
+            fi
+          }
+          trap cleanup EXIT
+          mv packages/compiler/compiler.wasi.cjs packages/compiler/compiler.wasi.cjs.smoke
+          mkdir -p packages/compiler/node_modules/@pandacss
+          ln -s ../../npm/wasm32-wasi packages/compiler/node_modules/@pandacss/compiler-wasm32-wasi
+          NAPI_RS_FORCE_WASI=error node -e "const binding = require('./packages/compiler/binding.cjs'); if (typeof binding.compile !== 'function' || typeof binding.Compiler?.fromConfig !== 'function') process.exit(1)"
 
       - name: Build package JS
         run: |
@@ -229,7 +249,8 @@ jobs:
 
       - name: Publish
         id: changesets
-        if: ${{ github.repository == 'chakra-ui/panda' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+        if: >-
+          ${{ github.repository == 'chakra-ui/panda' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
         uses: changesets/action@v1
         with:
           publish: pnpm release

--- a/design-notes/bindings.md
+++ b/design-notes/bindings.md
@@ -7,13 +7,18 @@ Panda's Rust pipeline ships through two cdylib crates with a shared philosophy: 
 binding crates are deliberate exceptions to the `pandacss_*` naming rule because the cdylib output filename is
 load-bearing on the JS side.
 
-| Crate                                          | Target                                  | Output                                                           | JS package               |
-| ---------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------- | ------------------------ |
-| `packages/compiler/crate` (`compiler_napi`)      | Native (NAPI)                           | `compiler.node`                                                   | `@pandacss/compiler`      |
+| Crate                                            | Target                                  | Output                                                             | JS package                |
+| ------------------------------------------------ | --------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
+| `packages/compiler/crate` (`compiler_napi`)      | Native (NAPI)                           | `compiler.node`                                                    | `@pandacss/compiler`      |
 | `packages/compiler-wasm/crate` (`compiler_wasm`) | `wasm32-unknown-unknown` (wasm-bindgen) | `pkg-node/compiler_wasm_bg.wasm` + `pkg-web/compiler_wasm_bg.wasm` | `@pandacss/compiler-wasm` |
 
 Both depend on `pandacss_fs` with a single feature toggled (`os` for NAPI, `memory` for wasm) plus the rest of the core
 crates with `default-features = false` to keep wasm bundles lean.
+
+`@pandacss/compiler-wasm` and `@pandacss/compiler-wasm32-wasi` are intentionally separate packages. The former is the
+wasm-bindgen browser/playground host with its own loading API. The latter is produced from the NAPI crate for
+WebContainer-style environments where `@pandacss/compiler` must keep the generated `binding.cjs` surface but native
+`.node` files cannot load.
 
 ## What lives in the binding crates
 
@@ -175,8 +180,8 @@ The binding caches the parsed `UserConfig` on `Project` construction so each com
 entire JSON config again. The current output is `{ css, sourceMap, manifest, diagnostics }`; `sourceMap` and manifest
 hashes are still placeholders.
 
-`pandacss_stylesheet` emits and writer-minifies CSS. It does not run a CSS optimizer. The old `optimize` knob was removed
-from the native API so the boundary is explicit.
+`pandacss_stylesheet` emits and writer-minifies CSS. It does not run a CSS optimizer. The old `optimize` knob was
+removed from the native API so the boundary is explicit.
 
 ## Performance: serialization cost is real
 
@@ -193,13 +198,21 @@ serializing `Literal` to `JsValue` walks the same tree. Same constraint applies:
 ## Loader and fallback (NAPI)
 
 The TS wrapper (`packages/compiler/src/index.ts`) defines the public API and a no-op fallback for unsupported platforms.
-`src/load-binary.ts` looks for `compiler.node` next to the package root, then falls back to `@pandacss/compiler-native`.
-The native artifact and its auto-generated `native.d.ts` are gitignored.
+`src/load-binary.ts` loads the generated `binding.cjs`; that loader prefers the local/platform native package and falls
+back to `@pandacss/compiler-wasm32-wasi` when the native binding is unavailable. In WebContainer, if optional dependency
+resolution still fails, the loader installs `@pandacss/compiler-wasm32-wasi@<compiler version>` into
+`/tmp/pandacss-compiler-<version>` and requires `compiler.wasi.cjs` from there, matching Rolldown/Oxc's fallback shape.
+The WASI build is linked as a reactor with `_initialize` exported so emnapi runs the module constructors before use.
+Native artifacts, generated WASI files, and the auto-generated `native.d.ts` are gitignored.
+
+Use `pnpm --filter @pandacss/compiler verify:webcontainer` to serve the browser-based `@webcontainer/api` verification
+fixture. Pass `-- --compiler-tgz <path> --wasi-tgz <path>` to test local package tarballs before publishing; without
+tarballs it installs the current package version from npm.
 
 ## JS-host config callbacks
 
-Resolved config snapshots can carry callback references for config entries that cannot be represented as plain JSON.
-The serialized config stores a stable id, and the live JS function is kept in a sidecar callback map:
+Resolved config snapshots can carry callback references for config entries that cannot be represented as plain JSON. The
+serialized config stores a stable id, and the live JS function is kept in a sidecar callback map:
 
 ```ts
 {
@@ -225,8 +238,8 @@ The callback kinds are intentionally different:
 - `pattern.transform` runs before atomic encoding and returns a full system style object. Pattern output can contain
   nested config-derived conditions and breakpoints because it flows back through the normal style encoder.
 - `pattern.defaultValues` runs in the JS host before `pattern.transform`. Explicit props override defaults.
-- `utility.values` affects utility metadata and type/value availability. Prefer serializing resolved data when
-  possible; only keep it executable if the JS config model truly requires it.
+- `utility.values` affects utility metadata and type/value availability. Prefer serializing resolved data when possible;
+  only keep it executable if the JS config model truly requires it.
 
 Current support:
 
@@ -238,12 +251,11 @@ Current support:
   JS rather than being stubbed in Rust.
 - Utility transforms execute during `parseFile()` / `refreshFile()` for file-derived atoms and encoded recipe entries.
   `atoms()` and `encodedRecipes()` are pure reads and never call back into JS.
-- Utility transform results are cached by callback id, property, and raw value. The cached result is condition-free;
-  the original atom or recipe entry conditions are applied after expansion. Failed callback executions are reported as
+- Utility transform results are cached by callback id, property, and raw value. The cached result is condition-free; the
+  original atom or recipe entry conditions are applied after expansion. Failed callback executions are reported as
   `parseFile()` diagnostics and are not cached, so the next parse can retry the callback.
-- WASM registers both `utility.transform` and `pattern.transform` callbacks through the TS host wrapper. Pattern
-  and utility callbacks are installed before `parseFile()` so the Rust project can call back into JS before atomic
-  encoding.
+- WASM registers both `utility.transform` and `pattern.transform` callbacks through the TS host wrapper. Pattern and
+  utility callbacks are installed before `parseFile()` so the Rust project can call back into JS before atomic encoding.
 - WASM pattern transform results are cached by callback id, pattern name, and serialized props. Thrown callbacks become
   `parseFile()` diagnostics; failed calls are not cached.
 - `@pandacss/compiler-wasm` exposes `createCompilerFromWasmModule(mod, config, options)` for browser callers that import
@@ -268,8 +280,8 @@ themselves when they need control over the wasm fetch, then pass the initialized
 `@pandacss/compiler-wasm` ships a `./web` subpath export (`dist/web.mjs`) that carries only the wasm-module facade —
 `createCompilerFromWasmModule` and the shared types — with **no** `import('../pkg-node/...')` in its module graph.
 
-Because `src/web.ts` never references `pkg-node`, tsup injects no Node `fileURLToPath` shim into `dist/web.mjs`.
-Browser bundlers (webpack, Vite) that stub or remove `node:url` will not throw at module-eval time.
+Because `src/web.ts` never references `pkg-node`, tsup injects no Node `fileURLToPath` shim into `dist/web.mjs`. Browser
+bundlers (webpack, Vite) that stub or remove `node:url` will not throw at module-eval time.
 
 ```ts
 import initWasm, * as wasmMod from '@pandacss/compiler-wasm/pkg-web/compiler_wasm.js'

--- a/package.json
+++ b/package.json
@@ -79,7 +79,10 @@
   "pnpm": {
     "overrides": {
       "@swc/helpers@~0.4": "0.4.36",
-      "picomatch@4.0.3": "4.0.4"
+      "picomatch@4.0.3": "4.0.4",
+      "emnapi": "1.11.1",
+      "@emnapi/core": "1.11.1",
+      "@emnapi/runtime": "1.11.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "prettier": "prettier --check packages",
     "prettier-fix": "prettier --write packages",
     "typecheck": "tsc --noEmit",
-    "release": "pnpm --filter @pandacss/compiler exec napi pre-publish --npm-dir npm --no-gh-release && changeset publish",
+    "release": "pnpm release:prepare && pnpm release:verify && changeset publish",
+    "release:prepare": "pnpm --filter @pandacss/compiler exec napi pre-publish --npm-dir npm --no-gh-release",
+    "release:verify": "node scripts/verify-release-artifacts.mjs",
     "release-dev": "changeset version --snapshot dev && changeset publish --tag dev",
     "mdx-check": "mdx-local-link-checker docs && mdx-local-link-checker website/pages/docs"
   },

--- a/package.json
+++ b/package.json
@@ -81,10 +81,7 @@
   "pnpm": {
     "overrides": {
       "@swc/helpers@~0.4": "0.4.36",
-      "picomatch@4.0.3": "4.0.4",
-      "emnapi": "1.11.1",
-      "@emnapi/core": "1.11.1",
-      "@emnapi/runtime": "1.11.1"
+      "picomatch@4.0.3": "4.0.4"
     }
   }
 }

--- a/packages/compiler/__tests__/load-binary.test.ts
+++ b/packages/compiler/__tests__/load-binary.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWebContainerBinding } from '../src/load-binary'
+
+describe('resolveWebContainerBinding', () => {
+  it('matches the WebContainer fallback install layout', () => {
+    expect(resolveWebContainerBinding('2.0.0-beta.5')).toEqual({
+      baseDir: '/tmp/pandacss-compiler-2.0.0-beta.5',
+      bindingPackage: '@pandacss/compiler-wasm32-wasi@2.0.0-beta.5',
+      bindingEntry: '/tmp/pandacss-compiler-2.0.0-beta.5/node_modules/@pandacss/compiler-wasm32-wasi/compiler.wasi.cjs',
+    })
+  })
+
+  it('allows a custom root for tests and non-default temp dirs', () => {
+    expect(resolveWebContainerBinding('2.0.0-beta.5', '/var/tmp')).toMatchObject({
+      baseDir: '/var/tmp/pandacss-compiler-2.0.0-beta.5',
+      bindingEntry:
+        '/var/tmp/pandacss-compiler-2.0.0-beta.5/node_modules/@pandacss/compiler-wasm32-wasi/compiler.wasi.cjs',
+    })
+  })
+})

--- a/packages/compiler/crate/build.rs
+++ b/packages/compiler/crate/build.rs
@@ -12,17 +12,18 @@ fn link_wasi_reactor() {
     }
 
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
-    let Some(sysroot) = Command::new(rustc)
+    let output = Command::new(rustc)
         .args(["--print", "sysroot"])
         .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
-    else {
-        return;
-    };
+        .expect("failed to run `rustc --print sysroot`");
+    assert!(output.status.success(), "`rustc --print sysroot` failed");
+    let sysroot = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
     let crt = format!("{sysroot}/lib/rustlib/{target}/lib/self-contained/crt1-reactor.o");
+    assert!(
+        std::path::Path::new(&crt).exists(),
+        "missing {crt}: the reactor crt is required so the module runs its constructors under the emnapi loader"
+    );
     println!("cargo:rustc-link-arg={crt}");
     println!("cargo:rustc-link-arg=--export=_initialize");
 }

--- a/packages/compiler/crate/build.rs
+++ b/packages/compiler/crate/build.rs
@@ -24,6 +24,7 @@ fn link_wasi_reactor() {
         std::path::Path::new(&crt).exists(),
         "missing {crt}: the reactor crt is required so the module runs its constructors under the emnapi loader"
     );
+    println!("cargo:rustc-link-arg=--allow-multiple-definition");
     println!("cargo:rustc-link-arg={crt}");
     println!("cargo:rustc-link-arg=--export=_initialize");
 }

--- a/packages/compiler/crate/build.rs
+++ b/packages/compiler/crate/build.rs
@@ -1,3 +1,28 @@
+use std::process::Command;
+
 fn main() {
     napi_build::setup();
+    link_wasi_reactor();
+}
+
+fn link_wasi_reactor() {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if !target.starts_with("wasm32-wasi") {
+        return;
+    }
+
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    let Some(sysroot) = Command::new(rustc)
+        .args(["--print", "sysroot"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    else {
+        return;
+    };
+
+    let crt = format!("{sysroot}/lib/rustlib/{target}/lib/self-contained/crt1-reactor.o");
+    println!("cargo:rustc-link-arg={crt}");
+    println!("cargo:rustc-link-arg=--export=_initialize");
 }

--- a/packages/compiler/crate/build.rs
+++ b/packages/compiler/crate/build.rs
@@ -24,7 +24,15 @@ fn link_wasi_reactor() {
         std::path::Path::new(&crt).exists(),
         "missing {crt}: the reactor crt is required so the module runs its constructors under the emnapi loader"
     );
-    println!("cargo:rustc-link-arg=--allow-multiple-definition");
-    println!("cargo:rustc-link-arg={crt}");
-    println!("cargo:rustc-link-arg=--export=_initialize");
+    cargo_link_arg("--allow-multiple-definition");
+    cargo_link_arg(&crt);
+    cargo_link_arg("--export=_initialize");
+}
+
+#[expect(
+    clippy::disallowed_macros,
+    reason = "Cargo build scripts emit instructions to Cargo through stdout"
+)]
+fn cargo_link_arg(arg: &str) {
+    println!("cargo:rustc-link-arg={arg}");
 }

--- a/packages/compiler/npm/wasm32-wasi/README.md
+++ b/packages/compiler/npm/wasm32-wasi/README.md
@@ -1,0 +1,3 @@
+# `@pandacss/compiler-wasm32-wasi`
+
+This is the **wasm32-wasip1-threads** binary for `@pandacss/compiler`

--- a/packages/compiler/npm/wasm32-wasi/package.json
+++ b/packages/compiler/npm/wasm32-wasi/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@pandacss/compiler-wasm32-wasi",
+  "version": "1.0.0",
+  "cpu": [
+    "wasm32"
+  ],
+  "main": "compiler.wasi.cjs",
+  "browser": "compiler.wasi-browser.js",
+  "files": [
+    "compiler.wasm32-wasi.wasm",
+    "compiler.wasi.cjs",
+    "compiler.wasi-browser.js",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs"
+  ],
+  "description": "Native Rust binding for the Panda compiler engine",
+  "author": "Segun Adebayo <joseshegs@gmail.com>",
+  "homepage": "https://panda-css.com",
+  "license": "MIT",
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.6",
+    "@emnapi/core": "1.11.1",
+    "@emnapi/runtime": "1.11.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/panda.git",
+    "directory": "packages/compiler"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -53,10 +53,12 @@
       "x86_64-unknown-linux-musl",
       "aarch64-unknown-linux-musl",
       "x86_64-pc-windows-msvc",
-      "aarch64-pc-windows-msvc"
+      "aarch64-pc-windows-msvc",
+      "wasm32-wasip1-threads"
     ]
   },
   "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.6",
     "@pandacss/compiler-shared": "workspace:*",
     "@pandacss/config": "workspace:*"
   },

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -36,7 +36,8 @@
     "build:fast": "tsup src/index.ts src/loader.ts --format=esm --platform=node --no-dts",
     "build:native": "napi build --platform --release --manifest-path crate/Cargo.toml --output-dir . --js binding.cjs --dts native.d.ts",
     "dev": "pnpm build:fast --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "verify:webcontainer": "node scripts/verify-webcontainer-api.mjs"
   },
   "files": [
     "dist",

--- a/packages/compiler/scripts/verify-webcontainer-api.mjs
+++ b/packages/compiler/scripts/verify-webcontainer-api.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http'
+import { existsSync, readFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+import { parseArgs } from 'node:util'
+
+const args = process.argv[2] === '--' ? process.argv.slice(3) : process.argv.slice(2)
+const { values } = parseArgs({
+  args,
+  allowPositionals: true,
+  options: {
+    'compiler-tgz': { type: 'string' },
+    'compiler-shared-tgz': { type: 'string' },
+    'config-tgz': { type: 'string' },
+    'types-tgz': { type: 'string' },
+    'wasi-tgz': { type: 'string' },
+    port: { type: 'string', default: '0' },
+  },
+})
+
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+const localTarballs = {
+  compiler: optionalFile(values['compiler-tgz'], '--compiler-tgz'),
+  compilerShared: optionalFile(values['compiler-shared-tgz'], '--compiler-shared-tgz'),
+  config: optionalFile(values['config-tgz'], '--config-tgz'),
+  types: optionalFile(values['types-tgz'], '--types-tgz'),
+  wasi: optionalFile(values['wasi-tgz'], '--wasi-tgz'),
+}
+
+if (Boolean(localTarballs.compiler) !== Boolean(localTarballs.wasi)) {
+  throw new Error('Pass both --compiler-tgz and --wasi-tgz, or neither')
+}
+
+const server = createServer((request, response) => {
+  response.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+  response.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+
+  const tarball = Object.values(getTarballRoutes(localTarballs)).find((route) => route.url === request.url)
+  if (tarball) {
+    response.setHeader('Content-Type', 'application/gzip')
+    response.end(readFileSync(tarball.path))
+    return
+  }
+
+  response.setHeader('Content-Type', 'text/html; charset=utf-8')
+  response.end(renderPage({ localTarballs, version: packageJson.version }))
+})
+
+server.listen(Number(values.port), '127.0.0.1', () => {
+  const address = server.address()
+  if (!address || typeof address === 'string') return
+  console.log(`Open http://127.0.0.1:${address.port} in a Chromium browser to run the WebContainer API check.`)
+  if (localTarballs.compiler) {
+    console.log(
+      `Using local tarballs: ${Object.values(localTarballs)
+        .filter(Boolean)
+        .map((path) => basename(path))
+        .join(', ')}`,
+    )
+  } else {
+    console.log(`Using published @pandacss/compiler@${packageJson.version}`)
+  }
+})
+
+function optionalFile(path, flag) {
+  if (!path) return undefined
+  const absolute = resolve(path)
+  if (!existsSync(absolute)) throw new Error(`${flag} does not exist: ${absolute}`)
+  return absolute
+}
+
+function getTarballRoutes(localTarballs) {
+  return {
+    compiler: { path: localTarballs.compiler, url: '/compiler.tgz' },
+    compilerShared: { path: localTarballs.compilerShared, url: '/compiler-shared.tgz' },
+    config: { path: localTarballs.config, url: '/config.tgz' },
+    types: { path: localTarballs.types, url: '/types.tgz' },
+    wasi: { path: localTarballs.wasi, url: '/compiler-wasm32-wasi.tgz' },
+  }
+}
+
+function renderPage({ localTarballs, version }) {
+  const routes = Object.fromEntries(Object.entries(getTarballRoutes(localTarballs)).filter(([, route]) => route.path))
+  const dependencies = localTarballs.compiler
+    ? {
+        '@pandacss/compiler': 'file:./compiler.tgz',
+        '@pandacss/compiler-wasm32-wasi': 'file:./compiler-wasm32-wasi.tgz',
+        ...(localTarballs.compilerShared ? { '@pandacss/compiler-shared': 'file:./compiler-shared.tgz' } : {}),
+        ...(localTarballs.config ? { '@pandacss/config': 'file:./config.tgz' } : {}),
+        ...(localTarballs.types ? { '@pandacss/types': 'file:./types.tgz' } : {}),
+      }
+    : {
+        '@pandacss/compiler': version,
+      }
+  const pnpm = localTarballs.compiler
+    ? {
+        overrides: {
+          '@pandacss/compiler': 'file:./compiler.tgz',
+          '@pandacss/compiler-wasm32-wasi': 'file:./compiler-wasm32-wasi.tgz',
+          ...(localTarballs.compilerShared ? { '@pandacss/compiler-shared': 'file:./compiler-shared.tgz' } : {}),
+          ...(localTarballs.config ? { '@pandacss/config': 'file:./config.tgz' } : {}),
+          ...(localTarballs.types ? { '@pandacss/types': 'file:./types.tgz' } : {}),
+        },
+      }
+    : undefined
+
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>Panda WebContainer Verification</title>
+<pre id="log">Booting WebContainer...</pre>
+<script type="module">
+import { WebContainer } from 'https://esm.sh/@webcontainer/api@1.6.4'
+
+const logEl = document.getElementById('log')
+const log = (line) => {
+  logEl.textContent += '\\n' + line
+}
+
+const dependencies = ${JSON.stringify(dependencies, null, 2)}
+const files = {
+  'package.json': {
+    file: {
+      contents: JSON.stringify({
+        type: 'module',
+        scripts: { test: 'node test.mjs' },
+        dependencies,
+        pnpm: ${JSON.stringify(pnpm)},
+      }, null, 2),
+    },
+  },
+  'test.mjs': {
+    file: {
+      contents: \`import { compile, getBindingInfo } from '@pandacss/compiler'
+
+const info = getBindingInfo()
+console.log('binding info:', JSON.stringify(info))
+if (!info.native) throw new Error('Expected native-compatible WASI binding')
+
+const output = compile()
+if (!output || typeof output.css !== 'string') {
+  throw new Error('Expected compile() to return CSS output')
+}
+console.log('compile ok')\`,
+    },
+  },
+}
+
+for (const [name, route] of Object.entries(${JSON.stringify(routes, null, 2)})) {
+  files[route.url.slice(1)] = {
+    file: { contents: new Uint8Array(await (await fetch(route.url)).arrayBuffer()) },
+  }
+}
+
+const webcontainer = await WebContainer.boot({ coep: 'require-corp' })
+await webcontainer.mount(files)
+log('Mounted test project')
+
+await run(webcontainer, 'pnpm', ['i'])
+await run(webcontainer, 'pnpm', ['test'])
+log('PASS: @pandacss/compiler loaded through WebContainer')
+
+async function run(webcontainer, command, args) {
+  log('$ ' + [command, ...args].join(' '))
+  const process = await webcontainer.spawn(command, args)
+  process.output.pipeTo(new WritableStream({
+    write(data) {
+      log(data.trimEnd())
+    },
+  }))
+  const exitCode = await process.exit
+  if (exitCode !== 0) throw new Error(command + ' failed with exit code ' + exitCode)
+}
+</script>`
+}

--- a/packages/compiler/src/load-binary.ts
+++ b/packages/compiler/src/load-binary.ts
@@ -1,12 +1,14 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { NativeBinding } from './types'
 
 // napi-generated loader at the package root. Require via a variable so bundlers
 // leave it external.
 const bindingUrl = new URL('../binding.cjs', import.meta.url)
+const webContainerWasiPackage = '@pandacss/compiler-wasm32-wasi'
 
 /** Returns `undefined` when the generated loader is absent so callers can fall back in source-only installs. */
 export function loadNativeBinding(): NativeBinding | undefined {
@@ -14,7 +16,12 @@ export function loadNativeBinding(): NativeBinding | undefined {
   if (!bindingPath) return undefined
 
   const require = createRequire(bindingPath)
-  return require(bindingPath) as NativeBinding
+  try {
+    return require(bindingPath) as NativeBinding
+  } catch (error) {
+    if (!isWebContainer()) throw error
+    return loadWebContainerBinding(require, bindingPath, error)
+  }
 }
 
 function resolveBindingPath(): string | undefined {
@@ -44,4 +51,59 @@ function isCompilerPackageRoot(cwd: string): boolean {
   } catch {
     return false
   }
+}
+
+export function isWebContainer(): boolean {
+  const versions = process.versions as NodeJS.ProcessVersions & { webcontainer?: string }
+  return Boolean(versions.webcontainer)
+}
+
+export function resolveWebContainerBinding(version: string, root = '/tmp') {
+  const baseDir = join(root, `pandacss-compiler-${version}`)
+  return {
+    baseDir,
+    bindingPackage: `${webContainerWasiPackage}@${version}`,
+    bindingEntry: join(baseDir, 'node_modules', webContainerWasiPackage, 'compiler.wasi.cjs'),
+  }
+}
+
+function loadWebContainerBinding(require: NodeJS.Require, bindingPath: string, nativeError: unknown): NativeBinding {
+  const version = readCompilerVersion(require, dirname(bindingPath))
+  const { baseDir, bindingPackage, bindingEntry } = resolveWebContainerBinding(version)
+
+  if (!existsSync(bindingEntry)) {
+    rmSync(baseDir, { recursive: true, force: true })
+    mkdirSync(baseDir, { recursive: true })
+    execFileSync('pnpm', ['i', bindingPackage], {
+      cwd: baseDir,
+      stdio: 'inherit',
+    })
+  }
+
+  try {
+    return require(bindingEntry) as NativeBinding
+  } catch (fallbackError) {
+    throw new Error('Failed to load @pandacss/compiler WebContainer WASI fallback', {
+      cause: chainError(nativeError, fallbackError),
+    })
+  }
+}
+
+function readCompilerVersion(require: NodeJS.Require, packageRoot: string): string {
+  try {
+    const packageJsonPath = require.resolve('@pandacss/compiler/package.json')
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+    return packageJson.version
+  } catch {
+    const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))
+    return packageJson.version
+  }
+}
+
+function chainError(primary: unknown, cause: unknown): unknown {
+  if (primary instanceof Error) {
+    primary.cause = cause
+    return primary
+  }
+  return cause
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,6 @@ settings:
 overrides:
   '@swc/helpers@~0.4': 0.4.36
   picomatch@4.0.3: 4.0.4
-  emnapi: 1.11.1
-  '@emnapi/core': 1.11.1
-  '@emnapi/runtime': 1.11.1
 
 importers:
 
@@ -2816,11 +2813,20 @@ packages:
   '@dxup/unimport@0.1.2':
     resolution: {integrity: sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -4600,7 +4606,7 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/runtime': ^1.7.1
     peerDependenciesMeta:
       '@emnapi/runtime':
         optional: true
@@ -4863,8 +4869,8 @@ packages:
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==}
@@ -20732,14 +20738,30 @@ snapshots:
 
   '@dxup/unimport@0.1.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
@@ -22407,6 +22429,13 @@ snapshots:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -24148,9 +24177,9 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   '@swc/helpers@~0.4': 0.4.36
   picomatch@4.0.3: 4.0.4
+  emnapi: 1.11.1
+  '@emnapi/core': 1.11.1
+  '@emnapi/runtime': 1.11.1
 
 importers:
 
@@ -167,6 +170,9 @@ importers:
 
   packages/compiler:
     dependencies:
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.6
+        version: 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@pandacss/compiler-shared':
         specifier: workspace:*
         version: link:../compiler-shared
@@ -176,7 +182,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.7.1
-        version: 3.7.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.10.1)(node-addon-api@7.1.1)
+        version: 3.7.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(node-addon-api@7.1.1)
       '@pandacss/preset-base':
         specifier: workspace:*
         version: link:../preset-base
@@ -628,7 +634,7 @@ importers:
         version: link:../css-lib
       nuxt:
         specifier: 4.2.1
-        version: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+        version: 4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       vue:
         specifier: 3.5.25
         version: 3.5.25(typescript@6.0.2)
@@ -800,7 +806,7 @@ importers:
         version: link:../../packages/vite
       nuxt:
         specifier: 4.2.1
-        version: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+        version: 4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       vue:
         specifier: 3.5.25
         version: 3.5.25(typescript@6.0.2)
@@ -2810,14 +2816,14 @@ packages:
   '@dxup/unimport@0.1.2':
     resolution: {integrity: sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -4594,7 +4600,7 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/runtime': 1.11.1
     peerDependenciesMeta:
       '@emnapi/runtime':
         optional: true
@@ -4854,11 +4860,11 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     resolution: {integrity: sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==}
@@ -6967,6 +6973,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -9927,8 +9936,8 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
-  emnapi@1.11.0:
-    resolution: {integrity: sha512-3+AyVLAzk2jr9FPnCT9fgU4/gGoHrB3MpYxqNG6JdmkWmFPpKAhArQgfK/WEiT9kExX2ecXVA6DoPceDShR47g==}
+  emnapi@1.11.1:
+    resolution: {integrity: sha512-kSRjhIcxjMFsBqk7ORvoc9aA5SBKDmecrtF5RMcmOTao0kD/zamaxsuTxMI8C1//wGUuvE7a+19pCE7AEhGVnA==}
     peerDependencies:
       node-addon-api: '>= 6.1.0'
     peerDependenciesMeta:
@@ -20723,21 +20732,18 @@ snapshots:
 
   '@dxup/unimport@0.1.2': {}
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
-    optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -21650,7 +21656,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -22200,22 +22206,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  '@napi-rs/cli@3.7.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.10.1)(node-addon-api@7.1.1)':
+  '@napi-rs/cli@3.7.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(node-addon-api@7.1.1)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.10.1)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       colorette: 2.0.20
-      emnapi: 1.11.0(node-addon-api@7.1.1)
+      emnapi: 1.11.1(node-addon-api@7.1.1)
       es-toolkit: 1.47.0
       js-yaml: 4.2.0
       obug: 2.1.2
       semver: 7.8.4
       typanion: 3.14.0
     optionalDependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
@@ -22232,10 +22238,10 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/lzma': 1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@napi-rs/tar': 1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/lzma': 1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/tar': 1.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       debug: 4.4.3
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -22281,9 +22287,9 @@ snapshots:
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     optional: true
 
-  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -22298,7 +22304,7 @@ snapshots:
   '@napi-rs/lzma-win32-x64-msvc@1.4.5':
     optional: true
 
-  '@napi-rs/lzma@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/lzma@1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
       '@napi-rs/lzma-android-arm-eabi': 1.4.5
       '@napi-rs/lzma-android-arm64': 1.4.5
@@ -22313,7 +22319,7 @@ snapshots:
       '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-musl': 1.4.5
-      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
       '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
       '@napi-rs/lzma-win32-x64-msvc': 1.4.5
@@ -22357,9 +22363,9 @@ snapshots:
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     optional: true
 
-  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -22374,7 +22380,7 @@ snapshots:
   '@napi-rs/tar-win32-x64-msvc@1.1.0':
     optional: true
 
-  '@napi-rs/tar@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/tar@1.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
       '@napi-rs/tar-android-arm-eabi': 1.1.0
       '@napi-rs/tar-android-arm64': 1.1.0
@@ -22388,7 +22394,7 @@ snapshots:
       '@napi-rs/tar-linux-s390x-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-musl': 1.1.0
-      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@napi-rs/tar-win32-arm64-msvc': 1.1.0
       '@napi-rs/tar-win32-ia32-msvc': 1.1.0
       '@napi-rs/tar-win32-x64-msvc': 1.1.0
@@ -22398,17 +22404,16 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
@@ -22437,9 +22442,9 @@ snapshots:
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -22454,7 +22459,7 @@ snapshots:
   '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     optionalDependencies:
       '@napi-rs/wasm-tools-android-arm-eabi': 1.0.1
       '@napi-rs/wasm-tools-android-arm64': 1.0.1
@@ -22465,7 +22470,7 @@ snapshots:
       '@napi-rs/wasm-tools-linux-arm64-musl': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-gnu': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-musl': 1.0.1
-      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1
@@ -22783,7 +22788,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)':
+  '@nuxt/nitro-server@4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.2.1(magicast@0.3.5)
@@ -22801,7 +22806,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.12.9(rolldown@1.0.0-rc.17)
-      nuxt: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -22847,7 +22852,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)':
+  '@nuxt/nitro-server@4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
@@ -22865,7 +22870,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.12.9(rolldown@1.0.0-rc.17)
-      nuxt: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -22953,7 +22958,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)':
+  '@nuxt/vite-builder@4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.53.1)
@@ -22973,7 +22978,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.14
@@ -23014,7 +23019,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)':
+  '@nuxt/vite-builder@4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.53.1)
@@ -23034,7 +23039,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.14
@@ -23181,9 +23186,9 @@ snapshots:
   '@oxc-minify/binding-linux-x64-musl@0.96.0':
     optional: true
 
-  '@oxc-minify/binding-wasm32-wasi@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-minify/binding-wasm32-wasi@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -23231,9 +23236,9 @@ snapshots:
   '@oxc-parser/binding-linux-x64-musl@0.96.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-parser/binding-wasm32-wasi@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -23285,9 +23290,9 @@ snapshots:
   '@oxc-transform/binding-linux-x64-musl@0.96.0':
     optional: true
 
-  '@oxc-transform/binding-wasm32-wasi@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-transform/binding-wasm32-wasi@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -24143,9 +24148,9 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
@@ -24939,6 +24944,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -28762,7 +28771,7 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
-  emnapi@1.11.0(node-addon-api@7.1.1):
+  emnapi@1.11.1(node-addon-api@7.1.1):
     optionalDependencies:
       node-addon-api: 7.1.1
 
@@ -33953,16 +33962,16 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
+  nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@dxup/nuxt': 0.2.2(magicast@0.3.5)
       '@nuxt/cli': 3.30.0(magicast@0.3.5)
       '@nuxt/devtools': 3.1.1(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.25(typescript@6.0.2))
       '@nuxt/kit': 4.2.1(magicast@0.3.5)
-      '@nuxt/nitro-server': 4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)
+      '@nuxt/nitro-server': 4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)
       '@nuxt/schema': 4.2.1
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)
+      '@nuxt/vite-builder': 4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)
       '@unhead/vue': 2.0.19(vue@3.5.25(typescript@6.0.2))
       '@vue/shared': 3.5.25
       c12: 3.3.1(magicast@0.3.5)
@@ -33990,10 +33999,10 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
       on-change: 6.0.1
-      oxc-minify: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      oxc-parser: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      oxc-transform: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      oxc-walker: 0.5.2(oxc-parser@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      oxc-minify: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-parser: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-transform: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-walker: 0.5.2(oxc-parser@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       pathe: 2.0.3
       perfect-debounce: 2.0.0
       pkg-types: 2.3.0
@@ -34076,16 +34085,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
+  nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@dxup/nuxt': 0.2.2(magicast@0.5.1)
       '@nuxt/cli': 3.30.0(magicast@0.5.1)
       '@nuxt/devtools': 3.1.1(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.25(typescript@6.0.2))
       '@nuxt/kit': 4.2.1(magicast@0.5.1)
-      '@nuxt/nitro-server': 4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)
+      '@nuxt/nitro-server': 4.2.1(db0@0.3.4)(ioredis@5.8.2)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rolldown@1.0.0-rc.17)(typescript@6.0.2)
       '@nuxt/schema': 4.2.1
       '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)
+      '@nuxt/vite-builder': 4.2.1(@types/node@24.10.1)(eslint@9.39.1(jiti@2.6.1))(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(nuxt@4.2.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@parcel/watcher@2.5.1)(@types/node@24.10.1)(@vue/compiler-sfc@3.5.25)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.8.2)(less@4.4.2)(lightningcss@1.31.1)(magicast@0.5.1)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.0.0-rc.17)(rollup@4.53.1)(terser@5.44.1)(tsx@4.20.6)(typescript@6.0.2)(vue@3.5.25(typescript@6.0.2))(yaml@2.8.1)
       '@unhead/vue': 2.0.19(vue@3.5.25(typescript@6.0.2))
       '@vue/shared': 3.5.25
       c12: 3.3.1(magicast@0.5.1)
@@ -34113,10 +34122,10 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
       on-change: 6.0.1
-      oxc-minify: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      oxc-parser: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      oxc-transform: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      oxc-walker: 0.5.2(oxc-parser@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      oxc-minify: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-parser: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-transform: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      oxc-walker: 0.5.2(oxc-parser@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       pathe: 2.0.3
       perfect-debounce: 2.0.0
       pkg-types: 2.3.0
@@ -34365,7 +34374,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-minify@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-minify@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-minify/binding-android-arm64': 0.96.0
       '@oxc-minify/binding-darwin-arm64': 0.96.0
@@ -34379,14 +34388,14 @@ snapshots:
       '@oxc-minify/binding-linux-s390x-gnu': 0.96.0
       '@oxc-minify/binding-linux-x64-gnu': 0.96.0
       '@oxc-minify/binding-linux-x64-musl': 0.96.0
-      '@oxc-minify/binding-wasm32-wasi': 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-minify/binding-wasm32-wasi': 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-minify/binding-win32-arm64-msvc': 0.96.0
       '@oxc-minify/binding-win32-x64-msvc': 0.96.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-parser@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-parser@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.96.0
     optionalDependencies:
@@ -34402,14 +34411,14 @@ snapshots:
       '@oxc-parser/binding-linux-s390x-gnu': 0.96.0
       '@oxc-parser/binding-linux-x64-gnu': 0.96.0
       '@oxc-parser/binding-linux-x64-musl': 0.96.0
-      '@oxc-parser/binding-wasm32-wasi': 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-parser/binding-wasm32-wasi': 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-parser/binding-win32-arm64-msvc': 0.96.0
       '@oxc-parser/binding-win32-x64-msvc': 0.96.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-transform@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-transform@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-transform/binding-android-arm64': 0.96.0
       '@oxc-transform/binding-darwin-arm64': 0.96.0
@@ -34423,17 +34432,17 @@ snapshots:
       '@oxc-transform/binding-linux-s390x-gnu': 0.96.0
       '@oxc-transform/binding-linux-x64-gnu': 0.96.0
       '@oxc-transform/binding-linux-x64-musl': 0.96.0
-      '@oxc-transform/binding-wasm32-wasi': 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-transform/binding-wasm32-wasi': 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-transform/binding-win32-arm64-msvc': 0.96.0
       '@oxc-transform/binding-win32-x64-msvc': 0.96.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-walker@0.5.2(oxc-parser@0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
+  oxc-walker@0.5.2(oxc-parser@0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
     dependencies:
       magic-regexp: 0.10.0
-      oxc-parser: 0.96.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-parser: 0.96.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   oxlint@1.70.0:
     optionalDependencies:

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs'
+
+const compilerPackage = JSON.parse(readFileSync('packages/compiler/package.json', 'utf8'))
+
+if (!compilerPackage.optionalDependencies?.['@pandacss/compiler-wasm32-wasi']) {
+  throw new Error(
+    'Missing @pandacss/compiler-wasm32-wasi optionalDependency. Run `pnpm release:prepare` before `pnpm release:verify`.',
+  )
+}


### PR DESCRIPTION
## 📝 Description

Ships a `wasm32-wasi` build of the compiler so Panda runs in WebContainer-based environments like StackBlitz.

## ⛳️ Current behavior (updates)

The v2 compiler is a native NAPI addon. WebContainers can't load `.node` binaries, so StackBlitz can't run Panda and the "edit on StackBlitz" link in the README is broken. v1 worked there because it was pure JS.

## 🚀 New behavior

Adds a `wasm32-wasip1-threads` target and publishes `@pandacss/compiler-wasm32-wasi`. The loader already falls back to it when no native binding is present, so these environments get a working compiler with no API changes. The release workflow builds the artifact alongside the native binaries.

Two things were needed to make it load:

- `build.rs` links the cdylib as a WASI reactor (exports `_initialize`). Without it the module hangs forever on `require()`: emnapi calls `wasi.initialize()`, which needs `_initialize` to run `__wasm_call_ctors`. A plain cdylib only exports `__wasm_init_memory`, so the runtime never initializes. It uses Rust's bundled `crt1-reactor.o`, so there's no wasi-sdk to install.
- emnapi packages are pinned to `1.11.1` to match `@napi-rs/wasm-runtime`. The build rejects a version mismatch, and a stale ABI is itself a cause of the load hang.

Verified by loading the build in a Linux `node:22` container: it instantiates in ~50ms and `compile()` returns the same output as the native binding on the same input.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The minify follow-up for `pandacss_stylesheet` is unrelated and still open. This only adds a new build target; it doesn't touch native output.
