### PR TITLE
fix: unblock v2 CI (pos shorthand types + changelog formatting)

### DIFF
--- a/.changeset/pos-shorthand-system-properties.md
+++ b/.changeset/pos-shorthand-system-properties.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix `pos` and other shorthands for value-less native properties (like `position`) missing from the generated types. Use
+them as style props, in `css()`, and on pattern components.

--- a/crates/pandacss_codegen/src/artifacts/types.rs
+++ b/crates/pandacss_codegen/src/artifacts/types.rs
@@ -428,6 +428,9 @@ fn is_native_strict_mirror(property: &UtilityPropertyTypeData) -> bool {
         .css_property
         .as_deref()
         .unwrap_or(property.name.as_str());
+    if css_property != property.name {
+        return false;
+    }
     strict_props::property_value_entry(css_property).is_some()
 }
 

--- a/crates/pandacss_codegen/tests/types_artifact.rs
+++ b/crates/pandacss_codegen/tests/types_artifact.rs
@@ -1070,6 +1070,54 @@ fn utility_shorthand_unions_css_property_value_in_default_mode() {
 }
 
 #[test]
+fn shorthand_of_valueless_native_property_emits_member() {
+    let input = CodegenInput {
+        types: TypeData {
+            utilities: UtilityTypeData {
+                properties: BTreeMap::from([
+                    (
+                        "position".into(),
+                        UtilityPropertyTypeData {
+                            name: "position".into(),
+                            css_property: Some("position".into()),
+                            alias: "PositionValue".into(),
+                            ..UtilityPropertyTypeData::default()
+                        },
+                    ),
+                    (
+                        "pos".into(),
+                        UtilityPropertyTypeData {
+                            name: "pos".into(),
+                            css_property: Some("position".into()),
+                            alias: "PositionValue".into(),
+                            ..UtilityPropertyTypeData::default()
+                        },
+                    ),
+                ]),
+                shorthands: BTreeMap::from([("pos".into(), "position".into())]),
+                ..UtilityTypeData::default()
+            },
+            ..TypeData::default()
+        },
+        ..CodegenInput::default()
+    };
+
+    let artifacts = ArtifactGraph.generate_with_input(
+        &input,
+        GenerateOptions {
+            format: CodegenFormat::Ts,
+            ..GenerateOptions::default()
+        },
+    );
+    let system = file(artifact(&artifacts, ArtifactId::Types), "types/system.ts");
+
+    assert!(
+        system.contains("  pos?: ConditionalValue<"),
+        "missing `pos` member:\n{system}"
+    );
+}
+
+#[test]
 fn utility_shorthand_omits_css_property_value_under_strict_tokens() {
     let mut input = CodegenInput {
         types: TypeData {

--- a/packages/compiler-shared/CHANGELOG.md
+++ b/packages/compiler-shared/CHANGELOG.md
@@ -49,7 +49,6 @@
   ```tsx
   // React / Next
   import { ViewTransition } from 'react'
-
   ;<ViewTransition name="hero" share={slide}>
     <img src="…" alt="…" />
   </ViewTransition>

--- a/packages/compiler-wasm/CHANGELOG.md
+++ b/packages/compiler-wasm/CHANGELOG.md
@@ -47,7 +47,6 @@
   ```tsx
   // React / Next
   import { ViewTransition } from 'react'
-
   ;<ViewTransition name="hero" share={slide}>
     <img src="…" alt="…" />
   </ViewTransition>

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -57,7 +57,6 @@
   ```tsx
   // React / Next
   import { ViewTransition } from 'react'
-
   ;<ViewTransition name="hero" share={slide}>
     <img src="…" alt="…" />
   </ViewTransition>

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -32,7 +32,6 @@
   ```tsx
   // React / Next
   import { ViewTransition } from 'react'
-
   ;<ViewTransition name="hero" share={slide}>
     <img src="…" alt="…" />
   </ViewTransition>

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -25,7 +25,6 @@
   ```tsx
   // React / Next
   import { ViewTransition } from 'react'
-
   ;<ViewTransition name="hero" share={slide}>
     <img src="…" alt="…" />
   </ViewTransition>


### PR DESCRIPTION
## 📝 Description

Unblocks the two failing checks on v2: the docs build and Prettier.

## ⛳️ Current behavior (updates)

The docs `next build` fails type-checking: `Property 'pos' does not exist on type '... HstackProps'`. The `pos` shorthand (for `position`) is generated nowhere in `SystemProperties`, so it's rejected as a style prop, in `css()`, and on pattern components.

Codegen classes a shorthand whose longhand is a value-less native property (`pos` → `position`) as a native-baseline mirror, so it emits no explicit member. But the baseline is keyed by the CSS property name (`position`), so the alias `pos` lands nowhere. Token-backed shorthands like `bg` and `px` carry a token category, so they're fine — `pos` is the only one that breaks.

Separately, `prettier --check packages` fails on five generated changelogs. Prettier formats embedded code in markdown, and the released changelogs carry a `viewTransition` tsx sample that isn't formatted.

## 🚀 New behavior

A member whose name differs from its CSS property can't be covered by the native baseline, so it's no longer treated as a mirror and carries its own type. `pos` works again everywhere. Added a regression test for the value-less native-property shorthand.

Reformatted the five changelogs so `prettier --check packages` passes.

Verified:

- `cargo nextest run -p pandacss_codegen` — 111 pass, including the new test
- `pnpm rust:fmt` and `cargo clippy -p pandacss_codegen -- -D warnings` — clean
- Rebuilt the native binding, regenerated the docs `styled-system`, `tsc --noEmit` — 0 errors, full `next build` succeeds
- `prettier --check packages` — passes

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

`pnpm prettier` only checks `packages/`, so unformatted embedded code in `.changeset/*.md` slips through until the release bot bakes it into a changelog. Worth a follow-up to extend the Prettier scope or format changesets.
