### PR TITLE
fix(compiler): keep native CSS keywords under strictTokens for empty token categories

### DIFF
--- a/.changeset/strict-tokens-empty-category-native-values.md
+++ b/.changeset/strict-tokens-empty-category-native-values.md
@@ -1,0 +1,9 @@
+---
+'@pandacss/compiler': patch
+---
+
+Keep native CSS keywords assignable under `strictTokens` for properties whose token category is empty.
+
+A property like `cursor` (no `cursor` tokens defined) now accepts `'pointer'`, `'grab'`, and other native
+keywords instead of requiring the `[pointer]` escape hatch. The same applies to any utility pointing at an
+unpopulated token category, such as `opacity` and `zIndex`.

--- a/crates/pandacss_codegen/src/artifacts/types.rs
+++ b/crates/pandacss_codegen/src/artifacts/types.rs
@@ -922,6 +922,12 @@ fn value_alias_type(
         return strict_property_value_type(entry, &literals, css_property);
     }
 
+    if let Some(entry) = strict_entry
+        && is_native_mirror_parts(parts)
+    {
+        return native_css_property_value_type(entry.name, options);
+    }
+
     // strictTokens: utilities with configured values are strict even without a
     // token category — v1 dropped the freeform csstype fallback for any utility
     // that had a values map. Number/boolean primitive hints keep their primitive
@@ -1001,6 +1007,20 @@ fn native_css_property_needs_any_string(entry: &strict_props::PropertyValueEntry
             | strict_props::PropertyValueKind::OverflowShort
             | strict_props::PropertyValueKind::OverscrollBehavior { open: false }
     )
+}
+
+fn is_native_mirror_parts(parts: &[ValueTypePart]) -> bool {
+    let mut has_string = false;
+    let mut has_number = false;
+    for part in parts {
+        match part {
+            ValueTypePart::Primitive(PrimitiveType::String) => has_string = true,
+            ValueTypePart::Primitive(PrimitiveType::Number) => has_number = true,
+            ValueTypePart::CssVars | ValueTypePart::AnyString => {}
+            _ => return false,
+        }
+    }
+    has_string && has_number
 }
 
 fn mapped_css_property_from_parts(parts: &[ValueTypePart]) -> Option<&str> {

--- a/crates/pandacss_utility/src/type_data.rs
+++ b/crates/pandacss_utility/src/type_data.rs
@@ -125,8 +125,18 @@ fn collapse_inferred_token_category(
     explicit_category: Option<&str>,
     tokens: Option<&TokenDictionary>,
 ) -> (Option<String>, Vec<String>) {
-    if explicit_category.is_some() {
-        return (explicit_category.map(str::to_owned), literals);
+    if let Some(category) = explicit_category {
+        let token_category = TokenCategory::from_path_segment(category);
+        let empty_known = !matches!(token_category, TokenCategory::Other(_))
+            && tokens.is_some_and(|tokens| {
+                tokens
+                    .category_values_str(&token_category)
+                    .is_none_or(FxHashMap::is_empty)
+            });
+        if empty_known {
+            return (None, literals);
+        }
+        return (Some(category.to_owned()), literals);
     }
 
     let Some(tokens) = tokens else {

--- a/crates/pandacss_utility/tests/type_data.rs
+++ b/crates/pandacss_utility/tests/type_data.rs
@@ -281,6 +281,38 @@ fn collapses_resolved_theme_category_keys_for_typegen() {
 }
 
 #[test]
+fn drops_empty_token_category_so_native_values_survive() {
+    let utility = Utility::from_config_with_options(
+        &utility_config(json!({
+            "cursor": { "values": "cursor" },
+            "color": { "values": "colors" }
+        })),
+        UtilityOptions {
+            tokens: Some(Arc::new(
+                TokenDictionary::builder()
+                    .insert(Token::new(
+                        "colors.red",
+                        "#f00",
+                        "var(--colors-red)",
+                        TokenCategory::Colors,
+                    ))
+                    .build(),
+            )),
+            ..UtilityOptions::default()
+        },
+    );
+
+    let type_data = utility.type_data();
+
+    let cursor = type_data.properties.get("cursor").expect("cursor");
+    assert_eq!(cursor.token_category, None);
+    assert_eq!(cursor.alias, "CursorValue");
+
+    let color = type_data.properties.get("color").expect("color");
+    assert_eq!(color.token_category.as_deref(), Some("colors"));
+}
+
+#[test]
 fn collapses_resolved_gradient_category_keys_for_typegen() {
     let utility = Utility::from_config_with_options(
         &utility_config(json!({

--- a/sandbox/codegen/__tests__/scenarios/strict.test.ts
+++ b/sandbox/codegen/__tests__/scenarios/strict.test.ts
@@ -24,6 +24,13 @@ describe('css', () => {
     assertType(css({ color: 'blue.300' }))
   })
 
+  test('native keyword for property backed by an empty token category', () => {
+    // `cursor` has no tokens in this config; native CSS keywords stay assignable
+    // under strictTokens rather than requiring the escape hatch.
+    assertType(css({ cursor: 'pointer' }))
+    assertType(css({ opacity: 0.5 }))
+  })
+
   test('css var', () => {
     assertType(css({ color: 'var(--button-color)' }))
     assertType(css({ display: 'var(--button-color)' }))


### PR DESCRIPTION
Reported in [#3599](https://github.com/chakra-ui/panda/discussions/3599#discussioncomment-17545208).

## 📝 Description

Under `strictTokens`, `cursor: 'pointer'` stopped type-checking in v2 (regressed in beta.3, fine in v1). `cursor` has no tokens, so its generated type collapsed to tokens-only and rejected every native keyword. Same for any utility on an unpopulated category — `opacity` and `zIndex` hit it too.

The fix lives entirely in type generation. Emitted CSS and runtime behavior are unchanged.

## ⛳️ Current behavior (updates)

`cursor` points at the `cursor` token category (`values: 'cursor'`), but that category has no tokens. v2 still treated it as token-backed and narrowed to `TokenValue<"cursor">`, which is `never`:

```ts
export type CursorValue = WithEscapeHatch<Globals | TokenValue<"cursor"> | CssVars>

cursor: 'pointer'    // ❌ type error since beta.3
cursor: '[pointer]'  // ✅ the forced workaround
```

v1 didn't do this: an empty token set produced no type, and the property fell back to the native CSS value.

## 🚀 New behavior

An empty token category is dropped, and a utility that only mirrors a native CSS property resolves to that property's value type — the same result you'd get if it weren't a utility:

```ts
export type CursorValue = PropertyValueMap["cursor"]

cursor: 'pointer'    // ✅
```

Native keywords are assignable again, and `cursor` tokens layer on top once you define them. Known special sources like `keyframes` and custom categories are left alone, so `animationName` keyframe completions still resolve.

Covered by: `cursor: 'pointer'` / `opacity: 0.5` in the strict codegen scenario, a new Rust test for the native fallback, and the full sandbox codegen suite, compiler tests, and `pandacss_codegen` / `pandacss_utility` / `pandacss_project` Rust tests.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Types only — no change to emitted CSS or runtime.
