### PR TITLE
fix(compiler): set jsxFramework in test configs so JSX extraction runs

### DIFF
--- a/packages/compiler/__tests__/callbacks.test.ts
+++ b/packages/compiler/__tests__/callbacks.test.ts
@@ -11,6 +11,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
         },
         hooks: {
           'parser:before': [
@@ -55,6 +56,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
         },
         hooks: {
           'parser:before': [
@@ -88,6 +90,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -138,6 +141,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             tint: {
               transform: {
@@ -200,6 +204,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -321,6 +326,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           conditions: {
             hover: '&:hover',
           },
@@ -388,6 +394,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             inset: {
               property: 'inset',
@@ -452,6 +459,7 @@ describe('Compiler callbacks', () => {
             cwd: '/virtual',
             outdir: 'styled-system',
             importMap,
+            jsxFramework: 'react',
             utilities: {
               size: {
                 transform: {
@@ -475,6 +483,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           conditions: {
             hover: '&:hover',
           },
@@ -525,6 +534,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -571,6 +581,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -610,6 +621,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -664,6 +676,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -720,6 +733,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -775,6 +789,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             size: {
               transform: {
@@ -823,6 +838,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           conditions: {
             hover: '&:hover',
           },
@@ -902,6 +918,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           conditions: {
             hover: '&:hover',
           },
@@ -971,6 +988,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           patterns: {
             stack: {
               jsxName: 'Stack',
@@ -1032,6 +1050,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           patterns: {
             stack: {
               jsxName: 'Stack',
@@ -1094,6 +1113,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           patterns: {
             stack: {
               properties: {
@@ -1157,6 +1177,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           patterns: {
             stack: {
               jsxName: 'Stack',
@@ -1216,6 +1237,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           patterns: {
             stack: {
               jsxName: 'Stack',
@@ -1286,6 +1308,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           patterns: {
             stack: {
               properties: { align: {} },
@@ -1368,6 +1391,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           conditions: {
             hover: '&:hover',
           },
@@ -1445,6 +1469,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             alignItems: { className: 'ai' },
           },
@@ -1503,6 +1528,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           theme: { tokens: { spacing: { '4': { value: '1rem' } } } },
           utilities: {
             spaceX: {
@@ -1542,6 +1568,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           theme: { tokens: { colors: { red: { '500': { value: '#f00' } } } } },
           utilities: {
             boxColor: {
@@ -1579,6 +1606,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           conditions: { hover: '&:hover' },
           utilities: {
             debug: {
@@ -1615,6 +1643,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           theme: {
             tokens: {
               radii: {
@@ -1667,6 +1696,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             gradientBorder: {
               className: 'gradient-border',
@@ -1737,6 +1767,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             stackDir: {
               className: 'stack-dir',
@@ -1777,6 +1808,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           utilities: {
             layer: {
               className: 'layer',
@@ -1816,6 +1848,7 @@ describe('Compiler callbacks', () => {
           cwd: '/virtual',
           outdir: 'styled-system',
           importMap,
+          jsxFramework: 'react',
           theme: {
             tokens: {
               radii: {

--- a/packages/compiler/__tests__/project.test.ts
+++ b/packages/compiler/__tests__/project.test.ts
@@ -122,6 +122,7 @@ describe('Compiler', () => {
         "types/system.d.ts",
         "types/pattern.d.ts",
         "types/recipe.d.ts",
+        "types/jsx.d.ts",
         "types/index.d.ts",
       ]
     `)
@@ -405,6 +406,7 @@ describe('Compiler', () => {
         cwd: '/virtual',
         outdir: 'styled-system',
         importMap,
+        jsxFramework: 'react',
         jsxStyleProps: 'none',
         patterns: {
           stack: {

--- a/packages/compiler/__tests__/recipes.test.ts
+++ b/packages/compiler/__tests__/recipes.test.ts
@@ -58,6 +58,7 @@ describe('Compiler recipes', () => {
         cwd: '/virtual',
         outdir: 'styled-system',
         importMap,
+        jsxFramework: 'react',
         theme: {
           recipes: {
             button: {
@@ -110,6 +111,7 @@ describe('Compiler recipes', () => {
         cwd: '/virtual',
         outdir: 'styled-system',
         importMap,
+        jsxFramework: 'react',
         theme: {
           recipes: {
             button: {
@@ -217,6 +219,7 @@ describe('Compiler recipes', () => {
         cwd: '/virtual',
         outdir: 'styled-system',
         importMap,
+        jsxFramework: 'react',
         theme: {
           recipes: {
             button: {
@@ -259,6 +262,7 @@ describe('Compiler recipes', () => {
         cwd: '/virtual',
         outdir: 'styled-system',
         importMap,
+        jsxFramework: 'react',
         theme: {
           recipes: {
             button: {
@@ -343,6 +347,7 @@ describe('Compiler recipes', () => {
         cwd: '/virtual',
         outdir: 'styled-system',
         importMap,
+        jsxFramework: 'react',
         theme: {
           breakpoints: {
             md: '768px',

--- a/packages/compiler/__tests__/test-utils.ts
+++ b/packages/compiler/__tests__/test-utils.ts
@@ -15,6 +15,7 @@ export function createUserConfig(overrides: SerializedConfig = {}): SerializedCo
     outdir: 'styled-system',
     importMap,
     jsxFactory: 'styled',
+    jsxFramework: 'react',
     ...overrides,
   }
 }


### PR DESCRIPTION
The `@pandacss/compiler` test suite has been failing on `v2` since June 3, and CI doesn't catch it. This sets the one config field that fixes it.

## What's wrong

JSX extraction is gated on `config.jsxFramework` (`crates/pandacss_project/src/config.rs`): no framework, no JSX scanning. That gate landed on 2026-06-03 (`12e4c46fb`). The compiler test configs set `jsxFactory` but never `jsxFramework`, so from that commit on, every JSX-dependent test in `packages/compiler/__tests__` returns empty JSX and fails. The `pandacss_extractor` crate tests pass because they enable the framework explicitly, so the engine itself is fine — only the JS test configs are stale.

It went unnoticed because CI runs root `pnpm test`, and the root vitest config **excludes `packages/compiler/__tests__/**`**. The suite only runs via `pnpm --filter @pandacss/compiler test`, which CI never invokes. So it's been green in CI and red locally for months.

## The fix

Set `jsxFramework: 'react'` in the test configs that exercise JSX — the shared `createUserConfig` and the inline configs in `callbacks`, `recipes`, and `project`. Most snapshots already expected the JSX-derived atoms; they just weren't being produced. One snapshot legitimately changes: a framework-enabled project now generates `types/jsx.d.ts`, so it's added to the codegen-artifacts list.

`pnpm --filter @pandacss/compiler test` goes from 24 failing to **0** (199 passing).

## Follow-up worth considering

Add the `@pandacss/compiler` suite to CI (it isn't run today) so this can't silently regress again. Left out of this PR to keep it focused.
