### PR TITLE
docs: fix stale v1 class names in examples

### DIFF
--- a/website/content/docs/concepts/color-opacity-modifier.mdx
+++ b/website/content/docs/concepts/color-opacity-modifier.mdx
@@ -25,7 +25,7 @@ css({
     background: color-mix(in oklab, var(--colors-red-300) 40%, transparent);
   }
 
-  .text_white {
+  .c_white {
     color: var(--colors-white);
   }
 }

--- a/website/content/docs/concepts/merging-styles.mdx
+++ b/website/content/docs/concepts/merging-styles.mdx
@@ -19,7 +19,7 @@ const style2 = {
   bg: 'blue'
 }
 
-const className = css(style1, style2) // => 'bg_blue text_white'
+const className = css(style1, style2) // => 'bg_blue c_white'
 ```
 
 In some cases though, the style object might not be colocated in the same file as the component. In this case, you can
@@ -45,7 +45,7 @@ const style2 = css.raw({
   bg: 'blue'
 })
 
-const className = css(style1, style2) // => 'bg_blue text_white'
+const className = css(style1, style2) // => 'bg_blue c_white'
 ```
 
 ## Spreading `css.raw` objects

--- a/website/content/docs/concepts/styled-system.mdx
+++ b/website/content/docs/concepts/styled-system.mdx
@@ -14,7 +14,7 @@ as output path to generate the `styled-system` in.
 This is the core of what the `styled-system` does:
 
 ```ts
-css({ color: 'blue.300' }) // => "text_blue_300"
+css({ color: 'blue.300' }) // => "c_blue.300"
 ```
 
 Since Panda doesn't rely on any bundler's (`vite`, `webpack`, etc) plugin, there is no code transformation happening to

--- a/website/content/docs/concepts/writing-styles.mdx
+++ b/website/content/docs/concepts/writing-styles.mdx
@@ -361,7 +361,7 @@ import { Button } from './Button'
 export default function Page() {
   return (
     <Button css={{ color: 'pink', _hover: { color: 'red' } }}>
-      will result in `class="d_flex items_center text_pink hover:text_red"`
+      will result in `class="d_flex items_center c_pink hover:c_red"`
     </Button>
   )
 }

--- a/website/content/docs/guides/dynamic-styling.mdx
+++ b/website/content/docs/guides/dynamic-styling.mdx
@@ -394,29 +394,29 @@ resulting in a css that looks like this:
 ```css
 /* ... */
 @layer utilities {
-  .hover\:text_red\.100:where(:hover, [data-hover]) {
+  .hover\:c_red\.100:is(:hover, [data-hover]) {
     color: var(--colors-red-100);
   }
 
-  .text_red\.200 {
+  .c_red\.200 {
     color: var(--colors-red-200);
   }
 
-  .hover\:text_red\.300:where(:hover, [data-hover]) {
+  .hover\:c_red\.300:is(:hover, [data-hover]) {
     color: var(--colors-red-300);
   }
 
-  @media screen and (min-width: 768px) {
-    .hover\:md\:text_red\.400:where(:hover, [data-hover]) {
+  @media (width >= 48rem) {
+    .hover\:md\:c_red\.400:is(:hover, [data-hover]) {
       color: var(--colors-red-400);
     }
   }
 
-  .text_red\.500 {
+  .c_red\.500 {
     color: var(--colors-red-500);
   }
 
-  .text_red\.600 {
+  .c_red\.600 {
     color: var(--colors-red-600);
   }
 }

--- a/website/content/docs/references/config.mdx
+++ b/website/content/docs/references/config.mdx
@@ -151,7 +151,7 @@ const App = () => {
 would result in:
 
 ```css
-.panda-text_blue\.500 {
+.panda-c_blue\.500 {
   color: var(--panda-colors-blue-500);
 }
 ```
@@ -184,7 +184,7 @@ would result in:
 
 ```css
 @layer panda_utilities {
-  .text_blue\.500 {
+  .c_blue\.500 {
     color: var(--colors-blue-500);
   }
 }
@@ -290,7 +290,7 @@ E.g. only hash the css variables:
 Then the result looks like this:
 
 ```css
-.text_blue\.500 {
+.c_blue\.500 {
   color: var(--cgpxvS);
 }
 ```


### PR DESCRIPTION
## 📝 Description

Fixes stale v1 class names in docs code examples so they match what v2 actually emits.

## ⛳️ Current behavior (updates)

Several examples still show v1 output:

- The color utility renders as `text_…` — v2 emits `c_…`.
- The default hover selector shows `:where(:hover, [data-hover])` — v2 emits `:is(:hover, [data-hover])`.
- Responsive rules show `@media screen and (min-width: 768px)` — v2 emits `@media (width >= 48rem)`.

## 🚀 New behavior

Updated the examples in:

- `references/config` — prefix, layers, and hash examples (`text_blue` → `c_blue`).
- `concepts/styled-system` — `css({ color: 'blue.300' })` → `"c_blue.300"`.
- `concepts/merging-styles` — `css(style1, style2)` → `"bg_blue c_white"`.
- `concepts/color-opacity-modifier` — `.text_white` → `.c_white`.
- `concepts/writing-styles` — `text_pink hover:text_red` → `c_pink hover:c_red`.
- `guides/dynamic-styling` — the generated-CSS block: `c_red`, `:is(:hover, [data-hover])`, and `@media (width >= 48rem)`.

Text-only. No prose rewrites and no other content changes.

## 💣 Is this a breaking change (Yes/No):

No. Docs only.

## 📝 Additional Information

Class names verified against `packages/preset-base` (`color` → `className: 'c'`), the default `_hover` condition (`&:is(:hover, [data-hover])`), the `md` breakpoint (`48rem`), and the `pandacss_stylesheet` emit snapshots. `velite --clean` builds green.
