### PR TITLE
fix(engine): run utility transform for shorthands in recipes

### DIFF
--- a/.changeset/utility-transform-recipe-shorthand.md
+++ b/.changeset/utility-transform-recipe-shorthand.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Run custom utility `transform` callbacks inside `cva`/`sva` recipes when you use the utility's shorthand. The recipe path dispatched on the raw shorthand, so it skipped the transform and emitted the utility key as a literal CSS property (for example `color-variable: ...` instead of your transform's output). It now resolves the shorthand to the canonical key first, matching atomic `css()`.

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -1753,12 +1753,15 @@ fn transform_atoms(
 ) -> FxHashSet<Atom> {
     let mut out = FxHashSet::default();
     for atom in atoms {
-        let resolved = resolved_atom_value(utility, atom.prop(), atom.value());
-        match transform(atom.prop(), &resolved, atom.value()) {
+        let prop = utility.map_or(atom.prop(), |utility| {
+            utility.resolve_shorthand(atom.prop())
+        });
+        let resolved = resolved_atom_value(utility, prop, atom.value());
+        match transform(prop, &resolved, atom.value()) {
             // A `{}` result drops the atom — matches node's behavior.
             Ok(Some(styles)) if is_empty_style_object(&styles) => {}
             Ok(Some(styles)) => {
-                overrides.insert((Box::from(atom.prop()), atom.value().clone()), styles);
+                overrides.insert((Box::from(prop), atom.value().clone()), styles);
                 out.insert(atom);
             }
             // No transform registered for this prop — keep the atom verbatim.
@@ -1769,7 +1772,7 @@ fn transform_atoms(
                 diagnostics.push(with_callback_target(
                     diagnostic,
                     "utility",
-                    atom.prop(),
+                    prop,
                     Some(&atom_value_summary(atom.value())),
                 ));
             }

--- a/crates/pandacss_project/src/recipes.rs
+++ b/crates/pandacss_project/src/recipes.rs
@@ -1187,6 +1187,11 @@ struct RecipeTransformCtx<'a> {
 }
 
 impl RecipeTransformCtx<'_> {
+    fn canonical_prop<'a>(&'a self, prop: &'a str) -> &'a str {
+        self.utility
+            .map_or(prop, |utility| utility.resolve_shorthand(prop))
+    }
+
     /// Runs a transform's style object through the normal encoder path, so
     /// nested conditions/selectors resolve instead of becoming junk props.
     fn encode(&self, styles: &Literal) -> FxHashSet<Atom> {
@@ -1239,8 +1244,9 @@ fn transform_atoms(
 ) -> FxHashSet<Atom> {
     let mut out = FxHashSet::default();
     for atom in atoms {
-        let resolved = crate::resolved_atom_value(ctx.utility, atom.prop(), atom.value());
-        match transform(atom.prop(), &resolved, atom.value()) {
+        let prop = ctx.canonical_prop(atom.prop());
+        let resolved = crate::resolved_atom_value(ctx.utility, prop, atom.value());
+        match transform(prop, &resolved, atom.value()) {
             // Empty result drops the carrier atom (parity with node).
             Ok(Some(styles)) if crate::is_empty_style_object(&styles) => {}
             Ok(Some(styles)) => {
@@ -1292,8 +1298,9 @@ fn transform_recipe_entries(
 ) -> FxHashSet<RecipeStyleEntry> {
     let mut out = FxHashSet::default();
     for entry in entries {
-        let resolved = crate::resolved_atom_value(ctx.utility, entry.prop.as_ref(), &entry.value);
-        match transform(entry.prop.as_ref(), &resolved, &entry.value) {
+        let prop = ctx.canonical_prop(entry.prop.as_ref());
+        let resolved = crate::resolved_atom_value(ctx.utility, prop, &entry.value);
+        match transform(prop, &resolved, &entry.value) {
             Ok(Some(styles)) if crate::is_empty_style_object(&styles) => {}
             Ok(Some(styles)) => {
                 if let Some(entries) =

--- a/crates/pandacss_project/src/recipes.rs
+++ b/crates/pandacss_project/src/recipes.rs
@@ -1266,7 +1266,7 @@ fn transform_atoms(
             Err(diagnostic) => diagnostics.push(crate::with_callback_target(
                 diagnostic,
                 "utility",
-                atom.prop(),
+                prop,
                 Some(&crate::atom_value_summary(atom.value())),
             )),
         }
@@ -1327,7 +1327,7 @@ fn transform_recipe_entries(
             Err(diagnostic) => diagnostics.push(crate::with_callback_target(
                 diagnostic,
                 "utility",
-                entry.prop.as_ref(),
+                prop,
                 Some(&crate::atom_value_summary(&entry.value)),
             )),
         }

--- a/crates/pandacss_stylesheet/tests/utility_transform.rs
+++ b/crates/pandacss_stylesheet/tests/utility_transform.rs
@@ -319,6 +319,61 @@ fn override_styles_are_refcounted_across_files() {
 }
 
 #[test]
+fn shorthand_in_recipe_dispatches_utility_transform() {
+    let cfg = config(serde_json::json!({
+        "importMap": { "css": ["@panda/css"], "recipe": ["@panda/css"], "pattern": [], "jsx": [], "tokens": [] },
+        "theme": { "tokens": { "colors": { "red": { "value": "#f00" }, "blue": { "value": "#00f" }, "green": { "value": "#0f0" }, "amber": { "value": "#fb0" } } } },
+        "utilities": {
+            "colorVariable": {
+                "shorthand": "colorVar",
+                "className": "color-variable",
+                "values": "colors",
+                "transform": { "kind": "js-callback", "id": "colorVariable" }
+            }
+        }
+    }));
+
+    let source = indoc::indoc! {r"
+        import { css, cva, sva } from '@panda/css';
+        css({ colorVar: 'red' });
+        export const box = cva({ base: { colorVar: 'blue' }, variants: { tone: { warm: { colorVar: 'amber' } } } });
+        export const panel = sva({ slots: ['root'], base: { root: { colorVar: 'green' } } });
+    "};
+
+    let css = compile_layer_with_transform(
+        &cfg,
+        source,
+        &[StylesheetLayer::Utilities, StylesheetLayer::Recipes],
+        |prop, resolved, _original| {
+            if prop != "colorVariable" {
+                return Ok(None);
+            }
+            Ok(Some(Literal::Object(vec![decl(
+                "--color-var",
+                &atom_value_str(resolved),
+            )])))
+        },
+    );
+
+    assert_snapshot!(css, @r"
+    @layer utilities {
+      .color-variable_amber {
+        --color-var: var(--colors-amber);
+      }
+      .color-variable_blue {
+        --color-var: var(--colors-blue);
+      }
+      .color-variable_green {
+        --color-var: var(--colors-green);
+      }
+      .color-variable_red {
+        --color-var: var(--colors-red);
+      }
+    }
+    ");
+}
+
+#[test]
 fn empty_transform_result_emits_nothing() {
     let cfg = config(serde_json::json!({
         "importMap": { "css": ["@panda/css"], "recipe": [], "pattern": [], "jsx": [], "tokens": [] },


### PR DESCRIPTION
## 📝 Description

Custom utility `transform` callbacks now run for `cva`/`sva` recipe styles when you author them with the utility's shorthand. Before, the recipe path skipped the transform and emitted the utility key as a literal CSS property, so you got invalid CSS with no build error.

Reported in [#3599](https://github.com/chakra-ui/panda/discussions/3599?sort=new#discussioncomment-17717066).

## ⛳️ Current behavior (updates)

Take a utility with a `transform` and a `shorthand`:

```ts
utilities: {
  extend: {
    colorVariable: {
      shorthand: 'colorVar',
      className: '--color-var',
      values: 'colors',
      transform: (value) => ({ '--color-var': value }),
    },
  },
}
```

The transform runs in atomic `css()` but not in recipes:

| Usage | Output |
| --- | --- |
| `css({ colorVar: 'red' })` | `--color-var: var(--colors-red)` |
| `cva({ base: { colorVar: 'blue' } })` | `color-variable: var(--colors-blue)` |
| `sva({ slots: ['root'], base: { root: { colorVar: 'green' } } })` | `color-variable: var(--colors-green)` |

`color-variable` is the hyphenated utility key, not the transform's output. It's invalid CSS and no error tells you. This also broke preset-base's own `shadowColor`.

## 🚀 New behavior

Recipes dispatch the transform the same as `css()`, so all three emit `--color-var: var(--colors-…)`.

The cause: atomic `css()` atoms reach the transform already canonicalized (`colorVar` → `colorVariable`), so the callback lookup, which is keyed on the canonical key, hits. Recipe styles keep the shorthand until emit, so the recipe path looked up the raw `colorVar` and missed. The fix resolves the shorthand to the canonical key before dispatch, in both the atomic-atom path (recipe base styles flow through it) and the recipe-entry path (variants and compounds).

## 💣 Is this a breaking change (Yes/No):

No. It fixes output that was already broken. If you depended on the literal `color-variable` declaration, that CSS was never valid.

## 📝 Additional Information

The fix lives in the shared `pandacss_project` crate, so both the native (`@pandacss/compiler`) and wasm (`@pandacss/compiler-wasm`) bindings get it.

Test: `shorthand_in_recipe_dispatches_utility_transform` covers `css`, `cva` base, a `cva` variant, and `sva`. Its transform closure only fires on the canonical key, mirroring the real binding's ref lookup, so a regressed dispatch fails it. `cargo test -p pandacss_stylesheet -p pandacss_project` passes (1021 tests); fmt and clippy are clean.
