### PR TITLE
fix(designSystem): harden build-info hydration (leak, corruption, crash, version skew, option mismatch)

### DIFF
--- a/.changeset/build-info-hydrate-robustness.md
+++ b/.changeset/build-info-hydrate-robustness.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-shared': patch
+'@pandacss/config': patch
+---
+
+Harden design-system build-info hydration against silent-wrong and crashing failure modes:
+
+- `panda lib` no longer embeds a hydrated parent's atoms in a middle package's own artifact; a published artifact carries only that package's own extraction.
+- A corrupt build-info (an out-of-range intern index that would silently drop atoms/recipes) is now treated as incompatible, so the consumer re-extracts from `files` instead of hydrating partial CSS.
+- A structurally invalid build-info that still parses as JSON no longer crashes config load; it falls back to re-extraction.
+- A version/schema-skewed layer now re-extracts from its `files` instead of hard-failing the whole build.
+- A consumer that overrides `hash`/`prefix`/`separator` away from the design system now gets a warning, since the design system's prebuilt class names won't match.

--- a/crates/pandacss_project/src/build_info.rs
+++ b/crates/pandacss_project/src/build_info.rs
@@ -23,6 +23,11 @@ use crate::{FileEntry, ParseFileReport};
 /// `SCHEMA_VERSION` falls back to re-extracting the library's source.
 pub const SCHEMA_VERSION: u32 = 3;
 
+/// Synthetic file-key prefix for atoms hydrated from a parent design system.
+/// Excluded from serialized build info so a published artifact carries only
+/// this project's own extraction, not a hydrated parent's.
+pub(crate) const HYDRATED_FILE_PREFIX: &str = "buildinfo:";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildInfo {
@@ -276,44 +281,42 @@ fn recipes_from_build(
     build: &BuildRecipes,
     strings: &[String],
     groups: Option<&FxHashSet<u32>>,
-) -> EncodedRecipesSnapshot {
+) -> Option<EncodedRecipesSnapshot> {
     let keep = |combined: usize| {
         groups.is_none_or(|set| u32::try_from(combined).is_ok_and(|index| set.contains(&index)))
     };
-    let base: Vec<_> = build
-        .base
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| keep(*index))
-        .filter_map(|(_, group)| group_from_build(group, strings))
-        .collect();
+    // Like `atom_from_build`, a kept group that fails to reconstruct means the
+    // intern table is corrupt; propagate `None` so the caller re-extracts.
+    let mut base = Vec::new();
+    for (index, group) in build.base.iter().enumerate() {
+        if keep(index) {
+            base.push(group_from_build(group, strings)?);
+        }
+    }
     let base_len = build.base.len();
     let variant_len = build.variants.len();
-    let variants: Vec<_> = build
-        .variants
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| keep(base_len + *index))
-        .filter_map(|(_, group)| group_from_build(group, strings))
-        .collect();
-    let compounds: Vec<_> = build
-        .compounds
-        .iter()
-        .enumerate()
-        .filter(|(index, _)| keep(base_len + variant_len + *index))
-        .filter_map(|(_, group)| group_from_build(group, strings))
-        .collect();
-    let atomic = build
-        .atomic
-        .iter()
-        .filter_map(|atom| atom_from_build(atom, strings))
-        .collect();
-    EncodedRecipesSnapshot {
+    let mut variants = Vec::new();
+    for (index, group) in build.variants.iter().enumerate() {
+        if keep(base_len + index) {
+            variants.push(group_from_build(group, strings)?);
+        }
+    }
+    let mut compounds = Vec::new();
+    for (index, group) in build.compounds.iter().enumerate() {
+        if keep(base_len + variant_len + index) {
+            compounds.push(group_from_build(group, strings)?);
+        }
+    }
+    let mut atomic = Vec::new();
+    for atom in &build.atomic {
+        atomic.push(atom_from_build(atom, strings)?);
+    }
+    Some(EncodedRecipesSnapshot {
         base,
         variants,
         compounds,
         atomic,
-    }
+    })
 }
 
 /// Indices selected by `only_modules`, reading `field` (`.atoms` or `.recipes`)
