### PR TITLE
test(compiler): update loader pattern snapshot for memoized pattern fns

### DIFF
--- a/packages/compiler/__tests__/loader.test.ts
+++ b/packages/compiler/__tests__/loader.test.ts
@@ -50,6 +50,7 @@ describe('loadCompiler', () => {
 
     expect(stack?.code).toMatchInlineSnapshot(`
       "import { getPatternStyles, patternFns } from './runtime';
+      import { memo } from '../helpers';
       import { css } from '../css/index';
 
       const stackConfig = {transform(props) {
@@ -65,9 +66,9 @@ describe('loadCompiler', () => {
         return stackConfig.transform(s, patternFns)
       }
 
-      export const stack = /* @__PURE__ */ Object.assign(function stack(styles = {}) {
+      export const stack = /* @__PURE__ */ Object.assign(memo(function stack(styles = {}) {
         return css(stackRaw(styles))
-      }, { raw: stackRaw })"
+      }), { raw: stackRaw, propKeys: ["gap"] })"
     `)
   })
 


### PR DESCRIPTION
## What

Compiler Tests are red on `v2`: `packages/compiler/__tests__/loader.test.ts` fails on `embeds the user pattern transform in the generated pattern module`.

## Why

The merged pattern-helper memoization changed the generated pattern module — `stack` is now wrapped in `memo(...)` and carries `propKeys` — but this inline snapshot wasn't regenerated. The diff is exactly that change; no behavior change here, just the stale snapshot.

## Verification

```
pnpm --filter @pandacss/compiler exec vitest run loader
→ 3 passed
```