### PR TITLE
fix(designSystem): stop panda lib from silently losing or clobbering package.json exports

### DIFF
--- a/.changeset/lib-exports-safety.md
+++ b/.changeset/lib-exports-safety.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/config': patch
+'@pandacss/compiler': patch
+---
+
+`panda lib` no longer silently loses or clobbers package.json `exports`. An array-form root export is preserved (under `"."`) instead of dropped, and overwriting a subpath whose value differs from Panda's now emits a warning naming the overwritten path.

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -392,7 +392,7 @@ export class NodeDriver extends BaseDriver {
       ],
     })
 
-    const exportsChanged = syncPackageExports(this.compiler, identity.packagePath, {
+    const { changed: exportsChanged, conflicts } = syncPackageExports(this.compiler, identity.packagePath, {
       manifestPath,
       presetPath,
     })
@@ -403,7 +403,7 @@ export class NodeDriver extends BaseDriver {
       presetPath,
       exportsChanged,
       parsedFileCount: parsed.parsedFileCount,
-      diagnostics: parsed.diagnostics,
+      diagnostics: [...parsed.diagnostics, ...exportConflictDiagnostics(identity.name, conflicts)],
     }
   }
 }
@@ -439,7 +439,7 @@ function syncPackageExports(
   compiler: Compiler,
   packagePath: string,
   paths: { manifestPath: string; presetPath: string },
-): boolean {
+): { changed: boolean; conflicts: string[] } {
   const base = compiler.path.dirname(packagePath)
   const entries = {
     './panda.lib.json': toPosixRelative(base, paths.manifestPath),
@@ -461,7 +461,21 @@ function syncPackageExports(
       ],
     })
   }
-  return result.changed
+  return { changed: result.changed, conflicts: result.conflicts }
+}
+
+function exportConflictDiagnostics(name: string, conflicts: string[]): Diagnostic[] {
+  if (conflicts.length === 0) return []
+  const paths = conflicts.map((path) => JSON.stringify(path)).join(', ')
+  const plural = conflicts.length > 1
+  return [
+    {
+      code: 'design_system_export_overwritten',
+      severity: 'warning',
+      category: 'designSystem',
+      message: `\`panda lib\` overwrote the existing ${paths} export${plural ? 's' : ''} in ${JSON.stringify(name)}'s package.json. Remove ${plural ? 'them' : 'it'} if Panda should own ${plural ? 'these paths' : 'this path'}.`,
+    },
+  ]
 }
 
 function stabilizePath(cwd: string, file: string): string {

--- a/packages/config/__tests__/lib-manifest.test.ts
+++ b/packages/config/__tests__/lib-manifest.test.ts
@@ -62,4 +62,32 @@ describe('lib-manifest', () => {
     expect(parsed.exports['.']).toEqual(root)
     expect(parsed.exports['./panda.lib.json']).toBe('./dist/panda.lib.json')
   })
+
+  test('syncExports preserves an array-form root export instead of dropping it', () => {
+    const array = ['./dist/index.mjs', './dist/fallback.js']
+    const { json } = syncExports({
+      packageJson: JSON.stringify({ name: '@acme/ds', exports: array }),
+      entries: { './panda.lib.json': './dist/panda.lib.json' },
+    })
+    const parsed = JSON.parse(json)
+    expect(parsed.exports['.']).toEqual(array)
+    expect(parsed.exports['./panda.lib.json']).toBe('./dist/panda.lib.json')
+  })
+
+  test('syncExports reports a conflict when overwriting a differing subpath', () => {
+    const result = syncExports({
+      packageJson: JSON.stringify({ name: '@acme/ds', exports: { './preset': './custom/preset.js' } }),
+      entries: { './preset': './dist/panda.preset.mjs' },
+    })
+    expect(result.conflicts).toEqual(['./preset'])
+    expect(JSON.parse(result.json).exports['./preset']).toBe('./dist/panda.preset.mjs')
+  })
+
+  test('syncExports does not report a conflict when the subpath value is identical', () => {
+    const result = syncExports({
+      packageJson: JSON.stringify({ name: '@acme/ds', exports: { './preset': './dist/panda.preset.mjs' } }),
+      entries: { './preset': './dist/panda.preset.mjs' },
+    })
+    expect(result.conflicts).toEqual([])
+  })
 })

--- a/packages/config/src/lib-manifest.ts
+++ b/packages/config/src/lib-manifest.ts
@@ -41,6 +41,8 @@ export function defaultImportMap(name: string): DesignSystemManifestImportMap {
 export interface SyncExportsResult {
   changed: boolean
   json: string
+  /** Existing subpaths whose value differed from the one Panda wrote (overwritten). */
+  conflicts: string[]
 }
 
 export interface SyncExportsOptions {
@@ -53,11 +55,17 @@ export function syncExports(options: SyncExportsOptions): SyncExportsResult {
   const pkg = JSON.parse(packageJson) as Record<string, unknown>
   const existing = normalizeExports(pkg.exports)
   const merged: Record<string, unknown> = { ...existing }
-  for (const [key, value] of Object.entries(entries)) merged[key] = value
+  const conflicts: string[] = []
+  for (const [key, value] of Object.entries(entries)) {
+    if (key in existing && JSON.stringify(existing[key]) !== JSON.stringify(value)) {
+      conflicts.push(key)
+    }
+    merged[key] = value
+  }
 
   const changed = JSON.stringify(pkg.exports) !== JSON.stringify(merged)
   const out = { ...pkg, exports: merged }
-  return { changed, json: `${JSON.stringify(out, null, 2)}\n` }
+  return { changed, json: `${JSON.stringify(out, null, 2)}\n`, conflicts }
 }
 
 export function toPosixPath(path: string): string {
@@ -80,6 +88,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function normalizeExports(exports: unknown): Record<string, unknown> {
   if (exports === undefined) return {}
   if (typeof exports === 'string') return { '.': exports }
+  if (Array.isArray(exports)) return { '.': exports }
   if (!isPlainObject(exports)) return {}
   if (isSubpathExportMap(exports)) return exports
   return { '.': exports }


### PR DESCRIPTION
## 📝 Description

Stop `panda lib` from silently losing or clobbering your `package.json` `exports`. From the design-system audit following #3599.

## ⛳️ Current behavior (updates)

- An array-form root export (`"exports": ["./a.js", "./b.js"]`, Node's fallback-array form) normalized to `{}`, so `panda lib` discarded it.
- Overwriting a subpath (`./preset`, `./panda.lib.json`) whose value differed from Panda's happened silently.

## 🚀 New behavior

- An array-form root export is preserved under `"."`.
- Overwriting a differing subpath emits a `design_system_export_overwritten` warning naming the path.

Tests: array preservation plus the conflict / no-conflict cases; typecheck and the config suite pass.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Part of the design-system edge-case audit from [#3599](https://github.com/chakra-ui/panda/discussions/3599). Recommended merge order across the six PRs, to minimize rebases on shared files (`config/design-system.ts`, `compiler-shared/design-system.ts`, `types/compiler.ts`):

1. #3652 — `minify` config key + design-system docs
2. #3654 — build-info hydration
3. #3653 — resolution diagnostics
4. #3655 — multi-major peer ranges
5. #3656 — package.json exports safety
6. #3657 — remove the unused chain resolver

_This PR is #5 — independent of the others._