@@ -357,8 +360,17 @@ impl super::Project {
     pub fn build_info(&self, panda: String) -> BuildInfo {
         let config_fingerprint = self.config_fingerprint.to_string();
 
-        // Deduped, emit-ordered — modules reference this index space.
-        let mut atoms: Vec<&Atom> = self.atoms_cache.iter().collect();
+        // Deduped, emit-ordered — modules reference this index space. Only this
+        // project's own atoms are serialized; hydrated parent atoms (under
+        // `HYDRATED_FILE_PREFIX` files) are excluded so the artifact stays local.
+        let mut local_atoms: FxHashSet<&Atom> = FxHashSet::default();
+        for (path, entry) in &self.files {
+            if path.starts_with(HYDRATED_FILE_PREFIX) {
+                continue;
+            }
+            local_atoms.extend(entry.atoms.iter());
+        }
+        let mut atoms: Vec<&Atom> = local_atoms.into_iter().collect();
         atoms.sort_by(|a, b| super::compare_atoms_by_emit_order(a, b));
         let position: FxHashMap<&Atom, u32> = atoms
             .iter()
@@ -385,6 +397,9 @@ impl super::Project {
         let mut modules = BTreeMap::new();
         let mut styled_modules = FxHashSet::default();
         for (path, entry) in &self.files {
+            if path.starts_with(HYDRATED_FILE_PREFIX) {
+                continue;
+            }
             let mut atom_indices: Vec<u32> = entry
                 .atoms
                 .iter()
@@ -452,23 +467,34 @@ impl super::Project {
         let selected_atoms = selected_module_indices(info, only_modules, |entry| &entry.atoms);
         let selected_recipes = selected_module_indices(info, only_modules, |entry| &entry.recipes);
 
-        let atoms: FxHashSet<Atom> = info
-            .atoms
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| {
-                selected_atoms
-                    .as_ref()
-                    .is_none_or(|set| u32::try_from(*index).is_ok_and(|index| set.contains(&index)))
-            })
-            .filter_map(|(_, build)| atom_from_build(build, &info.strings))
-            .collect();
+        // A selected atom that fails to reconstruct means the intern table is
+        // corrupt (an out-of-range string index). Refuse to hydrate partial data
+        // and let the caller re-extract, same as a schema-version mismatch.
+        let mut atoms: FxHashSet<Atom> = FxHashSet::default();
+        for (index, build) in info.atoms.iter().enumerate() {
+            let selected = selected_atoms
+                .as_ref()
+                .is_none_or(|set| u32::try_from(index).is_ok_and(|index| set.contains(&index)));
+            if !selected {
+                continue;
+            }
+            match atom_from_build(build, &info.strings) {
+                Some(atom) => {
+                    atoms.insert(atom);
+                }
+                None => return false,
+            }
+        }
 
         // Stored under the lib's name; `stylesheet_snapshots` merges it in.
-        let recipes = recipes_from_build(&info.recipes, &info.strings, selected_recipes.as_ref());
+        let Some(recipes) =
+            recipes_from_build(&info.recipes, &info.strings, selected_recipes.as_ref())
+        else {
+            return false;
+        };
         self.set_hydrated_recipes(name, recipes);
 
-        let key: Arc<str> = Arc::from(format!("buildinfo:{name}").as_str());
+        let key: Arc<str> = Arc::from(format!("{HYDRATED_FILE_PREFIX}{name}").as_str());
         if self.files.contains_key(&key) {
             self.drop_file_state(&key);
         }

--- a/crates/pandacss_project/tests/build_info.rs
+++ b/crates/pandacss_project/tests/build_info.rs
@@ -157,6 +157,48 @@ fn hydrate_reproduces_every_atom() {
 }
 
 #[test]
+fn build_info_excludes_hydrated_parent_atoms() {
+    let mut parent = create_project(json!({}));
+    parent.parse_file(
+        "base.tsx",
+        "import { css } from '@panda/css'; css({ color: 'red' });",
+    );
+    let parent_info = parent.build_info("^2.0.0".into());
+
+    // A middle package hydrates its parent, then adds its own local style.
+    let mut child = create_project(json!({}));
+    assert!(child.hydrate("@acme/base", &parent_info, None));
+    child.parse_file(
+        "local.tsx",
+        "import { css } from '@panda/css'; css({ margin: '8px' });",
+    );
+
+    // The published artifact must carry only the child's own extraction, not the
+    // hydrated parent's atoms or its synthetic `buildinfo:` module.
+    let child_info = child.build_info("^2.0.0".into());
+
+    let module_keys: Vec<&str> = child_info.modules.keys().map(String::as_str).collect();
+    assert_eq!(module_keys, ["local.tsx"]);
+    assert!(child_info.strings.iter().any(|s| s == "margin"));
+    assert!(!child_info.strings.iter().any(|s| s == "color"));
+    assert!(!child_info.strings.iter().any(|s| s == "red"));
+}
+
+#[test]
+fn hydrate_rejects_a_corrupt_intern_table() {
+    let source = lib_project();
+    let mut info = source.build_info("^2.0.0".into());
+    assert!(!info.atoms.is_empty());
+    // Point an atom's prop at a string index past the intern table.
+    info.atoms[0].p = 9999;
+
+    let mut consumer = create_project(json!({}));
+    // A dropped-atom corruption must be a no-op (caller re-extracts), not a
+    // partial hydrate reported as success.
+    assert!(!consumer.hydrate("@acme/ds", &info, None));
+}
+
+#[test]
 fn hydrate_with_module_filter_emits_only_imported_modules() {
     let source = lib_project();
     let info = source.build_info("^2.0.0".into());

--- a/packages/compiler-shared/src/build-info.ts
+++ b/packages/compiler-shared/src/build-info.ts
@@ -73,7 +73,11 @@ export class BuildInfo {
     const compat = this.validate(info)
     if (!compat.ok) return { ok: false, reason: compat.reason, modules: [] }
 
-    this.#native.applyBuildInfo(options.name, info, options.only)
+    // The engine returns false when the artifact is structurally corrupt (a
+    // dropped atom/recipe from an out-of-range intern index). Treat it like an
+    // incompatibility so the caller re-extracts instead of hydrating partial CSS.
+    const applied = this.#native.applyBuildInfo(options.name, info, options.only)
+    if (!applied) return { ok: false, reason: 'corrupt', modules: [] }
 
     // The engine hydrates only modules that exist; report that exact set so the
     // result never claims to have hydrated an unknown `only` key.

--- a/packages/compiler-shared/src/types/compiler.ts
+++ b/packages/compiler-shared/src/types/compiler.ts
@@ -109,7 +109,7 @@ export interface BuildInfoArtifact {
   exports?: Record<string, string>
 }
 
-export type BuildInfoIncompatibility = 'schemaVersion' | 'pandaRange'
+export type BuildInfoIncompatibility = 'schemaVersion' | 'pandaRange' | 'corrupt'
 
 export type BuildInfoCompatibility = { ok: true } | { ok: false; reason: BuildInfoIncompatibility }
 

--- a/packages/compiler/__tests__/design-system-hydrate.test.ts
+++ b/packages/compiler/__tests__/design-system-hydrate.test.ts
@@ -111,6 +111,76 @@ describe('hydrateDesignSystem (consumer)', () => {
     await expect(createNodeDriver({ cwd })).rejects.toThrow(/incompatible buildInfo/)
   })
 
+  it('re-extracts when the manifest Panda range is incompatible but files are present', async () => {
+    cwd = realpathSync(mkdtempSync(join(tmpdir(), 'panda-ds-hydrate-')))
+    writeFileTree(cwd, {
+      'panda.config.ts': `export default { designSystem: '@acme/ds', include: ['**/*.tsx'] }`,
+      'App.tsx': "import { css } from '@panda/css'; css({ color: 'red' })",
+      'node_modules/@acme/ds/package.json': json({
+        name: '@acme/ds',
+        version: '1.0.0',
+        exports: { './panda.lib.json': './dist/panda.lib.json', './preset': './dist/panda.preset.mjs' },
+      }),
+      'node_modules/@acme/ds/dist/panda.lib.json': json({
+        schemaVersion: 1,
+        name: '@acme/ds',
+        version: '1.0.0',
+        panda: '^999.0.0',
+        preset: './panda.preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+        files: ['./button.js'],
+        importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+      }),
+      'node_modules/@acme/ds/dist/panda.preset.mjs': `export default { theme: { tokens: {} } }`,
+      'node_modules/@acme/ds/dist/button.js': "import { css } from '@acme/ds/css'\ncss({ color: 'rebeccapurple' })",
+      'node_modules/@acme/ds/dist/panda.buildinfo.json': json({
+        schemaVersion: 3,
+        panda: '^999.0.0',
+        configFingerprint: 'x',
+        strings: [],
+        atoms: [],
+        modules: {},
+      }),
+    })
+
+    const driver = await createNodeDriver({ cwd })
+    const codes = (driver.designSystemDiagnostics ?? []).map((d) => d.code)
+    expect(codes).toContain('design_system_buildinfo_stale')
+    expect(driver.cssgen().css).toContain('rebeccapurple')
+  })
+
+  it('re-extracts when build info is structurally invalid but files are present', async () => {
+    cwd = realpathSync(mkdtempSync(join(tmpdir(), 'panda-ds-hydrate-')))
+    writeFileTree(cwd, {
+      'panda.config.ts': `export default { designSystem: '@acme/ds', include: ['**/*.tsx'] }`,
+      'App.tsx': "import { css } from '@panda/css'; css({ color: 'red' })",
+      'node_modules/@acme/ds/package.json': json({
+        name: '@acme/ds',
+        version: '1.0.0',
+        exports: { './panda.lib.json': './dist/panda.lib.json', './preset': './dist/panda.preset.mjs' },
+      }),
+      'node_modules/@acme/ds/dist/panda.lib.json': json({
+        schemaVersion: 1,
+        name: '@acme/ds',
+        version: '1.0.0',
+        panda: '^2.0.0',
+        preset: './panda.preset.mjs',
+        buildInfo: './panda.buildinfo.json',
+        files: ['./button.js'],
+        importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes', jsx: '@acme/ds/jsx' },
+      }),
+      'node_modules/@acme/ds/dist/panda.preset.mjs': `export default { theme: { tokens: {} } }`,
+      'node_modules/@acme/ds/dist/button.js': "import { css } from '@acme/ds/css'\ncss({ color: 'rebeccapurple' })",
+      // Valid JSON, but missing required build-info fields — deserialize fails.
+      'node_modules/@acme/ds/dist/panda.buildinfo.json': json({ schemaVersion: 3 }),
+    })
+
+    const driver = await createNodeDriver({ cwd })
+    const codes = (driver.designSystemDiagnostics ?? []).map((d) => d.code)
+    expect(codes).toContain('design_system_buildinfo_stale')
+    expect(driver.cssgen().css).toContain('rebeccapurple')
+  })
+
   it('warns on a token defined by both the design system and the consumer', async () => {
     cwd = realpathSync(mkdtempSync(join(tmpdir(), 'panda-ds-hydrate-')))
     writeFileTree(cwd, {

--- a/packages/compiler/src/design-system.ts
+++ b/packages/compiler/src/design-system.ts
@@ -1,4 +1,9 @@
-import { type BuildInfoArtifact, type Compiler, type Diagnostic } from '@pandacss/compiler-shared'
+import {
+  type BuildInfoArtifact,
+  type Compiler,
+  type DesignSystemLoadResult,
+  type Diagnostic,
+} from '@pandacss/compiler-shared'
 import { readPandaVersion, type LoadConfigResult } from '@pandacss/config'
 
 type ResolvedDesignSystem = NonNullable<NonNullable<LoadConfigResult['metadata']>['designSystem']>[number]
@@ -21,10 +26,18 @@ function hydrateLevel(
   pandaVersion: string | undefined,
   consumerTokenPaths: string[],
 ): Diagnostic[] {
-  const compat = compiler.designSystem.validate(ds.manifest, { pandaVersion })
-  if (!compat.ok) throw incompatibleManifestError(compiler, ds, compat.reason, pandaVersion)
-
   const diagnostics: Diagnostic[] = []
+
+  const compat = compiler.designSystem.validate(ds.manifest, { pandaVersion })
+  if (!compat.ok) {
+    // A version/schema-skewed layer can still re-extract from its `files`; only
+    // hard-fail when no re-extract source is available.
+    if (tryStaleFallback(compiler, ds, diagnostics)) {
+      diagnostics.push(...tokenConflictDiagnostics(ds, consumerTokenPaths))
+      return diagnostics
+    }
+    throw incompatibleManifestError(compiler, ds, compat.reason, pandaVersion)
+  }
 
   let buildInfo: BuildInfoArtifact | undefined
   try {
@@ -36,12 +49,36 @@ function hydrateLevel(
   }
 
   if (buildInfo) {
-    const result = compiler.designSystem.load(ds.manifest, { buildInfo, pandaVersion })
-    if (!result.ok && !tryStaleFallback(compiler, ds, diagnostics)) throw hydrateLoadError(ds, result.reason)
+    // `load` can throw when the artifact is JSON-parseable but structurally
+    // invalid (binding deserialize fails); treat that like a read failure and
+    // re-extract when possible.
+    let result: DesignSystemLoadResult | undefined
+    try {
+      result = compiler.designSystem.load(ds.manifest, { buildInfo, pandaVersion })
+    } catch (error) {
+      if (!tryStaleFallback(compiler, ds, diagnostics)) throw hydrateReadError(ds, error)
+    }
+    if (result && !result.ok && !tryStaleFallback(compiler, ds, diagnostics)) {
+      throw hydrateLoadError(ds, result.reason)
+    }
   }
 
   diagnostics.push(...tokenConflictDiagnostics(ds, consumerTokenPaths))
+  diagnostics.push(...optionMismatchDiagnostics(ds))
   return diagnostics
+}
+
+function optionMismatchDiagnostics(ds: ResolvedDesignSystem): Diagnostic[] {
+  if (!ds.optionMismatch || ds.optionMismatch.length === 0) return []
+  const options = ds.optionMismatch.join(', ')
+  return [
+    {
+      code: 'design_system_option_mismatch',
+      severity: 'warning',
+      category: 'designSystem',
+      message: `${JSON.stringify(ds.name)} was built with different ${options}; its prebuilt class names won't match yours, so its components can render unstyled. Match these options to the design system, or rebuild it with your options.`,
+    },
+  ]
 }
 
 function tryStaleFallback(compiler: Compiler, ds: ResolvedDesignSystem, diagnostics: Diagnostic[]): boolean {

--- a/packages/config/__tests__/design-system.test.ts
+++ b/packages/config/__tests__/design-system.test.ts
@@ -234,6 +234,16 @@ describe('resolveAuthoredPresets / designSystem', () => {
     )
   })
 
+  test('flags class-name option overrides that break the design system runtime', async () => {
+    const { metadata } = await resolveAuthoredPresets({ designSystem: '@acme/ds', hash: true }, cwd)
+    expect(metadata?.designSystem?.[0]?.optionMismatch).toEqual(['hash'])
+  })
+
+  test('does not flag when class-name options match the design system', async () => {
+    const { metadata } = await resolveAuthoredPresets({ designSystem: '@acme/ds' }, cwd)
+    expect(metadata?.designSystem?.[0]?.optionMismatch).toBeUndefined()
+  })
+
   // Manifest and package resolution failures.
 
   test('attaches diagnostics for an invalid manifest', async () => {

--- a/packages/config/src/design-system.ts
+++ b/packages/config/src/design-system.ts
@@ -21,6 +21,9 @@ export interface ResolvedDesignSystem {
   files: string[]
   tokenPaths: string[]
   importMap?: DesignSystemManifest['importMap']
+  /** Class-name options (`hash`/`prefix`/`separator`) the consumer overrode away
+   * from this design system's, which would break its prebuilt class names. */
+  optionMismatch?: string[]
 }
 
 export interface DesignSystemLevel {

--- a/packages/config/src/preset.ts
+++ b/packages/config/src/preset.ts
@@ -49,6 +49,21 @@ export interface ResolveAuthoredPresetsOptions {
   preserveRuntimeHooks?: boolean
 }
 
+const CLASS_NAME_OPTION_KEYS = ['hash', 'prefix', 'separator'] as const
+type ClassNameOptions = Partial<Record<(typeof CLASS_NAME_OPTION_KEYS)[number], unknown>>
+
+function pickClassNameOptions(config: UserConfig): ClassNameOptions {
+  return { hash: config.hash, prefix: config.prefix, separator: config.separator }
+}
+
+// Only an explicit consumer override that differs from the design system counts:
+// it changes generated class names, so the DS's prebuilt runtime renders unstyled.
+function classNameOptionMismatch(consumer: ClassNameOptions, ds: ClassNameOptions): string[] {
+  return CLASS_NAME_OPTION_KEYS.filter(
+    (key) => consumer[key] !== undefined && JSON.stringify(consumer[key]) !== JSON.stringify(ds[key]),
+  )
+}
+
 export async function resolveAuthoredPresets(
   config: ExtendableConfig,
   cwd: string,
@@ -67,6 +82,7 @@ export async function resolveAuthoredPresets(
 
   const designSystem = (config as UserConfig).designSystem
   let dsChain: DesignSystemLevel[] = []
+  const dsClassNameOptions: ClassNameOptions[] = []
   if (typeof designSystem === 'string' && designSystem.length > 0) {
     dsChain = await loadDesignSystemChain(designSystem, cwd, ctx.dependencies)
     for (const level of dsChain) {
@@ -78,12 +94,19 @@ export async function resolveAuthoredPresets(
         options.trackSources,
       )
       level.info.tokenPaths = collectTokenPaths(block.resolved)
+      dsClassNameOptions.push(pickClassNameOptions(block.resolved))
       appendConfigBlock(ctx, block)
     }
   }
 
   const rootBlock = await collectConfigBlock(config, rootSource, cwd, ctx.dependencies, options.trackSources)
   appendConfigBlock(ctx, rootBlock)
+
+  const consumerClassNameOptions = pickClassNameOptions(rootBlock.resolved)
+  dsChain.forEach((level, i) => {
+    const mismatch = classNameOptionMismatch(consumerClassNameOptions, dsClassNameOptions[i])
+    if (mismatch.length > 0) level.info.optionMismatch = mismatch
+  })
 
   const dsInfos = dsChain.map((level) => level.info)
   const finalize = (resolved: UserConfig): UserConfig => {


### PR DESCRIPTION
## 📝 Description

Harden design-system build-info hydration against the silent-wrong and crashing failure modes the audit surfaced. From the v2 beta feedback in #3599.

## ⛳️ Current behavior (updates)

Several hydration paths produced wrong or missing CSS, or crashed, without a clear signal:

- `panda lib` in a package that consumes a design system embedded the hydrated parent's atoms in that package's own artifact.
- A corrupt build-info (an out-of-range intern index) silently dropped atoms/recipes while `hydrate` still reported success.
- A structurally invalid but JSON-parseable build-info crashed config load.
- A version- or schema-skewed layer hard-failed the whole build even with a `files` fallback available.
- Overriding `hash`/`prefix`/`separator` away from the design system silently broke its prebuilt class names.

## 🚀 New behavior

- `panda lib` serializes only the package's own extraction; consumers re-hydrate the parent through the chain.
- A corrupt build-info now fails hydration so the consumer re-extracts from `files`.
- A structurally invalid build-info falls back to re-extraction instead of crashing.
- A version/schema-skewed layer re-extracts from `files`.
- You get a warning when your class-name options diverge from the design system's.

Tests: Rust round-trip tests for the parent-atom exclusion and corrupt-table bail; compiler hydrate tests for the version-skew and structural-invalid fallbacks; config tests for the option-mismatch warning. `rust:fmt`/`clippy`, `cargo nextest -p pandacss_project`, the compiler suite, and `typecheck` pass.

## 💣 Is this a breaking change (Yes/No):

No. The `panda lib` artifact shape changes for a package that hydrates a parent, but consumers resolve the parent through the chain, so emitted CSS is unchanged.

## 📝 Additional Information

Part of the design-system edge-case audit from [#3599](https://github.com/chakra-ui/panda/discussions/3599). Recommended merge order across the six PRs, to minimize rebases on shared files (`config/design-system.ts`, `compiler-shared/design-system.ts`, `types/compiler.ts`):

1. #3652 — `minify` config key + design-system docs
2. #3654 — build-info hydration
3. #3653 — resolution diagnostics
4. #3655 — multi-major peer ranges
5. #3656 — package.json exports safety
6. #3657 — remove the unused chain resolver

_This PR is #2 — merge before #3653 (shares `config/design-system.ts`) and #3657 (shares `types/compiler.ts`)._
