### PR TITLE
docs: add linting to the v2 migration guide

### DIFF
--- a/V2_MIGRATION.md
+++ b/V2_MIGRATION.md
@@ -349,6 +349,28 @@ pandacss({ transform: true })
 
 Same flag in `@pandacss/webpack` and `@pandacss/rollup`. Without it, the plugins only handle CSS, codegen, and HMR.
 
+### Linting
+
+The ESLint plugin is rebuilt on the v2 engine. It loads your config and the compiler once, so rules lint against the same extraction the build uses.
+
+```ts
+// eslint.config.mjs
+import panda from '@pandacss/eslint-plugin'
+
+export default [await panda.configs.recommended({ configPath: './panda.config.ts' })]
+```
+
+The same rules run under [oxlint](https://oxc.rs) through its JS plugin API. Point `jsPlugins` at the oxlint entry in `.oxlintrc.json`:
+
+```json
+{
+  "jsPlugins": ["@pandacss/eslint-plugin/oxlint"],
+  "rules": { "@pandacss/no-invalid-nesting": "error" }
+}
+```
+
+Install with `@pandacss/eslint-plugin@beta`. ESLint needs v9 flat config; oxlint needs `oxlint` and `@oxlint/plugins` (alpha).
+
 ---
 
 ## Breaking changes & migration


### PR DESCRIPTION
## 📝 Description

Adds a Linting section to the v2 migration guide. It was missing, so people upgrading had no way to find that Panda ships an ESLint plugin — and oxlint support — on the new engine.

## ⛳️ Current behavior (updates)

`V2_MIGRATION.md` covers CSS output, extraction, source transformation, and the breaking changes, but never mentions linting. Nothing points at `@pandacss/eslint-plugin` or its oxlint entry, so the tooling is effectively invisible during migration.

## 🚀 New behavior

Adds a Linting section under "What changed in v2":

- The ESLint v9 flat-config setup (`panda.configs.recommended`).
- The oxlint setup (`jsPlugins` in `.oxlintrc.json`).
- The `@pandacss/eslint-plugin@beta` install and the version requirements, including that oxlint's JS plugins are alpha.

Both run on the v2 engine, so rules lint against the same extraction the build uses.

## 💣 Is this a breaking change (Yes/No):

No. Docs only.
