### PR TITLE
fix(extractor): fold undefined properties, tighten parameter type literals

### DIFF
--- a/crates/pandacss_extractor/src/literal.rs
+++ b/crates/pandacss_extractor/src/literal.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{
     ChainElement, ChainExpression, ComputedMemberExpression, ConditionalExpression, Expression,
     LogicalExpression, LogicalOperator, ObjectExpression, ObjectPropertyKind, PropertyKey,
     PropertyKind, StaticMemberExpression, TaggedTemplateExpression, TemplateLiteral,
-    UnaryExpression, UnaryOperator,
+    IdentifierReference, UnaryExpression, UnaryOperator,
 };
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
@@ -224,7 +224,7 @@ pub(crate) fn expression_to_literal(
         Expression::ConditionalExpression(c) => eval_conditional(c, resolver),
         Expression::TemplateLiteral(t) => template_literal_to_literal(t, resolver),
 
-        Expression::Identifier(ident) => resolver?.resolve_identifier(ident),
+        Expression::Identifier(ident) => fold_identifier(ident, resolver),
         Expression::StaticMemberExpression(member) => static_member_to_literal(member, resolver),
         Expression::ComputedMemberExpression(member) => {
             computed_member_to_literal(member, resolver)
@@ -462,6 +462,27 @@ fn call_to_literal(
 
 fn number_as_key(value: f64) -> String {
     number_to_js_string(value)
+}
+
+/// Fold an identifier. Bound locals use [`Resolver`]; free global `undefined`
+/// is modeled as [`Literal::Null`] (same as array slots / `null == undefined`).
+/// A local binding named `undefined` that fails to resolve stays open.
+fn fold_identifier(
+    ident: &IdentifierReference<'_>,
+    resolver: Option<&Resolver<'_, '_>>,
+) -> Option<Literal> {
+    if let Some(r) = resolver {
+        if let Some(lit) = r.resolve_identifier(ident) {
+            return Some(lit);
+        }
+        if r.symbol_for_identifier(ident).is_some() {
+            return None;
+        }
+    }
+    if ident.name.as_str() == "undefined" {
+        return Some(Literal::Null);
+    }
+    None
 }
 
 fn eval_unary(u: &UnaryExpression<'_>, resolver: Option<&Resolver<'_, '_>>) -> Option<Literal> {

--- a/crates/pandacss_extractor/src/literal.rs
+++ b/crates/pandacss_extractor/src/literal.rs
@@ -7,9 +7,9 @@
 use oxc_ast::ast::{
     ArrayExpression, ArrayExpressionElement, BinaryExpression, BinaryOperator, CallExpression,
     ChainElement, ChainExpression, ComputedMemberExpression, ConditionalExpression, Expression,
-    LogicalExpression, LogicalOperator, ObjectExpression, ObjectPropertyKind, PropertyKey,
-    PropertyKind, StaticMemberExpression, TaggedTemplateExpression, TemplateLiteral,
-    IdentifierReference, UnaryExpression, UnaryOperator,
+    IdentifierReference, LogicalExpression, LogicalOperator, ObjectExpression, ObjectPropertyKind,
+    PropertyKey, PropertyKind, StaticMemberExpression, TaggedTemplateExpression, TemplateLiteral,
+    UnaryExpression, UnaryOperator,
 };
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};

--- a/crates/pandacss_extractor/src/scope.rs
+++ b/crates/pandacss_extractor/src/scope.rs
@@ -538,9 +538,7 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
             AstKind::TSEnumDeclaration(decl) => {
                 Some(literal_to_style_tree(resolve_enum_as_object(decl)))
             }
-            AstKind::FormalParameter(param) => {
-                resolve_param_as_type_literal(param).map(literal_to_style_tree)
-            }
+            AstKind::FormalParameter(param) => self.resolve_param_style_tree(param, symbol_id),
             _ => None,
         }
     }
@@ -565,7 +563,7 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
                 self.resolve_declarator(declarator, symbol_id)
             }
             AstKind::TSEnumDeclaration(decl) => Some(resolve_enum_as_object(decl)),
-            AstKind::FormalParameter(param) => resolve_param_as_type_literal(param),
+            AstKind::FormalParameter(param) => self.resolve_param(param, symbol_id),
             _ => None,
         }
     }
@@ -764,6 +762,38 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
             }
             BindingPattern::AssignmentPattern(_) => None,
         }
