### PR TITLE
fix(compiler): memoize css() runtime serialization

### DIFF
--- a/.changeset/css-runtime-memo.md
+++ b/.changeset/css-runtime-memo.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+---
+
+Speed up the generated `css()` runtime. Calling `css({ ... })` inline with the same styles now
+reuses a cached result instead of re-serializing on every call, so style-heavy trees render
+noticeably faster (~3x on a dense SSR page).

--- a/crates/pandacss_codegen/src/artifacts/helpers/css.rs
+++ b/crates/pandacss_codegen/src/artifacts/helpers/css.rs
@@ -77,7 +77,7 @@ pub(super) fn create_css_runtime() -> Item {
               parts.push(hash ? name : fmt(name))
               return hash ? fmt(u.toHash(parts, toHash)) : parts.join(":")
             }
-            const serializeCss = weakMemo(function serializeCss({ base, ...styles }: Record<string, any> = {}) {
+            const serializeCss = weakMemo(memo(function serializeCss({ base, ...styles }: Record<string, any> = {}) {
               const obj = normalizeStyleObject(base ? Object.assign(styles, base) : styles, context)
               const set = new Set<string>()
               walkObject(obj, (value: any, paths: string[]) => {
@@ -93,7 +93,7 @@ pub(super) fn create_css_runtime() -> Item {
               let out = ""
               for (const name of set) out += out ? " " + name : name
               return out
-            })
+            }))
             const resolve = (styles: Array<any> | IArguments) => {
               const out: any[] = []
               const visit = (items: Array<any> | IArguments) => {

--- a/crates/pandacss_codegen/tests/helpers_artifact.rs
+++ b/crates/pandacss_codegen/tests/helpers_artifact.rs
@@ -693,7 +693,7 @@ fn emits_ts_source() {
         parts.push(hash ? name : fmt(name))
         return hash ? fmt(u.toHash(parts, toHash)) : parts.join(":")
       }
-      const serializeCss = weakMemo(function serializeCss({ base, ...styles }: Record<string, any> = {}) {
+      const serializeCss = weakMemo(memo(function serializeCss({ base, ...styles }: Record<string, any> = {}) {
         const obj = normalizeStyleObject(base ? Object.assign(styles, base) : styles, context)
         const set = new Set<string>()
         walkObject(obj, (value: any, paths: string[]) => {
@@ -709,7 +709,7 @@ fn emits_ts_source() {
         let out = ""
         for (const name of set) out += out ? " " + name : name
         return out
-      })
+      }))
       const resolve = (styles: Array<any> | IArguments) => {
         const out: any[] = []
         const visit = (items: Array<any> | IArguments) => {
@@ -970,7 +970,7 @@ fn emits_js_runtime() {
         parts.push(hash ? name : fmt(name))
         return hash ? fmt(u.toHash(parts, toHash)) : parts.join(":")
       }
-      const serializeCss = weakMemo(function serializeCss({ base, ...styles } = {}) {
+      const serializeCss = weakMemo(memo(function serializeCss({ base, ...styles } = {}) {
         const obj = normalizeStyleObject(base ? Object.assign(styles, base) : styles, context)
         const set = new Set()
         walkObject(obj, (value, paths) => {
@@ -986,7 +986,7 @@ fn emits_js_runtime() {
         let out = ""
         for (const name of set) out += out ? " " + name : name
         return out
-      })
+      }))
       const resolve = (styles) => {
         const out = []
         const visit = (items) => {


### PR DESCRIPTION
## What

The generated `css()` runtime re-serializes on every call for the most common usage pattern. This memoizes it so repeated calls reuse a cached result, cutting render time for style-heavy trees by ~3x.

## Why

`serializeCss` was wrapped only in `weakMemo`, which keys its cache on object **reference**. Inline `css({ ... })` builds a fresh object every render, so the key is new every time — the cache never hits, and every call walks the style object and rebuilds the class string from scratch.

v1 avoided this by memoizing with a value-keyed `Map` (`JSON.stringify` of the args), so a fresh object with identical content still hit. v2 traded that for reference identity, which only helps when you reuse the same object (hoisted or memoized styles) — not the inline literals that make up most `css()` calls.

The fix layers both: `weakMemo(memo(serialize))`. Stable references hit the `WeakMap` (fastest), fresh-but-repeated content hits the value-keyed `memo`, and only genuinely new styles pay full serialization. Both caches are already emitted in the runtime helpers, so this is a one-line wrap.

## Impact

A dense 400-tile SSR page (react-dom/server, medians), swapping the generated runtime via symlink:

| complex page (ms/render) | style-props | css fn |
| ------------------------ | ----------- | ------ |
| before                   | 40.5        | 29.2   |
| after                    | 21.6        | 9.9    |

`css()` drops from 29.2 to 9.9 ms — faster than the v1 baseline (~11 ms). Style-props inherits the win because the JSX factory serializes internally.

A focused microbenchmark (200k calls, fresh objects with identical content): 776 ms → 130 ms.

## Verification

- `cargo test -p pandacss_codegen` — runtime-helper snapshots updated to the layered wrap
- `cargo fmt --check` and `cargo clippy -p pandacss_codegen -- -D warnings` clean
- Rebuilt the native compiler, regenerated a real project's styled-system, and measured before/after against `1.11.4` and `2.0.0-beta.8`

Thanks to Jan Nicklas for the benchmark that surfaced this.
