### PR TITLE
fix(studio): drop unused HTMLPandaProps import from is-valid-prop

### DIFF
--- a/packages/studio/styled-system/jsx/is-valid-prop.d.ts
+++ b/packages/studio/styled-system/jsx/is-valid-prop.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { DistributiveOmit, HTMLPandaProps, JsxStyleProps, Pretty } from '../types';
+import type { DistributiveOmit, JsxStyleProps, Pretty } from '../types';
 
 declare const isCssProperty: (value: string) => boolean;
 


### PR DESCRIPTION
## 📝 Description

The studio's generated `is-valid-prop.d.ts` imports `HTMLPandaProps` but never uses it. This drops the unused import so the file matches what codegen emits.

## ⛳️ Current behavior (updates)

`packages/studio/styled-system/jsx/is-valid-prop.d.ts` imports `HTMLPandaProps` next to the types it actually uses — `DistributiveOmit`, `JsxStyleProps`, and `Pretty`. Nothing in the file references it, so the import is dead weight and drifts from what the generator produces.

## 🚀 New behavior

The import lists only the types the file uses. Output is otherwise identical — no runtime or type behavior changes, and the snapshot now lines up with codegen.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

Studio-internal generated snapshot only — no published API or runtime surface changes, so there's no changeset.
