### PR TITLE
fix(compiler): accept multi-major || peer ranges for design systems

### DIFF
--- a/.changeset/panda-range-multimajor.md
+++ b/.changeset/panda-range-multimajor.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/compiler-shared': patch
+---
+
+`panda lib` peer ranges now accept multi-major `||` unions. A design system declaring `"panda": "^2.0.0 || ^3.0.0"` is compatible with consumers on either major, instead of only the first one listed.

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -29,6 +29,19 @@ const major = (value: string): number => {
   return match ? Number(match[0]) : NaN
 }
 
+/**
+ * Accepted majors from a peer range. Handles `||` unions (`^2 || ^3` -> {2,3});
+ * an empty set (no number found) means "unreadable", which fails closed.
+ */
+const acceptedMajors = (range: string): Set<number> => {
+  const majors = new Set<number>()
+  for (const alternative of range.split('||')) {
+    const value = major(alternative)
+    if (!Number.isNaN(value)) majors.add(value)
+  }
+  return majors
+}
+
 export class DesignSystem {
   readonly #binding: DesignSystemBinding
   readonly #buildInfo: BuildInfo
@@ -48,7 +61,7 @@ export class DesignSystem {
     if (manifest.schemaVersion !== this.schemaVersion) return { ok: false, reason: 'schemaVersion' }
 
     const running = options?.pandaVersion
-    if (running !== undefined && major(running) !== major(manifest.panda)) {
+    if (running !== undefined && !acceptedMajors(manifest.panda).has(major(running))) {
       return { ok: false, reason: 'pandaRange' }
     }
 

--- a/packages/compiler/__tests__/design-system.test.ts
+++ b/packages/compiler/__tests__/design-system.test.ts
@@ -104,6 +104,14 @@ describe('compiler.designSystem', () => {
     expect(app.designSystem.validate(manifest, { pandaVersion: '1.9.0' })).toEqual({ ok: false, reason: 'pandaRange' })
   })
 
+  it('validate() accepts either major of a multi-major `||` range', () => {
+    const app = project()
+    const manifest: DesignSystemManifest = { ...app.designSystem.create(fullInput), panda: '^2.0.0 || ^3.0.0' }
+    expect(app.designSystem.validate(manifest, { pandaVersion: '2.5.1' })).toEqual({ ok: true })
+    expect(app.designSystem.validate(manifest, { pandaVersion: '3.1.0' })).toEqual({ ok: true })
+    expect(app.designSystem.validate(manifest, { pandaVersion: '4.0.0' })).toEqual({ ok: false, reason: 'pandaRange' })
+  })
+
   // --- load(): consumer side — validate + hydrate the library's build info ---
 
   // A library publishing two styled modules, plus the manifest pointing at it.


### PR DESCRIPTION
## 📝 Description

Accept multi-major `||` peer ranges when checking design-system compatibility. From the design-system audit following #3599.

## ⛳️ Current behavior (updates)

The consumer compatibility check read only the first major from a manifest's `panda` range, so a design system declaring `"panda": "^2.0.0 || ^3.0.0"` rejected consumers on major 3 — a trap that would surface at the v3 cut.

## 🚀 New behavior

The check accepts any major in a `||` union, keeping the fail-closed behavior for unreadable ranges. No new dependency, so it stays wasm-safe.

Tests: multi-major accept/reject cases in `design-system.test.ts`; the existing major-match tests are unchanged.

## 💣 Is this a breaking change (Yes/No):

No — strictly more permissive.

## 📝 Additional Information

Part of the design-system edge-case audit from [#3599](https://github.com/chakra-ui/panda/discussions/3599). Recommended merge order across the six PRs, to minimize rebases on shared files (`config/design-system.ts`, `compiler-shared/design-system.ts`, `types/compiler.ts`):

1. #3652 — `minify` config key + design-system docs
2. #3654 — build-info hydration
3. #3653 — resolution diagnostics
4. #3655 — multi-major peer ranges
5. #3656 — package.json exports safety
6. #3657 — remove the unused chain resolver

_This PR is #4 — merge before #3657 (both touch `compiler-shared/design-system.ts`)._
