### PR TITLE
test: resolve @pandacss/*/subpath imports in vitest alias

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,7 +44,11 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@pandacss\/(.*)$/,
+        find: /^@pandacss\/([^/]+)\/(.*)$/,
+        replacement: resolve('./packages/$1/src/$2'),
+      },
+      {
+        find: /^@pandacss\/([^/]+)$/,
         replacement: resolve('./packages/$1/src'),
       },
     ],


### PR DESCRIPTION
## What

The Unit Tests job is red on `v2`: the `language-server` and `typescript-plugin` suites fail to load with `Failed to resolve import "@pandacss/compiler/tooling"`. This fixes the vitest alias so subpath imports resolve.

## Why

The alias was:

```ts
{ find: /^@pandacss\/(.*)$/, replacement: resolve('./packages/$1/src') }
```

The greedy `(.*)` captures the whole tail, so `@pandacss/compiler/tooling` resolves to `packages/compiler/tooling/src` — which doesn't exist — instead of `packages/compiler/src/tooling`. It worked until now only because nothing imported a `@pandacss/*` subpath; the new tooling-consuming packages are the first to.

The fix matches the package name and subpath separately, specific rule first:

```ts
{ find: /^@pandacss\/([^/]+)\/(.*)$/, replacement: resolve('./packages/$1/src/$2') },
{ find: /^@pandacss\/([^/]+)$/,        replacement: resolve('./packages/$1/src') },
```

Plain-package imports resolve exactly as before. Subpath imports were all broken previously (they pointed at `packages/x/y/src`), so nothing that worked can regress.

## Verification

```
pnpm vitest run packages/typescript-plugin packages/language-server
→ 5 files, 29 tests, all pass (the 4 that were failing + ast)
```
