### PR TITLE
refactor(compiler): remove the unused designSystem.resolveChain binding

### DIFF
--- a/.changeset/remove-dead-chain-resolver.md
+++ b/.changeset/remove-dead-chain-resolver.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-shared': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Remove the unused `designSystem.resolveChain` binding. Design-system chains are resolved by the config loader (`loadDesignSystemChain`), which walks the single parent link each manifest declares; the separate Rust `resolve_chain` primitive was never called on that path, so the duplicate ordering/cycle logic is gone.

--- a/crates/pandacss_project/src/design_system.rs
+++ b/crates/pandacss_project/src/design_system.rs
@@ -2,7 +2,6 @@
 //! with one `designSystem: '@acme/ds'` field. Values only; the host owns fs +
 //! module resolution. See `design-notes/design-system-manifest.md`.
 
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 /// Bumped when the wire shape changes; a version mismatch surfaces a diagnostic
@@ -92,87 +91,4 @@ impl super::Project {
             files: input.files,
         }
     }
-}
-
-/// Outcome of [`resolve_chain`]: the order to merge presets + hydrate build
-/// info, or the cycle that makes the chain unresolvable.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "status", rename_all = "camelCase")]
-pub enum ChainPlan {
-    /// Deduped, root-first order (ancestors before descendants) — preset
-    /// inheritance precedence.
-    Ordered { order: Vec<String> },
-    /// The chain revisits a package; `cycle` is the loop path (`@a → @b → @a`).
-    Cycle { cycle: Vec<String> },
-}
-
-/// Order already-read manifests by their `designSystem` parent links into a
-/// root-first merge/hydrate plan, deduping shared ancestors and catching cycles.
-/// A parent absent from the set is a chain boundary (the host resolves it).
-#[must_use]
-pub fn resolve_chain(manifests: &[DesignSystemManifest]) -> ChainPlan {
-    // name → parent link, deduped by name (first wins); `present` preserves input
-    // order so roots emit deterministically.
-    let mut parent_of: FxHashMap<&str, Option<&str>> = FxHashMap::default();
-    let mut present: Vec<&str> = Vec::new();
-    for manifest in manifests {
-        if parent_of
-            .insert(&manifest.name, manifest.design_system.as_deref())
-            .is_none()
-        {
-            present.push(&manifest.name);
-        }
-    }
-
-    let mut state: FxHashMap<&str, Mark> = FxHashMap::default();
-    let mut order: Vec<String> = Vec::new();
-    for name in present {
-        let mut path: Vec<&str> = Vec::new();
-        if let Err(cycle) = visit(name, &parent_of, &mut state, &mut order, &mut path) {
-            return ChainPlan::Cycle { cycle };
-        }
-    }
-    ChainPlan::Ordered { order }
-}
-
-/// DFS colour: `Gray` is on the current path (a back-edge to it is a cycle),
-/// `Black` is fully placed.
-#[derive(PartialEq, Eq)]
-enum Mark {
-    Gray,
-    Black,
-}
-
-/// Emit `name`'s present ancestors before `name` (post-order ⇒ root-first),
-/// erroring with the loop path on a back-edge to a node on the current path.
-fn visit<'a>(
-    name: &'a str,
-    parent_of: &FxHashMap<&'a str, Option<&'a str>>,
-    state: &mut FxHashMap<&'a str, Mark>,
-    order: &mut Vec<String>,
-    path: &mut Vec<&'a str>,
-) -> Result<(), Vec<String>> {
-    match state.get(name) {
-        Some(Mark::Black) => return Ok(()),
-        Some(Mark::Gray) => {
-            let start = path.iter().position(|&n| n == name).unwrap_or(0);
-            let mut cycle: Vec<String> = path[start..].iter().map(|&n| n.to_owned()).collect();
-            cycle.push(name.to_owned());
-            return Err(cycle);
-        }
-        None => {}
-    }
-
-    state.insert(name, Mark::Gray);
-    path.push(name);
-    // Only order against a parent that's present in the set.
-    if let Some(parent) = parent_of.get(name).copied().flatten()
-        && parent_of.contains_key(parent)
-    {
-        visit(parent, parent_of, state, order, path)?;
-    }
-    path.pop();
-    state.insert(name, Mark::Black);
-    order.push(name.to_owned());
-    Ok(())
 }

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -61,8 +61,7 @@ pub type UtilityStyleKey = (Box<str>, AtomValue);
 
 pub use build_info::{BuildAtom, BuildInfo, BuildValue, ModuleEntry, SCHEMA_VERSION};
 pub use design_system::{
-    ChainPlan, DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestImportMap, ManifestInput,
-    resolve_chain,
+    DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestImportMap, ManifestInput,
 };
 pub use error::{ConfigError, Result};
 pub use hook_filter::HookFilter;

