### PR TITLE
docs: document ESM-only requirement and fix CJS install guides

### DIFF
--- a/website/content/docs/installation/astro.mdx
+++ b/website/content/docs/installation/astro.mdx
@@ -97,14 +97,13 @@ import '../index.css';
 
 ### Update the postcss config
 
-Astro requires a little change for the `postcss.config.[c]js`:
+Astro loads PostCSS plugins as an array, so import the plugin and call it in your `postcss.config.mjs`:
 
-```diff {3} filename="postcss.config.js"
-module.exports = {
--  plugins: {
--   '@pandacss/dev/postcss': {}
--  }
-+  plugins: [require('@pandacss/dev/postcss')()]
+```js filename="postcss.config.mjs"
+import pandacss from '@pandacss/dev/postcss'
+
+export default {
+  plugins: [pandacss()],
 }
 ```
 

--- a/website/content/docs/installation/storybook.mdx
+++ b/website/content/docs/installation/storybook.mdx
@@ -74,15 +74,14 @@ Install panda and create your `panda.config.ts` file.
   {/* <!-- prettier-ignore-end --> */}
 </Tabs>
 
-If you are using Storybook with the Vite builder, you will have to update your PostCSS config file to use the array
-syntax for the plugins instead of the object syntax. Simply change `postcss.config.[c]js`:
+If you are using Storybook with the Vite builder, use the array syntax for the plugins instead of the object syntax.
+Import the plugin and call it in your `postcss.config.mjs`:
 
-```diff filename="postcss.config.js"
-module.exports = {
--  plugins: {
--   '@pandacss/dev/postcss': {}
--  }
-+  plugins: [require('@pandacss/dev/postcss')()]
+```js filename="postcss.config.mjs"
+import pandacss from '@pandacss/dev/postcss'
+
+export default {
+  plugins: [pandacss()],
 }
 ```
 
@@ -286,12 +285,14 @@ With that in place, you should see the light/dark switcher in Storybook's toolba
 
 ### Cannot find postcss plugin
 
-If you are having issues with the PostCSS plugin similar to `Cannot find module '@pandacss/dev/postcss'`, update the
-PostCSS config as follows:
+If you are having issues with the PostCSS plugin similar to `Cannot find module '@pandacss/dev/postcss'`, import the
+plugin directly instead of referencing it by name:
 
-```js filename="postcss.config.js"
-module.exports = {
-  plugins: [require('@pandacss/dev/postcss')]
+```js filename="postcss.config.mjs"
+import pandacss from '@pandacss/dev/postcss'
+
+export default {
+  plugins: [pandacss()],
 }
 ```
 

--- a/website/content/docs/overview/getting-started.mdx
+++ b/website/content/docs/overview/getting-started.mdx
@@ -12,6 +12,21 @@ Just-in-Time)
 
 > TLDR; Panda is a CSS-in-JS engine that generates atomic CSS at build time (via CLI or PostCSS)
 
+## Requirements
+
+Panda v2 is **ESM-only**. Every `@pandacss/*` package ships as an ES module — there's no separate CommonJS build. Two
+things follow from that:
+
+- **Node.js 22.12 or newer.** This is the first release where `require()` can load an ES module, so CommonJS tooling can
+  still pull Panda in. On older versions Panda won't load at all.
+- **Author your config as ESM.** `panda.config.ts` already uses `import` and `export default`, so nothing changes there.
+  For a plain `postcss.config.js`, make sure the file is ESM — set `"type": "module"` in your `package.json`, or name it
+  `.mjs`.
+
+Some build tools still expect a CommonJS PostCSS config — Next.js is the main one. For those, keep a `postcss.config.cjs`
+that does `require('@pandacss/dev/postcss')`; the plugin ships a CommonJS entry for exactly this case. Each
+[framework guide](#framework-guides) shows the right form for its setup.
+
 ## Installation
 
 ### General Guides


### PR DESCRIPTION
## 📝 Description

Panda v2 is ESM-only, but the docs never say so — and a couple of install guides still show CommonJS syntax in a `.js` file, which breaks in a `"type": "module"` project. This documents the requirement and fixes the guides.

## ⛳️ Current behavior (updates)

- Nothing in the docs states that v2 is ESM-only or that it needs Node.js 22.12 or newer.
- The Astro and Storybook guides set up PostCSS with `module.exports` and `require()` in a `postcss.config.js`. That throws once the project is ESM.

## 🚀 New behavior

- `overview/getting-started` gains a Requirements section: Node.js 22.12+ (the first release where `require()` can load an ES module) and how to author your config as ESM. It's upfront about the exception — some tools, mainly Next.js, still expect a CommonJS PostCSS config, and the plugin ships a CJS entry for exactly that.
- `installation/astro` and `installation/storybook` now use an ESM `postcss.config.mjs` (`import pandacss from '@pandacss/dev/postcss'`), matching the `sandbox/astro` and `sandbox/storybook` configs.
- `installation/ember` and `installation/nextjs` keep `postcss.config.cjs` on purpose — their build tooling is CommonJS, and the plugin's `require()` entry supports it.

## 💣 Is this a breaking change (Yes/No):

No. Docs only.

## 📝 Additional Information

The Node 22.12 floor is deliberate: it's the first LTS with `require(esm)` unflagged, which is what lets CommonJS tooling load the ESM-only plugin.
