### PR TITLE
docs: clean up removed config options in the reference

### DIFF
--- a/website/content/docs/references/cli.mdx
+++ b/website/content/docs/references/cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: CLI Reference
 description:
-  Use Panda's command-line interface to initialize, build, check, view project info, and debug your project.
+  Use Panda's command-line interface to initialize, build, check, diagnose, and debug your project.
 ---
 
 Use Panda's command-line interface (CLI) to generate the styled-system output and CSS from a terminal.
@@ -14,8 +14,7 @@ Use Panda's command-line interface (CLI) to generate the styled-system output an
 | `panda dev`       | Watch project files and rebuild the generated system and CSS. |
 | `panda build`     | Generate the styled-system output and CSS once. Bare `panda` runs the same build. |
 | `panda check`     | Check generated files without writing. Use this in CI. |
-| `panda info`      | Print project and compiler info. |
-| `panda doctor`    | Check config loading and compiler diagnostics. |
+| `panda doctor`    | Check config loading, print the project summary, and surface compiler diagnostics. |
 | `panda debug`     | Write bug-report artifacts under `<outdir>/debug`. |
 | `panda codegen`   | Advanced: generate the styled-system output only. |
 | `panda cssgen`    | Advanced: generate CSS only. |
@@ -130,28 +129,19 @@ pnpm panda check --format github --max-warnings 0
 
 `panda check` uses the same output flags as `panda build`, but write/watch-only flags are hidden from help.
 
-## info
-
-Print project and compiler information.
-
-```bash
-pnpm panda info
-pnpm panda info --json
-```
-
-The result includes config path, source count, watch directories, artifact IDs, condition count, token category count,
-and utility count.
-
 ## doctor
 
-Check config loading and compiler diagnostics.
+Check config loading, print the project summary, and surface compiler diagnostics.
 
 ```bash
 pnpm panda doctor
+pnpm panda doctor --json
 pnpm panda doctor --format github --max-warnings 0
 ```
 
-Use this command when you want a fast setup and diagnostics health check without writing generated files.
+Use this command when you want a fast setup and diagnostics health check without writing generated files. The summary
+includes config path, source count, watch directories, artifact IDs, condition count, token category count, and utility
+count.
 
 ## debug
 
@@ -235,6 +225,6 @@ pnpm panda buildinfo --minify
 
 ## Removed Commands
 
-`panda inspect` and `panda validate` are removed. Use `panda info` and `panda doctor`.
+`panda inspect`, `panda validate`, and `panda info` are removed. Use `panda doctor`, which validates your setup and prints the project summary.
 
 Legacy commands such as `studio`, `analyze`, `ship`, and `emit-pkg` are not part of the v2 CLI surface.

--- a/website/content/docs/references/config.mdx
+++ b/website/content/docs/references/config.mdx
@@ -32,20 +32,6 @@ as a set of overrides and extensions.
 }
 ```
 
-### eject
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to opt-out of the defaults config presets: [`@pandacss/preset-base`, `@pandacss/preset-panda`]
-
-```json
-{
-  "eject": true
-}
-```
-
 ### preflight
 
 **Type**: `boolean` | `{ scope: string; }`
@@ -231,6 +217,8 @@ would result in:
 **Default**: `false`
 
 Whether to minify the generated css. This can be set to `true` to reduce the size of the generated css.
+
+Panda emits and optimizes CSS natively, so the old `lightningcss` and `browserslist` options no longer apply.
 
 Often enabled only in production — see [Environment-specific config](/docs/guides/environment-specific-config).
 
@@ -533,34 +521,6 @@ const Container = styled.div`
   background-color: gainsboro;
   padding: 10px 15px;
 `
-```
-
-### lightningcss
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to use `lightningcss` instead of `postcss` for css optimization.
-
-```json
-{
-  "lightningcss": true
-}
-```
-
-### browserslist
-
-**Type**: `string[]`
-
-**Default**: `[]`
-
-Browserslist query to target specific browsers. Only used when `lightningcss` is set to `true`.
-
-```json
-{
-  "browserslist": ["last 2 versions", "not dead", "not < 2%"]
-}
 ```
 
 ### polyfill
@@ -942,23 +902,6 @@ Ex with 'none':
 ```
 
 ## Documentation options
-
-### studio
-
-**Type**: `Partial<Studio>`
-
-**Default**: `{ title: 'Panda', logo: '🐼' }`
-
-Used to customize the design system studio
-
-```json
-{
-  "studio": {
-    "logo": "🐼",
-    "title": "Panda"
-  }
-}
-```
 
 ### log level
 


### PR DESCRIPTION
## 📝 Description

The config and CLI reference still document options and a command that Panda v2 no longer ships. This trims them so the reference matches the actual v2 surface.

## ⛳️ Current behavior (updates)

- `references/config.mdx` documents four options that don't exist in v2: `eject`, `lightningcss`, `browserslist`, and `studio`.
- `references/cli.mdx` still points users at `panda info`, which folded into `panda doctor`.

## 🚀 New behavior

- Removed the four dead config options (confirmed absent from `packages/types/src/config.ts` and `crates/pandacss_config`). v2 emits and optimizes CSS natively in the Rust `pandacss_stylesheet` crate, so `lightningcss` and `browserslist` are gone — a one-line note under `minify` points returning users there.
- Dropped the `panda info` command row and section, folding its project-summary details into `panda doctor`, and updated the "Removed Commands" note and page description to match.

## 💣 Is this a breaking change (Yes/No):

No. Docs only.

## 📝 Additional Information

While in `cli.mdx` I noticed `analyze` is described as not part of the v2 CLI, but `analyze.ts` exists and is wired into `cli-main.ts`. Left it untouched — out of scope here, worth a follow-up.