--- a/crates/pandacss_project/tests/design_system.rs
+++ b/crates/pandacss_project/tests/design_system.rs
@@ -3,9 +3,7 @@
 //! round-trip it through JSON. Pure (no fs).
 
 use crate::common::create_project;
-use pandacss_project::{
-    ChainPlan, DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestInput, resolve_chain,
-};
+use pandacss_project::{DesignSystemManifest, MANIFEST_SCHEMA_VERSION, ManifestInput};
 use serde_json::{from_value, json, to_value};
 
 fn full_input() -> ManifestInput {
@@ -70,71 +68,4 @@ fn round_trips_through_json() {
     let restored: DesignSystemManifest = serde_json::from_str(&json).expect("deserialize manifest");
 
     assert_eq!(manifest, restored);
-}
-
-/// A bare manifest with just a name and optional parent — chain resolution only
-/// reads those two fields.
-fn node(name: &str, parent: Option<&str>) -> DesignSystemManifest {
-    from_value(json!({
-        "schemaVersion": MANIFEST_SCHEMA_VERSION,
-        "name": name,
-        "panda": "^2.0.0",
-        "preset": "./panda.preset.mjs",
-        "buildInfo": "./panda.buildinfo.json",
-        "designSystem": parent,
-    }))
-    .expect("deserialize node")
-}
-
-fn order(plan: ChainPlan) -> Vec<String> {
-    match plan {
-        ChainPlan::Ordered { order } => order,
-        ChainPlan::Cycle { cycle } => panic!("expected an ordered plan, got cycle {cycle:?}"),
-    }
-}
-
-#[test]
-fn resolve_chain_orders_a_depth_n_stack_root_first() {
-    // leaf → marketing → foundations; input in leaf-first order.
-    let plan = resolve_chain(&[
-        node("@acme/marketing", Some("@acme/foundations")),
-        node("@acme/foundations", None),
-    ]);
-    assert_eq!(order(plan), ["@acme/foundations", "@acme/marketing"]);
-}
-
-#[test]
-fn resolve_chain_dedupes_a_shared_parent() {
-    // Two libraries sharing one ancestor — the ancestor emits once, before both.
-    let plan = resolve_chain(&[
-        node("@acme/a", Some("@acme/base")),
-        node("@acme/b", Some("@acme/base")),
-        node("@acme/base", None),
-    ]);
-    assert_eq!(order(plan), ["@acme/base", "@acme/a", "@acme/b"]);
-}
-
-#[test]
-fn resolve_chain_treats_an_absent_parent_as_a_boundary() {
-    // The parent isn't in the set (host owns parent-not-found); the node still
-    // resolves as a root rather than erroring.
-    let plan = resolve_chain(&[node("@acme/leaf", Some("@acme/missing"))]);
-    assert_eq!(order(plan), ["@acme/leaf"]);
-}
-
-#[test]
-fn resolve_chain_reports_a_cycle_path() {
-    let plan = resolve_chain(&[
-        node("@acme/a", Some("@acme/b")),
-        node("@acme/b", Some("@acme/a")),
-    ]);
-    match plan {
-        ChainPlan::Cycle { cycle } => assert_eq!(cycle, ["@acme/a", "@acme/b", "@acme/a"]),
-        ChainPlan::Ordered { order } => panic!("expected a cycle, got order {order:?}"),
-    }
-}
-
-#[test]
-fn resolve_chain_handles_an_empty_set() {
-    assert_eq!(order(resolve_chain(&[])), Vec::<String>::new());
 }

--- a/packages/compiler-shared/src/design-system.ts
+++ b/packages/compiler-shared/src/design-system.ts
@@ -1,7 +1,5 @@
 import type { BuildInfo } from './build-info'
 import type {
-  DesignSystemChainPlan,
-  DesignSystemChainResult,
   DesignSystemLoadOptions,
   DesignSystemLoadResult,
   DesignSystemManifest,
@@ -17,7 +15,6 @@ import type {
 export interface DesignSystemBinding {
   createManifest(input: DesignSystemManifestInput): DesignSystemManifest
   manifestSchemaVersion(): number
-  resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
 /**
@@ -67,12 +64,5 @@ export class DesignSystem {
     if (!result.ok) return { ok: false, reason: result.reason, modules: [] }
 
     return { ok: true, name: manifest.name, modules: result.modules }
-  }
-
-  resolveChain(manifests: DesignSystemManifest[]): DesignSystemChainResult {
-    const plan = this.#binding.resolveChain(manifests)
-    return plan.status === 'ordered'
-      ? { ok: true, order: plan.order }
-      : { ok: false, reason: 'cycle', cycle: plan.cycle }
   }
 }

--- a/packages/compiler-shared/src/types/compiler.ts
+++ b/packages/compiler-shared/src/types/compiler.ts
@@ -187,10 +187,6 @@ export interface DesignSystemValidateOptions {
   pandaVersion?: string
 }
 
-export type DesignSystemChainPlan = { status: 'ordered'; order: string[] } | { status: 'cycle'; cycle: string[] }
-
-export type DesignSystemChainResult = { ok: true; order: string[] } | { ok: false; reason: 'cycle'; cycle: string[] }
-
 export interface DesignSystemLoadOptions {
   buildInfo: BuildInfoArtifact
   /**

--- a/packages/compiler-wasm/__tests__/design-system.test.ts
+++ b/packages/compiler-wasm/__tests__/design-system.test.ts
@@ -130,29 +130,6 @@ describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
       modules: [],
     })
   })
-
-  // resolveChain across the boundary: ordered plan and cycle detection.
-  it('resolveChain() orders a chain root-first and reports cycles', async () => {
-    const app = await createCompiler(baseConfig)
-    const node = (name: string, parent?: string) =>
-      app.designSystem.create({
-        name,
-        panda: '^2.0.0',
-        preset: './panda.preset.mjs',
-        buildInfo: './panda.buildinfo.json',
-        designSystem: parent,
-      })
-
-    expect(
-      app.designSystem.resolveChain([node('@acme/marketing', '@acme/foundations'), node('@acme/foundations')]),
-    ).toEqual({ ok: true, order: ['@acme/foundations', '@acme/marketing'] })
-
-    expect(app.designSystem.resolveChain([node('@acme/a', '@acme/b'), node('@acme/b', '@acme/a')])).toEqual({
-      ok: false,
-      reason: 'cycle',
-      cycle: ['@acme/a', '@acme/b', '@acme/a'],
-    })
-  })
 })
 
 describeMissingWasm()

--- a/packages/compiler-wasm/crate/src/project/design_system.rs
+++ b/packages/compiler-wasm/crate/src/project/design_system.rs
@@ -21,23 +21,6 @@ impl WasmCompiler {
             .map_err(|err| JsValue::from_str(&err.to_string()))
     }
 
-    /// Order already-read manifests by their `designSystem` parent links into a
-    /// root-first hydrate/merge plan (or report a cycle). Backs the
-    /// `designSystem.resolveChain` JS namespace. Pure — the host did the reads.
-    ///
-    /// # Errors
-    /// Returns a JS error if `manifests` is invalid or the plan fails to serialize.
-    #[wasm_bindgen(js_name = resolveDesignSystemChain)]
-    pub fn resolve_design_system_chain(&self, manifests: JsValue) -> Result<JsValue, JsValue> {
-        let manifests: Vec<pandacss_project::DesignSystemManifest> =
-            serde_wasm_bindgen::from_value(manifests)
-                .map_err(|err| JsValue::from_str(&err.to_string()))?;
-        let plan = pandacss_project::resolve_chain(&manifests);
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        plan.serialize(&serializer)
-            .map_err(|err| JsValue::from_str(&err.to_string()))
-    }
-
     /// The manifest wire-format version this binding reads/writes.
     #[wasm_bindgen(js_name = designSystemManifestSchemaVersion)]
     #[must_use]

--- a/packages/compiler-wasm/src/types.ts
+++ b/packages/compiler-wasm/src/types.ts
@@ -13,7 +13,6 @@
 import type {
   Atom,
   BuildInfoArtifact,
-  DesignSystemChainPlan,
   DesignSystemManifest,
   DesignSystemManifestInput,
   CodegenArtifact,
@@ -170,5 +169,4 @@ export declare class WasmCompiler {
   // `DesignSystemBinding` contract used by the public namespace.
   createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
   designSystemManifestSchemaVersion(): number
-  resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }

--- a/packages/compiler-wasm/src/web.ts
+++ b/packages/compiler-wasm/src/web.ts
@@ -150,7 +150,6 @@ function toDesignSystemBinding(compiler: RuntimeWasmCompiler): DesignSystemBindi
   return {
     createManifest: (input) => compiler.createDesignSystemManifest(input),
     manifestSchemaVersion: () => compiler.designSystemManifestSchemaVersion(),
-    resolveChain: (manifests) => compiler.resolveDesignSystemChain(manifests),
   }
 }
 

--- a/packages/compiler/__tests__/design-system.test.ts
+++ b/packages/compiler/__tests__/design-system.test.ts
@@ -199,39 +199,4 @@ describe('compiler.designSystem', () => {
       modules: [],
     })
   })
-
-  // --- resolveChain(): composition — order a chain of parent design systems ---
-
-  // A bare manifest with just identity + parent; resolveChain reads only those.
-  const node = (name: string, parent?: string): DesignSystemManifest =>
-    project().designSystem.create({
-      name,
-      panda: '^2.0.0',
-      preset: './panda.preset.mjs',
-      buildInfo: './panda.buildinfo.json',
-      designSystem: parent,
-    })
-
-  it('resolveChain() orders a chain root-first', () => {
-    const app = project()
-    expect(
-      app.designSystem.resolveChain([node('@acme/marketing', '@acme/foundations'), node('@acme/foundations')]),
-    ).toEqual({ ok: true, order: ['@acme/foundations', '@acme/marketing'] })
-  })
-
-  it('resolveChain() dedupes a shared parent', () => {
-    const app = project()
-    expect(
-      app.designSystem.resolveChain([node('@acme/a', '@acme/base'), node('@acme/b', '@acme/base'), node('@acme/base')]),
-    ).toEqual({ ok: true, order: ['@acme/base', '@acme/a', '@acme/b'] })
-  })
-
-  it('resolveChain() reports a cycle path', () => {
-    const app = project()
-    expect(app.designSystem.resolveChain([node('@acme/a', '@acme/b'), node('@acme/b', '@acme/a')])).toEqual({
-      ok: false,
-      reason: 'cycle',
-      cycle: ['@acme/a', '@acme/b', '@acme/a'],
-    })
-  })
 })

--- a/packages/compiler/crate/src/project/design_system.rs
+++ b/packages/compiler/crate/src/project/design_system.rs
@@ -31,27 +31,4 @@ impl Compiler {
     pub fn design_system_manifest_schema_version(&self) -> u32 {
         pandacss_project::MANIFEST_SCHEMA_VERSION
     }
-
-    /// Order already-read manifests by their `designSystem` parent links into a
-    /// root-first hydrate/merge plan (or report a cycle). Backs the
-    /// `designSystem.resolveChain` JS namespace. Pure — the host did the reads.
-    ///
-    /// # Errors
-    /// Returns an error if `manifests` isn't a valid manifest array or the plan
-    /// fails to serialize.
-    #[napi(js_name = resolveDesignSystemChain)]
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "NAPI requires owned arguments"
-    )]
-    pub fn resolve_design_system_chain(
-        &self,
-        manifests: serde_json::Value,
-    ) -> napi::Result<serde_json::Value> {
-        let manifests: Vec<pandacss_project::DesignSystemManifest> =
-            serde_json::from_value(manifests)
-                .map_err(|err| napi::Error::from_reason(err.to_string()))?;
-        let plan = pandacss_project::resolve_chain(&manifests);
-        serde_json::to_value(&plan).map_err(|err| napi::Error::from_reason(err.to_string()))
-    }
 }

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -48,7 +48,6 @@ const fallbackDesignSystem = new DesignSystem(
   {
     createManifest: (input) => ({ ...input, schemaVersion: -1 }),
     manifestSchemaVersion: () => -1,
-    resolveChain: () => ({ status: 'ordered', order: [] }),
   },
   fallbackBuildInfo,
 )
@@ -98,9 +97,6 @@ class FallbackCompiler implements Compiler {
   }
   designSystemManifestSchemaVersion() {
     return -1
-  }
-  resolveDesignSystemChain() {
-    return { status: 'ordered', order: [] } as const
   }
   config() {
     return {}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -196,7 +196,6 @@ function toDesignSystemBinding(
   return {
     createManifest: (input) => compiler.createDesignSystemManifest(input),
     manifestSchemaVersion: () => compiler.designSystemManifestSchemaVersion(),
-    resolveChain: (manifests) => compiler.resolveDesignSystemChain(manifests),
   }
 }
 

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -2,7 +2,6 @@ import type {
   BuildInfoNative,
   Compiler as SharedCompiler,
   CompileOutput,
-  DesignSystemChainPlan,
   DesignSystemManifest,
   DesignSystemManifestInput,
   Diagnostic,
@@ -141,7 +140,6 @@ export interface NativeCompilerOptions {
 interface RawDesignSystemBinding {
   createDesignSystemManifest(input: DesignSystemManifestInput): DesignSystemManifest
   designSystemManifestSchemaVersion(): number
-  resolveDesignSystemChain(manifests: DesignSystemManifest[]): DesignSystemChainPlan
 }
 
 interface RawFileSystemBinding {


### PR DESCRIPTION
## 📝 Description

Remove the unused `designSystem.resolveChain` binding, so chain resolution has one source of truth. From the design-system audit following #3599.

## ⛳️ Current behavior (updates)

`resolveChain` was a second, divergent implementation: the Rust `resolve_chain` primitive (cycle key = name, DFS), exposed on the native and wasm bindings but never called on the live path. Production chains resolve through the config loader's `loadDesignSystemChain` (cycle key = manifest path, single-parent walk), and branching design systems are an explicit non-goal — so the primitive's generality served a case that can't occur.

## 🚀 New behavior

Removed `resolve_chain` + `ChainPlan` from `pandacss_project`, the `resolveDesignSystemChain` methods on both bindings, the `DesignSystemChainPlan`/`DesignSystemChainResult` types, the `DesignSystem.resolveChain` wrapper, and the associated tests.

Tests: `cargo check` on the native and `wasm32-unknown-unknown` crates, `clippy`, `cargo nextest -p pandacss_project`, `typecheck`, and the compiler + compiler-shared suites pass.

## 💣 Is this a breaking change (Yes/No):

No — `resolveChain` was an internal binding method, unused on the live path and not part of the public `@pandacss/dev` API.

## 📝 Additional Information

Part of the design-system edge-case audit from [#3599](https://github.com/chakra-ui/panda/discussions/3599). Recommended merge order across the six PRs, to minimize rebases on shared files (`config/design-system.ts`, `compiler-shared/design-system.ts`, `types/compiler.ts`):

1. #3652 — `minify` config key + design-system docs
2. #3654 — build-info hydration
3. #3653 — resolution diagnostics
4. #3655 — multi-major peer ranges
5. #3656 — package.json exports safety
6. #3657 — remove the unused chain resolver

_This PR is #6 — merge last (shares `compiler-shared/design-system.ts` with #3655 and `types/compiler.ts` with #3654)._
