### PR TITLE
test(tracing): make span-timing tests deterministic

### DIFF
--- a/crates/pandacss_tracing/src/aggregator.rs
+++ b/crates/pandacss_tracing/src/aggregator.rs
@@ -214,3 +214,62 @@ where
         self.timings.add(name, elapsed, label);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_orders_spans_by_total_time_descending() {
+        let timings = SpanTimings::new();
+        timings.add("beta", 2_000, None);
+        timings.add("alpha", 5_000, None);
+
+        let names: Vec<&str> = timings.snapshot().iter().map(|s| s.name).collect();
+        assert_eq!(names, ["alpha", "beta"]);
+    }
+
+    #[test]
+    fn snapshot_orders_slowest_instances_by_duration_descending() {
+        let timings = SpanTimings::new();
+        timings.add("extraction", 5, Some("a.tsx".into()));
+        timings.add("extraction", 30, Some("b.tsx".into()));
+        timings.add("extraction", 15, Some("c.tsx".into()));
+
+        let snap = timings.snapshot();
+        let extraction = snap.iter().find(|s| s.name == "extraction").expect("span");
+        let labels: Vec<&str> = extraction
+            .slowest
+            .iter()
+            .map(|i| i.label.as_str())
+            .collect();
+        assert_eq!(labels, ["b.tsx", "c.tsx", "a.tsx"]);
+    }
+
+    #[test]
+    fn snapshot_caps_slowest_instances_at_five_in_descending_order() {
+        let timings = SpanTimings::new();
+        for i in 0..8u128 {
+            timings.add("extraction", (i + 1) * 15, Some(format!("file-{i}.tsx")));
+        }
+
+        let snap = timings.snapshot();
+        let extraction = snap.iter().find(|s| s.name == "extraction").expect("span");
+        assert_eq!(extraction.count, 8);
+        let labels: Vec<&str> = extraction
+            .slowest
+            .iter()
+            .map(|i| i.label.as_str())
+            .collect();
+        assert_eq!(
+            labels,
+            [
+                "file-7.tsx",
+                "file-6.tsx",
+                "file-5.tsx",
+                "file-4.tsx",
+                "file-3.tsx"
+            ],
+        );
+    }
+}

--- a/crates/pandacss_tracing/tests/aggregator.rs
+++ b/crates/pandacss_tracing/tests/aggregator.rs
@@ -25,7 +25,6 @@ fn aggregates_span_enter_exit() {
     assert_eq!(beta.count, 1);
     assert!(alpha.total_nanos > 0);
     assert!(beta.total_nanos > 0);
-    assert!(snap.first().expect("first").total_nanos >= snap.last().expect("last").total_nanos);
 }
 
 #[test]
@@ -34,21 +33,20 @@ fn records_slowest_instances_by_path_field() {
     let subscriber = tracing_subscriber::registry().with(timings.layer());
     let _guard = subscriber.set_default();
 
-    // Widely spaced sleeps so scheduler jitter can't reorder the result.
-    for (path, millis) in [("a.tsx", 5), ("b.tsx", 30), ("c.tsx", 15)] {
+    for path in ["a.tsx", "b.tsx", "c.tsx"] {
         let _entered = tracing::trace_span!("extraction", path = path).entered();
-        std::thread::sleep(std::time::Duration::from_millis(millis));
     }
 
     let snap = timings.snapshot();
     let extraction = snap.iter().find(|s| s.name == "extraction").expect("span");
     assert_eq!(extraction.count, 3);
-    let labels: Vec<&str> = extraction
+    let mut labels: Vec<&str> = extraction
         .slowest
         .iter()
         .map(|instance| instance.label.as_str())
         .collect();
-    assert_eq!(labels, ["b.tsx", "c.tsx", "a.tsx"]);
+    labels.sort_unstable();
+    assert_eq!(labels, ["a.tsx", "b.tsx", "c.tsx"]);
 }
 
 #[test]
@@ -73,20 +71,19 @@ fn records_slowest_instances_by_id_field_when_no_path() {
     let subscriber = tracing_subscriber::registry().with(timings.layer());
     let _guard = subscriber.set_default();
 
-    // Widely spaced sleeps so scheduler jitter can't reorder the result.
-    for (id, millis) in [("conditions", 5), ("types", 30), ("css", 15)] {
+    for id in ["conditions", "types", "css"] {
         let _entered = tracing::trace_span!("artifact", id = id).entered();
-        std::thread::sleep(std::time::Duration::from_millis(millis));
     }
 
     let snap = timings.snapshot();
     let artifact = snap.iter().find(|s| s.name == "artifact").expect("span");
-    let labels: Vec<&str> = artifact
+    let mut labels: Vec<&str> = artifact
         .slowest
         .iter()
         .map(|instance| instance.label.as_str())
         .collect();
-    assert_eq!(labels, ["types", "css", "conditions"]);
+    labels.sort_unstable();
+    assert_eq!(labels, ["conditions", "css", "types"]);
 }
 
 #[test]
@@ -111,33 +108,15 @@ fn slowest_instances_are_capped_at_five() {
     let subscriber = tracing_subscriber::registry().with(timings.layer());
     let _guard = subscriber.set_default();
 
-    // Widely spaced sleeps so scheduler jitter can't reorder the result.
     for i in 0..8u64 {
         let path = format!("file-{i}.tsx");
         let _entered = tracing::trace_span!("extraction", path = path.as_str()).entered();
-        std::thread::sleep(std::time::Duration::from_millis((i + 1) * 15));
     }
 
     let snap = timings.snapshot();
     let extraction = snap.iter().find(|s| s.name == "extraction").expect("span");
     assert_eq!(extraction.count, 8);
     assert_eq!(extraction.slowest.len(), 5);
-    // Slowest overall (file-7 through file-3) survive the cap, in descending order.
-    let labels: Vec<&str> = extraction
-        .slowest
-        .iter()
-        .map(|instance| instance.label.as_str())
-        .collect();
-    assert_eq!(
-        labels,
-        [
-            "file-7.tsx",
-            "file-6.tsx",
-            "file-5.tsx",
-            "file-4.tsx",
-            "file-3.tsx"
-        ]
-    );
 }
 
 #[test]


### PR DESCRIPTION
## 📝 Description

Deflake the `pandacss_tracing` aggregator tests, which fail intermittently on the macOS CI runner.

## ⛳️ Current behavior (updates)

`slowest_instances_are_capped_at_five` (and the sibling ordering tests) derived span durations from `thread::sleep` spacing and asserted the resulting order. Under nextest's parallel test processes on the 3-core macOS runner, threads are starved hard enough that a `sleep(15ms)` span outranks a `sleep(90ms)` one — so `file-0` landed in the slowest five. No sleep spacing survives that.

## 🚀 New behavior

The ordering and cap-at-five assertions move to inline unit tests that feed synthetic durations to the private `add()`, so they're deterministic and independent of the scheduler. The integration tests keep only timing-independent checks: span count, that each `path`/`id` field is recorded as a label, and that the slowest list caps at five.

Runs 3× locally with 20/20 passing (and ~300× faster, since the sleeps are gone); `clippy` clean.

## 💣 Is this a breaking change (Yes/No):

No — test-only.

## 📝 Additional Information

Surfaced while getting the design-system audit PRs (#3652–#3657) green; the four that run the Rust matrix were red only on this pre-existing macOS flake.