### PR TITLE
feat(config): support minify config key; docs: design system migration path

### DIFF
--- a/.changeset/config-minify-key.md
+++ b/.changeset/config-minify-key.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/types': patch
+'@pandacss/cli': patch
+---
+
+Support `minify` as a top-level config key. The migration guide and `panda cssgen --minify` already treated it as one, but the `Config` type rejected it and nothing read it. `cssgen` now honors `minify` from config, and the `--minify` flag still overrides it.

--- a/V2_MIGRATION.md
+++ b/V2_MIGRATION.md
@@ -324,8 +324,8 @@ Set `"type": "module"`, use `.mjs`, or run through an ESM-aware bundler. `panda.
 
 ### `--cpu-prof` is now `--profile`
 
-v1's `--cpu-prof` recorded a Node `.cpuprofile` via `node:inspector`. It's gone in v2 — the hot path moved into the
-Rust engine behind NAPI, so a Node CPU profiler only sees the thin JS dispatcher, not where time actually goes.
+v1's `--cpu-prof` recorded a Node `.cpuprofile` via `node:inspector`. It's gone in v2 — the hot path moved into the Rust
+engine behind NAPI, so a Node CPU profiler only sees the thin JS dispatcher, not where time actually goes.
 
 Use `--profile` instead, on any command:
 
@@ -338,8 +338,8 @@ panda build --profile
 ```
 
 It writes `.panda/trace.json` (a Chrome trace — open in `chrome://tracing` or `ui.perfetto.dev`) and
