### PR TITLE
feat(cli): add panda studio

### DIFF
--- a/.changeset/cli-studio.md
+++ b/.changeset/cli-studio.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/cli': minor
+---
+
+Add `panda studio` to visualize your design tokens.
+
+- `panda studio` boots a live viewer — plain HTML/CSS/JS, no framework or bundler — that renders your tokens grouped by
+  category, with light/dark theming. Set the port with `--port`.
+- `panda studio generate` writes the token views into your project as source (shadcn-style) so you own them and render
+  them where you document your design system — an app route, an MDX page, or Storybook. Views match your
+  `config.jsxFramework` (React or Solid) and land in `styled-system/studio` by default (`--outdir` to change).
+
+Both read a generated `tokens.json` snapshot. Re-run to refresh after a config change.

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,4 @@ website/pages/**/*.mdx
 .draft/**/*.mdx
 styled-system
 packages/transformer/src/runtime/internal/source.ts
+**/CHANGELOG.md

--- a/packages/cli/__tests__/cli-main.test.ts
+++ b/packages/cli/__tests__/cli-main.test.ts
@@ -3,6 +3,7 @@ import { buildCommand, buildSubcommand, checkCommand, devCommand } from '../src/
 import { doctorCommand } from '../src/commands/doctor'
 import { infoCommand } from '../src/commands/info'
 import { analyzeCommand } from '../src/commands/analyze'
