### PR TITLE
docs: drop version framing from the Why Panda engine section

### DIFF
--- a/website/content/docs/overview/why-panda.mdx
+++ b/website/content/docs/overview/why-panda.mdx
@@ -126,10 +126,9 @@ straight from its recipe with `RecipeVariantProps`.
 
 ## Fast, native builds
 
-v2 rewrites the compiler's hot path in Rust on the [Oxc](https://oxc.rs) toolchain. It parses each file once, with no
-TypeScript program in the hot path, and produces the same CSS as v1 from a smaller install — the `ts-morph` and
-`ts-evaluator` dependency tree is gone. The same engine compiles to WebAssembly, which is how the playground runs Panda
-in your browser.
+Panda compiles your styles with a Rust engine built on the [Oxc](https://oxc.rs) toolchain. It parses each file once,
+with no TypeScript program in the hot path, so builds stay fast and the install stays small. The same engine compiles to
+WebAssembly, which is how the playground runs Panda in your browser.
 
 ## Works with your stack
 


### PR DESCRIPTION
## 📝 Description

The "Fast, native builds" section on the Why Panda page framed the engine as "v2" and compared it to "v1". On a page a new reader lands on, that version framing dates the copy. This rewrites it in the present tense, about Panda.

## ⛳️ Current behavior (updates)

The section opens with "v2 rewrites the compiler's hot path…" and mentions "the same CSS as v1" and the removed `ts-morph`/`ts-evaluator` tree — migration framing that doesn't belong on the overview page.

## 🚀 New behavior

Version-free copy: Panda compiles with a Rust engine on the Oxc toolchain, parses each file once with no TypeScript program in the hot path, keeps builds fast and the install small, and the same engine powers the playground through WebAssembly.

## 💣 Is this a breaking change (Yes/No):

No. Docs only.
