### PR TITLE
fix(cli): recover from @parcel/watcher FSEvents "must be re-scanned" instead of crashing

### DIFF
--- a/.changeset/watch-fsevents-rescan.md
+++ b/.changeset/watch-fsevents-rescan.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/cli': patch
+---
+
+Fix `panda --watch` crashing on macOS with `Error: Events were dropped by the FSEvents client. File system must be re-scanned.`
+
+`@parcel/watcher` surfaces a macOS FSEvents backpressure condition — its event buffer overflowed and the OS coalesced the backlog — as a _recoverable_ subscribe-callback error. Apple's FSEvents API sets `kFSEventStreamEventFlagMustScanSubDirs` and expects the client to re-scan. The watcher was rethrowing this error inside `@parcel/watcher`'s native callback, which becomes an uncaught exception and kills the watch process (commonly hit when `panda --watch` runs next to a bundler's dependency pre-bundle, e.g. `vite`). It now recognizes the "must be re-scanned" signal and triggers a full re-scan — re-reading every source file from disk — instead of crashing; any other error is left to propagate unchanged.

--- a/packages/cli/__tests__/watch.test.ts
+++ b/packages/cli/__tests__/watch.test.ts
@@ -9,17 +9,73 @@ import {
   formatWatchRebuildStart,
   formatWatchRebuildSuccess,
   handleWatchBatch,
+  isFsEventsRescanError,
   isOutputEvent,
   isWatchableDirectory,
   normalizeParcelEvent,
+  startProjectWatch,
 } from '../src/watch'
 import { createWatchLogger } from '../src/watch-logger'
+import * as parcelWatcher from '@parcel/watcher'
+
+vi.mock('@parcel/watcher', () => ({ subscribe: vi.fn() }))
 
 describe('watch helpers', () => {
   it('normalizes parcel event types', () => {
     expect(normalizeParcelEvent({ type: 'create', path: '/x.tsx' })).toEqual({ kind: 'add', path: '/x.tsx' })
     expect(normalizeParcelEvent({ type: 'update', path: '/x.tsx' })).toEqual({ kind: 'change', path: '/x.tsx' })
     expect(normalizeParcelEvent({ type: 'delete', path: '/x.tsx' })).toEqual({ kind: 'unlink', path: '/x.tsx' })
+  })
+
+  it('recognizes recoverable @parcel/watcher re-scan errors', () => {
+    // The three macOS FSEvents backpressure messages @parcel/watcher can surface.
+    expect(
+      isFsEventsRescanError(new Error('Events were dropped by the FSEvents client. File system must be re-scanned.')),
+    ).toBe(true)
+    expect(isFsEventsRescanError(new Error('Events were dropped by the kernel. File system must be re-scanned.'))).toBe(
+      true,
+    )
+    expect(isFsEventsRescanError(new Error('Too many events. File system must be re-scanned.'))).toBe(true)
+
+    // Genuine watcher failures (and non-errors) must not be treated as recoverable.
+    expect(isFsEventsRescanError(new Error('Not a directory'))).toBe(false)
+    expect(isFsEventsRescanError('must be re-scanned')).toBe(false)
+    expect(isFsEventsRescanError(null)).toBe(false)
+  })
+
+  it('re-scans instead of crashing when the OS watcher drops events, and rethrows other errors', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'panda-watch-'))
+    let captured: ((error: Error | null, events: never[]) => void) | undefined
+
+    vi.mocked(parcelWatcher.subscribe).mockImplementation(async (_dir, callback) => {
+      captured = callback
+      return { unsubscribe: () => Promise.resolve() }
+    })
+
+    const onRescan = vi.fn()
+    const onSourceChange = vi.fn()
+    const stop = await startProjectWatch({
+      driver: { watchTargets: () => ({ config: [], dirs: [dir] }), isConfigFile: () => false } as any,
+      cwd: dir,
+      outdir: 'styled-system',
+      onSourceChange,
+      onConfigChange: vi.fn(),
+      onRescan,
+    })
+
+    try {
+      // A dropped-events backpressure signal must recover via a full re-scan, not crash.
+      captured!(new Error('Events were dropped by the FSEvents client. File system must be re-scanned.'), [])
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(onRescan).toHaveBeenCalledTimes(1)
+      expect(onSourceChange).not.toHaveBeenCalled()
+
+      // Any other error is a genuine watcher failure and still propagates.
+      expect(() => captured!(new Error('watcher backend crashed'), [])).toThrow('watcher backend crashed')
+    } finally {
+      await stop()
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('debounces multiple events into one batch', async () => {

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -166,6 +166,11 @@ export async function runAnalyze(flags: AnalyzeFlags = {}, output: OutputSink = 
         result.driver!.applyChanges(events)
         await refresh(reason)
       },
+      // onSourceChange short-circuits when the fingerprints are unchanged; a
+      // dropped-events re-scan has no events to fingerprint, so refresh directly.
+      onRescan: async () => {
+        await refresh('re-scan')
+      },
       onConfigChange: async (events) => {
         const reason = formatAnalyzeUiChange(runCtx!.cwd, 'config', events)
         watchLogger.log(`analyze: ${reason}`, { dedupeKey: `change:${reason}` })

--- a/packages/cli/src/commands/cssgen.ts
+++ b/packages/cli/src/commands/cssgen.ts
@@ -97,6 +97,12 @@ export async function runCssgen(flags: CssgenFlags = {}, output: OutputSink = co
         current = await writeCssgenOutput(runCtx!, resolveOutfile!(), flags, current.parsed)
         Object.assign(result, current)
       },
+      // The incremental path above reuses the cached parse; on a dropped-events
+      // re-scan we must re-read every file, so go through cssgenOnce (parseFiles).
+      onRescan: async () => {
+        current = await cssgenOnce(runCtx!, resolveOutfile!(), flags)
+        Object.assign(result, current)
+      },
       onConfigChange: async () => {
         const diff = await result.driver!.reload()
 

--- a/packages/cli/src/watch.ts
+++ b/packages/cli/src/watch.ts
@@ -19,11 +19,26 @@ export interface ProjectWatchOptions {
   onError?(error: unknown): void
   onSourceChange(events: WatchEvent[]): Promise<void> | void
   onConfigChange(events: WatchEvent[]): Promise<void> | void
+  // Full rebuild used to recover from a dropped-events signal (see the subscribe
+  // handler below). Defaults to `onSourceChange([])`, which re-reads from disk for
+  // the default `build`/`lib` commands; commands whose incremental `onSourceChange`
+  // skips a re-parse (`cssgen`, `analyze`) override this to force a full re-scan.
+  onRescan?(): Promise<void> | void
 }
 
 export function formatWatchError(error: unknown): string {
   if (error instanceof Error) return error.stack ?? error.message
   return String(error)
+}
+
+// `@parcel/watcher` relays a macOS FSEvents backpressure condition — its user- or
+// kernel-side event buffer overflowed and the OS coalesced the backlog — as a
+// *recoverable* subscribe-callback error whose message contains "must be
+// re-scanned" (the three variants live in @parcel/watcher's FSEventsBackend.cc).
+// Per Apple's FSEvents contract (`kFSEventStreamEventFlagMustScanSubDirs`) the
+// correct response is to re-scan, not to treat the watch as broken.
+export function isFsEventsRescanError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('must be re-scanned')
 }
 
 export function normalizeParcelEvent(event: { type: string; path: string }): WatchEvent | undefined {
@@ -94,6 +109,13 @@ export async function startProjectWatch(options: ProjectWatchOptions): Promise<(
     return serialGate
   }
 
+  // Recovery for a dropped-events signal: a full rebuild that must re-read the
+  // filesystem, since the specific missed paths are unknown. Defaults to
+  // `onSourceChange([])`; commands with an incremental `onSourceChange` pass an
+  // explicit `onRescan` that re-parses from disk.
+  const rescan = (): Promise<void> =>
+    Promise.resolve(options.onRescan ? options.onRescan() : options.onSourceChange([]))
+
   const debouncer = createEventDebouncer<WatchEvent>(async (events) => {
     const batch = splitEvents(events, options.driver)
     await runSerialized(async () => {
@@ -116,7 +138,19 @@ export async function startProjectWatch(options: ProjectWatchOptions): Promise<(
     const subscription = await parcelWatcher.subscribe(
       dir,
       (error, events) => {
-        if (error) throw error
+        if (error) {
+          // Rethrowing here escapes into @parcel/watcher's native callback as an
+          // uncaught exception and kills the watch process. A dropped-events
+          // signal is recoverable — the OS is asking us to re-scan — so run a
+          // full rebuild through the serial gate instead of crashing. Anything
+          // else is a genuine watcher failure and keeps the original throw.
+          if (isFsEventsRescanError(error)) {
+            options.onStatus?.('watch: dropped events, re-scanning')
+            void runSerialized(rescan)
+            return
+          }
+          throw error
+        }
         const normalized = events
           .map((event) => normalizeParcelEvent(event))
           .filter((event): event is WatchEvent => !!event)


### PR DESCRIPTION
## Summary

`panda --watch` crashes on macOS with:

```
[Error: Events were dropped by the FSEvents client. File system must be re-scanned.]
```

which kills the watch process (and any dev server that spawns it — e.g. a Vite-backed app run through `nx serve`). It reproduces reliably when `panda --watch` starts alongside a bundler that churns the filesystem (Vite's dependency pre-bundle, esbuild, …).

## Root cause

`@parcel/watcher`'s macOS FSEvents backend surfaces a **backpressure** condition as a `subscribe` callback error. When the user- or kernel-side event buffer overflows, macOS coalesces the backlog and sets `kFSEventStreamEventFlagMustScanSubDirs`; `@parcel/watcher` reports this as one of three errors, all ending in `File system must be re-scanned.` (see [`FSEventsBackend.cc`](https://github.com/parcel-bundler/watcher/blob/v2.5.1/src/macos/FSEventsBackend.cc#L82-L88)).

Per Apple's FSEvents contract this is a **recoverable** signal — the client is expected to re-scan — but `packages/cli/src/watch.ts` rethrew it:

```ts
;(error, events) => {
  if (error) throw error // ← inside @parcel/watcher's native callback → uncaught exception → process dies
  // ...
}
```

Throwing inside the native callback becomes an uncaught exception (`napi_fatal_exception`), so the whole process dies rather than recovering. For reference, both [Parcel core](https://github.com/parcel-bundler/parcel/blob/v2/packages/core/core/src/Parcel.js) and the [Tailwind CSS CLI](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/%40tailwindcss-cli/src/commands/build/index.ts) log-and-continue in this callback rather than rethrow.

## Fix

Detect the recoverable "must be re-scanned" signal and trigger a **full re-scan** — re-reading every source file from disk — through the existing serial gate, instead of crashing. Every other error keeps the original `throw`.

The re-scan is exposed as an optional `onRescan()` hook on `ProjectWatchOptions`, defaulting to `onSourceChange([])` (a genuine full re-parse for the `build` / default / `lib` commands). `cssgen` and `analyze` — whose incremental `onSourceChange` intentionally reuses the cached parse, and, for `analyze`, short-circuits when fingerprints are unchanged — pass an explicit `onRescan` that re-parses from disk. This keeps the recovery honest for **every** watch command; without it, `cssgen`/`analyze` would stop crashing but silently miss the changes the dropped events represented.

The callback `err` is a plain `Error` with no `code`/subtype (`Watcher.cc` builds it via `Error::New(env, message)`), so the message is the only available discriminator; `"must be re-scanned"` is the common tail of all three FSEvents variants (`UserDropped`, `KernelDropped`, "Too many events").

## Test

- `isFsEventsRescanError` recognizes all three FSEvents backpressure messages and rejects genuine errors / non-`Error` values.
- A behavioral test drives `startProjectWatch` with a mocked `@parcel/watcher`: a dropped-events signal triggers a re-scan (no crash), and any other error still propagates.