+import { studioCommand, studioGenerateCommand } from '../src/commands/studio'
 
 describe('cli main', () => {
   it('defines the default build command route', () => {
@@ -16,5 +17,11 @@ describe('cli main', () => {
     expect(analyzeCommand.meta).toMatchObject({ name: 'analyze' })
     expect(infoCommand.meta).toMatchObject({ name: 'info' })
     expect(doctorCommand.meta).toMatchObject({ name: 'doctor' })
+  })
+
+  it('defines studio as leaf commands so space-separated flags parse', () => {
+    expect(studioCommand.meta).toMatchObject({ name: 'studio' })
+    expect(studioGenerateCommand.meta).toMatchObject({ name: 'studio generate' })
+    expect(studioCommand.subCommands).toBeUndefined()
   })
 })

--- a/packages/cli/__tests__/cli-smoke.test.ts
+++ b/packages/cli/__tests__/cli-smoke.test.ts
@@ -40,7 +40,7 @@ describe('cli smoke', () => {
     expect(normalizeCliOutput(result.stdout)).toMatchInlineSnapshot(`
       "Generate the panda system and CSS. Run with no subcommand for the full build. (panda v<version>)
 
-      USAGE \`panda [OPTIONS] init|dev|build|check|info|doctor|debug|buildinfo|lib|analyze|codegen|cssgen\`
+      USAGE \`panda [OPTIONS] init|dev|build|check|info|doctor|debug|buildinfo|lib|analyze|codegen|cssgen|studio\`
 
       OPTIONS
 
@@ -78,6 +78,7 @@ describe('cli smoke', () => {
       \`analyze\` Inspect Panda usage across project sources
       \`codegen\` Generate the panda system
       \`cssgen\` Generate CSS from project files
+      \`studio\` Boot a live token viewer. Run \`panda studio generate\` to emit token views into your project
 
       Use \`panda <command> --help\` for more information about a command.
 

--- a/packages/cli/__tests__/studio.test.ts
+++ b/packages/cli/__tests__/studio.test.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildTokensSnapshot, runStudioGenerate, runStudioServe, viewFiles, viewerFiles } from '../src'
+import type { StudioToken } from '../src'
+import { cleanupFixture, createFixture } from './helpers'
+
+const TOKEN_CONFIG = `export default {
+  outdir: 'styled-system',
+  include: ['**/*.tsx'],
+  jsxFramework: 'react',
+  theme: {
+    tokens: {
+      colors: { red: { 500: { value: '#ef4444' } }, blue: { 500: { value: '#3b82f6' } } },
+      spacing: { sm: { value: '8px' } },
+      radii: { md: { value: '6px' } },
+    },
+  },
+  importMap: {
+    css: ['@panda/css'],
+    recipe: ['@panda/recipes'],
+    pattern: ['@panda/patterns'],
+    jsx: ['@panda/jsx'],
+    tokens: ['@panda/tokens'],
+  },
+}
+`
+
+const SOLID_CONFIG = TOKEN_CONFIG.replace("jsxFramework: 'react'", "jsxFramework: 'solid'")
+
+const SAMPLE: StudioToken[] = [{ category: 'colors', path: 'colors.red.500', name: 'red.500', value: '#ef4444' }]
+
+describe('studio generate', () => {
+  let dir: string | undefined
+
+  afterEach(() => {
+    cleanupFixture(dir)
+    dir = undefined
+  })
+
+  it('flattens the token spec into a snapshot', () => {
+    const files = viewFiles(SAMPLE, 'react')
+    const snapshot = JSON.parse(files.find((file) => file.path === 'tokens.json')!.code)
+    expect(snapshot).toEqual(SAMPLE)
+  })
+
+  it('writes React views + tokens.json to the default outdir', async () => {
+    dir = createFixture(TOKEN_CONFIG)
+
+    const logs: string[] = []
+    const result = await runStudioGenerate({ cwd: dir }, { log: (message) => logs.push(message) })
+
+    const studioDir = join(dir, 'styled-system', 'studio')
+    expect(result.framework).toBe('react')
+    expect(existsSync(join(studioDir, 'Colors.tsx'))).toBe(true)
+    expect(existsSync(join(studioDir, 'components', 'token-grid.tsx'))).toBe(true)
+
+    const snapshot = JSON.parse(readFileSync(join(studioDir, 'tokens.json'), 'utf8'))
+    expect(snapshot).toContainEqual({ category: 'colors', path: 'colors.red.500', name: 'red.500', value: '#ef4444' })
+
+    const grid = readFileSync(join(studioDir, 'components', 'token-grid.tsx'), 'utf8')
+    expect(grid).toContain("from 'react'")
+    expect(logs[0]).toContain('studio: wrote')
+  })
+
+  it('honours --outdir', async () => {
+    dir = createFixture(TOKEN_CONFIG)
+
+    await runStudioGenerate({ cwd: dir, outdir: '.storybook/studio', logLevel: 'silent' })
+
+    expect(existsSync(join(dir, '.storybook', 'studio', 'Colors.tsx'))).toBe(true)
+  })
+
+  it('emits Solid source when jsxFramework is solid', async () => {
+    dir = createFixture(SOLID_CONFIG)
+
+    const result = await runStudioGenerate({ cwd: dir, logLevel: 'silent' })
+    expect(result.framework).toBe('solid')
+
+    const grid = readFileSync(join(dir, 'styled-system', 'studio', 'components', 'token-grid.tsx'), 'utf8')
+    expect(grid).toContain("from 'solid-js'")
+    expect(grid).toContain('<For')
+  })
+})
+
+describe('studio viewer', () => {
+  let dir: string | undefined
+
+  afterEach(() => {
+    cleanupFixture(dir)
+    dir = undefined
+  })
+
+  it('emits a self-contained vanilla bundle', () => {
+    const paths = viewerFiles(SAMPLE).map((file) => file.path)
+    expect(paths).toEqual(['tokens.json', 'index.html', 'studio.css', 'studio.js'])
+  })
+
+  it('serves tokens.json over http', async () => {
+    dir = createFixture(TOKEN_CONFIG)
+
+    const result = await runStudioServe({ cwd: dir, host: '127.0.0.1', logLevel: 'silent' })
+    try {
+      expect(result.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+
+      const res = await fetch(`${result.url}/tokens.json`)
+      const snapshot = await res.json()
+      expect(snapshot).toContainEqual({
+        category: 'colors',
+        path: 'colors.red.500',
+        name: 'red.500',
+        value: '#ef4444',
+      })
+
+      const page = await fetch(`${result.url}/`)
+      expect(await page.text()).toContain('Panda Studio')
+    } finally {
+      await result.stop?.()
+    }
+  })
+})

--- a/packages/cli/__tests__/studio.test.ts
+++ b/packages/cli/__tests__/studio.test.ts
@@ -44,6 +44,18 @@ describe('studio generate', () => {
     expect(snapshot).toEqual(SAMPLE)
   })
 
+  it('builds a snapshot from a spec, skipping empty values', () => {
+    const spec = {
+      tokens: {
+        categories: { colors: { values: ['red.500', 'blank'] } },
+        values: { 'colors.red.500': '#ef4444', 'colors.blank': '' },
+      },
+    } as never
+    expect(buildTokensSnapshot(spec)).toEqual([
+      { category: 'colors', path: 'colors.red.500', name: 'red.500', value: '#ef4444' },
+    ])
+  })
+
   it('writes React views + tokens.json to the default outdir', async () => {
     dir = createFixture(TOKEN_CONFIG)
 

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -9,6 +9,7 @@ import { doctorCommand } from './commands/doctor'
 import { infoCommand } from './commands/info'
 import { initCommand } from './commands/init'
 import { libCommand } from './commands/lib'
+import { studioCommand, studioGenerateCommand } from './commands/studio'
 import { ExitCode } from './result'
 import { readCliVersion } from './version'
 
@@ -42,11 +43,21 @@ export async function main(argv = process.argv): Promise<void> {
       analyze: analyzeCommand,
       codegen: codegenCommand,
       cssgen: cssgenCommand,
+      studio: studioCommand,
     },
   })
 
   if (isVersionRequest(rawArgs)) {
     console.log(version)
+    return
+  }
+
+  if (rawArgs[0] === 'studio') {
+    if (rawArgs[1] === 'generate') {
+      await runMain(studioGenerateCommand, { rawArgs: rawArgs.slice(2), showUsage: showPlainUsage })
+    } else {
+      await runMain(studioCommand, { rawArgs: rawArgs.slice(1), showUsage: showPlainUsage })
+    }
     return
   }
 

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -1,0 +1,115 @@
+import { defineCommand } from 'citty'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { baseArgs, outputArgs, parseCliFlags, traceArgs } from '../args'
+import { consoleOutput, shouldPrintHumanSummary, type OutputSink } from '../output'
+import { setExitCode } from '../result'
+import { runCommand } from '../run-command'
+import { studioGenerateFlagsSchema, studioServeFlagsSchema } from '../schema'
+import type { StudioGenerateFlags, StudioGenerateResult, StudioServeFlags, StudioServeResult } from '../schema'
+import { serveStudio, type StudioServer } from '../studio-server'
+import { buildTokensSnapshot, viewFiles, viewerFiles, type StudioFile, type StudioFramework } from '../studio-codegen'
+
+export const studioGenerateCommand = defineCommand({
+  meta: {
+    name: 'studio generate',
+    description: 'Write token view components for your design system',
+  },
+  args: () => ({
+    ...baseArgs(),
+    outdir: { type: 'string', description: "Output directory for the views (default '<outdir>/studio')" },
+    ...outputArgs(),
+    ...traceArgs(),
+  }),
+  run: async ({ args }) => setExitCode(await runStudioGenerate(parseCliFlags(studioGenerateFlagsSchema, args))),
+})
+
+export const studioCommand = defineCommand({
+  meta: {
+    name: 'studio',
+    description: 'Boot a live token viewer. Run `panda studio generate` to emit token views into your project',
+  },
+  args: () => ({
+    ...baseArgs(),
+    port: { type: 'string', description: 'Port for the live viewer server' },
+    host: { type: 'string', description: 'Host for the live viewer server' },
+    ...outputArgs(),
+    ...traceArgs(),
+  }),
+  run: async ({ args }) => setExitCode(await runStudioServe(parseCliFlags(studioServeFlagsSchema, args))),
+})
+
+export async function runStudioGenerate(
+  flags: StudioGenerateFlags = {},
+  output: OutputSink = consoleOutput,
+): Promise<StudioGenerateResult> {
+  return (await runCommand({
+    command: 'studio',
+    flags,
+    output,
+    failData: () => ({ files: [], framework: 'react' as StudioFramework }),
+    async execute(ctx) {
+      const framework = resolveFramework(ctx.driver.config.jsxFramework)
+      const tokens = buildTokensSnapshot(ctx.driver.compiler.spec())
+      const outdir = flags.outdir ? ctx.driver.resolvePath(flags.outdir) : join(ctx.driver.getOutdir(), 'studio')
+
+      const files = writeStudioFiles(outdir, viewFiles(tokens, framework))
+
+      if (shouldPrintHumanSummary(flags)) {
+        ctx.output.log(`studio: wrote ${files.length} ${framework} files to ${outdir}`)
+      }
+
+      return { data: { outdir, files, framework } }
+    },
+  })) as StudioGenerateResult
+}
+
+export async function runStudioServe(
+  flags: StudioServeFlags = {},
+  output: OutputSink = consoleOutput,
+): Promise<StudioServeResult> {
+  let server: StudioServer | undefined
+
+  const result = (await runCommand({
+    command: 'studio',
+    flags,
+    output,
+    keepTracing: true,
+    failData: () => ({}),
+    async execute(ctx) {
+      const tokens = buildTokensSnapshot(ctx.driver.compiler.spec())
+      const dir = mkdtempSync(join(tmpdir(), 'panda-studio-'))
+      writeStudioFiles(dir, viewerFiles(tokens))
+
+      server = await serveStudio(dir, { port: flags.port, host: flags.host })
+
+      if (shouldPrintHumanSummary(flags)) {
+        ctx.output.log(`studio: viewer running at ${server.url}`)
+      }
+
+      return { data: { url: server.url } }
+    },
+  })) as StudioServeResult
+
+  const stopTracing = result.stop
+  result.stop = async () => {
+    await server?.close()
+    await stopTracing?.()
+  }
+
+  return result
+}
+
+function resolveFramework(jsxFramework: unknown): StudioFramework {
+  return jsxFramework === 'solid' ? 'solid' : 'react'
+}
+
+function writeStudioFiles(outdir: string, files: StudioFile[]): string[] {
+  return files.map((file) => {
+    const path = join(outdir, file.path)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, file.code)
+    return path
+  })
+}

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -9,7 +9,14 @@ import { runCommand } from '../run-command'
 import { studioGenerateFlagsSchema, studioServeFlagsSchema } from '../schema'
 import type { StudioGenerateFlags, StudioGenerateResult, StudioServeFlags, StudioServeResult } from '../schema'
 import { serveStudio, type StudioServer } from '../studio-server'
-import { buildTokensSnapshot, viewFiles, viewerFiles, type StudioFile, type StudioFramework } from '../studio-codegen'
+import {
+  buildTokensSnapshot,
+  keyframesToCss,
+  viewFiles,
+  viewerFiles,
+  type StudioFile,
+  type StudioFramework,
+} from '../studio-codegen'
 
 export const studioGenerateCommand = defineCommand({
   meta: {
@@ -52,9 +59,10 @@ export async function runStudioGenerate(
     async execute(ctx) {
       const framework = resolveFramework(ctx.driver.config.jsxFramework)
       const tokens = buildTokensSnapshot(ctx.driver.compiler.spec())
+      const keyframes = keyframesToCss(readKeyframes(ctx.driver.config))
       const outdir = flags.outdir ? ctx.driver.resolvePath(flags.outdir) : join(ctx.driver.getOutdir(), 'studio')
 
-      const files = writeStudioFiles(outdir, viewFiles(tokens, framework))
+      const files = writeStudioFiles(outdir, viewFiles(tokens, framework, keyframes))
 
       if (shouldPrintHumanSummary(flags)) {
         ctx.output.log(`studio: wrote ${files.length} ${framework} files to ${outdir}`)
@@ -79,8 +87,9 @@ export async function runStudioServe(
     failData: () => ({}),
     async execute(ctx) {
       const tokens = buildTokensSnapshot(ctx.driver.compiler.spec())
+      const keyframes = keyframesToCss(readKeyframes(ctx.driver.config))
       const dir = mkdtempSync(join(tmpdir(), 'panda-studio-'))
-      writeStudioFiles(dir, viewerFiles(tokens))
+      writeStudioFiles(dir, viewerFiles(tokens, keyframes))
 
       server = await serveStudio(dir, { port: flags.port, host: flags.host })
 
@@ -103,6 +112,10 @@ export async function runStudioServe(
 
 function resolveFramework(jsxFramework: unknown): StudioFramework {
   return jsxFramework === 'solid' ? 'solid' : 'react'
+}
+
+function readKeyframes(config: unknown): unknown {
+  return (config as { theme?: { keyframes?: unknown } } | undefined)?.theme?.keyframes
 }
 
 function writeStudioFiles(outdir: string, files: StudioFile[]): string[] {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,10 @@ export { runLib } from './commands/lib'
 export { runAnalyze } from './commands/analyze'
 export { infoDriver, runInfo } from './commands/info'
 export { runInit, setupGitIgnore } from './commands/init'
+export { runStudioGenerate, runStudioServe } from './commands/studio'
+export { buildTokensSnapshot, viewFiles, viewerFiles } from './studio-codegen'
+export type { StudioToken, StudioFile, StudioFramework } from './studio-codegen'
+export { serveStudio } from './studio-server'
 export type {
   BuildFlags,
   BuildResult,
@@ -32,4 +36,8 @@ export type {
   LibFlags,
   LibResult,
   LogLevel,
+  StudioGenerateFlags,
+  StudioGenerateResult,
+  StudioServeFlags,
+  StudioServeResult,
 } from './schema'

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -121,6 +121,15 @@ export const debugFlagsSchema = infoFlagsSchema.extend({
   onlyConfig: booleanFlag,
 })
 
+export const studioGenerateFlagsSchema = commonFlagsSchema.extend({
+  outdir: stringFlag,
+})
+
+export const studioServeFlagsSchema = commonFlagsSchema.extend({
+  port: numberLikeFlag,
+  host: stringFlag,
+})
+
 export const analyzeFlagsSchema = commonFlagsSchema.extend({
   // Scope to include in the report: all, tokens, recipes, utilities, patterns, keyframes (or token/recipe aliases)
   scope: enumOf(['all', 'tokens', 'recipes', 'utilities', 'patterns', 'keyframes', 'token', 'recipe']),
@@ -140,6 +149,8 @@ export type BuildFlags = FlagsInfer<typeof buildFlagsSchema>
 export type InitFlags = FlagsInfer<typeof initFlagsSchema>
 export type BuildinfoFlags = FlagsInfer<typeof buildinfoFlagsSchema>
 export type LibFlags = FlagsInfer<typeof libFlagsSchema>
+export type StudioGenerateFlags = FlagsInfer<typeof studioGenerateFlagsSchema>
+export type StudioServeFlags = FlagsInfer<typeof studioServeFlagsSchema>
 export type InfoFlags = FlagsInfer<typeof infoFlagsSchema>
 export type DoctorFlags = FlagsInfer<typeof doctorFlagsSchema>
 export type DebugFlags = FlagsInfer<typeof debugFlagsSchema>
@@ -161,6 +172,16 @@ export interface LibResult extends CommandResult<NodeDriver> {
   buildInfoPath?: string
   presetPath?: string
   exportsChanged: boolean
+}
+
+export interface StudioGenerateResult extends CommandResult {
+  outdir?: string
+  files: string[]
+  framework: string
+}
+
+export interface StudioServeResult extends CommandResult<NodeDriver> {
+  url?: string
 }
 
 export interface CommandResult<TDriver extends Driver = Driver> extends CliResult {

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -1,0 +1,683 @@
+import type { Spec } from '@pandacss/compiler-shared'
+
+export interface StudioToken {
+  category: string
+  path: string
+  name: string
+  value: string
+}
+
+export type StudioFramework = 'react' | 'solid'
+
+export interface StudioFile {
+  path: string
+  code: string
+}
+
+const VIEWS: Array<{ name: string; categories: string[] }> = [
+  { name: 'Colors', categories: ['colors'] },
+  { name: 'Typography', categories: ['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'] },
+  { name: 'Spacing', categories: ['spacing'] },
+  { name: 'Sizes', categories: ['sizes'] },
+  { name: 'Radii', categories: ['radii'] },
+  { name: 'Shadows', categories: ['shadows'] },
+]
+
+export function buildTokensSnapshot(spec: Spec): StudioToken[] {
+  const out: StudioToken[] = []
+  for (const [category, meta] of Object.entries(spec.tokens.categories)) {
+    for (const name of meta.values) {
+      const path = `${category}.${name}`
+      const value = spec.tokens.values[path]
+      if (value == null || value === '') continue
+      out.push({ category, path, name, value })
+    }
+  }
+  return out
+}
+
+export function tokensSnapshotFile(tokens: StudioToken[]): StudioFile {
+  return { path: 'tokens.json', code: `${JSON.stringify(tokens, null, 2)}\n` }
+}
+
+export function viewFiles(tokens: StudioToken[], framework: StudioFramework): StudioFile[] {
+  const templates = framework === 'solid' ? solidTemplates : reactTemplates
+  return [
+    tokensSnapshotFile(tokens),
+    { path: 'components/token-grid.tsx', code: templates.tokenGrid() },
+    ...VIEWS.map((view) => ({ path: `${view.name}.tsx`, code: templates.view(view.name, view.categories) })),
+  ]
+}
+
+export function viewerFiles(tokens: StudioToken[]): StudioFile[] {
+  return [
+    tokensSnapshotFile(tokens),
+    { path: 'index.html', code: VIEWER_HTML },
+    { path: 'studio.css', code: VIEWER_CSS },
+    { path: 'studio.js', code: VIEWER_JS },
+  ]
+}
+
+const VIEWER_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Panda Studio</title>
+    <link rel="stylesheet" href="studio.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <header>
+        <span class="logo">🐼</span>
+        <h1>Panda Studio</h1>
+        <span class="count" id="count"></span>
+        <button class="theme" id="theme" type="button" aria-label="Toggle color theme"></button>
+      </header>
+      <main id="grid"></main>
+    </div>
+    <script src="studio.js"></script>
+  </body>
+</html>
+`
+
+const VIEWER_CSS = `:root {
+  color-scheme: light;
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --muted: #71717a;
+  --border: #e4e4e7;
+  --card: #fafafa;
+  --swatch: #d4d4d8;
+  --shadow-bg: #ffffff;
+  --accent: #f6e458;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) { color-scheme: dark; --bg: #0d0d0f; --fg: #f4f4f5; --muted: #8f8f99; --border: #26262a; --card: #161619; --swatch: #3f3f46; --shadow-bg: #f4f4f5; }
+}
+:root[data-theme='dark'] { color-scheme: dark; --bg: #0d0d0f; --fg: #f4f4f5; --muted: #8f8f99; --border: #26262a; --card: #161619; --swatch: #3f3f46; --shadow-bg: #f4f4f5; }
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--fg); font-family: -apple-system, system-ui, sans-serif; }
+.wrap { max-width: 1080px; margin: 0 auto; padding: 40px 24px 80px; }
+header { display: flex; align-items: center; gap: 10px; margin-bottom: 40px; }
+header .logo { font-size: 22px; line-height: 1; }
+header h1 { font-size: 18px; font-weight: 700; margin: 0; letter-spacing: -0.01em; }
+header .count { margin-left: auto; color: var(--muted); font-size: 13px; }
+.theme { width: 34px; height: 34px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); font-size: 15px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+.theme:hover { border-color: var(--accent); }
+section { margin-bottom: 44px; }
+section h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin: 0 0 16px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 12px; align-items: start; }
+.card { border: 1px solid var(--border); border-radius: 10px; background: var(--card); padding: 12px; }
+.preview { height: 72px; display: flex; align-items: center; justify-content: center; overflow: hidden; margin-bottom: 10px; }
+.name { font-size: 12px; font-weight: 600; }
+.value { font-size: 11px; color: var(--muted); font-family: ui-monospace, SFMono-Regular, monospace; margin-top: 3px; word-break: break-word; }
+.chip { width: 48px; height: 48px; border-radius: 8px; }
+.palette { margin-bottom: 24px; }
+.palette-name { font-size: 13px; font-weight: 600; text-transform: capitalize; margin: 0 0 10px; }
+.shades { display: grid; grid-template-columns: repeat(auto-fill, minmax(88px, 1fr)); gap: 8px; }
+.shade-chip { height: 56px; border-radius: 8px; border: 1px solid var(--border); }
+.shade-name { font-size: 11px; font-weight: 600; margin-top: 6px; }
+.shade-value { font-size: 10px; color: var(--muted); font-family: ui-monospace, monospace; word-break: break-all; }
+.type-list { display: flex; flex-direction: column; gap: 24px; }
+.type-meta { display: flex; gap: 8px; align-items: baseline; margin-bottom: 6px; }
+.type-name { font-size: 12px; font-weight: 600; }
+.type-value { font-size: 11px; color: var(--muted); font-family: ui-monospace, monospace; }
+.type-sample { overflow: hidden; }
+.scale { display: grid; grid-template-columns: max-content max-content max-content 1fr; column-gap: 24px; row-gap: 12px; align-items: center; }
+.scale .s-name { font-size: 13px; font-weight: 600; }
+.scale .s-value { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
+.scale .s-px { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
+.scale .s-track { background: var(--card); border-radius: 999px; }
+.scale .s-bar { height: 12px; border-radius: 999px; background: var(--accent); }
+`
+
+const VIEWER_JS = `const root = document.documentElement
+const stored = localStorage.getItem('panda-studio-theme')
+if (stored) root.setAttribute('data-theme', stored)
+
+function activeTheme() {
+  return root.getAttribute('data-theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+}
+
+const themeButton = document.getElementById('theme')
+function renderThemeButton() {
+  themeButton.textContent = activeTheme() === 'dark' ? '☀' : '☾'
+}
+themeButton.addEventListener('click', () => {
+  const next = activeTheme() === 'dark' ? 'light' : 'dark'
+  root.setAttribute('data-theme', next)
+  localStorage.setItem('panda-studio-theme', next)
+  renderThemeButton()
+})
+renderThemeButton()
+
+const CATEGORY_ORDER = ['colors', 'fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings', 'spacing', 'sizes', 'radii', 'borders', 'shadows', 'blurs', 'aspectRatios', 'durations', 'easings', 'animations', 'breakpoints']
+const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
+const SCALE_CATEGORIES = new Set(['spacing', 'sizes'])
+const GRID_KIND = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio' }
+const SAMPLE = 'The quick brown fox jumps over the lazy dog'
+
+function toPx(value) {
+  const match = /^([\\d.]+)(rem|em|px)$/.exec(value)
+  if (!match) return NaN
+  return match[2] === 'px' ? parseFloat(match[1]) : parseFloat(match[1]) * 16
+}
+
+function renderScale(container, tokens) {
+  const rows = tokens
+    .filter((token) => !token.name.includes('breakpoint-') && !Number.isNaN(toPx(token.value)))
+    .map((token) => ({ token, px: toPx(token.value) }))
+    .sort((a, b) => a.px - b.px)
+  if (rows.length === 0) return
+
+  const maxPx = rows[rows.length - 1].px || 1
+  const scale = document.createElement('div')
+  scale.className = 'scale'
+  for (const { token, px } of rows) {
+    const name = document.createElement('div')
+    name.className = 's-name'
+    name.textContent = token.name
+    const value = document.createElement('div')
+    value.className = 's-value'
+    value.textContent = token.value
+    const pixels = document.createElement('div')
+    pixels.className = 's-px'
+    pixels.textContent = Math.round(px) + 'px'
+    const track = document.createElement('div')
+    track.className = 's-track'
+    const bar = document.createElement('div')
+    bar.className = 's-bar'
+    bar.style.width = Math.max((px / maxPx) * 100, 2) + '%'
+    track.appendChild(bar)
+    scale.append(name, value, pixels, track)
+  }
+  container.appendChild(scale)
+}
+
+function familyOf(name) { const i = name.lastIndexOf('.'); return i === -1 ? name : name.slice(0, i) }
+function shadeOf(name) { const i = name.lastIndexOf('.'); return i === -1 ? name : name.slice(i + 1) }
+
+function renderColors(container, tokens) {
+  const families = new Map()
+  for (const token of tokens) {
+    const family = familyOf(token.name)
+    if (!families.has(family)) families.set(family, [])
+    families.get(family).push(token)
+  }
+  for (const [family, shades] of families) {
+    const group = document.createElement('div')
+    group.className = 'palette'
+    const label = document.createElement('div')
+    label.className = 'palette-name'
+    label.textContent = family
+    const row = document.createElement('div')
+    row.className = 'shades'
+    const sorted = shades.slice().sort((a, b) => (parseFloat(shadeOf(a.name)) || 0) - (parseFloat(shadeOf(b.name)) || 0))
+    for (const token of sorted) {
+      const cell = document.createElement('div')
+      const chip = document.createElement('div')
+      chip.className = 'shade-chip'
+      chip.style.background = token.value
+      chip.title = token.value
+      const name = document.createElement('div')
+      name.className = 'shade-name'
+      name.textContent = shadeOf(token.name)
+      const value = document.createElement('div')
+      value.className = 'shade-value'
+      value.textContent = token.value
+      cell.append(chip, name, value)
+      row.appendChild(cell)
+    }
+    group.append(label, row)
+    container.appendChild(group)
+  }
+}
+
+function applyType(el, category, value) {
+  if (category === 'fontSizes') el.style.fontSize = value
+  else if (category === 'fontWeights') { el.style.fontWeight = value; el.style.fontSize = '1.75rem' }
+  else if (category === 'fonts') { el.style.fontFamily = value; el.style.fontSize = '1.75rem' }
+  else if (category === 'lineHeights') { el.style.lineHeight = value; el.style.maxWidth = '540px'; el.textContent = SAMPLE + '. ' + SAMPLE + '.' }
+  else if (category === 'letterSpacings') { el.style.letterSpacing = value; el.style.fontSize = '1.25rem' }
+}
+
+function renderType(container, category, tokens) {
+  const list = document.createElement('div')
+  list.className = 'type-list'
+  for (const token of tokens) {
+    const row = document.createElement('div')
+    const meta = document.createElement('div')
+    meta.className = 'type-meta'
+    const name = document.createElement('span')
+    name.className = 'type-name'
+    name.textContent = token.name
+    const value = document.createElement('span')
+    value.className = 'type-value'
+    value.textContent = token.value
+    meta.append(name, value)
+    const sample = document.createElement('div')
+    sample.className = 'type-sample'
+    sample.textContent = SAMPLE
+    applyType(sample, category, token.value)
+    row.append(meta, sample)
+    list.appendChild(row)
+  }
+  container.appendChild(list)
+}
+
+function makePreview(category, value) {
+  const kind = GRID_KIND[category]
+  if (!kind) return null
+
+  const wrap = document.createElement('div')
+  wrap.className = 'preview'
+
+  if (kind === 'radius' || kind === 'border' || kind === 'shadow' || kind === 'blur') {
+    const chip = document.createElement('div')
+    chip.className = 'chip'
+    if (kind === 'radius') { chip.style.background = 'var(--swatch)'; chip.style.borderRadius = value }
+    if (kind === 'border') chip.style.border = value
+    if (kind === 'shadow') { chip.style.background = 'var(--shadow-bg)'; chip.style.boxShadow = value }
+    if (kind === 'blur') { chip.style.background = 'linear-gradient(135deg, var(--accent), #ec4899)'; chip.style.filter = 'blur(' + value + ')' }
+    wrap.appendChild(chip)
+    return wrap
+  }
+  const chip = document.createElement('div')
+  chip.style.height = '48px'
+  chip.style.aspectRatio = value
+  chip.style.background = 'var(--swatch)'
+  chip.style.borderRadius = '6px'
+  wrap.appendChild(chip)
+  return wrap
+}
+
+function makeCard(token) {
+  const card = document.createElement('div')
+  card.className = 'card'
+  const preview = makePreview(token.category, token.value)
+  if (preview) card.appendChild(preview)
+  const name = document.createElement('div')
+  name.className = 'name'
+  name.textContent = token.name
+  const value = document.createElement('div')
+  value.className = 'value'
+  value.textContent = token.value
+  card.append(name, value)
+  return card
+}
+
+fetch('tokens.json').then((res) => res.json()).then((tokens) => {
+  const grid = document.getElementById('grid')
+  document.getElementById('count').textContent = tokens.length + ' tokens'
+
+  const byCategory = new Map()
+  for (const token of tokens) {
+    if (!byCategory.has(token.category)) byCategory.set(token.category, [])
+    byCategory.get(token.category).push(token)
+  }
+
+  const rank = (category) => {
+    const index = CATEGORY_ORDER.indexOf(category)
+    return index === -1 ? CATEGORY_ORDER.length : index
+  }
+
+  for (const category of [...byCategory.keys()].sort((a, b) => rank(a) - rank(b))) {
+    const section = document.createElement('section')
+    const heading = document.createElement('h2')
+    heading.textContent = category
+    const body = document.createElement('div')
+    if (category === 'colors') renderColors(body, byCategory.get(category))
+    else if (TYPE_CATEGORIES.has(category)) renderType(body, category, byCategory.get(category))
+    else if (SCALE_CATEGORIES.has(category)) renderScale(body, byCategory.get(category))
+    else {
+      body.className = 'grid'
+      for (const token of byCategory.get(category)) body.appendChild(makeCard(token))
+    }
+    section.append(heading, body)
+    grid.appendChild(section)
+  }
+})
+`
+
+const COMPONENT_CSS = `.panda-studio { --fg: #1a1a1a; --muted: #71717a; --border: #e4e4e7; --card: #fafafa; --swatch: #d4d4d8; --shadow-bg: #ffffff; --accent: #f6e458; color: var(--fg); font-family: -apple-system, system-ui, sans-serif; }
+@media (prefers-color-scheme: dark) { .panda-studio { --fg: #f4f4f5; --muted: #8f8f99; --border: #26262a; --card: #161619; --swatch: #3f3f46; --shadow-bg: #f4f4f5; } }
+.panda-studio .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 12px; align-items: start; }
+.panda-studio .card { border: 1px solid var(--border); border-radius: 10px; background: var(--card); padding: 12px; }
+.panda-studio .preview { height: 72px; display: flex; align-items: center; justify-content: center; overflow: hidden; margin-bottom: 10px; }
+.panda-studio .name { font-size: 12px; font-weight: 600; }
+.panda-studio .value { font-size: 11px; color: var(--muted); font-family: ui-monospace, monospace; margin-top: 3px; word-break: break-word; }
+.panda-studio .chip { width: 48px; height: 48px; border-radius: 8px; }
+.panda-studio .palette { margin-bottom: 24px; }
+.panda-studio .palette-name { font-size: 13px; font-weight: 600; text-transform: capitalize; margin: 0 0 10px; }
+.panda-studio .shades { display: grid; grid-template-columns: repeat(auto-fill, minmax(88px, 1fr)); gap: 8px; }
+.panda-studio .shade-chip { height: 56px; border-radius: 8px; border: 1px solid var(--border); }
+.panda-studio .shade-name { font-size: 11px; font-weight: 600; margin-top: 6px; }
+.panda-studio .shade-value { font-size: 10px; color: var(--muted); font-family: ui-monospace, monospace; word-break: break-all; }
+.panda-studio .type-list { display: flex; flex-direction: column; gap: 24px; }
+.panda-studio .type-meta { display: flex; gap: 8px; align-items: baseline; margin-bottom: 6px; }
+.panda-studio .type-name { font-size: 12px; font-weight: 600; }
+.panda-studio .type-value { font-size: 11px; color: var(--muted); font-family: ui-monospace, monospace; }
+.panda-studio .type-sample { overflow: hidden; }
+.panda-studio .scale { display: grid; grid-template-columns: max-content max-content max-content 1fr; column-gap: 24px; row-gap: 12px; align-items: center; }
+.panda-studio .s-name { font-size: 13px; font-weight: 600; }
+.panda-studio .s-value { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
+.panda-studio .s-px { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
+.panda-studio .s-track { background: var(--card); border-radius: 999px; }
+.panda-studio .s-bar { height: 12px; border-radius: 999px; background: var(--accent); }`
+
+const SHARED_HELPERS = `const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
+const SCALE_CATEGORIES = new Set(['spacing', 'sizes'])
+const GRID_KIND: Record<string, string> = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio' }
+const SAMPLE = 'The quick brown fox jumps over the lazy dog'
+
+const familyOf = (name: string) => (name.includes('.') ? name.slice(0, name.lastIndexOf('.')) : name)
+const shadeOf = (name: string) => (name.includes('.') ? name.slice(name.lastIndexOf('.') + 1) : name)
+const byShade = (a: StudioToken, b: StudioToken) => (parseFloat(shadeOf(a.name)) || 0) - (parseFloat(shadeOf(b.name)) || 0)
+
+function toPx(value: string) {
+  const match = /^([\\d.]+)(rem|em|px)$/.exec(value)
+  return match ? (match[2] === 'px' ? parseFloat(match[1]) : parseFloat(match[1]) * 16) : NaN
+}
+
+function groupFamilies(items: StudioToken[]) {
+  const families = new Map<string, StudioToken[]>()
+  for (const token of items) {
+    const family = familyOf(token.name)
+    if (!families.has(family)) families.set(family, [])
+    families.get(family)!.push(token)
+  }
+  return [...families.entries()]
+}
+
+function scaleRows(items: StudioToken[]) {
+  const rows = items
+    .filter((token) => !token.name.includes('breakpoint-') && !Number.isNaN(toPx(token.value)))
+    .map((token) => ({ token, px: toPx(token.value) }))
+    .sort((a, b) => a.px - b.px)
+  const maxPx = rows.length ? rows[rows.length - 1].px || 1 : 1
+  return rows.map((row) => ({ ...row, width: Math.max((row.px / maxPx) * 100, 2) }))
+}`
+
+const reactTemplates = {
+  tokenGrid: () => `import { Fragment } from 'react'
+import type { CSSProperties } from 'react'
+import tokens from '../tokens.json'
+
+interface StudioToken {
+  category: string
+  path: string
+  name: string
+  value: string
+}
+
+const all = tokens as StudioToken[]
+const CSS = \`${COMPONENT_CSS}\`
+${SHARED_HELPERS}
+
+function typeStyle(category: string, value: string): CSSProperties {
+  switch (category) {
+    case 'fontSizes': return { fontSize: value }
+    case 'fontWeights': return { fontWeight: value as CSSProperties['fontWeight'], fontSize: '1.75rem' }
+    case 'fonts': return { fontFamily: value, fontSize: '1.75rem' }
+    case 'lineHeights': return { lineHeight: value, maxWidth: 540 }
+    case 'letterSpacings': return { letterSpacing: value, fontSize: '1.25rem' }
+    default: return {}
+  }
+}
+
+function GridPreview({ category, value }: { category: string; value: string }) {
+  switch (GRID_KIND[category]) {
+    case 'radius': return <div className="chip" style={{ background: 'var(--swatch)', borderRadius: value }} />
+    case 'border': return <div className="chip" style={{ border: value }} />
+    case 'shadow': return <div className="chip" style={{ background: 'var(--shadow-bg)', boxShadow: value }} />
+    case 'blur': return <div className="chip" style={{ background: 'linear-gradient(135deg, var(--accent), #ec4899)', filter: \`blur(\${value})\` }} />
+    case 'ratio': return <div style={{ height: 48, aspectRatio: value, background: 'var(--swatch)', borderRadius: 6 }} />
+    default: return null
+  }
+}
+
+function Palette({ items }: { items: StudioToken[] }) {
+  return (
+    <>
+      {groupFamilies(items).map(([family, shades]) => (
+        <div className="palette" key={family}>
+          <div className="palette-name">{family}</div>
+          <div className="shades">
+            {[...shades].sort(byShade).map((token) => (
+              <div key={token.path}>
+                <div className="shade-chip" style={{ background: token.value }} title={token.value} />
+                <div className="shade-name">{shadeOf(token.name)}</div>
+                <div className="shade-value">{token.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+function TypeList({ category, items }: { category: string; items: StudioToken[] }) {
+  return (
+    <div className="type-list">
+      {items.map((token) => (
+        <div key={token.path}>
+          <div className="type-meta">
+            <span className="type-name">{token.name}</span>
+            <span className="type-value">{token.value}</span>
+          </div>
+          <div className="type-sample" style={typeStyle(category, token.value)}>
+            {category === 'lineHeights' ? SAMPLE + '. ' + SAMPLE + '.' : SAMPLE}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Scale({ items }: { items: StudioToken[] }) {
+  return (
+    <div className="scale">
+      {scaleRows(items).map(({ token, px, width }) => (
+        <Fragment key={token.path}>
+          <div className="s-name">{token.name}</div>
+          <div className="s-value">{token.value}</div>
+          <div className="s-px">{Math.round(px)}px</div>
+          <div className="s-track"><div className="s-bar" style={{ width: \`\${width}%\` }} /></div>
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
+export function TokenGrid({ category }: { category: string }) {
+  const items = all.filter((token) => token.category === category)
+  if (items.length === 0) return null
+
+  return (
+    <div className="panda-studio">
+      <style>{CSS}</style>
+      {category === 'colors' ? (
+        <Palette items={items} />
+      ) : TYPE_CATEGORIES.has(category) ? (
+        <TypeList category={category} items={items} />
+      ) : SCALE_CATEGORIES.has(category) ? (
+        <Scale items={items} />
+      ) : (
+        <div className="grid">
+          {items.map((token) => (
+            <div className="card" key={token.path}>
+              <div className="preview"><GridPreview category={token.category} value={token.value} /></div>
+              <div className="name">{token.name}</div>
+              <div className="value">{token.value}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+`,
+  view: (name: string, categories: string[]) => `import { TokenGrid } from './components/token-grid'
+
+export function ${name}() {
+  return (
+    <>
+${categories.map((category) => `      <TokenGrid category="${category}" />`).join('\n')}
+    </>
+  )
+}
+`,
+}
+
+const solidTemplates = {
+  tokenGrid: () => `import { For, Match, Switch } from 'solid-js'
+import type { JSX } from 'solid-js'
+import tokens from '../tokens.json'
+
+interface StudioToken {
+  category: string
+  path: string
+  name: string
+  value: string
+}
+
+const all = tokens as StudioToken[]
+const CSS = \`${COMPONENT_CSS}\`
+${SHARED_HELPERS}
+
+function typeStyle(category: string, value: string): JSX.CSSProperties {
+  switch (category) {
+    case 'fontSizes': return { 'font-size': value }
+    case 'fontWeights': return { 'font-weight': value, 'font-size': '1.75rem' }
+    case 'fonts': return { 'font-family': value, 'font-size': '1.75rem' }
+    case 'lineHeights': return { 'line-height': value, 'max-width': '540px' }
+    case 'letterSpacings': return { 'letter-spacing': value, 'font-size': '1.25rem' }
+    default: return {}
+  }
+}
+
+function GridPreview(props: { category: string; value: string }) {
+  switch (GRID_KIND[props.category]) {
+    case 'radius': return <div class="chip" style={{ background: 'var(--swatch)', 'border-radius': props.value }} />
+    case 'border': return <div class="chip" style={{ border: props.value }} />
+    case 'shadow': return <div class="chip" style={{ background: 'var(--shadow-bg)', 'box-shadow': props.value }} />
+    case 'blur': return <div class="chip" style={{ background: 'linear-gradient(135deg, var(--accent), #ec4899)', filter: \`blur(\${props.value})\` }} />
+    case 'ratio': return <div style={{ height: '48px', 'aspect-ratio': props.value, background: 'var(--swatch)', 'border-radius': '6px' }} />
+    default: return null
+  }
+}
+
+function Palette(props: { items: StudioToken[] }) {
+  return (
+    <For each={groupFamilies(props.items)}>
+      {([family, shades]) => (
+        <div class="palette">
+          <div class="palette-name">{family}</div>
+          <div class="shades">
+            <For each={[...shades].sort(byShade)}>
+              {(token) => (
+                <div>
+                  <div class="shade-chip" style={{ background: token.value }} title={token.value} />
+                  <div class="shade-name">{shadeOf(token.name)}</div>
+                  <div class="shade-value">{token.value}</div>
+                </div>
+              )}
+            </For>
+          </div>
+        </div>
+      )}
+    </For>
+  )
+}
+
+function TypeList(props: { category: string; items: StudioToken[] }) {
+  return (
+    <div class="type-list">
+      <For each={props.items}>
+        {(token) => (
+          <div>
+            <div class="type-meta">
+              <span class="type-name">{token.name}</span>
+              <span class="type-value">{token.value}</span>
+            </div>
+            <div class="type-sample" style={typeStyle(props.category, token.value)}>
+              {props.category === 'lineHeights' ? SAMPLE + '. ' + SAMPLE + '.' : SAMPLE}
+            </div>
+          </div>
+        )}
+      </For>
+    </div>
+  )
+}
+
+function Scale(props: { items: StudioToken[] }) {
+  return (
+    <div class="scale">
+      <For each={scaleRows(props.items)}>
+        {(row) => (
+          <>
+            <div class="s-name">{row.token.name}</div>
+            <div class="s-value">{row.token.value}</div>
+            <div class="s-px">{Math.round(row.px)}px</div>
+            <div class="s-track"><div class="s-bar" style={{ width: \`\${row.width}%\` }} /></div>
+          </>
+        )}
+      </For>
+    </div>
+  )
+}
+
+export function TokenGrid(props: { category: string }) {
+  const items = () => all.filter((token) => token.category === props.category)
+  const mode = () =>
+    props.category === 'colors'
+      ? 'palette'
+      : TYPE_CATEGORIES.has(props.category)
+        ? 'type'
+        : SCALE_CATEGORIES.has(props.category)
+          ? 'scale'
+          : 'grid'
+
+  return (
+    <Switch>
+      <Match when={items().length === 0}>{null}</Match>
+      <Match when={items().length > 0}>
+        <div class="panda-studio">
+          <style>{CSS}</style>
+          <Switch>
+            <Match when={mode() === 'palette'}><Palette items={items()} /></Match>
+            <Match when={mode() === 'type'}><TypeList category={props.category} items={items()} /></Match>
+            <Match when={mode() === 'scale'}><Scale items={items()} /></Match>
+            <Match when={mode() === 'grid'}>
+              <div class="grid">
+                <For each={items()}>
+                  {(token) => (
+                    <div class="card">
+                      <div class="preview"><GridPreview category={token.category} value={token.value} /></div>
+                      <div class="name">{token.name}</div>
+                      <div class="value">{token.value}</div>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Match>
+          </Switch>
+        </div>
+      </Match>
+    </Switch>
+  )
+}
+`,
+  view: (name: string, categories: string[]) => `import { TokenGrid } from './components/token-grid'
+
+export function ${name}() {
+  return (
+    <>
+${categories.map((category) => `      <TokenGrid category="${category}" />`).join('\n')}
+    </>
+  )
+}
+`,
+}

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -40,22 +40,43 @@ export function tokensSnapshotFile(tokens: StudioToken[]): StudioFile {
   return { path: 'tokens.json', code: `${JSON.stringify(tokens, null, 2)}\n` }
 }
 
-export function viewFiles(tokens: StudioToken[], framework: StudioFramework): StudioFile[] {
+export function viewFiles(tokens: StudioToken[], framework: StudioFramework, keyframesCss = ''): StudioFile[] {
   const templates = framework === 'solid' ? solidTemplates : reactTemplates
   return [
     tokensSnapshotFile(tokens),
-    { path: 'components/token-grid.tsx', code: templates.tokenGrid() },
+    { path: 'components/token-grid.tsx', code: templates.tokenGrid(keyframesCss) },
     ...VIEWS.map((view) => ({ path: `${view.name}.tsx`, code: templates.view(view.name, view.categories) })),
   ]
 }
 
-export function viewerFiles(tokens: StudioToken[]): StudioFile[] {
+export function viewerFiles(tokens: StudioToken[], keyframesCss = ''): StudioFile[] {
   return [
     tokensSnapshotFile(tokens),
     { path: 'index.html', code: VIEWER_HTML },
-    { path: 'studio.css', code: VIEWER_CSS },
+    { path: 'studio.css', code: keyframesCss ? `${VIEWER_CSS}\n${keyframesCss}` : VIEWER_CSS },
     { path: 'studio.js', code: VIEWER_JS },
   ]
+}
+
+export function keyframesToCss(keyframes: unknown): string {
+  if (!keyframes || typeof keyframes !== 'object') return ''
+  const kebab = (prop: string) => prop.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
+  const blocks: string[] = []
+  for (const [name, frames] of Object.entries(keyframes as Record<string, unknown>)) {
+    if (!frames || typeof frames !== 'object') continue
+    const steps = Object.entries(frames as Record<string, unknown>)
+      .map(([step, decls]) => {
+        if (!decls || typeof decls !== 'object') return ''
+        const props = Object.entries(decls as Record<string, unknown>)
+          .map(([prop, value]) => `${kebab(prop)}: ${String(value)}`)
+          .join('; ')
+        return `${step} { ${props} }`
+      })
+      .filter(Boolean)
+      .join(' ')
+    if (steps) blocks.push(`@keyframes ${name} { ${steps} }`)
+  }
+  return blocks.join('\n')
 }
 
 const VIEWER_HTML = `<!doctype html>
@@ -130,6 +151,10 @@ section h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; lette
 .scale .s-px { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
 .scale .s-track { background: var(--card); border-radius: 999px; }
 .scale .s-bar { height: 12px; border-radius: 999px; background: var(--accent); }
+.anim-box { width: 44px; height: 44px; border-radius: 8px; background: var(--accent); }
+.ease-track { width: 100%; padding: 0 4px; }
+.ease-dot { width: 18px; height: 18px; border-radius: 999px; background: var(--accent); animation: panda-studio-ease 1.4s infinite alternate; }
+@keyframes panda-studio-ease { from { transform: translateX(0); } to { transform: translateX(130px); } }
 `
 
 const VIEWER_JS = `const root = document.documentElement
@@ -155,7 +180,7 @@ renderThemeButton()
 const CATEGORY_ORDER = ['colors', 'fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings', 'spacing', 'sizes', 'radii', 'borders', 'shadows', 'blurs', 'aspectRatios', 'durations', 'easings', 'animations', 'breakpoints']
 const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
 const SCALE_CATEGORIES = new Set(['spacing', 'sizes'])
-const GRID_KIND = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio' }
+const GRID_KIND = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing' }
 const SAMPLE = 'The quick brown fox jumps over the lazy dog'
 
 function toPx(value) {
@@ -283,6 +308,23 @@ function makePreview(category, value) {
     wrap.appendChild(chip)
     return wrap
   }
+  if (kind === 'animation') {
+    const box = document.createElement('div')
+    box.className = 'anim-box'
+    box.style.animation = value
+    wrap.appendChild(box)
+    return wrap
+  }
+  if (kind === 'easing') {
+    const track = document.createElement('div')
+    track.className = 'ease-track'
+    const dot = document.createElement('div')
+    dot.className = 'ease-dot'
+    dot.style.animationTimingFunction = value
+    track.appendChild(dot)
+    wrap.appendChild(track)
+    return wrap
+  }
   const chip = document.createElement('div')
   chip.style.height = '48px'
   chip.style.aspectRatio = value
@@ -364,11 +406,15 @@ const COMPONENT_CSS = `.panda-studio { --fg: #1a1a1a; --muted: #71717a; --border
 .panda-studio .s-value { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
 .panda-studio .s-px { font-size: 12px; color: var(--muted); font-family: ui-monospace, monospace; }
 .panda-studio .s-track { background: var(--card); border-radius: 999px; }
-.panda-studio .s-bar { height: 12px; border-radius: 999px; background: var(--accent); }`
+.panda-studio .s-bar { height: 12px; border-radius: 999px; background: var(--accent); }
+.panda-studio .anim-box { width: 44px; height: 44px; border-radius: 8px; background: var(--accent); }
+.panda-studio .ease-track { width: 100%; padding: 0 4px; }
+.panda-studio .ease-dot { width: 18px; height: 18px; border-radius: 999px; background: var(--accent); animation: panda-studio-ease 1.4s infinite alternate; }
+@keyframes panda-studio-ease { from { transform: translateX(0); } to { transform: translateX(130px); } }`
 
 const SHARED_HELPERS = `const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
 const SCALE_CATEGORIES = new Set(['spacing', 'sizes'])
-const GRID_KIND: Record<string, string> = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio' }
+const GRID_KIND: Record<string, string> = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing' }
 const SAMPLE = 'The quick brown fox jumps over the lazy dog'
 
 const familyOf = (name: string) => (name.includes('.') ? name.slice(0, name.lastIndexOf('.')) : name)
@@ -400,7 +446,7 @@ function scaleRows(items: StudioToken[]) {
 }`
 
 const reactTemplates = {
-  tokenGrid: () => `import { Fragment } from 'react'
+  tokenGrid: (keyframesCss: string) => `import { Fragment } from 'react'
 import type { CSSProperties } from 'react'
 import tokens from '../tokens.json'
 
@@ -412,7 +458,7 @@ interface StudioToken {
 }
 
 const all = tokens as StudioToken[]
-const CSS = \`${COMPONENT_CSS}\`
+const CSS = \`${COMPONENT_CSS}\n${keyframesCss}\`
 ${SHARED_HELPERS}
 
 function typeStyle(category: string, value: string): CSSProperties {
@@ -433,6 +479,8 @@ function GridPreview({ category, value }: { category: string; value: string }) {
     case 'shadow': return <div className="chip" style={{ background: 'var(--shadow-bg)', boxShadow: value }} />
     case 'blur': return <div className="chip" style={{ background: 'linear-gradient(135deg, var(--accent), #ec4899)', filter: \`blur(\${value})\` }} />
     case 'ratio': return <div style={{ height: 48, aspectRatio: value, background: 'var(--swatch)', borderRadius: 6 }} />
+    case 'animation': return <div className="anim-box" style={{ animation: value }} />
+    case 'easing': return <div className="ease-track"><div className="ease-dot" style={{ animationTimingFunction: value }} /></div>
     default: return null
   }
 }
@@ -532,7 +580,7 @@ ${categories.map((category) => `      <TokenGrid category="${category}" />`).joi
 }
 
 const solidTemplates = {
-  tokenGrid: () => `import { For, Match, Switch } from 'solid-js'
+  tokenGrid: (keyframesCss: string) => `import { For, Match, Switch } from 'solid-js'
 import type { JSX } from 'solid-js'
 import tokens from '../tokens.json'
 
@@ -544,7 +592,7 @@ interface StudioToken {
 }
 
 const all = tokens as StudioToken[]
-const CSS = \`${COMPONENT_CSS}\`
+const CSS = \`${COMPONENT_CSS}\n${keyframesCss}\`
 ${SHARED_HELPERS}
 
 function typeStyle(category: string, value: string): JSX.CSSProperties {
@@ -565,6 +613,8 @@ function GridPreview(props: { category: string; value: string }) {
     case 'shadow': return <div class="chip" style={{ background: 'var(--shadow-bg)', 'box-shadow': props.value }} />
     case 'blur': return <div class="chip" style={{ background: 'linear-gradient(135deg, var(--accent), #ec4899)', filter: \`blur(\${props.value})\` }} />
     case 'ratio': return <div style={{ height: '48px', 'aspect-ratio': props.value, background: 'var(--swatch)', 'border-radius': '6px' }} />
+    case 'animation': return <div class="anim-box" style={{ animation: props.value }} />
+    case 'easing': return <div class="ease-track"><div class="ease-dot" style={{ 'animation-timing-function': props.value }} /></div>
     default: return null
   }
 }

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -406,7 +406,7 @@ function render(tokens, query) {
     section.append(heading, body)
     grid.appendChild(section)
   }
-  observeSections()
+  updateActiveNav()
 }
 
 function buildNav(tokens) {
@@ -423,22 +423,34 @@ function buildNav(tokens) {
   }
 }
 
-let sectionObserver
-function observeSections() {
-  if (sectionObserver) sectionObserver.disconnect()
-  const links = new Map([...document.querySelectorAll('#nav a')].map((link) => [link.dataset.cat, link]))
-  sectionObserver = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        if (!entry.isIntersecting) continue
-        for (const link of document.querySelectorAll('#nav a.active')) link.classList.remove('active')
-        links.get(entry.target.dataset.cat)?.classList.add('active')
-      }
-    },
-    { rootMargin: '0px 0px -80% 0px' },
-  )
-  for (const section of document.querySelectorAll('section[data-cat]')) sectionObserver.observe(section)
+function updateActiveNav() {
+  const sections = [...document.querySelectorAll('section[data-cat]')]
+  if (sections.length === 0) return
+  const atBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2
+  let active = sections[0].dataset.cat
+  if (atBottom) {
+    active = sections[sections.length - 1].dataset.cat
+  } else {
+    for (const section of sections) {
+      if (section.getBoundingClientRect().top <= 120) active = section.dataset.cat
+    }
+  }
+  for (const link of document.querySelectorAll('#nav a')) link.classList.toggle('active', link.dataset.cat === active)
 }
+
+let navScrollQueued = false
+window.addEventListener(
+  'scroll',
+  () => {
+    if (navScrollQueued) return
+    navScrollQueued = true
+    requestAnimationFrame(() => {
+      navScrollQueued = false
+      updateActiveNav()
+    })
+  },
+  { passive: true },
+)
 
 function persistQuery(query) {
   const url = new URL(location.href)

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -88,14 +88,20 @@ const VIEWER_HTML = `<!doctype html>
     <link rel="stylesheet" href="studio.css" />
   </head>
   <body>
-    <div class="wrap">
-      <header>
-        <span class="logo">🐼</span>
-        <h1>Panda Studio</h1>
-        <span class="count" id="count"></span>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="brand"><span class="logo">🐼</span> Panda Studio</div>
+        <div class="search-wrap">
+          <svg class="search-icon" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" /></svg>
+          <input class="search" id="search" type="search" placeholder="Filter tokens…" aria-label="Filter tokens" />
+        </div>
+        <nav class="nav"><div class="nav-label">Tokens</div><ul id="nav"></ul></nav>
         <button class="theme" id="theme" type="button" aria-label="Toggle color theme"></button>
-      </header>
-      <main id="grid"></main>
+      </aside>
+      <main class="content">
+        <div class="content-head"><span class="count" id="count"></span></div>
+        <div id="grid"></div>
+      </main>
     </div>
     <script src="studio.js"></script>
   </body>
@@ -118,15 +124,29 @@ const VIEWER_CSS = `:root {
 }
 :root[data-theme='dark'] { color-scheme: dark; --bg: #0d0d0f; --fg: #f4f4f5; --muted: #8f8f99; --border: #26262a; --card: #161619; --swatch: #3f3f46; --shadow-bg: #f4f4f5; }
 * { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 body { margin: 0; background: var(--bg); color: var(--fg); font-family: -apple-system, system-ui, sans-serif; }
-.wrap { max-width: 1080px; margin: 0 auto; padding: 40px 24px 80px; }
-header { display: flex; align-items: center; gap: 10px; margin-bottom: 40px; }
-header .logo { font-size: 22px; line-height: 1; }
-header h1 { font-size: 18px; font-weight: 700; margin: 0; letter-spacing: -0.01em; }
-header .count { margin-left: auto; color: var(--muted); font-size: 13px; }
-.theme { width: 34px; height: 34px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); font-size: 15px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+.app { display: flex; min-height: 100vh; }
+.sidebar { width: 240px; flex-shrink: 0; height: 100vh; position: sticky; top: 0; overflow: auto; border-right: 1px solid var(--border); padding: 24px 16px; display: flex; flex-direction: column; gap: 20px; }
+.brand { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 700; letter-spacing: -0.01em; }
+.brand .logo { font-size: 20px; line-height: 1; }
+.search-wrap { position: relative; display: flex; align-items: center; }
+.search-icon { position: absolute; left: 10px; color: var(--muted); pointer-events: none; }
+.search { width: 100%; padding: 8px 10px 8px 32px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); font-size: 13px; }
+.search::placeholder { color: var(--muted); }
+.search:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent); }
+.nav { display: flex; flex-direction: column; }
+.nav-label { font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); margin-bottom: 8px; }
+.nav ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
+.nav a { display: block; padding: 6px 10px; border-radius: 7px; font-size: 13px; font-weight: 500; color: var(--fg); text-decoration: none; text-transform: capitalize; }
+.nav a:hover { background: var(--card); }
+.nav a.active { background: var(--accent); color: #1a1a1a; }
+.theme { margin-top: auto; width: 34px; height: 34px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); font-size: 15px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
 .theme:hover { border-color: var(--accent); }
-section { margin-bottom: 44px; }
+.content { flex: 1; min-width: 0; padding: 28px 40px 80px; }
+.content-head { margin-bottom: 24px; min-height: 16px; }
+.content .count { color: var(--muted); font-size: 13px; }
+section { margin-bottom: 44px; scroll-margin-top: 24px; }
 section h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin: 0 0 16px; }
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 12px; align-items: start; }
 .card { border: 1px solid var(--border); border-radius: 10px; background: var(--card); padding: 12px; }
@@ -349,23 +369,30 @@ function makeCard(token) {
   return card
 }
 
-fetch('tokens.json').then((res) => res.json()).then((tokens) => {
+const rank = (category) => {
+  const index = CATEGORY_ORDER.indexOf(category)
+  return index === -1 ? CATEGORY_ORDER.length : index
+}
+
+function render(tokens, query) {
   const grid = document.getElementById('grid')
-  document.getElementById('count').textContent = tokens.length + ' tokens'
+  grid.textContent = ''
+  const term = query.trim().toLowerCase()
+  const matches = term
+    ? tokens.filter((token) => (token.name + ' ' + token.value + ' ' + token.category).toLowerCase().includes(term))
+    : tokens
+  document.getElementById('count').textContent = matches.length + ' tokens'
 
   const byCategory = new Map()
-  for (const token of tokens) {
+  for (const token of matches) {
     if (!byCategory.has(token.category)) byCategory.set(token.category, [])
     byCategory.get(token.category).push(token)
   }
 
-  const rank = (category) => {
-    const index = CATEGORY_ORDER.indexOf(category)
-    return index === -1 ? CATEGORY_ORDER.length : index
-  }
-
   for (const category of [...byCategory.keys()].sort((a, b) => rank(a) - rank(b))) {
     const section = document.createElement('section')
+    section.id = 'cat-' + category
+    section.dataset.cat = category
     const heading = document.createElement('h2')
     heading.textContent = category
     const body = document.createElement('div')
@@ -379,6 +406,56 @@ fetch('tokens.json').then((res) => res.json()).then((tokens) => {
     section.append(heading, body)
     grid.appendChild(section)
   }
+  observeSections()
+}
+
+function buildNav(tokens) {
+  const nav = document.getElementById('nav')
+  const categories = [...new Set(tokens.map((token) => token.category))].sort((a, b) => rank(a) - rank(b))
+  for (const category of categories) {
+    const item = document.createElement('li')
+    const link = document.createElement('a')
+    link.href = '#cat-' + category
+    link.dataset.cat = category
+    link.textContent = category
+    item.appendChild(link)
+    nav.appendChild(item)
+  }
+}
+
+let sectionObserver
+function observeSections() {
+  if (sectionObserver) sectionObserver.disconnect()
+  const links = new Map([...document.querySelectorAll('#nav a')].map((link) => [link.dataset.cat, link]))
+  sectionObserver = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue
+        for (const link of document.querySelectorAll('#nav a.active')) link.classList.remove('active')
+        links.get(entry.target.dataset.cat)?.classList.add('active')
+      }
+    },
+    { rootMargin: '0px 0px -80% 0px' },
+  )
+  for (const section of document.querySelectorAll('section[data-cat]')) sectionObserver.observe(section)
+}
+
+function persistQuery(query) {
+  const url = new URL(location.href)
+  if (query) url.searchParams.set('q', query)
+  else url.searchParams.delete('q')
+  history.replaceState(null, '', url)
+}
+
+fetch('tokens.json').then((res) => res.json()).then((tokens) => {
+  buildNav(tokens)
+  const search = document.getElementById('search')
+  search.value = new URLSearchParams(location.search).get('q') || ''
+  search.addEventListener('input', () => {
+    persistQuery(search.value)
+    render(tokens, search.value)
+  })
+  render(tokens, search.value)
 })
 `
 

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -233,7 +233,7 @@ function renderScale(container, tokens) {
     track.className = 's-track'
     const bar = document.createElement('div')
     bar.className = 's-bar'
-    bar.style.width = Math.max((px / maxPx) * 100, 2) + '%'
+    bar.style.width = (px <= 0 ? 0 : Math.max((px / maxPx) * 100, 2)) + '%'
     track.appendChild(bar)
     scale.append(name, value, pixels, track)
   }
@@ -533,7 +533,7 @@ function scaleRows(items: StudioToken[]) {
     .map((token) => ({ token, px: toPx(token.value) }))
     .sort((a, b) => a.px - b.px)
   const maxPx = rows.length ? rows[rows.length - 1].px || 1 : 1
-  return rows.map((row) => ({ ...row, width: Math.max((row.px / maxPx) * 100, 2) }))
+  return rows.map((row) => ({ ...row, width: row.px <= 0 ? 0 : Math.max((row.px / maxPx) * 100, 2) }))
 }`
 
 const reactTemplates = {

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -96,12 +96,12 @@ const VIEWER_HTML = `<!doctype html>
           <input class="search" id="search" type="search" placeholder="Filter tokens…" aria-label="Filter tokens" />
         </div>
         <nav class="nav"><div class="nav-label">Tokens</div><ul id="nav"></ul></nav>
-        <button class="theme" id="theme" type="button" aria-label="Toggle color theme"></button>
       </aside>
       <main class="content">
         <div class="content-head"><span class="count" id="count"></span></div>
         <div id="grid"></div>
       </main>
+      <button class="theme" id="theme" type="button" aria-label="Toggle color theme"></button>
     </div>
     <script src="studio.js"></script>
   </body>
@@ -141,7 +141,7 @@ body { margin: 0; background: var(--bg); color: var(--fg); font-family: -apple-s
 .nav a { display: block; padding: 6px 10px; border-radius: 7px; font-size: 13px; font-weight: 500; color: var(--fg); text-decoration: none; text-transform: capitalize; }
 .nav a:hover { background: var(--card); }
 .nav a.active { background: var(--accent); color: #1a1a1a; }
-.theme { margin-top: auto; width: 34px; height: 34px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); font-size: 15px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+.theme { position: fixed; top: 14px; right: 20px; z-index: 20; width: 34px; height: 34px; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--fg); font-size: 15px; cursor: pointer; display: flex; align-items: center; justify-content: center; }
 .theme:hover { border-color: var(--accent); }
 .content { flex: 1; min-width: 0; padding: 28px 40px 80px; }
 .content-head { margin-bottom: 24px; min-height: 16px; }
@@ -199,7 +199,7 @@ renderThemeButton()
 
 const CATEGORY_ORDER = ['colors', 'fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings', 'spacing', 'sizes', 'radii', 'borders', 'shadows', 'blurs', 'aspectRatios', 'durations', 'easings', 'animations', 'breakpoints']
 const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
-const SCALE_CATEGORIES = new Set(['spacing', 'sizes'])
+const SCALE_CATEGORIES = new Set(['spacing', 'sizes', 'breakpoints'])
 const GRID_KIND = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing' }
 const SAMPLE = 'The quick brown fox jumps over the lazy dog'
 
@@ -502,7 +502,7 @@ const COMPONENT_CSS = `.panda-studio { --fg: #1a1a1a; --muted: #71717a; --border
 @keyframes panda-studio-ease { from { transform: translateX(0); } to { transform: translateX(130px); } }`
 
 const SHARED_HELPERS = `const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
-const SCALE_CATEGORIES = new Set(['spacing', 'sizes'])
+const SCALE_CATEGORIES = new Set(['spacing', 'sizes', 'breakpoints'])
 const GRID_KIND: Record<string, string> = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing' }
 const SAMPLE = 'The quick brown fox jumps over the lazy dog'
 

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -209,6 +209,12 @@ function toPx(value) {
   return match[2] === 'px' ? parseFloat(match[1]) : parseFloat(match[1]) * 16
 }
 
+function scaleWidth(px, min, max) {
+  if (px <= 0) return 0
+  if (max <= min) return 100
+  return ((Math.log(px) - Math.log(min)) / (Math.log(max) - Math.log(min))) * 98 + 2
+}
+
 function renderScale(container, tokens) {
   const rows = tokens
     .filter((token) => !token.name.includes('breakpoint-') && !Number.isNaN(toPx(token.value)))
@@ -217,6 +223,7 @@ function renderScale(container, tokens) {
   if (rows.length === 0) return
 
   const maxPx = rows[rows.length - 1].px || 1
+  const minPx = rows.find((row) => row.px > 0)?.px ?? maxPx
   const scale = document.createElement('div')
   scale.className = 'scale'
   for (const { token, px } of rows) {
@@ -233,7 +240,7 @@ function renderScale(container, tokens) {
     track.className = 's-track'
     const bar = document.createElement('div')
     bar.className = 's-bar'
-    bar.style.width = (px <= 0 ? 0 : Math.max((px / maxPx) * 100, 2)) + '%'
+    bar.style.width = scaleWidth(px, minPx, maxPx) + '%'
     track.appendChild(bar)
     scale.append(name, value, pixels, track)
   }
@@ -527,13 +534,20 @@ function groupFamilies(items: StudioToken[]) {
   return [...families.entries()]
 }
 
+function scaleWidth(px: number, min: number, max: number) {
+  if (px <= 0) return 0
+  if (max <= min) return 100
+  return ((Math.log(px) - Math.log(min)) / (Math.log(max) - Math.log(min))) * 98 + 2
+}
+
 function scaleRows(items: StudioToken[]) {
   const rows = items
     .filter((token) => !token.name.includes('breakpoint-') && !Number.isNaN(toPx(token.value)))
     .map((token) => ({ token, px: toPx(token.value) }))
     .sort((a, b) => a.px - b.px)
   const maxPx = rows.length ? rows[rows.length - 1].px || 1 : 1
-  return rows.map((row) => ({ ...row, width: row.px <= 0 ? 0 : Math.max((row.px / maxPx) * 100, 2) }))
+  const minPx = rows.find((row) => row.px > 0)?.px ?? maxPx
+  return rows.map((row) => ({ ...row, width: scaleWidth(row.px, minPx, maxPx) }))
 }`
 
 const reactTemplates = {

--- a/packages/cli/src/studio-codegen.ts
+++ b/packages/cli/src/studio-codegen.ts
@@ -200,7 +200,7 @@ renderThemeButton()
 const CATEGORY_ORDER = ['colors', 'fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings', 'spacing', 'sizes', 'radii', 'borders', 'shadows', 'blurs', 'aspectRatios', 'durations', 'easings', 'animations', 'breakpoints']
 const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
 const SCALE_CATEGORIES = new Set(['spacing', 'sizes', 'breakpoints'])
-const GRID_KIND = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing' }
+const GRID_KIND = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing', durations: 'duration' }
 const SAMPLE = 'The quick brown fox jumps over the lazy dog'
 
 function toPx(value) {
@@ -335,19 +335,21 @@ function makePreview(category, value) {
     wrap.appendChild(box)
     return wrap
   }
-  if (kind === 'easing') {
+  if (kind === 'easing' || kind === 'duration') {
     const track = document.createElement('div')
     track.className = 'ease-track'
     const dot = document.createElement('div')
     dot.className = 'ease-dot'
-    dot.style.animationTimingFunction = value
+    if (kind === 'easing') dot.style.animationTimingFunction = value
+    else { dot.style.animationDuration = value; dot.style.animationTimingFunction = 'linear' }
     track.appendChild(dot)
     wrap.appendChild(track)
     return wrap
   }
   const chip = document.createElement('div')
-  chip.style.height = '48px'
+  chip.style.height = '64px'
   chip.style.aspectRatio = value
+  chip.style.maxWidth = '100%'
   chip.style.background = 'var(--swatch)'
   chip.style.borderRadius = '6px'
   wrap.appendChild(chip)
@@ -503,7 +505,7 @@ const COMPONENT_CSS = `.panda-studio { --fg: #1a1a1a; --muted: #71717a; --border
 
 const SHARED_HELPERS = `const TYPE_CATEGORIES = new Set(['fontSizes', 'fontWeights', 'fonts', 'lineHeights', 'letterSpacings'])
 const SCALE_CATEGORIES = new Set(['spacing', 'sizes', 'breakpoints'])
-const GRID_KIND: Record<string, string> = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing' }
+const GRID_KIND: Record<string, string> = { radii: 'radius', borders: 'border', shadows: 'shadow', blurs: 'blur', aspectRatios: 'ratio', animations: 'animation', easings: 'easing', durations: 'duration' }
 const SAMPLE = 'The quick brown fox jumps over the lazy dog'
 
 const familyOf = (name: string) => (name.includes('.') ? name.slice(0, name.lastIndexOf('.')) : name)
@@ -567,9 +569,10 @@ function GridPreview({ category, value }: { category: string; value: string }) {
     case 'border': return <div className="chip" style={{ border: value }} />
     case 'shadow': return <div className="chip" style={{ background: 'var(--shadow-bg)', boxShadow: value }} />
     case 'blur': return <div className="chip" style={{ background: 'linear-gradient(135deg, var(--accent), #ec4899)', filter: \`blur(\${value})\` }} />
-    case 'ratio': return <div style={{ height: 48, aspectRatio: value, background: 'var(--swatch)', borderRadius: 6 }} />
+    case 'ratio': return <div style={{ height: 64, aspectRatio: value, maxWidth: '100%', background: 'var(--swatch)', borderRadius: 6 }} />
     case 'animation': return <div className="anim-box" style={{ animation: value }} />
     case 'easing': return <div className="ease-track"><div className="ease-dot" style={{ animationTimingFunction: value }} /></div>
+    case 'duration': return <div className="ease-track"><div className="ease-dot" style={{ animationDuration: value, animationTimingFunction: 'linear' }} /></div>
     default: return null
   }
 }
@@ -701,9 +704,10 @@ function GridPreview(props: { category: string; value: string }) {
     case 'border': return <div class="chip" style={{ border: props.value }} />
     case 'shadow': return <div class="chip" style={{ background: 'var(--shadow-bg)', 'box-shadow': props.value }} />
     case 'blur': return <div class="chip" style={{ background: 'linear-gradient(135deg, var(--accent), #ec4899)', filter: \`blur(\${props.value})\` }} />
-    case 'ratio': return <div style={{ height: '48px', 'aspect-ratio': props.value, background: 'var(--swatch)', 'border-radius': '6px' }} />
+    case 'ratio': return <div style={{ height: '64px', 'aspect-ratio': props.value, 'max-width': '100%', background: 'var(--swatch)', 'border-radius': '6px' }} />
     case 'animation': return <div class="anim-box" style={{ animation: props.value }} />
     case 'easing': return <div class="ease-track"><div class="ease-dot" style={{ 'animation-timing-function': props.value }} /></div>
+    case 'duration': return <div class="ease-track"><div class="ease-dot" style={{ 'animation-duration': props.value, 'animation-timing-function': 'linear' }} /></div>
     default: return null
   }
 }

--- a/packages/cli/src/studio-server.ts
+++ b/packages/cli/src/studio-server.ts
@@ -1,0 +1,100 @@
+import { createServer, type Server } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { extname, join, normalize, sep } from 'node:path'
+
+const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_PORT = 4000
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+}
+
+export interface StudioServerOptions {
+  host?: string
+  port?: string | number
+}
+
+export interface StudioServer {
+  url: string
+  close(): Promise<void>
+}
+
+export async function serveStudio(dir: string, options: StudioServerOptions = {}): Promise<StudioServer> {
+  const host = options.host || DEFAULT_HOST
+  const preferredPort = parsePort(options.port)
+
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url || '/', `http://${host}`).pathname
+    const requestPath = pathname === '/' ? 'index.html' : pathname.replace(/^\/+/, '')
+    const file = normalize(join(dir, requestPath))
+    if (file !== dir && !file.startsWith(dir + sep)) {
+      response.writeHead(403).end('Forbidden')
+      return
+    }
+
+    readFile(file).then(
+      (body) => {
+        response.writeHead(200, { 'content-type': CONTENT_TYPES[extname(file)] || 'application/octet-stream' })
+        response.end(body)
+      },
+      () => {
+        response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' }).end('Not found')
+      },
+    )
+  })
+
+  const address = await listen(server, { host, port: preferredPort })
+  return {
+    url: `http://${host}:${address.port}`,
+    close: () => close(server),
+  }
+}
+
+function parsePort(value: StudioServerOptions['port']): number {
+  if (value === undefined) return DEFAULT_PORT
+  const port = typeof value === 'number' ? value : Number(value)
+  return Number.isInteger(port) && port >= 0 && port <= 65535 ? port : DEFAULT_PORT
+}
+
+function listen(server: Server, options: { host: string; port: number }): Promise<{ port: number }> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.off('error', onError)
+      server.off('listening', onListening)
+    }
+
+    const onError = (error: NodeJS.ErrnoException) => {
+      if (error.code === 'EADDRINUSE' && options.port !== 0) {
+        server.off('error', onError)
+        server.once('error', reject)
+        server.listen(0, options.host)
+        return
+      }
+      cleanup()
+      reject(error)
+    }
+
+    const onListening = () => {
+      cleanup()
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Unable to determine studio server address'))
+        return
+      }
+      resolve({ port: address.port })
+    }
+
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(options.port, options.host)
+  })
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+}

--- a/website/content/docs/theming/studio.mdx
+++ b/website/content/docs/theming/studio.mdx
@@ -1,42 +1,107 @@
 ---
-title: Using Panda Studio
-description: Document your design system visually using Panda Studio.
+title: Panda Studio
+description: Visualize your design tokens with a live viewer, or generate token views you render yourself.
 ---
 
-### Panda Studio
+# Panda Studio
 
-Panda Studio is a visual interface for exploring and understanding your entire design system. It provides a read-only
-view of your tokens, semantic tokens, recipes, patterns, conditions, and more.
+`panda studio` turns your resolved design tokens into a visual reference. It has two tracks that share one token
+snapshot:
 
-![Panda Studio UI](/panda-studio.png)
+- **`panda studio`** boots a live viewer to look at your tokens.
+- **`panda studio generate`** writes the token views into your project as source, so you render them wherever you
+  document your design system.
 
-If you don't want to manually generate spec files or build a documentation website, Panda Studio is the easiest option.
+Both read a generated `tokens.json` snapshot of your fully-resolved tokens. Re-run after a config change to refresh.
 
-- Studio does not require separate spec generation.
+## Live viewer
 
-- Studio generates and visualizes your design system automatically.
-
-- Studio acts as a fully-featured documentation tool without writing any documentation code.
-
-> Spec files are primarily for custom documentation setups and Storybook integrations. Panda Studio is for teams who
-> want instant documentation.
-
-## Panda Studio Setup
-
-To use panda studio, first install it:
+Boot the viewer against your config:
 
 ```bash
-pnpm i @pandacss/studio
+panda studio
 ```
 
-Next, launch it locally using:
+This builds a self-contained bundle (plain HTML, CSS, and JS — no framework, no bundler) and serves it locally. It
+groups your tokens by category and renders a preview for each: colors as swatches, spacing and sizes as bars, radii and
+shadows as boxes, and typography as text samples. It follows your system light/dark theme, with a toggle in the header.
+
+Set the port with `--port`:
 
 ```bash
-pnpm panda studio
+panda studio --port 4000
 ```
 
-This starts a local server and launches an interactive dashboard showing all your design system elements. Since Studio
-reads your theme configuration directly, any changes to your `panda.config.ts` will appear automatically the next time
-you run it.
+## Generating views
 
-You can also deploy the studio as a standalone design system portal for your team.
+If you already document your design system your own way, generate the views as source and render them yourself:
+
+```bash
+panda studio generate
+```
+
+This writes to `styled-system/studio` by default. Use `--outdir` to change it:
+
+```bash
+panda studio generate --outdir .storybook/studio
+```
+
+You get one component per category plus the shared grid and the snapshot:
+
+```
+styled-system/studio/
+  tokens.json
+  components/
+    token-grid.tsx
+  Colors.tsx
+  Typography.tsx
+  Spacing.tsx
+  Sizes.tsx
+  Radii.tsx
+  Shadows.tsx
+```
+
+Each view is a plain component with inline styles that reads `tokens.json`. It doesn't import the styled-system runtime,
+so it renders anywhere regardless of how your app consumes Panda.
+
+You own these files. Edit them freely, and re-run `panda studio generate` to refresh the snapshot after a config change.
+
+### Framework support
+
+The generated views match your `config.jsxFramework`:
+
+- `react` (the default) emits `.tsx` components using React.
+- `solid` emits `.tsx` components using `solid-js`.
+
+For any other framework, use the live viewer — it's framework-agnostic.
+
+## Rendering the views
+
+The views are plain components, so drop them wherever you render UI.
+
+### Storybook
+
+Wrap a view in a story:
+
+```tsx
+// stories/design-system.stories.tsx
+import { Colors } from '../styled-system/studio/Colors'
+import { Typography } from '../styled-system/studio/Typography'
+
+export default { title: 'Design System/Tokens' }
+
+export const AllColors = () => <Colors />
+export const AllTypography = () => <Typography />
+```
+
+### An app route or MDX page
+
+Import a view and render it:
+
+```tsx
+import { Colors } from './styled-system/studio/Colors'
+
+export default function TokensPage() {
+  return <Colors />
+}
+```


### PR DESCRIPTION
## 📝 Description

`panda studio` visualizes your design tokens. It replaces the removed v1 Astro studio with two lighter tracks that share one token snapshot:

- `panda studio` — a live viewer built from plain HTML/CSS/JS (no framework, no bundler).
- `panda studio generate` — emits the token views into your project as source, shadcn-style, so you render them wherever you document your design system.

Both read a generated `tokens.json` snapshot. Re-run to refresh after a config change. Design rationale lives in `design-notes/cli-studio-generate.md`.

## ⛳️ Current behavior (updates)

The v1 studio (`@pandacss/studio`, an Astro app) was removed in the Rust migration. There's no built-in way to look at your resolved tokens.

## 🚀 New behavior

`panda studio` boots a local viewer with a sidebar shell (category nav + scroll-spy + theme toggle), matching the old studio layout but kept light in vanilla HTML/CSS/JS. Each category is presented the way the old studio did:

- colors grouped by family, shades in order
- typography as real sample text at the actual size/weight/font
- spacing and sizes as a scale table (name, value, pixel equivalent, proportional bar)
- radii, borders, shadows, blurs, aspect-ratios as previews
- animations run live and easings animate a dot with their timing function (keyframes are emitted from your config)

It follows your system light/dark theme, has a filter box whose query persists in the URL (`?q=`), and takes `--port`.

`panda studio generate` writes one component per category plus a shared grid into `styled-system/studio` (`--outdir` to change). Views match `config.jsxFramework` (React or Solid), reuse the same presentation, and don't import the styled-system runtime, so they render anywhere. You own the files and re-run to refresh.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Notes:

- Generated views are React or Solid. Other frameworks use the vanilla viewer; they can be added later the same way.
- `studio` and `studio generate` are routed as leaf commands in `cli-main` rather than a citty subcommand group, so space-separated flags (`panda studio --port 4000`) parse correctly.
- The contrast checker, typography playground, and semantic tokens all land as stacked PRs on top of this one (see the stack below) — CLI-only, no engine change.

Test plan:

- [x] `pnpm --filter @pandacss/cli test` — studio unit + command tests and help snapshots pass
- [x] `panda studio generate` in `sandbox/storybook` — generated React views typecheck under strict, and a `*.stories.tsx` importing them compiles against the sandbox tsconfig
- [x] `panda studio` against the sandbox — the viewer serves the snapshot and renders the sandbox tokens in light and dark; search filters and round-trips through `?q=`; animations and easings run

## 🧬 Stack

- **this PR** — `panda studio` (base)
- #3664 — contrast checker
- #3665 — typography playground
- #3666 — semantic tokens + named themes
