### PR TITLE
fix(generator): remove redundant HTMLPandaProps type

### DIFF
--- a/.changeset/happy-flies-swim.md
+++ b/.changeset/happy-flies-swim.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/generator': patch
+'@pandacss/studio': patch
+---
+
+remove redundant HTMLPandaProps type

--- a/packages/generator/src/artifacts/js/is-valid-prop.ts
+++ b/packages/generator/src/artifacts/js/is-valid-prop.ts
@@ -38,7 +38,7 @@ export function generateIsValidProp(ctx: Context) {
   return {
     js: content,
     dts: outdent`
-    import type { DistributiveOmit, HTMLPandaProps, JsxStyleProps, Pretty } from '../types';
+    import type { DistributiveOmit, JsxStyleProps, Pretty } from '../types';
 
     declare const isCssProperty: (value: string) => boolean;
 

--- a/packages/studio/styled-system/jsx/is-valid-prop.d.ts
+++ b/packages/studio/styled-system/jsx/is-valid-prop.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { DistributiveOmit, HTMLPandaProps, JsxStyleProps, Pretty } from '../types';
+import type { DistributiveOmit, JsxStyleProps, Pretty } from '../types';
 
 declare const isCssProperty: (value: string) => boolean;
 


### PR DESCRIPTION
## 📝 Description

Fix generator creating redundant/nonexistent imports.

## ⛳️ Current behavior (updates)

HTMLPandaProps type was used in the `is-valid-prop` generator code, but does actually not exist. The nonexistent type import still creates errors, when a builder like rolldown 'hits' the file.

## 🚀 New behavior

Nonexistent type import was removed.

## 💣 Is this a breaking change (Yes/No): No