-`.panda/timings.json` (per-span totals and the slowest files). See [Profiling a slow
-build](https://panda-css.com/docs/references/cli#profiling-a-slow-build) for the full flag reference.
+`.panda/timings.json` (per-span totals and the slowest files). See
+[Profiling a slow build](https://panda-css.com/docs/references/cli#profiling-a-slow-build) for the full flag reference.
 
 ### MCP moved out of the CLI
 
@@ -501,10 +501,65 @@ Recommended monorepo workflow:
 
 1. **App/root:** run a normal `panda build` or `panda cssgen` to emit the full stylesheet once.
 2. **Per package:** run `panda cssgen --minimal` to emit package-local usage CSS.
-3. **Published design systems:** ship `panda buildinfo` and hydrate in consumers (see `design-notes/build-info.md`).
+3. **Published design systems:** run `panda lib` and point consumers at it with `designSystem` (see
+   [Design systems](#design-systems) below).
 
 The v1 positional layer names (`preflight`, `global`, `tokens`, …) and positional glob override are not part of the v2
 CLI surface yet.
+
+---
+
+## Design systems
+
+To publish a component library so consumers share your tokens, recipes, and generated CSS without re-extracting your
+source, ship it as a design system. This replaces v1's `panda ship`.
+
+### Publish the library
+
+Run `panda lib` in the library package:
+
+```sh
+panda lib
+```
+
+It writes three artifacts to the output dir (`dist` by default) and syncs the package's `exports`:
+
+- `panda.lib.json` — the manifest: name, version, stamped peer range, import map, and pointers to the other two files.
+- `panda.buildinfo.json` — portable extraction state (atoms and recipes) that consumers hydrate.
+- `panda.preset.mjs` — a compiled preset carrying your tokens, recipes, and patterns.
+
+`panda lib` stamps a peer Panda range into the manifest so a consumer can detect a version mismatch. It uses the
+package's `@pandacss/dev` peer dependency. Pass `--panda <range>` to set one explicitly, for example when your peer uses
+a workspace protocol like `catalog:` that can't be published as-is.
+
+### Consume the library
+
+In the consumer's config, point `designSystem` at the published package name:
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  designSystem: '@acme/design-system',
+  include: ['./src/**/*.{ts,tsx}'],
+})
+```
+
+Panda resolves `@acme/design-system/panda.lib.json`, merges the preset, and hydrates the build info, so the library's
+CSS is emitted without re-scanning its source. The manifest carries the import map, so you don't set `importMap`
+separately.
+
+Don't add `panda.buildinfo.json` to `include`. `include` lists source files to scan; Panda parses each one as a module,
+so a JSON artifact there fails with a parse error. `designSystem` is the only wiring you need.
+
+### Known gaps
+
+- **Nested chains.** A single-level `designSystem` is the supported path. A deeper chain (`app → @acme/ds → @acme/base`)
+  still produces correct CSS and tokens but hydrates the full tree rather than each package's local slice, and parent
+  tokens may not yet appear in the consumer's generated types.
+- **Unresolved tokens emit silently.** Referencing a token the design system doesn't define emits the raw value as
+  literal CSS with no diagnostic; the generated types still (correctly) reject it. See
+  `design-notes/design-system-deferred.md` for the full ledger of deferred behavior.
 
 ---
 
@@ -525,8 +580,8 @@ Known gaps in the beta. Expect them to change before stable:
 ## Feedback
 
 It's a beta, so bug reports are the most useful thing you can send. Attach a `panda debug` dump (`panda debug` →
-`<outdir>/debug`) so maintainers can reproduce. For a slow build, add `--profile` (`panda debug --outdir <dir>
---profile`) so the dump includes `trace.json` and `timings.json` too.
+`<outdir>/debug`) so maintainers can reproduce. For a slow build, add `--profile`
+(`panda debug --outdir <dir> --profile`) so the dump includes `trace.json` and `timings.json` too.
 
 - Issues: <https://github.com/chakra-ui/panda/issues>
 - Docs: <https://panda-css.com>

--- a/design-notes/build-info.md
+++ b/design-notes/build-info.md
@@ -31,7 +31,7 @@ recomputed on hydrate.
 
 ```jsonc
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "panda": "^2.0.0",                               // peer range (collision guard); author-supplied
   "configFingerprint": "cfg1-…",                          // engine fingerprint of output-affecting config
   "strings": ["color", "red", "padding", "4px"],   // intern table (every prop/cond/value string)

--- a/packages/cli/__tests__/cssgen.test.ts
+++ b/packages/cli/__tests__/cssgen.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { runCssgen, writeCssgenOutput } from '../src'
 import {
   cleanupFixture,
+  CONFIG,
   createFixture,
   EMPTY_CONFIG,
   normalizeOutput,
@@ -57,6 +58,17 @@ describe('cssgen command', () => {
     dir = createFixture()
 
     await runCssgen({ cwd: dir, minify: true, logLevel: 'silent' })
+
+    const css = readFileSync(join(dir, 'styled-system', 'styles.css'), 'utf8')
+
+    expect(css).toContain('{')
+    expect(css).not.toContain('\n  ')
+  })
+
+  it('minify: true in config writes compact CSS without the flag', async () => {
+    dir = createFixture(CONFIG.replace('export default {', 'export default {\n  minify: true,'))
+
+    await runCssgen({ cwd: dir, logLevel: 'silent' })
 
     const css = readFileSync(join(dir, 'styled-system', 'styles.css'), 'utf8')
 

--- a/packages/cli/src/commands/cssgen.ts
+++ b/packages/cli/src/commands/cssgen.ts
@@ -136,20 +136,24 @@ type CssgenOnceResult = Pick<
 
 const MINIMAL_LAYERS = ['recipes', 'utilities'] satisfies StylesheetLayerName[]
 
+function resolveMinify(ctx: RunContext, flags: CssgenFlags): boolean {
+  return flags.minify ?? ctx.driver.config.minify === true
+}
+
 function splitCssOptions(ctx: RunContext, flags: CssgenFlags) {
   return {
     outdir: ctx.outdir,
     layers: flags.minimal ? MINIMAL_LAYERS : undefined,
     emitLayerDeclaration: flags.minimal ? false : undefined,
-    minify: flags.minify,
+    minify: resolveMinify(ctx, flags),
   }
 }
 
-function layerCssOptions(flags: CssgenFlags) {
+function layerCssOptions(ctx: RunContext, flags: CssgenFlags) {
   return {
     layers: MINIMAL_LAYERS,
     emitLayerDeclaration: false,
-    minify: flags.minify,
+    minify: resolveMinify(ctx, flags),
   }
 }
 
@@ -208,8 +212,8 @@ export async function writeCssgenOutput(
     phase: 'write',
     run: () =>
       flags.minimal
-        ? ctx.driver.writeLayerCss({ outfile, ...layerCssOptions(flags) })
-        : ctx.driver.writeCss({ outfile, minify: flags.minify }),
+        ? ctx.driver.writeLayerCss({ outfile, ...layerCssOptions(ctx, flags) })
+        : ctx.driver.writeCss({ outfile, minify: resolveMinify(ctx, flags) }),
   })
 
   const cssBytes = Buffer.byteLength(output.css)
@@ -274,7 +278,9 @@ function checkCssgenOutput(
     timings: ctx.timings,
     phase: 'emit',
     run: () =>
-      flags.minimal ? ctx.driver.getLayerCss(layerCssOptions(flags)) : ctx.driver.cssgen({ minify: flags.minify }),
+      flags.minimal
+        ? ctx.driver.getLayerCss(layerCssOptions(ctx, flags))
+        : ctx.driver.cssgen({ minify: resolveMinify(ctx, flags) }),
   })
 
   const cssBytes = Buffer.byteLength(output.css)

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -323,6 +323,11 @@ interface CssgenOptions {
    * @default 'true'
    */
   layers?: Partial<CascadeLayers>
+  /**
+   * Whether to minify the emitted css. The `--minify` CLI flag overrides this.
+   * @default false
+   */
+  minify?: boolean
 }
 
 export interface OptimizeOptions {


### PR DESCRIPTION
## 📝 Description

Support `minify` as a top-level config key, and document how to publish and consume a design system. From the v2 beta feedback in #3599.

## ⛳️ Current behavior (updates)

The migration guide and `panda cssgen --minify` (its help reads "overrides config minify") already treated `minify` as a config key, but the `Config` type rejected it and nothing read it — so `minify: true` in `panda.config.ts` failed to typecheck and did nothing. Publishing a design system was also undocumented in the v2 guide.

## 🚀 New behavior

`minify` is a valid top-level config key that `cssgen` reads; the `--minify` flag still overrides it. The v2 migration guide gains a **Design systems** section covering `panda lib`, the artifacts it emits, and the `designSystem` contract — including the trap from the feedback: the build-info file goes in `designSystem`, not `include`. The build-info design note's stale schema version is corrected.

Tests: a `cssgen` case proving config `minify` compacts output without the flag; typecheck and the `cssgen` suite pass.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Part of the design-system edge-case audit from [#3599](https://github.com/chakra-ui/panda/discussions/3599). Recommended merge order across the six PRs, to minimize rebases on shared files (`config/design-system.ts`, `compiler-shared/design-system.ts`, `types/compiler.ts`):

1. #3652 — `minify` config key + design-system docs
2. #3654 — build-info hydration
3. #3653 — resolution diagnostics
4. #3655 — multi-major peer ranges
5. #3656 — package.json exports safety
6. #3657 — remove the unused chain resolver

_This PR is #1 — independent of the others._