+    }
+
+    /// Resolve one symbol bound by a parameter against its `TSTypeLiteral`
+    /// annotation. A destructured parameter binds several symbols, so the
+    /// pattern is walked for the slice belonging to `target_symbol`.
+    fn resolve_param(
+        &self,
+        param: &oxc_ast::ast::FormalParameter<'a>,
+        target_symbol: SymbolId,
+    ) -> Option<Literal> {
+        let source = resolve_param_as_type_literal(param)?;
+        match &param.pattern {
+            BindingPattern::BindingIdentifier(id) => {
+                if id.symbol_id.get() != Some(target_symbol) {
+                    return None;
+                }
+                Some(source)
+            }
+            BindingPattern::ObjectPattern(_) | BindingPattern::ArrayPattern(_) => {
+                resolve_pattern_path(&param.pattern, &source, target_symbol, Some(self))
+            }
+            BindingPattern::AssignmentPattern(_) => None,
+        }
+    }
+
+    fn resolve_param_style_tree(
+        &self,
+        param: &oxc_ast::ast::FormalParameter<'a>,
+        target_symbol: SymbolId,
+    ) -> Option<StyleTree> {
+        self.resolve_param(param, target_symbol)
+            .map(literal_to_style_tree)
     }
 }
 
@@ -1060,6 +1090,10 @@ fn resolve_enum_as_object(decl: &oxc_ast::ast::TSEnumDeclaration<'_>) -> Literal
 
 /// Fold a parameter's `TSTypeLiteral` annotation into a synthetic object
 /// so `function f(x: { color: 'red' })` lets `x.color` resolve.
+///
+/// All-or-nothing: a member that doesn't fold to a literal makes the whole
+/// annotation unresolvable. A partial object would answer `undefined` for keys
+/// the type says nothing about, silently dropping the caller's real value.
 fn resolve_param_as_type_literal(param: &oxc_ast::ast::FormalParameter<'_>) -> Option<Literal> {
     let annotation = param.type_annotation.as_ref()?;
     let oxc_ast::ast::TSType::TSTypeLiteral(type_lit) = &annotation.type_annotation else {
@@ -1068,19 +1102,20 @@ fn resolve_param_as_type_literal(param: &oxc_ast::ast::FormalParameter<'_>) -> O
     let mut entries: Vec<(String, Literal)> = Vec::with_capacity(type_lit.members.len());
     for member in &type_lit.members {
         let oxc_ast::ast::TSSignature::TSPropertySignature(prop) = member else {
-            continue;
+            return None;
         };
+        // `{ color?: 'red' }` may be absent at runtime, so the literal type
+        // isn't a value.
+        if prop.optional {
+            return None;
+        }
         let key = match &prop.key {
             PropertyKey::StaticIdentifier(id) => id.name.to_string(),
             PropertyKey::StringLiteral(s) => s.value.to_string(),
-            _ => continue,
+            _ => return None,
         };
-        let Some(ann) = prop.type_annotation.as_ref() else {
-            continue;
-        };
-        if let Some(value) = ts_type_to_literal(&ann.type_annotation) {
-            entries.push((key, value));
-        }
+        let ann = prop.type_annotation.as_ref()?;
+        entries.push((key, ts_type_to_literal(&ann.type_annotation)?));
     }
     Some(Literal::Object(entries))
 }

--- a/crates/pandacss_extractor/tests/polish.rs
+++ b/crates/pandacss_extractor/tests/polish.rs
@@ -272,3 +272,41 @@ fn destructure_default_with_object_literal_value() {
         end: 127
     ");
 }
+
+#[test]
+fn an_undefined_property_does_not_block_the_object() {
+    // `width: cond ? '100%' : undefined` is everyday React. The undefined arm
+    // must fold like a null so the rest of the object still extracts.
+    let src = indoc! {r"
+        import { css } from '@panda/css';
+        export const cls = css({ color: 'red', width: undefined });
+    "};
+    assert_yaml_snapshot!(run(src).calls, @"
+    - category: css
+      name: css
+      alias: css
+      data:
+        - color: red
+          width: ~
+      span:
+        start: 53
+        end: 92
+    ");
+}
+
+#[test]
+fn a_local_binding_named_undefined_stays_open() {
+    // Shadowing `undefined` is legal in a function scope; a binding we cannot
+    // resolve must not be mistaken for the global.
+    let src = indoc! {r"
+        import { css } from '@panda/css';
+        export function paint(undefined) {
+          return css({ color: undefined });
+        }
+    "};
+    let calls = run(src).calls;
+    assert!(
+        calls.iter().all(|call| call.data.iter().flatten().count() == 0),
+        "shadowed undefined should stay unresolved: {calls:#?}"
+    );
+}

--- a/crates/pandacss_extractor/tests/polish.rs
+++ b/crates/pandacss_extractor/tests/polish.rs
@@ -139,6 +139,60 @@ fn function_param_without_annotation_still_drops() {
 }
 
 #[test]
+fn destructured_param_type_literal_binds_the_member_not_the_wrapper() {
+    let src = indoc! {r"
+        import { css } from '@panda/css';
+        function paint({ color }: { color: 'red' }) {
+          return css({ color });
+        }
+    "};
+    assert_yaml_snapshot!(run(src).calls, @r"
+    - category: css
+      name: css
+      alias: css
+      data:
+        - color: red
+      span:
+        start: 89
+        end: 103
+    ");
+}
+
+#[test]
+fn optional_type_literal_member_does_not_fold() {
+    // `{ color?: 'red' }` may be absent at runtime, so the literal type is
+    // not a value.
+    let src = indoc! {r"
+        import { css } from '@panda/css';
+        function paint(props: { color?: 'red' }) {
+          return css({ color: props.color });
+        }
+    "};
+    let calls = run(src).calls;
+    assert!(
+        calls.is_empty(),
+        "optional member shouldn't fold to its literal type: {calls:#?}"
+    );
+}
+
+#[test]
+fn unfoldable_type_literal_member_leaves_siblings_unresolved() {
+    // `children` doesn't fold, so the annotation can't answer for `color`
+    // either — a partial object would report the missing keys as undefined.
+    let src = indoc! {r"
+        import { css } from '@panda/css';
+        function paint({ color, children }: { color: 'red'; children: unknown }) {
+          return css({ color, content: children });
+        }
+    "};
+    let calls = run(src).calls;
+    assert!(
+        calls.is_empty(),
+        "partial type literal shouldn't resolve any member: {calls:#?}"
+    );
+}
+
+#[test]
 fn function_param_with_non_literal_type_drops() {
     // `string` type annotation — not a literal type. We need a
     // `TSLiteralType('red')` to extract a value; bare `string` provides
@@ -306,7 +360,9 @@ fn a_local_binding_named_undefined_stays_open() {
     "};
     let calls = run(src).calls;
     assert!(
-        calls.iter().all(|call| call.data.iter().flatten().count() == 0),
+        calls
+            .iter()
+            .all(|call| call.data.iter().flatten().count() == 0),
         "shadowed undefined should stay unresolved: {calls:#?}"
     );
 }

--- a/design-notes/literal-evaluator.md
+++ b/design-notes/literal-evaluator.md
@@ -54,7 +54,9 @@ Production `extract()` paths always supply a `Resolver`, which unlocks identifie
   (`cond && X` → `X`).
 - **`ConditionalExpression`** — Foldable test picks a branch; open test emits `Conditional` with both branches.
 - **`TemplateLiteral`** — Including tagged templates (tag identity ignored).
-- **`Identifier`** — Same-file `const` / `let` / `var` with literal initializer, never mutated.
+- **`Identifier`** — Same-file `const` / `let` / `var` with literal initializer, never mutated. Free
+  global `undefined` folds to `Null` (parity with array slots and `null == undefined`); a shadowed
+  local named `undefined` that doesn't resolve stays open.
 - **`StaticMemberExpression`, `ComputedMemberExpression`** — After the object folds to a literal.
 - **Computed object keys** — When the key expression folds to a string or number (including nested condition objects).
 - **Object / array destructuring** — Renames, computed binding keys, defaults, and rest.

--- a/packages/compiler/__tests__/transform-source/css.test.ts
+++ b/packages/compiler/__tests__/transform-source/css.test.ts
@@ -501,9 +501,7 @@ describe('compiler.transformSource: css', () => {
       {
         "changed": true,
         "bailed": false,
-        "code": "import { cx as __pcx } from '@pandacss-internal/css';
-      import { css } from '@panda/css'
-      export const cls = __pcx("color_red", css({ width: undefined }))",
+        "code": "export const cls = "color_red"",
       }
     `)
   })


### PR DESCRIPTION
Two independent extraction fixes. Both change what Panda can see at build time; neither changes CSS for code that already extracted.

## An `undefined` property no longer blocks the object

`width: cond ? '100%' : undefined` is everyday React, and the `undefined` arm kept the whole object out of extraction. The call survived to runtime:

```js
// before
import { cx as __pcx } from '@pandacss-internal/css'
import { css } from '@panda/css'
export const cls = __pcx("color_red", css({ width: undefined }))

// after
export const cls = "color_red"
```

A free `undefined` is now modelled as `Null`, the way array holes and `null == undefined` already are. A local binding named `undefined` still resolves through the scope table, so shadowing keeps the call dynamic.

## A parameter's type literal is all-or-nothing

Given `function Button(props: { color: 'red'; size?: 'sm' })`, the annotation was folded member by member and a member that didn't fold was skipped. Reading `props.size` then answered with the *type's* literal instead of the caller's real value — so Panda emitted classes for a variant the component never received.

Now every member folds or none does, optional members are rejected outright, and resolution runs against the symbol the parameter actually binds, so a destructured parameter answers for its own member rather than the wrapper. The cost is a few fewer folds; the gain is that a fold is never confidently wrong.

## Tests

Five new cases in `pandacss_extractor`:

- an `undefined` property folds and the rest of the object still extracts
- a local binding named `undefined` stays unresolved
- a destructured parameter binds its member, not the wrapper
- an optional member does not fold
- one unfoldable member leaves its siblings unresolved

Plus the compiler snapshot above, which is the user-visible half of the first fix.

## Verified locally

Against a binary built from a clean worktree of this branch:

- `cargo nextest run --workspace` — 2142 passed
- `pnpm --filter @pandacss/compiler test` — 533 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVzc85Z4YGMGwQz2FnEfFo
