### PR TITLE
fix(transform): keep .raw() a style object instead of a class string

### DIFF
--- a/.changeset/raw-style-composition.md
+++ b/.changeset/raw-style-composition.md
@@ -1,0 +1,16 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix `.raw()` handing back a class string instead of a style object, which broke anything composing those styles.
+
+```ts
+const button = cva({ base: { color: 'red' } })
+
+const styles = button.raw() // was "color_red", now { color: 'red' }
+
+css(styles, { color: 'blue' }) // merges, instead of dropping the base
+```
+
+Covers `css.raw()`, `recipe.raw()`, `pattern.raw()` and inline `cva`/`sva`. When an imported recipe's variants aren't
+known at build time, Panda now warns instead of returning a string.

--- a/crates/pandacss_extractor/src/calls.rs
+++ b/crates/pandacss_extractor/src/calls.rs
@@ -133,6 +133,7 @@ pub fn extract_calls(
         source_path: Some(std::path::PathBuf::from(path)),
         line_index: None,
         pattern_raw_transform: None,
+        recipe_raw_resolve: None,
     });
     let ctx = crate::VisitorContext::new(matched, config).with_resolver(&resolver);
     let line_index = crate::LineIndex::new(source);
@@ -391,6 +392,11 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                     value: resolver.token_call_value(call),
                 });
             }
+        }
+
+        // Records the fold so the transform can pin the styles at this site.
+        if let Some(resolver) = self.ctx.resolver {
+            resolver.resolve_imported_recipe_raw_call(call);
         }
 
         if let Some(resolved) = self.resolve_callee(call) {

--- a/crates/pandacss_extractor/src/cross_file.rs
+++ b/crates/pandacss_extractor/src/cross_file.rs
@@ -18,7 +18,8 @@ use std::sync::Mutex;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    BindingPattern, Declaration, ExportNamedDeclaration, Program, Statement, VariableDeclaration,
+    BindingPattern, Declaration, ExportNamedDeclaration, Expression, Program, Statement,
+    VariableDeclaration,
 };
 use oxc_parser::Parser;
 use oxc_resolver::{ResolveOptions, ResolverGeneric, TsconfigDiscovery};
@@ -30,15 +31,26 @@ use crate::Literal;
 use crate::literal::expression_to_literal;
 use crate::pure_fn::{OwnedPureFn, lower_callable_expr, lower_function};
 use crate::{
-    Matchers, TokenDictionary, collect_imports, imports::module_export_name, match_import_records,
-    scope::Resolver,
+    MatchCategory, MatchedImport, Matchers, TokenDictionary, collect_imports,
+    imports::module_export_name, match_import_records, scope::Resolver,
 };
 
-/// A folded named export: a style literal or a pure callable descriptor.
+/// A folded named export: a style literal, a pure callable, or an inline recipe.
 #[derive(Debug, Clone)]
 pub(crate) enum ExportEntry {
     Literal(Literal),
     PureFn(OwnedPureFn),
+    Recipe(ExportedRecipe),
+}
+
+/// `export const button = cva({ … })` — enough for an importer to resolve
+/// `button.raw(props)` without running the recipe.
+#[derive(Debug, Clone)]
+pub struct ExportedRecipe {
+    /// `"cva"` or `"sva"`.
+    pub factory: String,
+    /// The config object as authored.
+    pub config: Literal,
 }
 
 type FileExports = FxHashMap<String, ExportEntry>;
@@ -183,6 +195,7 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
             source_path: Some(path.to_path_buf()),
             line_index: None,
             pattern_raw_transform: None,
+            recipe_raw_resolve: None,
         });
 
         // Oxc returns a partial AST on parse errors — walk what we get.
@@ -191,6 +204,7 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
             path,
             self,
             &resolver,
+            &matched,
         ))
     }
 }
@@ -285,6 +299,7 @@ fn collect_exports(
     path: &Path,
     lookup: &dyn CrossFileLookup,
     resolver: &Resolver<'_, '_>,
+    matched: &[MatchedImport],
 ) -> FileExports {
     let mut exports = FxHashMap::default();
 
@@ -292,10 +307,40 @@ fn collect_exports(
         let Statement::ExportNamedDeclaration(decl) = stmt else {
             continue;
         };
-        collect_from_named(decl, path, lookup, resolver, &mut exports);
+        collect_from_named(decl, path, lookup, resolver, matched, &mut exports);
     }
 
     exports
+}
+
+/// `cva`/`sva` when `callee` is a Panda recipe factory imported in this file.
+fn recipe_factory_name(callee: &Expression<'_>, matched: &[MatchedImport]) -> Option<String> {
+    let Expression::Identifier(id) = callee.get_inner_expression() else {
+        return None;
+    };
+    matched
+        .iter()
+        .find(|import| {
+            import.alias == id.name.as_str()
+                && import.category == MatchCategory::Css
+                && matches!(import.name.as_str(), "cva" | "sva")
+        })
+        .map(|import| import.name.clone())
+}
+
+/// `export const button = cva({ … })` as a resolvable recipe.
+fn exported_recipe(
+    init: &Expression<'_>,
+    resolver: &Resolver<'_, '_>,
+    matched: &[MatchedImport],
+) -> Option<ExportedRecipe> {
+    let Expression::CallExpression(call) = init.get_inner_expression() else {
+        return None;
+    };
+    let factory = recipe_factory_name(&call.callee, matched)?;
+    let arg = call.arguments.first()?.as_expression()?;
+    let config = expression_to_literal(arg, Some(resolver))?;
+    Some(ExportedRecipe { factory, config })
 }
 
 fn collect_from_named(
@@ -303,11 +348,12 @@ fn collect_from_named(
     path: &Path,
     lookup: &dyn CrossFileLookup,
     resolver: &Resolver<'_, '_>,
+    matched: &[MatchedImport],
     out: &mut FileExports,
 ) {
     match &decl.declaration {
         Some(Declaration::VariableDeclaration(var)) => {
-            collect_from_var(var, resolver, out);
+            collect_from_var(var, resolver, matched, out);
             return;
         }
         Some(Declaration::FunctionDeclaration(func)) => {
@@ -349,6 +395,7 @@ fn collect_from_named(
 fn collect_from_var(
     var: &VariableDeclaration<'_>,
     resolver: &Resolver<'_, '_>,
+    matched: &[MatchedImport],
     out: &mut FileExports,
 ) {
     for declarator in &var.declarations {
@@ -357,7 +404,9 @@ fn collect_from_var(
         };
         match &declarator.id {
             BindingPattern::BindingIdentifier(id) => {
-                if let Some(value) = expression_to_literal(init, Some(resolver)) {
+                if let Some(recipe) = exported_recipe(init, resolver, matched) {
+                    out.insert(id.name.to_string(), ExportEntry::Recipe(recipe));
+                } else if let Some(value) = expression_to_literal(init, Some(resolver)) {
                     out.insert(id.name.to_string(), ExportEntry::Literal(value));
                 } else if let Some(pure_fn) = lower_callable_expr(init, Some(resolver)) {
                     out.insert(id.name.to_string(), ExportEntry::PureFn(pure_fn));

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -7,7 +7,10 @@ use crate::calls::{collect_calls_verbose, collect_calls_with_token_refs};
 use crate::jsx::{collect_jsx, collect_jsx_verbose};
 use std::cell::RefCell;
 
-use crate::scope::{PatternRawTransformCell, PatternRawTransformFn, Resolver};
+use crate::scope::{
+    PatternRawTransformCell, PatternRawTransformFn, RecipeRawResolveCell, RecipeRawResolveFn,
+    Resolver,
+};
 use crate::source_refs::StyleSourceRef;
 use crate::{
     Diagnostic, ExportInfo, ExtractedCall, ExtractedJsx, ExtractorConfig, ImportRecord, Literal,
@@ -19,6 +22,15 @@ use oxc_ast::ast::{Comment, Program};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use serde::Serialize;
+
+/// A folded `imported.raw(props)` call on an inline `cva`/`sva` exported from
+/// another file. The definition file precomputes its class strings, so the
+/// transform must rewrite this site to the styles it resolved to.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportedRecipeRawCall {
+    pub span: Span,
+    pub styles: Literal,
+}
 
 /// A resolved `token()` / `token.var()` call site: the referenced token path and
 /// its span. Token-call resolution lowers the call to its value/var, erasing the
@@ -86,6 +98,9 @@ pub struct ExtractUsage {
     /// Original-parse module and symbol facts used by source transforms.
     #[serde(skip)]
     pub module: ModuleFacts,
+    /// Folded `.raw(...)` calls on recipes imported from another file.
+    #[serde(skip)]
+    pub imported_recipe_raw_calls: Vec<ImportedRecipeRawCall>,
 }
 
 /// Verbose extraction result for on-demand tooling. Includes the same core
@@ -129,7 +144,7 @@ pub fn extract(source: &str, path: &str, config: &ExtractorConfig) -> ExtractUsa
     let _span =
         tracing::trace_span!(target: "extract", "extract", path = path, source_len = source.len())
             .entered();
-    let outcome = run_extract(source, path, config, None, false, false);
+    let outcome = run_extract(source, path, config, None, None, false, false);
     extract_usage(outcome)
 }
 
@@ -143,7 +158,31 @@ pub fn extract_for_transform(source: &str, path: &str, config: &ExtractorConfig)
         source_len = source.len()
     )
     .entered();
-    let outcome = run_extract(source, path, config, None, false, true);
+    let outcome = run_extract(source, path, config, None, None, false, true);
+    extract_usage(outcome)
+}
+
+/// [`extract_for_transform`] plus the project-supplied resolver for imported
+/// inline `cva`/`sva` recipes, so `imported.raw(props)` folds to its styles.
+pub fn extract_for_transform_with_recipe_resolver<R>(
+    source: &str,
+    path: &str,
+    config: &ExtractorConfig,
+    recipe_resolve: &mut R,
+) -> ExtractUsage
+where
+    R: FnMut(&str, &Literal, &Literal) -> Option<Literal>,
+{
+    let _span = tracing::trace_span!(
+        target: "extract",
+        "extract_for_transform",
+        path = path,
+        source_len = source.len()
+    )
+    .entered();
+    let erased: &mut RecipeRawResolveFn<'_> = recipe_resolve;
+    let cell: RecipeRawResolveCell<'_> = RefCell::new(erased);
+    let outcome = run_extract(source, path, config, None, Some(&cell), false, true);
     extract_usage(outcome)
 }
 
@@ -156,29 +195,48 @@ fn extract_usage(outcome: ExtractResult) -> ExtractUsage {
         exports: outcome.exports,
         dependencies: outcome.dependencies,
         module: outcome.module,
+        imported_recipe_raw_calls: outcome.imported_recipe_raw_calls,
     }
 }
 
-pub fn extract_with_pattern_raw_transform<F>(
+/// [`extract`] plus the project-supplied hooks that resolve `.raw(...)` calls:
+/// the pattern transform, and the resolver for imported inline `cva`/`sva`
+/// recipes. Both need config the extractor doesn't own.
+pub fn extract_with_raw_resolvers<P, R>(
     source: &str,
     path: &str,
     config: &ExtractorConfig,
-    pattern_transform: &mut F,
+    pattern_transform: Option<&mut P>,
+    recipe_resolve: &mut R,
 ) -> ExtractUsage
 where
-    F: FnMut(&str, &Literal) -> Result<Option<Literal>, Diagnostic>,
+    P: FnMut(&str, &Literal) -> Result<Option<Literal>, Diagnostic>,
+    R: FnMut(&str, &Literal, &Literal) -> Option<Literal>,
 {
+    let has_pattern_transform = pattern_transform.is_some();
     let _span = tracing::trace_span!(
         target: "extract",
         "extract",
         path = path,
         source_len = source.len(),
-        pattern_raw_transform = true
+        pattern_raw_transform = has_pattern_transform
     )
     .entered();
-    let erased: &mut PatternRawTransformFn<'_> = pattern_transform;
-    let transform_cell: PatternRawTransformCell<'_> = RefCell::new(erased);
-    let outcome = run_extract(source, path, config, Some(&transform_cell), false, false);
+    let pattern_cell = pattern_transform.map(|transform| {
+        let erased: &mut PatternRawTransformFn<'_> = transform;
+        RefCell::new(erased)
+    });
+    let recipe_erased: &mut RecipeRawResolveFn<'_> = recipe_resolve;
+    let recipe_cell: RecipeRawResolveCell<'_> = RefCell::new(recipe_erased);
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        pattern_cell.as_ref(),
+        Some(&recipe_cell),
+        false,
+        false,
+    );
     extract_usage(outcome)
 }
 
@@ -186,7 +244,7 @@ where
 pub fn extract_debug(source: &str, path: &str, config: &ExtractorConfig) -> ExtractDebugResult {
     let _span = tracing::trace_span!(target: "extract", "extract_debug", path = path, source_len = source.len())
         .entered();
-    let outcome = run_extract(source, path, config, None, false, true);
+    let outcome = run_extract(source, path, config, None, None, false, true);
     ExtractDebugResult {
         imports: outcome.module.imports,
         matched: outcome.matched,
@@ -205,7 +263,7 @@ pub fn extract_verbose(source: &str, path: &str, config: &ExtractorConfig) -> Ex
         source_len = source.len()
     )
     .entered();
-    let outcome = run_extract(source, path, config, None, true, false);
+    let outcome = run_extract(source, path, config, None, None, true, false);
     ExtractVerboseResult {
         calls: outcome.calls,
         jsx: outcome.jsx,
@@ -228,6 +286,7 @@ struct ExtractResult {
     style_source_refs: Vec<StyleSourceRef>,
     exports: ExportInfo,
     dependencies: Vec<String>,
+    imported_recipe_raw_calls: Vec<ImportedRecipeRawCall>,
 }
 
 fn match_file_imports(
@@ -254,6 +313,7 @@ fn run_extract<'cb>(
     path: &str,
     config: &ExtractorConfig,
     pattern_raw_transform: Option<&'cb PatternRawTransformCell<'cb>>,
+    recipe_raw_resolve: Option<&'cb RecipeRawResolveCell<'cb>>,
     verbose: bool,
     retain_transform_facts: bool,
 ) -> ExtractResult {
@@ -319,6 +379,7 @@ fn run_extract<'cb>(
             style_source_refs: Vec::new(),
             exports,
             dependencies: Vec::new(),
+            imported_recipe_raw_calls: Vec::new(),
         };
     }
 
@@ -337,6 +398,7 @@ fn run_extract<'cb>(
             source_path: Some(std::path::PathBuf::from(path)),
             line_index: Some(&line_index),
             pattern_raw_transform,
+            recipe_raw_resolve,
         })
     };
     let ctx = VisitorContext::new(&matched, config).with_resolver(&resolver);
@@ -403,6 +465,7 @@ fn run_extract<'cb>(
     token_refs.extend(resolver.take_token_refs());
     let token_refs = dedupe_token_refs(token_refs);
     let dependencies = resolver.take_cross_file_deps();
+    let imported_recipe_raw_calls = resolver.take_imported_recipe_raw_calls();
     let module = if retain_transform_facts {
         let local_call_bindings = if calls.is_empty() {
             Vec::new()
@@ -435,6 +498,7 @@ fn run_extract<'cb>(
         style_source_refs,
         exports,
         dependencies,
+        imported_recipe_raw_calls,
     }
 }
 
@@ -464,6 +528,7 @@ pub fn analyze_module(source: &str, path: &str) -> ModuleFacts {
         source_path: None,
         line_index: None,
         pattern_raw_transform: None,
+        recipe_raw_resolve: None,
     });
     let import_bindings = resolver.import_binding_facts(&imports);
     ModuleFacts {

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -53,6 +53,9 @@ pub struct ImportBindingFacts {
 pub struct ModuleFacts {
     pub imports: Vec<ImportRecord>,
     pub import_bindings: Vec<ImportBindingFacts>,
+    /// Local bindings initialized from a collected Panda call site.
+    /// Populated only by [`extract_for_transform`].
+    pub local_call_bindings: Vec<crate::LocalCallBinding>,
     /// Safe helper-import insertion point after a hashbang/directive prologue.
     pub after_directives: u32,
     /// Whether `import_bindings` came from an Oxc semantic pass.
@@ -299,6 +302,7 @@ fn run_extract<'cb>(
             ModuleFacts {
                 imports,
                 import_bindings: Vec::new(),
+                local_call_bindings: Vec::new(),
                 after_directives,
                 symbols_resolved: false,
             }
@@ -400,9 +404,20 @@ fn run_extract<'cb>(
     let token_refs = dedupe_token_refs(token_refs);
     let dependencies = resolver.take_cross_file_deps();
     let module = if retain_transform_facts {
+        let local_call_bindings = if calls.is_empty() {
+            Vec::new()
+        } else {
+            let init_spans = calls.iter().map(|call| call.span).collect();
+            crate::local_bindings::collect_local_call_bindings(
+                &parser_return.program,
+                resolver.semantic(),
+                &init_spans,
+            )
+        };
         ModuleFacts {
             import_bindings: resolver.import_binding_facts(&imports),
             imports,
+            local_call_bindings,
             after_directives,
             symbols_resolved: true,
         }
@@ -454,6 +469,7 @@ pub fn analyze_module(source: &str, path: &str) -> ModuleFacts {
     ModuleFacts {
         imports,
         import_bindings,
+        local_call_bindings: Vec::new(),
         after_directives,
         symbols_resolved: true,
     }

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -165,6 +165,7 @@ pub fn extract_jsx(
         source_path: Some(std::path::PathBuf::from(path)),
         line_index: None,
         pattern_raw_transform: None,
+        recipe_raw_resolve: None,
     });
     let ctx = VisitorContext::new(matched, config).with_resolver(&resolver);
     let mut jsx = collect_jsx(&parser_return.program, &ctx, true);

--- a/crates/pandacss_extractor/src/lib.rs
+++ b/crates/pandacss_extractor/src/lib.rs
@@ -22,6 +22,7 @@ mod imports;
 mod jsx;
 mod jsx_react_runtime;
 mod literal;
+mod local_bindings;
 mod matcher;
 mod pure_fn;
 mod scope;
@@ -49,6 +50,7 @@ pub use imports::{
     ImportKind, ImportRecord, ImportScanResult, ImportSpecifier, ImportSpecifierKind,
     ScanImportsOptions, scan_imports, scan_imports_with,
 };
+pub use local_bindings::{LocalBindingCall, LocalCallBinding, LocalDeclarationKind};
 // Internal helpers that take Oxc-shaped inputs — kept out of the public
 // surface so consumers don't accidentally couple to oxc_ast / oxc_diagnostics.
 pub use cross_file::CrossFileResolver;

--- a/crates/pandacss_extractor/src/lib.rs
+++ b/crates/pandacss_extractor/src/lib.rs
@@ -42,9 +42,10 @@ pub use design_system_imports::{
     collect_design_system_imports_for_packages, selection_from_import_records,
 };
 pub use extract::{
-    ExtractDebugResult, ExtractUsage, ExtractVerboseResult, ImportBindingFacts, ModuleFacts,
-    TokenRef, analyze_module, extract, extract_debug, extract_for_transform, extract_verbose,
-    extract_with_pattern_raw_transform,
+    ExtractDebugResult, ExtractUsage, ExtractVerboseResult, ImportBindingFacts,
+    ImportedRecipeRawCall, ModuleFacts, TokenRef, analyze_module, extract, extract_debug,
+    extract_for_transform, extract_for_transform_with_recipe_resolver, extract_verbose,
+    extract_with_raw_resolvers,
 };
 pub use imports::{
     ImportKind, ImportRecord, ImportScanResult, ImportSpecifier, ImportSpecifierKind,

--- a/crates/pandacss_extractor/src/literal.rs
+++ b/crates/pandacss_extractor/src/literal.rs
@@ -457,6 +457,7 @@ fn call_to_literal(
     resolver
         .resolve_token_call(call)
         .or_else(|| resolver.resolve_raw_style_call(call))
+        .or_else(|| resolver.resolve_imported_recipe_raw_call(call))
         .or_else(|| resolver.resolve_pure_call(call))
 }
 

--- a/crates/pandacss_extractor/src/local_bindings.rs
+++ b/crates/pandacss_extractor/src/local_bindings.rs
@@ -1,0 +1,215 @@
+//! Same-file bindings whose initializer is a collected Panda call site.
+//!
+//! Transform-only IR: spans + compact expression facts, no Oxc nodes, so the
+//! allocator can drop after extraction. Join key to [`crate::ExtractedCall`] is
+//! `init_span` (byte-identical to the call expression span).
+
+use oxc_ast::AstKind;
+use oxc_ast::ast::{
+    BindingPattern, Expression, Program, VariableDeclaration, VariableDeclarationKind,
+    VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_semantic::Semantic;
+use oxc_span::GetSpan;
+use oxc_syntax::node::NodeId;
+use rustc_hash::FxHashSet;
+
+use crate::transform_facts::{ExpressionFacts, expression_facts};
+use crate::{Span, span_from_oxc};
+
+/// A same-file binding initialized by a Panda call, plus every resolved reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalCallBinding {
+    pub local: String,
+    /// Initializer call span — joins to [`crate::ExtractedCall::span`].
+    pub init_span: Span,
+    pub declaration: LocalDeclarationKind,
+    /// Plain `binding(...)` call sites, in source order.
+    pub calls: Vec<LocalBindingCall>,
+    /// Direct `binding.raw(...)` call sites, in source order. Also counted in
+    /// `has_other_references`, so existing consumers stay conservative.
+    pub raw_calls: Vec<LocalBindingCall>,
+    /// A `.raw` access that is not a direct call — a bare `binding.raw`
+    /// reference, or `binding?.raw(…)`. The value escapes, so a caller that
+    /// rewrites `raw` semantics cannot prove it has seen every use.
+    pub has_opaque_raw_access: bool,
+    /// Any reference that is not a plain call (`binding.raw`, value use, export, …).
+    pub has_other_references: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalDeclarationKind {
+    Const,
+    Let,
+    Var,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalBindingCall {
+    /// Whole `binding(...)` expression — the rewrite range.
+    pub span: Span,
+    /// One entry per argument. `None` is a spread element.
+    pub args: Vec<Option<ExpressionFacts>>,
+}
+
+/// Collect local bindings initialized from `init_spans` (Panda call spans).
+#[must_use]
+pub(crate) fn collect_local_call_bindings<'a>(
+    program: &Program<'a>,
+    semantic: &Semantic<'a>,
+    init_spans: &FxHashSet<Span>,
+) -> Vec<LocalCallBinding> {
+    if init_spans.is_empty() {
+        return Vec::new();
+    }
+    let mut collector = BindingCollector {
+        semantic,
+        init_spans,
+        out: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.out
+}
+
+struct BindingCollector<'a, 's> {
+    semantic: &'s Semantic<'a>,
+    init_spans: &'s FxHashSet<Span>,
+    out: Vec<LocalCallBinding>,
+}
+
+impl<'a> BindingCollector<'a, '_> {
+    fn consider(&mut self, declarator: &VariableDeclarator<'a>, kind: LocalDeclarationKind) {
+        let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+            return;
+        };
+        let Some(symbol_id) = id.symbol_id.get() else {
+            return;
+        };
+        if self.semantic.scoping().symbol_is_mutated(symbol_id) {
+            return;
+        }
+        let Some(init) = declarator.init.as_ref() else {
+            return;
+        };
+        let init_span = span_from_oxc(init.get_inner_expression().span());
+        if !self.init_spans.contains(&init_span) {
+            return;
+        }
+
+        let mut calls = Vec::new();
+        let mut raw_calls = Vec::new();
+        let mut has_opaque_raw_access = false;
+        let mut has_other_references = false;
+        for reference in self.semantic.symbol_references(symbol_id) {
+            let node_id = reference.node_id();
+            let ref_span = span_from_oxc(self.semantic.nodes().get_node(node_id).kind().span());
+            match classify_reference(self.semantic, node_id, ref_span) {
+                ReferenceKind::PlainCall(call) => calls.push(call),
+                ReferenceKind::RawCall(call) => {
+                    raw_calls.push(call);
+                    has_other_references = true;
+                }
+                ReferenceKind::OpaqueRawAccess => {
+                    has_opaque_raw_access = true;
+                    has_other_references = true;
+                }
+                ReferenceKind::Other => has_other_references = true,
+            }
+        }
+        calls.sort_by_key(|call| call.span.start);
+        raw_calls.sort_by_key(|call| call.span.start);
+
+        self.out.push(LocalCallBinding {
+            local: id.name.to_string(),
+            init_span,
+            declaration: kind,
+            calls,
+            raw_calls,
+            has_opaque_raw_access,
+            has_other_references,
+        });
+    }
+}
+
+impl<'a> Visit<'a> for BindingCollector<'a, '_> {
+    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
+        let Some(kind) = declaration_kind(decl.kind) else {
+            walk::walk_variable_declaration(self, decl);
+            return;
+        };
+        for declarator in &decl.declarations {
+            self.consider(declarator, kind);
+        }
+        walk::walk_variable_declaration(self, decl);
+    }
+}
+
+fn declaration_kind(kind: VariableDeclarationKind) -> Option<LocalDeclarationKind> {
+    match kind {
+        VariableDeclarationKind::Const => Some(LocalDeclarationKind::Const),
+        VariableDeclarationKind::Let => Some(LocalDeclarationKind::Let),
+        VariableDeclarationKind::Var => Some(LocalDeclarationKind::Var),
+        VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing => None,
+    }
+}
+
+enum ReferenceKind {
+    PlainCall(LocalBindingCall),
+    RawCall(LocalBindingCall),
+    OpaqueRawAccess,
+    Other,
+}
+
+fn classify_reference(semantic: &Semantic<'_>, node_id: NodeId, ref_span: Span) -> ReferenceKind {
+    match semantic.nodes().parent_kind(node_id) {
+        AstKind::CallExpression(call) => {
+            let callee_is_ref = matches!(
+                call.callee.get_inner_expression(),
+                Expression::Identifier(id) if span_from_oxc(id.span) == ref_span
+            );
+            if !callee_is_ref || call.optional || call.type_arguments.is_some() {
+                return ReferenceKind::Other;
+            }
+            ReferenceKind::PlainCall(binding_call(call))
+        }
+        AstKind::StaticMemberExpression(member) => {
+            if member.property.name != "raw"
+                || span_from_oxc(member.object.get_inner_expression().span()) != ref_span
+            {
+                return ReferenceKind::Other;
+            }
+            if member.optional {
+                return ReferenceKind::OpaqueRawAccess;
+            }
+            match semantic
+                .nodes()
+                .parent_kind(semantic.nodes().parent_id(node_id))
+            {
+                AstKind::CallExpression(call)
+                    if !call.optional
+                        && call.type_arguments.is_none()
+                        && span_from_oxc(call.callee.get_inner_expression().span())
+                            == span_from_oxc(member.span) =>
+                {
+                    ReferenceKind::RawCall(binding_call(call))
+                }
+                // `const fn = styles.raw`, `styles.raw?.(…)`, `f(styles.raw)` —
+                // the function escapes, so its semantics must not change.
+                _ => ReferenceKind::OpaqueRawAccess,
+            }
+        }
+        _ => ReferenceKind::Other,
+    }
+}
+
+fn binding_call(call: &oxc_ast::ast::CallExpression<'_>) -> LocalBindingCall {
+    LocalBindingCall {
+        span: span_from_oxc(call.span),
+        args: call
+            .arguments
+            .iter()
+            .map(|arg| arg.as_expression().map(expression_facts))
+            .collect(),
+    }
+}

--- a/crates/pandacss_extractor/src/scope.rs
+++ b/crates/pandacss_extractor/src/scope.rs
@@ -170,6 +170,10 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
             .collect()
     }
 
+    pub(crate) fn semantic(&self) -> &Semantic<'a> {
+        &self.semantic
+    }
+
     pub(crate) fn import_binding_facts(&self, imports: &[ImportRecord]) -> Vec<ImportBindingFacts> {
         imports
             .iter()

--- a/crates/pandacss_extractor/src/scope.rs
+++ b/crates/pandacss_extractor/src/scope.rs
@@ -31,11 +31,19 @@ use crate::pure_fn::{
 use crate::style_tree::{
     StyleTree, expression_to_style_tree, literal_to_style_tree, project_literal,
 };
-use crate::{ImportBindingFacts, ImportRecord, ImportSpecifierKind, Literal, TokenRef};
+use crate::{
+    ImportBindingFacts, ImportRecord, ImportSpecifierKind, ImportedRecipeRawCall, Literal, TokenRef,
+};
 
 pub(crate) type PatternRawTransformFn<'a> =
     dyn FnMut(&str, &Literal) -> Result<Option<Literal>, crate::Diagnostic> + 'a;
 pub(crate) type PatternRawTransformCell<'a> = RefCell<&'a mut PatternRawTransformFn<'a>>;
+
+/// Resolve an imported recipe's `.raw(props)` — `(factory, config, props)`.
+/// Supplied by the project layer, which owns the config needed to merge styles.
+pub(crate) type RecipeRawResolveFn<'a> =
+    dyn FnMut(&str, &Literal, &Literal) -> Option<Literal> + 'a;
+pub(crate) type RecipeRawResolveCell<'a> = RefCell<&'a mut RecipeRawResolveFn<'a>>;
 
 /// Per-file symbol/scope index plus a memo of resolved literal values. Also
 /// resolves Panda `token()` / `token.var()` calls through the supplied
@@ -59,10 +67,12 @@ pub(crate) struct Resolver<'a, 'cb> {
     line_index: Option<&'a crate::LineIndex<'a>>,
     diagnostics: RefCell<Vec<crate::Diagnostic>>,
     token_refs: RefCell<Vec<TokenRef>>,
+    imported_recipe_raw_calls: RefCell<Vec<ImportedRecipeRawCall>>,
     /// Resolved paths of cross-file modules read during this file's extraction,
     /// surfaced as transform build dependencies for watch invalidation.
     cross_file_deps: RefCell<FxHashSet<PathBuf>>,
     pattern_raw_transform: Option<&'cb PatternRawTransformCell<'cb>>,
+    recipe_raw_resolve: Option<&'cb RecipeRawResolveCell<'cb>>,
 }
 
 struct TokenCallResolution {
@@ -107,6 +117,7 @@ pub(crate) struct ResolverBuildInput<'a, 'cb> {
     pub source_path: Option<PathBuf>,
     pub line_index: Option<&'a crate::LineIndex<'a>>,
     pub pattern_raw_transform: Option<&'cb PatternRawTransformCell<'cb>>,
+    pub recipe_raw_resolve: Option<&'cb RecipeRawResolveCell<'cb>>,
 }
 
 impl<'a, 'cb> Resolver<'a, 'cb> {
@@ -130,6 +141,7 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
             source_path,
             line_index,
             pattern_raw_transform,
+            recipe_raw_resolve,
         } = input;
         let semantic = SemanticBuilder::new().build(program).semantic;
         Self {
@@ -145,8 +157,10 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
             line_index,
             diagnostics: RefCell::default(),
             token_refs: RefCell::default(),
+            imported_recipe_raw_calls: RefCell::default(),
             cross_file_deps: RefCell::default(),
             pattern_raw_transform,
+            recipe_raw_resolve,
         }
     }
 
@@ -160,6 +174,11 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
     /// (`usages`), not the build path.
     pub(crate) fn take_token_refs(&self) -> Vec<TokenRef> {
         std::mem::take(&mut self.token_refs.borrow_mut())
+    }
+
+    /// Folded `imported.raw(props)` call sites, for the transform to rewrite.
+    pub(crate) fn take_imported_recipe_raw_calls(&self) -> Vec<ImportedRecipeRawCall> {
+        std::mem::take(&mut self.imported_recipe_raw_calls.borrow_mut())
     }
 
     /// Resolved cross-file module paths read during extraction.
@@ -295,7 +314,7 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
         self.resolve_import_entry(symbol_id)
             .and_then(|entry| match entry {
                 ExportEntry::PureFn(func) => Some(func),
-                ExportEntry::Literal(_) => None,
+                ExportEntry::Literal(_) | ExportEntry::Recipe(_) => None,
             })
     }
 
@@ -578,7 +597,8 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
     fn resolve_import_symbol(&self, symbol_id: SymbolId) -> Option<Literal> {
         match self.resolve_import_entry(symbol_id)? {
             ExportEntry::Literal(lit) => Some(lit),
-            ExportEntry::PureFn(_) => None,
+            // A recipe is a function, not a value — only `.raw(props)` resolves it.
+            ExportEntry::PureFn(_) | ExportEntry::Recipe(_) => None,
         }
     }
 
@@ -646,6 +666,78 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
                 None
             }
         }
+    }
+
+    fn resolve_recipe_raw_styles(
+        &self,
+        call: &CallExpression<'_>,
+        recipe: &crate::cross_file::ExportedRecipe,
+        resolve: &RecipeRawResolveCell<'_>,
+    ) -> Option<Literal> {
+        if call.arguments.len() > 1 {
+            return None;
+        }
+        let props = match call.arguments.first() {
+            None => Literal::Object(Vec::new()),
+            Some(arg) => expression_to_literal(arg.as_expression()?, Some(self))?,
+        };
+        (resolve.borrow_mut())(&recipe.factory, &recipe.config, &props)
+    }
+
+    /// The definition file precomputes its class strings independently, so a
+    /// `.raw` we can't resolve here would return one at runtime.
+    fn report_dynamic_imported_raw(&self, call: &CallExpression<'_>, name: &str) {
+        let span = crate::span_from_oxc(call.span);
+        let mut diagnostic = crate::Diagnostic::warning(
+            crate::diagnostic_codes::IMPORTED_RECIPE_RAW_DYNAMIC,
+            format!(
+                "`{name}.raw(...)` needs statically known variants because `{name}` is defined in \
+                 another file. It will return a class string, not a style object. Pass literal \
+                 variant values, or move the composition into the file that defines `{name}`."
+            ),
+        );
+        diagnostic.span = Some(span);
+        diagnostic.location = self
+            .line_index
+            .map(|idx| idx.locate_range(span.start, span.end));
+        self.diagnostics.borrow_mut().push(diagnostic);
+    }
+
+    /// Fold `button.raw(props)` where `button` is an imported inline
+    /// `cva`/`sva`. The definition file precomputes its class strings, so its
+    /// runtime `raw` would return a string — resolving here keeps the object.
+    pub(crate) fn resolve_imported_recipe_raw_call(
+        &self,
+        call: &CallExpression<'_>,
+    ) -> Option<Literal> {
+        let resolve = self.recipe_raw_resolve?;
+        let (object, path) = flatten_static_member_path(&call.callee)?;
+        if path.as_slice() != ["raw"] || !self.is_import_binding(object) {
+            return None;
+        }
+        // Panda's own `.raw` surfaces are handled by `resolve_raw_style_call`.
+        if self.aliases.contains_key(object.name.as_str()) {
+            return None;
+        }
+
+        let symbol_id = self.symbol_for_identifier(object)?;
+        let ExportEntry::Recipe(recipe) = self.resolve_import_entry(symbol_id)? else {
+            return None;
+        };
+
+        let Some(styles) = self.resolve_recipe_raw_styles(call, &recipe, resolve) else {
+            self.report_dynamic_imported_raw(call, object.name.as_str());
+            return None;
+        };
+        let span = crate::span_from_oxc(call.span);
+        let mut folded = self.imported_recipe_raw_calls.borrow_mut();
+        if !folded.iter().any(|call| call.span == span) {
+            folded.push(ImportedRecipeRawCall {
+                span,
+                styles: styles.clone(),
+            });
+        }
+        Some(styles)
     }
 
     /// [`StyleTree`] for a `.raw(...)` arg. Pattern transform: project → transform → rehydrate.

--- a/crates/pandacss_extractor/src/template_styles.rs
+++ b/crates/pandacss_extractor/src/template_styles.rs
@@ -630,6 +630,7 @@ fn parse_expression_literal(
             source_path: Some(std::path::PathBuf::from(context.path)),
             line_index: None,
             pattern_raw_transform: None,
+            recipe_raw_resolve: None,
         })
     });
     for stmt in parser_return.program.body.iter().rev() {

--- a/crates/pandacss_extractor/src/transform_facts.rs
+++ b/crates/pandacss_extractor/src/transform_facts.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::{
     CallExpression, Expression, LogicalOperator, ObjectExpression, ObjectPropertyKind, PropertyKey,
+    PropertyKind,
 };
 use oxc_span::GetSpan;
 use oxc_syntax::precedence::{GetPrecedence, Precedence};
@@ -37,6 +38,8 @@ pub struct ExpressionFacts {
     pub array_append_at: Option<u32>,
     pub array_has_elements: bool,
     pub parenthesize_for_addition: bool,
+    /// Wrap when re-emitted as the left operand of `&&` (e.g. `a || b`, `a ? b : c`).
+    pub parenthesize_for_logical_and: bool,
 }
 
 impl Default for ExpressionFacts {
@@ -53,6 +56,7 @@ impl Default for ExpressionFacts {
             array_append_at: None,
             array_has_elements: false,
             parenthesize_for_addition: false,
+            parenthesize_for_logical_and: false,
         }
     }
 }
@@ -89,6 +93,8 @@ pub struct ObjectPropertyFacts {
     pub key: Option<String>,
     pub value: Option<ExpressionFacts>,
     pub spread_argument: Option<ExpressionFacts>,
+    /// `{ k() {} }` / `{ get k() {} }` — value is not a re-emittable expression.
+    pub is_accessor_or_method: bool,
 }
 
 impl Default for ObjectPropertyFacts {
@@ -98,6 +104,7 @@ impl Default for ObjectPropertyFacts {
             key: None,
             value: None,
             spread_argument: None,
+            is_accessor_or_method: false,
         }
     }
 }
@@ -115,6 +122,7 @@ pub(crate) fn expression_facts(expression: &Expression<'_>) -> ExpressionFacts {
     let mut facts = ExpressionFacts {
         span: span_from_oxc(expression.span()),
         parenthesize_for_addition: needs_addition_parentheses(expression),
+        parenthesize_for_logical_and: needs_logical_and_parentheses(expression),
         ..Default::default()
     };
 
@@ -197,12 +205,15 @@ pub(crate) fn object_facts(object: &ObjectExpression<'_>) -> ObjectFacts {
                     key: static_key(&property.key),
                     value: Some(expression_facts(&property.value)),
                     spread_argument: None,
+                    is_accessor_or_method: property.method
+                        || !matches!(property.kind, PropertyKind::Init),
                 },
                 ObjectPropertyKind::SpreadProperty(spread) => ObjectPropertyFacts {
                     span: span_from_oxc(spread.span),
                     key: None,
                     value: None,
                     spread_argument: Some(expression_facts(&spread.argument)),
+                    is_accessor_or_method: false,
                 },
             })
             .collect(),
@@ -227,6 +238,14 @@ fn needs_addition_parentheses(expression: &Expression<'_>) -> bool {
     }
     let inner = expression.get_inner_expression();
     expression_precedence(inner).is_some_and(|precedence| precedence < Precedence::Add)
+}
+
+fn needs_logical_and_parentheses(expression: &Expression<'_>) -> bool {
+    if matches!(expression, Expression::ParenthesizedExpression(_)) {
+        return false;
+    }
+    let inner = expression.get_inner_expression();
+    expression_precedence(inner).is_some_and(|precedence| precedence < Precedence::LogicalAnd)
 }
 
 fn expression_precedence(expression: &Expression<'_>) -> Option<Precedence> {

--- a/crates/pandacss_extractor/tests/local_bindings.rs
+++ b/crates/pandacss_extractor/tests/local_bindings.rs
@@ -1,0 +1,230 @@
+//! Local call-binding facts for transform (`extract_for_transform` only).
+
+use crate::common::panda_config;
+use indoc::indoc;
+use pandacss_extractor::{ExpressionKind, LocalDeclarationKind, extract, extract_for_transform};
+
+#[test]
+fn collects_plain_calls_for_cva_binding() {
+    let source = indoc! {r"
+        import { cva } from '@panda/css'
+        const recipe = cva({ base: { color: 'red' }, variants: { on: { true: { opacity: '0.5' } } } })
+        export const a = recipe({ on: x })
+        export const b = recipe()
+    "};
+    let result = extract_for_transform(source, "fixture.tsx", &panda_config());
+    assert_eq!(result.module.local_call_bindings.len(), 1);
+    let binding = &result.module.local_call_bindings[0];
+    assert_eq!(binding.local, "recipe");
+    assert_eq!(binding.declaration, LocalDeclarationKind::Const);
+    assert!(!binding.has_other_references);
+    assert_eq!(binding.calls.len(), 2);
+    assert_eq!(binding.init_span, result.calls[0].span);
+    assert_eq!(binding.calls[0].args.len(), 1);
+    let arg = binding.calls[0].args[0].as_ref().expect("object arg");
+    assert_eq!(arg.kind, ExpressionKind::Object);
+    assert_eq!(binding.calls[1].args.len(), 0);
+}
+
+#[test]
+fn shadowed_binding_is_not_collected_as_call() {
+    let source = indoc! {r"
+        import { cva } from '@panda/css'
+        const recipe = cva({ base: { color: 'red' } })
+        function f(recipe) {
+          return recipe({ color: 'blue' })
+        }
+    "};
+    let result = extract_for_transform(source, "fixture.tsx", &panda_config());
+    let binding = result
+        .module
+        .local_call_bindings
+        .iter()
+        .find(|b| b.local == "recipe")
+        .expect("outer binding");
+    assert!(binding.calls.is_empty());
+    assert!(!binding.has_other_references);
+}
+
+#[test]
+fn rename_marks_other_references() {
+    let source = indoc! {r"
+        import { cva } from '@panda/css'
+        const recipe = cva({ base: { color: 'red' } })
+        const other = recipe
+        export const cls = other({})
+    "};
+    let result = extract_for_transform(source, "fixture.tsx", &panda_config());
+    let binding = result
+        .module
+        .local_call_bindings
+        .iter()
+        .find(|b| b.local == "recipe")
+        .expect("binding");
+    assert!(binding.calls.is_empty());
+    assert!(binding.has_other_references);
+}
+
+#[test]
+fn member_raw_call_is_other_reference() {
+    let source = indoc! {r"
+        import { cva } from '@panda/css'
+        const recipe = cva({ base: { color: 'red' } })
+        export const raw = recipe.raw({ color: 'blue' })
+        export const cls = recipe({})
+    "};
+    let result = extract_for_transform(source, "fixture.tsx", &panda_config());
+    let binding = result
+        .module
+        .local_call_bindings
+        .iter()
+        .find(|b| b.local == "recipe")
+        .expect("binding");
+    assert_eq!(binding.calls.len(), 1);
+    assert!(binding.has_other_references);
+}
+
+#[test]
+fn mutated_let_binding_is_skipped() {
+    let source = indoc! {r"
+        import { cva } from '@panda/css'
+        let recipe = cva({ base: { color: 'red' } })
+        recipe = cva({ base: { color: 'blue' } })
+        export const cls = recipe({})
+    "};
+    let result = extract_for_transform(source, "fixture.tsx", &panda_config());
+    assert!(
+        result
+            .module
+            .local_call_bindings
+            .iter()
+            .all(|b| b.local != "recipe")
+    );
+}
+
+#[test]
+fn extract_hot_path_keeps_local_bindings_empty() {
+    let source = indoc! {r"
+        import { cva } from '@panda/css'
+        const recipe = cva({ base: { color: 'red' } })
+        export const cls = recipe({})
+    "};
+    let result = extract(source, "fixture.tsx", &panda_config());
+    assert!(result.module.local_call_bindings.is_empty());
+}
+
+#[test]
+fn collects_raw_calls_on_a_local_cva_binding() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const a = styles.raw({ size: 'sm' });
+        export const b = styles({ size: 'lg' });
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert_eq!(binding.local, "styles");
+    assert_eq!(binding.calls.len(), 1, "plain call");
+    assert_eq!(binding.raw_calls.len(), 1, "raw call");
+    assert_eq!(binding.raw_calls[0].args.len(), 1);
+    assert!(
+        binding.has_other_references,
+        ".raw still counts as a non-plain reference"
+    );
+}
+
+#[test]
+fn a_bare_raw_reference_is_not_a_raw_call() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const fn = styles.raw;
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert!(binding.raw_calls.is_empty());
+    assert!(
+        binding.has_opaque_raw_access,
+        "the function escapes as a value"
+    );
+    assert!(binding.has_other_references);
+}
+
+#[test]
+fn a_non_raw_member_call_is_not_a_raw_call() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const keys = styles.splitVariantProps({ size: 'sm' });
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert!(binding.raw_calls.is_empty());
+    assert!(binding.has_other_references);
+}
+
+#[test]
+fn an_optional_chained_raw_call_is_opaque() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = styles?.raw({});
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert!(binding.raw_calls.is_empty());
+    assert!(binding.has_opaque_raw_access);
+}
+
+#[test]
+fn raw_passed_as_a_value_is_opaque() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = [].map(styles.raw);
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert!(binding.raw_calls.is_empty());
+    assert!(binding.has_opaque_raw_access);
+}
+
+#[test]
+fn a_direct_raw_call_is_not_opaque() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = styles.raw({ size: 'sm' });
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert_eq!(binding.raw_calls.len(), 1);
+    assert!(!binding.has_opaque_raw_access);
+}
+
+#[test]
+fn a_non_raw_member_access_is_not_opaque_raw() {
+    let src = indoc! {r"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const keys = styles.variantKeys;
+    "};
+
+    let result = extract_for_transform(src, "fixture.tsx", &panda_config());
+    let binding = &result.module.local_call_bindings[0];
+
+    assert!(!binding.has_opaque_raw_access);
+    assert!(binding.has_other_references);
+}

--- a/crates/pandacss_extractor/tests/main.rs
+++ b/crates/pandacss_extractor/tests/main.rs
@@ -11,6 +11,7 @@ mod framework_vue;
 mod import_map;
 mod imports;
 mod jsx;
+mod local_bindings;
 mod optional_chaining;
 mod polish;
 mod raw_spreads;

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -365,8 +365,9 @@ impl Project {
             None => source,
         };
 
-        let result = if pattern_transform.is_some() {
+        let result = {
             let compiled = self.config.as_ref();
+            let has_pattern_transform = pattern_transform.is_some();
             let mut raw_transform = |name: &str, styles: &Literal| {
                 let pattern = compiled.patterns.transform_input(name, styles);
                 let Some(transform) = pattern_transform.as_deref_mut() else {
@@ -376,14 +377,17 @@ impl Project {
                     with_callback_target(diagnostic, "pattern", pattern.name, None)
                 })
             };
-            pandacss_extractor::extract_with_pattern_raw_transform(
+            let mut resolve_recipe_raw = |factory: &str, config: &Literal, props: &Literal| {
+                let props = transform::recipe_inline::literal_variant_props(props)?;
+                transform::recipe_inline::resolve_inline_recipe_raw(self, factory, config, &props)
+            };
+            pandacss_extractor::extract_with_raw_resolvers(
                 source,
                 path,
                 &self.config.extractor_config,
-                &mut raw_transform,
+                has_pattern_transform.then_some(&mut raw_transform),
+                &mut resolve_recipe_raw,
             )
-        } else {
-            extract(source, path, &self.config.extractor_config)
         };
         let token_refs = result
             .token_refs
@@ -1780,7 +1784,7 @@ impl Project {
         Some(Literal::Object(merged))
     }
 
-
+    /// Resolve one static style object to atomic utility class names.
     #[must_use]
     pub fn class_names_for_style_literal(&self, style: &Literal) -> Option<Vec<String>> {
         let mut encoder = Encoder::with_conditions(self.config.conditions.clone());

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -1686,6 +1686,19 @@ impl Project {
         args: &[Option<Literal>],
         pattern_transform: Option<&mut PatternTransformFn<'_>>,
     ) -> Option<Vec<String>> {
+        let styles = self.style_literal_for_pattern_call(pattern_name, args, pattern_transform)?;
+        self.class_names_for_style_literal(&styles)
+    }
+
+    /// Run a pattern call through its transform and return the style object it
+    /// produces — the value `pattern.raw(…)` resolves to at runtime.
+    #[must_use]
+    pub fn style_literal_for_pattern_call(
+        &self,
+        pattern_name: &str,
+        args: &[Option<Literal>],
+        pattern_transform: Option<&mut PatternTransformFn<'_>>,
+    ) -> Option<Literal> {
         let requires_transform = self.config.patterns.requires_transform(pattern_name);
         if requires_transform && pattern_transform.is_none() {
             return None;
@@ -1697,15 +1710,14 @@ impl Project {
             Some(_) => return None,
         };
         let prepared = self.config.patterns.transform_input(pattern_name, arg);
-        let styles = if let Some(transform) = pattern_transform {
+        if let Some(transform) = pattern_transform {
             match transform(prepared.name, prepared.styles.as_ref()) {
-                Ok(Some(style)) => style,
-                Ok(None) | Err(_) => return None,
+                Ok(Some(style)) => Some(style),
+                Ok(None) | Err(_) => None,
             }
         } else {
-            prepared.styles.into_owned()
-        };
-        self.class_names_for_style_literal(&styles)
+            Some(prepared.styles.into_owned())
+        }
     }
 
     /// Resolve one encoded atom to the runtime `css()` class string.
@@ -1723,7 +1735,52 @@ impl Project {
         )
     }
 
-    /// Resolve one static style object to atomic utility class names.
+    /// Merge multi-argument `css.raw(a, b, …)` into the single object the
+    /// runtime would build.
+    ///
+    /// Mirrors `mergeCss`: `resolve()` drops empty objects, then normalizes
+    /// (shorthand keys, responsive arrays) only when two or more survive.
+    /// A lone survivor is returned as authored.
+    #[must_use]
+    pub fn merged_style_literal(&self, args: &[Option<Literal>]) -> Option<Literal> {
+        if args.len() < 2 {
+            return None;
+        }
+        let mut contributing = Vec::with_capacity(args.len());
+        for arg in args {
+            let Some(style @ Literal::Object(entries)) = arg.as_ref() else {
+                return None;
+            };
+            if !entries.is_empty() {
+                contributing.push(style);
+            }
+        }
+        if contributing.len() < 2 {
+            return Some(
+                contributing
+                    .first()
+                    .map_or_else(|| Literal::Object(Vec::new()), |style| (*style).clone()),
+            );
+        }
+
+        let normalizer = StyleNormalizer::new(
+            self.config.utility.as_ref(),
+            &self.config.breakpoints,
+            ShorthandPolicy::UserFacing,
+        );
+        let mut merged = Vec::new();
+        for style in contributing {
+            let Literal::Object(entries) = normalizer.normalize(style).into_owned() else {
+                return None;
+            };
+            for (key, value) in entries {
+                merge_style_entry(&mut merged, key, value);
+            }
+        }
+        Some(Literal::Object(merged))
+    }
+
+
     #[must_use]
     pub fn class_names_for_style_literal(&self, style: &Literal) -> Option<Vec<String>> {
         let mut encoder = Encoder::with_conditions(self.config.conditions.clone());
@@ -1832,6 +1889,34 @@ fn json_scalar_to_atom_value(value: &serde_json::Value) -> Option<AtomValue> {
         )),
         _ => None,
     }
+}
+
+/// `mergeProps` — deep merge left to right, no normalization.
+#[must_use]
+pub fn merge_style_props(objects: &[&Literal]) -> Literal {
+    let mut merged = Vec::new();
+    for object in objects {
+        if let Literal::Object(entries) = object {
+            for (key, value) in entries {
+                merge_style_entry(&mut merged, key.clone(), value.clone());
+            }
+        }
+    }
+    Literal::Object(merged)
+}
+
+/// One `mergeProps` step: nested objects merge, everything else is replaced.
+/// Arrays count as values, matching the runtime `isObject`.
+fn merge_style_entry(entries: &mut Vec<(String, Literal)>, key: String, value: Literal) {
+    if let Some((_, existing)) = entries.iter_mut().find(|(name, _)| name == &key)
+        && let (Literal::Object(target), Literal::Object(incoming)) = (&mut *existing, &value)
+    {
+        for (nested_key, nested_value) in incoming.clone() {
+            merge_style_entry(target, nested_key, nested_value);
+        }
+        return;
+    }
+    Literal::upsert_object_entry(entries, key, value);
 }
 
 fn atom_value_to_transform_literal(value: &pandacss_encoder::AtomValue) -> Option<Literal> {

--- a/crates/pandacss_project/src/transform/apply.rs
+++ b/crates/pandacss_project/src/transform/apply.rs
@@ -276,6 +276,7 @@ mod tests {
                         end: call_span.start + 3,
                     }],
                 }],
+                local_call_bindings: Vec::new(),
                 after_directives: 0,
                 symbols_resolved: false,
             },
@@ -305,6 +306,7 @@ mod tests {
             module: ModuleFacts {
                 imports: Vec::new(),
                 import_bindings: Vec::new(),
+                local_call_bindings: Vec::new(),
                 after_directives: 0,
                 symbols_resolved: false,
             },
@@ -347,6 +349,7 @@ mod tests {
                     local: helper::CX_HELPER_LOCAL.to_owned(),
                     references: vec![Span { start: 72, end: 77 }],
                 }],
+                local_call_bindings: Vec::new(),
                 after_directives: 0,
                 symbols_resolved: false,
             },

--- a/crates/pandacss_project/src/transform/imports.rs
+++ b/crates/pandacss_project/src/transform/imports.rs
@@ -258,6 +258,7 @@ mod tests {
                 local: "css".to_owned(),
                 references: vec![Span { start: 50, end: 53 }],
             }],
+            local_call_bindings: Vec::new(),
             after_directives: 0,
             symbols_resolved,
         }

--- a/crates/pandacss_project/src/transform/mod.rs
+++ b/crates/pandacss_project/src/transform/mod.rs
@@ -18,11 +18,11 @@ mod jsx_runtime;
 mod jsx_shared;
 mod jsx_skip;
 mod plan;
-mod recipe_inline;
+pub(crate) mod recipe_inline;
 mod resolve;
 mod style_lower;
 
-use pandacss_extractor::extract_for_transform;
+use pandacss_extractor::{Literal, extract_for_transform_with_recipe_resolver};
 
 use crate::ParseTransforms;
 use crate::Project;
@@ -82,7 +82,18 @@ impl Project {
             None => source,
         };
 
-        let extracted = extract_for_transform(source, path, self.config().extractor_config());
+        let extracted = {
+            let mut resolve_recipe_raw = |factory: &str, config: &Literal, props: &Literal| {
+                let props = recipe_inline::literal_variant_props(props)?;
+                recipe_inline::resolve_inline_recipe_raw(self, factory, config, &props)
+            };
+            extract_for_transform_with_recipe_resolver(
+                source,
+                path,
+                self.config().extractor_config(),
+                &mut resolve_recipe_raw,
+            )
+        };
         let plan = plan::build_plan(self, source, &extracted, options, transforms.pattern);
         let diagnostics = extracted.diagnostics;
 

--- a/crates/pandacss_project/src/transform/plan.rs
+++ b/crates/pandacss_project/src/transform/plan.rs
@@ -141,6 +141,16 @@ pub(crate) fn build_plan(
         return plan;
     }
 
+    // An imported recipe's definition file precomputes its class strings, so
+    // its runtime `raw` would hand back a string — pin the styles here instead.
+    for raw_call in &extracted.imported_recipe_raw_calls {
+        if let Some(rewrite) =
+            resolve::rewrite_for_style_literal(source, raw_call.span, &raw_call.styles)
+        {
+            plan.rewrites.push(rewrite);
+        }
+    }
+
     for call in &extracted.calls {
         // `.raw()` returns a style object, never a class string. Rewriting it
         // to classes hands composition sites a string where they expect styles.
@@ -158,6 +168,10 @@ pub(crate) fn build_plan(
         }
         match call.category {
             MatchCategory::Css if targets.css_enabled() => match call.name.as_str() {
+                "cva" | "sva"
+                    if !push_inline_recipe_raw_rewrites(
+                        &mut plan, project, source, extracted, call,
+                    ) => {}
                 "cva" => {
                     if let Some(rewrite) = super::recipe_inline::rewrite_for_cva_call(
                         project,
@@ -167,6 +181,10 @@ pub(crate) fn build_plan(
                         &call.arg_spans,
                         &call.style_args,
                     ) {
+                        // Keep call sites as `__pcva` runtime — boolean bitset
+                        // + memo beats `__pcx(cond && slot)` when prop tuples
+                        // reuse (css-in-js-bench btn-variant). Call-site
+                        // lowering must stay opt-in, never the default.
                         plan.rewrites.push(rewrite);
                         plan.helper.needs_cva = true;
                     }
@@ -265,6 +283,60 @@ pub(crate) fn build_plan(
     }
 
     plan
+}
+
+/// Fold `binding.raw(props)` for an inline `cva`/`sva` definition, and report
+/// whether the definition may still be desugared to string branches.
+///
+/// The desugared runtime's `raw` returns class strings where the real one
+/// returns style objects, so a `.raw` call this can't fold has to keep the
+/// original runtime.
+fn push_inline_recipe_raw_rewrites(
+    plan: &mut TransformPlan,
+    project: &Project,
+    source: &str,
+    extracted: &ExtractUsage,
+    call: &ExtractedCall,
+) -> bool {
+    let Some(binding) = extracted
+        .module
+        .local_call_bindings
+        .iter()
+        .find(|binding| binding.init_span == call.span)
+    else {
+        return true;
+    };
+    // A `.raw` that escapes as a value can't be folded, and the desugared
+    // runtime would hand it back a class string.
+    if binding.has_opaque_raw_access {
+        return false;
+    }
+    if binding.raw_calls.is_empty() {
+        return true;
+    }
+    let Some(config) = call.data.first().and_then(|arg| arg.as_ref()) else {
+        return false;
+    };
+
+    let mut rewrites = Vec::with_capacity(binding.raw_calls.len());
+    for raw_call in &binding.raw_calls {
+        let Some(props) = super::recipe_inline::raw_call_variant_props(source, &raw_call.args)
+        else {
+            return false;
+        };
+        let Some(styles) =
+            super::recipe_inline::resolve_inline_recipe_raw(project, &call.name, config, &props)
+        else {
+            return false;
+        };
+        let Some(rewrite) = resolve::rewrite_for_style_literal(source, raw_call.span, &styles)
+        else {
+            return false;
+        };
+        rewrites.push(rewrite);
+    }
+    plan.rewrites.extend(rewrites);
+    true
 }
 
 /// Fold a `.raw()` call to the style object it evaluates to.

--- a/crates/pandacss_project/src/transform/plan.rs
+++ b/crates/pandacss_project/src/transform/plan.rs
@@ -1,6 +1,6 @@
 //! Transform planning: match sites, bailouts, and rewrite decisions.
 
-use pandacss_extractor::{ExtractUsage, MatchCategory};
+use pandacss_extractor::{ExtractUsage, ExtractedCall, MatchCategory};
 
 use crate::PatternTransformFn;
 use crate::Project;
@@ -142,12 +142,23 @@ pub(crate) fn build_plan(
     }
 
     for call in &extracted.calls {
+        // `.raw()` returns a style object, never a class string. Rewriting it
+        // to classes hands composition sites a string where they expect styles.
+        // Where `.raw` is an identity the wrapper can still go; the rest stay.
+        if call.facts.raw {
+            push_raw_rewrites(
+                &mut plan,
+                project,
+                source,
+                call,
+                targets,
+                pattern_transform.as_deref_mut(),
+            );
+            continue;
+        }
         match call.category {
             MatchCategory::Css if targets.css_enabled() => match call.name.as_str() {
                 "cva" => {
-                    if call.facts.raw {
-                        continue;
-                    }
                     if let Some(rewrite) = super::recipe_inline::rewrite_for_cva_call(
                         project,
                         source,
@@ -161,9 +172,6 @@ pub(crate) fn build_plan(
                     }
                 }
                 "sva" => {
-                    if call.facts.raw {
-                        continue;
-                    }
                     if let Some(rewrite) =
                         super::recipe_inline::rewrite_for_sva_call(project, call.span, &call.data)
                     {
@@ -172,9 +180,6 @@ pub(crate) fn build_plan(
                     }
                 }
                 "viewTransition" => {
-                    if call.facts.raw {
-                        continue;
-                    }
                     match resolve::rewrite_for_view_transition_call(project, call.span, &call.data)
                     {
                         Some(rewrite) => plan.rewrites.push(rewrite),
@@ -219,6 +224,7 @@ pub(crate) fn build_plan(
                     &call.name,
                     call.span,
                     &call.data,
+                    &call.style_args,
                     &call.facts,
                     pattern_transform.as_deref_mut(),
                 ) {
@@ -259,6 +265,63 @@ pub(crate) fn build_plan(
     }
 
     plan
+}
+
+/// Fold a `.raw()` call to the style object it evaluates to.
+///
+/// `css.raw(o)` is `mergeCss(o)`, which skips normalization for a single
+/// object, and `recipe.raw` is `props => props` — both unwrap to their
+/// argument, edited around it so nested rewrites still apply. `css.raw(a, b)`
+/// normalizes and deep-merges, and `pattern.raw(props)` runs the pattern
+/// transform, so both are replaced by the computed object.
+fn push_raw_rewrites(
+    plan: &mut TransformPlan,
+    project: &Project,
+    source: &str,
+    call: &ExtractedCall,
+    targets: &TransformTargets,
+    pattern_transform: Option<&mut PatternTransformFn<'_>>,
+) {
+    match call.category {
+        MatchCategory::Pattern if targets.patterns_enabled() => {
+            if let Some(rewrite) =
+                resolve::rewrite_for_pattern_raw_call(project, source, call, pattern_transform)
+            {
+                plan.rewrites.push(rewrite);
+            }
+        }
+        MatchCategory::Css if targets.css_enabled() && call.name == "css" => {
+            push_identity_or_merged_raw(plan, project, source, call);
+        }
+        MatchCategory::Recipe if targets.recipes_enabled() => {
+            if let Some(rewrites) = resolve::rewrites_for_identity_raw_call(
+                source,
+                call.span,
+                &call.arg_spans,
+                &call.facts,
+            ) {
+                plan.rewrites.extend(rewrites);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_identity_or_merged_raw(
+    plan: &mut TransformPlan,
+    project: &Project,
+    source: &str,
+    call: &ExtractedCall,
+) {
+    if let Some(rewrites) =
+        resolve::rewrites_for_identity_raw_call(source, call.span, &call.arg_spans, &call.facts)
+    {
+        plan.rewrites.extend(rewrites);
+    } else if let Some(rewrite) =
+        resolve::rewrite_for_merged_raw_call(project, source, call.span, &call.data, &call.facts)
+    {
+        plan.rewrites.push(rewrite);
+    }
 }
 
 fn css_style_tree_should_bail(style_args: &[Option<pandacss_extractor::StyleTree>]) -> bool {

--- a/crates/pandacss_project/src/transform/recipe_inline.rs
+++ b/crates/pandacss_project/src/transform/recipe_inline.rs
@@ -1,8 +1,10 @@
 //! Inline `cva()` / `sva()` call transforms to string-branch runtime configs.
 
 use crate::Project;
-use pandacss_extractor::{Literal, StyleTree};
-use pandacss_recipes::{CompoundVariant, Recipe, SlotCompoundVariant, SlotRecipe};
+use pandacss_extractor::{ExpressionFacts, ExpressionKind, Literal, StyleTree};
+use pandacss_recipes::{
+    CompoundVariant, Recipe, SlotCompoundVariant, SlotRecipe, VariantGroup, VariantOption,
+};
 
 use super::helper::{CVA_HELPER_LOCAL, SVA_HELPER_LOCAL};
 use super::plan::Rewrite;
@@ -332,8 +334,6 @@ fn push_default_variants_part(parts: &mut Vec<String>, default_variants: &[(Stri
     parts.push(format!("defaultVariants: {{ {defaults} }}"));
 }
 
-/// `true` / `false` are printed unquoted so the runtime sees the boolean the
-/// user authored, not the string `'true'`.
 fn format_default_variant_value(value: &str) -> String {
     match value {
         "true" | "false" => value.to_owned(),
@@ -424,7 +424,7 @@ fn print_compound_conditions(conditions: &[(String, Vec<String>)]) -> Vec<String
         .collect()
 }
 
-fn escape_js(value: &str) -> String {
+pub(crate) fn escape_js(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
@@ -515,4 +515,224 @@ fn styled_config_arg(call: &pandacss_extractor::ExtractedCall) -> Option<(usize,
             Some((0, config))
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// `binding.raw(props)` on an inline cva/sva — folds to the resolved styles.
+// ---------------------------------------------------------------------------
+
+/// Static variant selection from a `.raw({ … })` argument.
+///
+/// `None` means the call can't be resolved at build time, which also blocks the
+/// string-branch desugar of the definition — the runtime `raw` returns style
+/// objects and the desugared one returns class strings.
+pub(crate) fn raw_call_variant_props(
+    source: &str,
+    args: &[Option<ExpressionFacts>],
+) -> Option<Vec<(String, String)>> {
+    if args.len() > 1 {
+        return None;
+    }
+    let Some(arg) = args.first() else {
+        return Some(Vec::new());
+    };
+    let facts = arg.as_ref()?;
+    if facts.kind != ExpressionKind::Object {
+        return None;
+    }
+    let object = facts.object.as_ref()?;
+
+    let mut props = Vec::with_capacity(object.properties.len());
+    for prop in &object.properties {
+        if prop.is_spread() || prop.is_accessor_or_method {
+            return None;
+        }
+        let key = prop.key.as_ref()?;
+        let value = prop.value.as_ref()?;
+        let value = static_variant_value(source, value)?;
+        upsert_prop(&mut props, key.clone(), value);
+    }
+    Some(props)
+}
+
+/// Variant values are looked up as object keys at runtime, so every static
+/// literal reduces to its string form.
+fn static_variant_value(source: &str, facts: &ExpressionFacts) -> Option<String> {
+    if let Some(value) = facts.string_value.as_ref() {
+        return Some(value.clone());
+    }
+    if facts.kind != ExpressionKind::Static {
+        return None;
+    }
+    let start = usize::try_from(facts.span.start).ok()?;
+    let end = usize::try_from(facts.span.end).ok()?;
+    let text = source.get(start..end)?.trim();
+    match text {
+        "true" | "false" => Some(text.to_owned()),
+        _ if text.parse::<f64>().is_ok() => Some(text.to_owned()),
+        _ => None,
+    }
+}
+
+fn upsert_prop(props: &mut Vec<(String, String)>, key: String, value: String) {
+    if let Some(entry) = props.iter_mut().find(|(name, _)| name == &key) {
+        entry.1 = value;
+    } else {
+        props.push((key, value));
+    }
+}
+
+/// `withDefaults(defaultVariants, props)` — defaults first, props override.
+fn computed_variants(
+    default_variants: &[(String, String)],
+    props: &[(String, String)],
+) -> Vec<(String, String)> {
+    let mut computed = default_variants.to_vec();
+    for (key, value) in props {
+        upsert_prop(&mut computed, key.clone(), value.clone());
+    }
+    computed
+}
+
+fn compound_matches(conditions: &[(String, Vec<String>)], computed: &[(String, String)]) -> bool {
+    conditions.iter().all(|(key, expected)| {
+        computed
+            .iter()
+            .find(|(name, _)| name == key)
+            .is_some_and(|(_, actual)| expected.iter().any(|value| value == actual))
+    })
+}
+
+/// Mirror of the generated `cva(...).raw` — base, matching variants, then
+/// compound css, merged by `mergeCss`.
+pub(crate) fn resolve_cva_raw_styles(
+    project: &Project,
+    recipe: &Recipe,
+    props: &[(String, String)],
+) -> Option<Literal> {
+    let computed = computed_variants(&recipe.default_variants, props);
+    let empty = Literal::Object(Vec::new());
+
+    let mut styles = vec![Some(recipe.base.clone().unwrap_or_else(|| empty.clone()))];
+    for (key, value) in &computed {
+        let Some(group) = recipe.variants.iter().find(|group| &group.name == key) else {
+            continue;
+        };
+        if let Some(option) = group.options.iter().find(|option| &option.key == value) {
+            styles.push(Some(option.style.clone()));
+        }
+    }
+
+    let compounds: Vec<&Literal> = recipe
+        .compound_variants
+        .iter()
+        .filter(|compound| compound_matches(&compound.conditions, &computed))
+        .map(|compound| &compound.css)
+        .collect();
+    styles.push(Some(crate::merge_style_props(&compounds)));
+
+    project.merged_style_literal(&styles)
+}
+
+/// Mirror of the generated `sva(...).raw` — one resolved style object per slot.
+pub(crate) fn resolve_sva_raw_styles(
+    project: &Project,
+    recipe: &SlotRecipe,
+    props: &[(String, String)],
+) -> Option<Literal> {
+    let mut slots = Vec::with_capacity(recipe.slots.len());
+    for slot in &recipe.slots {
+        let per_slot = slot_recipe_for(recipe, slot);
+        slots.push((
+            slot.clone(),
+            resolve_cva_raw_styles(project, &per_slot, props)?,
+        ));
+    }
+    Some(Literal::Object(slots))
+}
+
+/// The per-slot `cva` config `sva` builds internally via `getSlotRecipes`.
+fn slot_recipe_for(recipe: &SlotRecipe, slot: &str) -> Recipe {
+    let pick = |entries: &[(String, Literal)]| {
+        entries
+            .iter()
+            .find(|(name, _)| name == slot)
+            .map(|(_, style)| style.clone())
+    };
+
+    Recipe {
+        base: pick(&recipe.base),
+        variants: recipe
+            .variants
+            .iter()
+            .map(|group| VariantGroup {
+                name: group.name.clone(),
+                options: group
+                    .options
+                    .iter()
+                    .filter_map(|option| {
+                        pick(&option.styles).map(|style| VariantOption {
+                            key: option.key.clone(),
+                            style,
+                        })
+                    })
+                    .collect(),
+            })
+            .collect(),
+        compound_variants: recipe
+            .compound_variants
+            .iter()
+            .filter_map(|compound| {
+                pick(&compound.css).map(|css| CompoundVariant {
+                    conditions: compound.conditions.clone(),
+                    css,
+                    class_name: compound.class_name.clone(),
+                })
+            })
+            .collect(),
+        default_variants: recipe.default_variants.clone(),
+    }
+}
+
+/// Resolve `binding.raw(props)` for an inline `cva` or `sva` definition.
+/// Variant props folded from an expression, as `resolve_inline_recipe_raw`
+/// wants them. `None` if any value isn't a static scalar.
+pub(crate) fn literal_variant_props(props: &Literal) -> Option<Vec<(String, String)>> {
+    let Literal::Object(entries) = props else {
+        return None;
+    };
+    let mut out = Vec::with_capacity(entries.len());
+    for (key, value) in entries {
+        let text = match value {
+            Literal::String(text) => text.clone(),
+            Literal::Bool(flag) => flag.to_string(),
+            Literal::Number(number) => pandacss_shared::number_to_js_string(*number),
+            // An explicitly absent variant falls back to `defaultVariants`.
+            Literal::Null => continue,
+            _ => return None,
+        };
+        upsert_prop(&mut out, key.clone(), text);
+    }
+    Some(out)
+}
+
+pub(crate) fn resolve_inline_recipe_raw(
+    project: &Project,
+    factory: &str,
+    config: &Literal,
+    props: &[(String, String)],
+) -> Option<Literal> {
+    if factory == "sva" {
+        let recipe = SlotRecipe::from_literal(config)?;
+        return resolve_sva_raw_styles(project, &recipe, props);
+    }
+    let recipe = if is_recipe_config(config) {
+        Recipe::from_literal(config)?
+    } else {
+        Recipe {
+            base: Some(config.clone()),
+            ..Recipe::default()
+        }
+    };
+    resolve_cva_raw_styles(project, &recipe, props)
 }

--- a/crates/pandacss_project/src/transform/resolve.rs
+++ b/crates/pandacss_project/src/transform/resolve.rs
@@ -3,7 +3,9 @@
 use std::collections::HashSet;
 
 use pandacss_encoder::{Atom, Encoder, compare_atoms_by_emit_order};
-use pandacss_extractor::{CallFacts, CallSyntax, Literal, StyleTree};
+use pandacss_extractor::{
+    CallFacts, CallSyntax, ExpressionKind, ExtractedCall, Literal, StyleTree,
+};
 use pandacss_shared::view_transition_class_name;
 use pandacss_utility::ShorthandPolicy;
 
@@ -321,14 +323,147 @@ pub(crate) fn rewrite_for_pattern_call(
     pattern_name: &str,
     span: pandacss_shared::Span,
     args: &[Option<Literal>],
+    style_args: &[Option<StyleTree>],
     facts: &CallFacts,
     pattern_transform: Option<&mut PatternTransformFn<'_>>,
 ) -> Option<Rewrite> {
-    if pattern_call_has_unextractable_args(args, facts) {
+    if pattern_call_has_unextractable_args(args, style_args, facts) {
         return None;
     }
     let classes = project.class_names_for_pattern_call(pattern_name, args, pattern_transform)?;
     Some(rewrite_for_class_names(span, &classes))
+}
+
+/// Unwrap an identity `.raw({ … })` call to its object literal.
+///
+/// Callers decide which `.raw` qualifies; this only enforces the shape a
+/// wrapper-strip needs — one object-literal argument, call syntax. Multiple
+/// args are rejected because `css.raw(a, b)` deep-merges and normalizes.
+///
+/// Emitted as two edits around the argument rather than one call-wide rewrite so
+/// nested rewrites (token folding) inside the object still apply.
+pub(crate) fn rewrites_for_identity_raw_call(
+    source: &str,
+    span: pandacss_shared::Span,
+    arg_spans: &[pandacss_shared::Span],
+    facts: &CallFacts,
+) -> Option<[Rewrite; 2]> {
+    if facts.syntax != CallSyntax::Call {
+        return None;
+    }
+    let [arg] = arg_spans else {
+        return None;
+    };
+    if facts.args.first()?.as_ref()?.kind != ExpressionKind::Object {
+        return None;
+    }
+
+    let (open, close) = if object_literal_needs_parens(source, span.start) {
+        ("(", ")")
+    } else {
+        ("", "")
+    };
+    Some([
+        Rewrite {
+            start: span.start,
+            end: arg.start,
+            content: open.to_owned(),
+            preserved: Vec::new(),
+        },
+        Rewrite {
+            start: arg.end,
+            end: span.end,
+            content: close.to_owned(),
+            preserved: Vec::new(),
+        },
+    ])
+}
+
+/// Fold `css.raw(a, b, …)` to the single object the runtime would build.
+///
+/// Only static object arguments qualify. `Literal::Conditional` is a runtime
+/// branch rather than data, so anything carrying one is left alone.
+pub(crate) fn rewrite_for_merged_raw_call(
+    project: &Project,
+    source: &str,
+    span: pandacss_shared::Span,
+    args: &[Option<Literal>],
+    facts: &CallFacts,
+) -> Option<Rewrite> {
+    if facts.syntax != CallSyntax::Call {
+        return None;
+    }
+    let merged = project.merged_style_literal(args)?;
+    rewrite_for_style_literal(source, span, &merged)
+}
+
+/// Fold `pattern.raw(props)` to the style object the pattern's transform
+/// returns — the same value the runtime would hand back.
+pub(crate) fn rewrite_for_pattern_raw_call(
+    project: &Project,
+    source: &str,
+    call: &ExtractedCall,
+    pattern_transform: Option<&mut PatternTransformFn<'_>>,
+) -> Option<Rewrite> {
+    if call.facts.syntax != CallSyntax::Call
+        || pattern_call_has_unextractable_args(&call.data, &call.style_args, &call.facts)
+    {
+        return None;
+    }
+    let styles =
+        project.style_literal_for_pattern_call(&call.name, &call.data, pattern_transform)?;
+    rewrite_for_style_literal(source, call.span, &styles)
+}
+
+/// Replace a whole call with the object literal it evaluates to.
+///
+/// `Literal::Conditional` is a runtime branch rather than data, so anything
+/// carrying one is left alone.
+pub(crate) fn rewrite_for_style_literal(
+    source: &str,
+    span: pandacss_shared::Span,
+    styles: &Literal,
+) -> Option<Rewrite> {
+    if !matches!(styles, Literal::Object(_)) || literal_has_conditional(styles) {
+        return None;
+    }
+    let object = serde_json::to_string(styles).ok()?;
+    let content = if object_literal_needs_parens(source, span.start) {
+        format!("({object})")
+    } else {
+        object
+    };
+    Some(Rewrite {
+        start: span.start,
+        end: span.end,
+        content,
+        preserved: Vec::new(),
+    })
+}
+
+fn literal_has_conditional(literal: &Literal) -> bool {
+    match literal {
+        Literal::Conditional(_) => true,
+        Literal::Object(entries) => entries
+            .iter()
+            .any(|(_, value)| literal_has_conditional(value)),
+        Literal::Array(items) => items.iter().any(literal_has_conditional),
+        _ => false,
+    }
+}
+
+/// A bare object literal needs parentheses wherever `{` would open a block —
+/// a concise arrow body or statement position.
+fn object_literal_needs_parens(source: &str, at: u32) -> bool {
+    let Some(before) = usize::try_from(at).ok().and_then(|at| source.get(..at)) else {
+        return true;
+    };
+    let before = before.trim_end();
+    match before.chars().next_back() {
+        Some('>') => before.ends_with("=>"),
+        None | Some(';' | '{' | '}') => true,
+        Some(_) => false,
+    }
 }
 
 fn rewrite_for_class_names(span: pandacss_shared::Span, classes: &[String]) -> Rewrite {
@@ -370,8 +505,23 @@ fn recipe_call_has_unextractable_args(args: &[Option<Literal>], facts: &CallFact
     )
 }
 
-fn pattern_call_has_unextractable_args(args: &[Option<Literal>], facts: &CallFacts) -> bool {
+fn pattern_call_has_unextractable_args(
+    args: &[Option<Literal>],
+    style_args: &[Option<StyleTree>],
+    facts: &CallFacts,
+) -> bool {
     if facts.syntax != CallSyntax::Call || args.iter().any(Option::is_none) {
+        return true;
+    }
+    // A pattern call collapses to one value, so anything the literal can't
+    // carry on its own — a dropped dynamic spread, or a branch only the
+    // runtime can pick — has to stay a runtime call.
+    if style_args.iter().flatten().any(|tree| {
+        tree.is_open()
+            || super::style_lower::style_tree_has_open_spread(tree)
+            || super::style_lower::style_tree_has_open_value(tree)
+            || super::style_lower::style_tree_has_runtime_branch(tree)
+    }) {
         return true;
     }
     if args.is_empty()

--- a/crates/pandacss_project/src/transform/resolve.rs
+++ b/crates/pandacss_project/src/transform/resolve.rs
@@ -458,11 +458,18 @@ fn object_literal_needs_parens(source: &str, at: u32) -> bool {
     let Some(before) = usize::try_from(at).ok().and_then(|at| source.get(..at)) else {
         return true;
     };
-    let before = before.trim_end();
-    match before.chars().next_back() {
-        Some('>') => before.ends_with("=>"),
+    let trimmed = before.trim_end();
+    // Without a semicolon, a line break ends the previous statement, so this
+    // call starts one and `{` would open a block.
+    let starts_a_line = before[trimmed.len()..].contains('\n');
+    match trimmed.chars().next_back() {
+        Some('>') => trimmed.ends_with("=>"),
         None | Some(';' | '{' | '}') => true,
-        Some(_) => false,
+        // These can only continue an expression, so the literal is unambiguous.
+        Some(
+            '(' | '[' | ',' | '=' | ':' | '?' | '+' | '-' | '*' | '/' | '%' | '&' | '|' | '!' | '~',
+        ) => false,
+        Some(_) => starts_a_line,
     }
 }
 

--- a/crates/pandacss_project/src/transform/style_lower.rs
+++ b/crates/pandacss_project/src/transform/style_lower.rs
@@ -90,6 +90,37 @@ pub(crate) fn style_tree_has_open_spread(tree: &StyleTree) -> bool {
     }
 }
 
+/// True when the tree contains a branch only the runtime can decide.
+///
+/// Callers that collapse a whole call to one value — pattern calls, which emit
+/// a single class string or a single object — can't express a branch, so they
+/// have to leave the call to the runtime.
+#[must_use]
+pub(crate) fn style_tree_has_runtime_branch(tree: &StyleTree) -> bool {
+    match tree {
+        StyleTree::Ternary { .. } | StyleTree::And { .. } | StyleTree::Branches(_) => true,
+        StyleTree::Object(obj) => {
+            obj.spreads.iter().any(|spread| {
+                matches!(
+                    spread,
+                    StyleSpread::Ternary { .. } | StyleSpread::And { .. }
+                )
+            }) || obj
+                .entries
+                .iter()
+                .any(|(_, v)| style_tree_has_runtime_branch(v))
+        }
+        StyleTree::Array(items) => items.iter().any(style_tree_has_runtime_branch),
+        StyleTree::Open
+        | StyleTree::OpenWithFallback(_)
+        | StyleTree::String(_)
+        | StyleTree::Number(_)
+        | StyleTree::Bool(_)
+        | StyleTree::Null
+        | StyleTree::Token { .. } => false,
+    }
+}
+
 /// True when any leaf/`Open` value is present (including property-level `||` / `??`).
 #[must_use]
 pub(crate) fn style_tree_has_open_value(tree: &StyleTree) -> bool {

--- a/crates/pandacss_project/tests/transform/advanced.rs
+++ b/crates/pandacss_project/tests/transform/advanced.rs
@@ -40,7 +40,7 @@ advanced_snapshot!(
         transform("src/styles.tsx", source)
     },
     @r#"
-const baseStyles = "color_red padding_8px";
+const baseStyles = { color: 'red', padding: '8px' };
 export const cls = "color_red margin-top_4px padding_8px";
 "#
 );
@@ -65,7 +65,7 @@ advanced_snapshot!(
         transform("src/styles.tsx", source)
     },
     @r#"
-const baseStyles = "padding_10px";
+const baseStyles = { padding: '10px' };
 export const cls = "padding_10px hover:padding_10px hover:[&:focus]:outline_2px_solid_blue hover:[&:focus]:padding_10px";
 "#
 );
@@ -88,7 +88,7 @@ advanced_snapshot!(
         transform("src/styles.tsx", source)
     },
     @r#"
-const baseStyles = "color_blue padding_8px";
+const baseStyles = { color: 'blue', padding: '8px' };
 const isActive = true;
 export const cls = "color_blue padding_8px hover:color_blue hover:opacity_0.9 hover:padding_8px";
 "#
@@ -659,7 +659,7 @@ advanced_snapshot!(
         transform("src/styles.tsx", source)
     },
     @r#"
-const baseStyles = "color_blue padding_8px";
+const baseStyles = { color: 'blue', padding: '8px' };
 export const cls = cond ? "color_blue padding_8px" : "";
 "#
 );

--- a/crates/pandacss_project/tests/transform/bailout.rs
+++ b/crates/pandacss_project/tests/transform/bailout.rs
@@ -1,4 +1,6 @@
-use super::common::{patterns_only_options, transform, transform_with_options};
+use super::common::{
+    patterns_only_options, transform, transform_with_options, transform_with_shorthands,
+};
 use indoc::indoc;
 use insta::assert_snapshot;
 
@@ -31,7 +33,9 @@ fn leaves_unresolved_identifier_css_value_unchanged() {
 }
 
 #[test]
-fn rewrites_css_raw_call_to_class_string() {
+fn unwraps_css_raw_call_to_its_object() {
+    // `css.raw()` returns a style object, not a class string. One-arg `css.raw`
+    // just clones its argument, so the wrapper and the import can both go.
     let source = indoc! {r#"
         import { css } from '@panda/css';
         export const styles = css.raw({ color: 'red', padding: '4px' });
@@ -41,7 +45,161 @@ fn rewrites_css_raw_call_to_class_string() {
 
     assert!(output.changed);
     assert!(!output.bailed);
-    assert_snapshot!(output.code, @r#"export const styles = "color_red padding_4px";"#);
+    assert_snapshot!(
+        output.code,
+        @"export const styles = { color: 'red', padding: '4px' };"
+    );
+}
+
+#[test]
+fn parenthesizes_unwrapped_css_raw_in_arrow_body() {
+    // A bare `{` would open a block, not an object.
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = () => css.raw({ color: 'red' });
+    "#};
+
+    let output = transform("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @"export const styles = () => ({ color: 'red' });");
+}
+
+#[test]
+fn folds_multi_arg_css_raw_to_the_merged_object() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({ color: 'red' }, { padding: '4px' });
+    "#};
+
+    let output = transform("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"color":"red","padding":"4px"};"#
+    );
+}
+
+#[test]
+fn multi_arg_css_raw_merge_is_last_wins_and_deep() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw(
+            { color: 'red', _hover: { color: 'blue', padding: '1px' } },
+            { color: 'green', _hover: { color: 'teal' } },
+        );
+    "#};
+
+    let output = transform("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"color":"green","_hover":{"color":"teal","padding":"1px"}};"#
+    );
+}
+
+#[test]
+fn multi_arg_css_raw_resolves_shorthand_keys_like_the_runtime() {
+    // `mergeCss` normalizes before merging, so `bg` reaches its canonical key
+    // and collides with a later `background`.
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({ bg: 'red' }, { backgroundColor: 'blue' });
+    "#};
+
+    let output = transform_with_shorthands("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"backgroundColor":"blue"};"#);
+}
+
+#[test]
+fn multi_arg_css_raw_keys_responsive_arrays_like_the_runtime() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({ color: ['red', 'blue'] }, { padding: '4px' });
+    "#};
+
+    let output = transform("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"color":{"base":"red","sm":"blue"},"padding":"4px"};"#
+    );
+}
+
+#[test]
+fn multi_arg_css_raw_skips_normalization_when_only_one_object_contributes() {
+    // `resolve()` drops the empty object, leaving a single survivor — which
+    // the runtime returns as authored, shorthand and all.
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({ bg: 'red' }, {});
+    "#};
+
+    let output = transform_with_shorthands("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"bg":"red"};"#);
+}
+
+#[test]
+fn multi_arg_css_raw_normalizes_across_an_intervening_empty_object() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({ bg: 'red' }, {}, { color: 'blue' });
+    "#};
+
+    let output = transform_with_shorthands("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"backgroundColor":"red","color":"blue"};"#
+    );
+}
+
+#[test]
+fn multi_arg_css_raw_of_only_empty_objects_folds_to_an_empty_object() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({}, {});
+    "#};
+
+    let output = transform_with_shorthands("src/styles.ts", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @"export const styles = {};");
+}
+
+#[test]
+fn multi_arg_css_raw_with_a_dynamic_argument_stays_intact() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw({ color: 'red' }, overrides);
+    "#};
+
+    let output = transform("src/styles.ts", source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn leaves_css_raw_with_non_object_argument_intact() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = css.raw(base);
+    "#};
+
+    let output = transform("src/styles.ts", source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
 }
 
 #[test]

--- a/crates/pandacss_project/tests/transform/conditional.rs
+++ b/crates/pandacss_project/tests/transform/conditional.rs
@@ -266,13 +266,13 @@ conditional_snapshot!(
 );
 
 conditional_snapshot!(
-    css_raw_rewrites_conditional_object,
+    css_raw_conditional_object_unwraps_to_the_object,
     r#"
         import { css } from '@panda/css';
         export const cls = css.raw({ color: { base: 'red', md: 'blue' } });
     "#,
     true,
-    @r#"export const cls = "color_red md:color_blue";"#
+    @"export const cls = { color: { base: 'red', md: 'blue' } };"
 );
 
 conditional_snapshot!(
@@ -293,6 +293,45 @@ conditional_snapshot!(
     "#,
     true,
     @r#"export const cls = isWide ? "hover:md:color_blue" : "hover:md:color_green";"#
+);
+
+// --- shared base hoisted out of multi-site conditionals ---
+
+conditional_snapshot!(
+    static_base_is_emitted_once_across_conditional_sites,
+    r#"
+        import { css } from '@panda/css';
+        export const cls = css({
+            display: 'flex',
+            color: 'red',
+            padding: wide ? '8px' : '4px',
+            margin: tall ? '2px' : '1px',
+        });
+    "#,
+    true,
+    @r#"export const cls = (wide ? "color_red d_flex padding_8px" : "color_red d_flex padding_4px") + " " + (tall ? "color_red d_flex margin_2px" : "color_red d_flex margin_1px");"#
+);
+
+conditional_snapshot!(
+    single_conditional_site_keeps_base_inline,
+    // One site renders the base once at runtime either way, so there's
+    // nothing to hoist.
+    r#"
+        import { css } from '@panda/css';
+        export const cls = css({ display: 'flex', padding: wide ? '8px' : '4px' });
+    "#,
+    true,
+    @r#"export const cls = wide ? "d_flex padding_8px" : "d_flex padding_4px";"#
+);
+
+conditional_snapshot!(
+    disjoint_conditional_sites_hoist_nothing,
+    r#"
+        import { css } from '@panda/css';
+        export const cls = css({ padding: wide ? '8px' : '4px', margin: tall ? '2px' : '1px' });
+    "#,
+    true,
+    @r#"export const cls = (wide ? "padding_8px" : "padding_4px") + " " + (tall ? "margin_2px" : "margin_1px");"#
 );
 
 // --- unresolved condition keys (encoder emits nothing) ---

--- a/crates/pandacss_project/tests/transform/css_cases.rs
+++ b/crates/pandacss_project/tests/transform/css_cases.rs
@@ -90,13 +90,13 @@ transform_snapshot!(
 );
 
 transform_snapshot!(
-    css_raw_static_object,
+    css_raw_static_object_unwraps_to_the_object,
     r#"
         import { css } from '@panda/css';
         export const raw = css.raw({ color: 'red', padding: '4px' });
     "#,
     true,
-    @r#"export const raw = "color_red padding_4px";"#
+    @"export const raw = { color: 'red', padding: '4px' };"
 );
 
 transform_snapshot!(

--- a/crates/pandacss_project/tests/transform/css_cases.rs
+++ b/crates/pandacss_project/tests/transform/css_cases.rs
@@ -234,3 +234,65 @@ fn raw_member_text_inside_a_value_does_not_change_call_classification() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"export const cls = "content_.raw(";"#);
 }
+
+// A `.raw()` call folds to a bare object literal, which needs parentheses
+// wherever `{` would start a block instead of an expression.
+
+#[test]
+fn raw_in_a_concise_arrow_body_is_parenthesized() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const make = () => css.raw({ color: 'red' });
+    "#};
+    assert_snapshot!(transform("src/styles.tsx", source).code, @"export const make = () => ({ color: 'red' });");
+}
+
+#[test]
+fn raw_in_statement_position_without_semicolons_is_parenthesized() {
+    // ASI: the previous line ends without `;`, so a bare `{` here would parse
+    // as a block, not an object.
+    let source = indoc! {r#"
+        import { css } from '@panda/css'
+        const first = 1
+        css.raw({ color: 'red' })
+    "#};
+    let output = transform("src/styles.tsx", source);
+    assert_snapshot!(output.code, @r"
+    const first = 1
+    ({ color: 'red' })
+    ");
+}
+
+#[test]
+fn raw_after_return_keeps_the_object_bare() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export function make() {
+          return css.raw({ color: 'red' });
+        }
+    "#};
+    assert_snapshot!(transform("src/styles.tsx", source).code, @r"
+    export function make() {
+      return { color: 'red' };
+    }
+    ");
+}
+
+#[test]
+fn raw_as_a_call_argument_keeps_the_object_bare() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const cls = css(css.raw({ color: 'red' }), { color: 'blue' });
+    "#};
+    // the whole call folds, so the object never reaches the output
+    assert_snapshot!(transform("src/styles.tsx", source).code, @r#"export const cls = "color_blue";"#);
+}
+
+#[test]
+fn raw_as_an_object_property_value_keeps_the_object_bare() {
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const styles = { button: css.raw({ color: 'red' }) };
+    "#};
+    assert_snapshot!(transform("src/styles.tsx", source).code, @"export const styles = { button: { color: 'red' } };");
+}

--- a/crates/pandacss_project/tests/transform/css_mixed.rs
+++ b/crates/pandacss_project/tests/transform/css_mixed.rs
@@ -325,3 +325,32 @@ fn dynamic_value_kept_verbatim_in_runtime_css() {
     export const cls = __pcx("color_red", css({ gridTemplate: computeGrid(props.cols) }));
     "#);
 }
+
+// ─── css composition through a component prop ───
+
+#[test]
+fn css_prop_forwarded_through_typed_destructured_param_is_not_dropped() {
+    // `{ css?: any }` is a type annotation, not a value. Folding it to an
+    // empty object dropped `cssProp` and lost every style the caller passed.
+    let out = css(indoc! {r#"
+        import { css } from '@panda/css';
+        const base = { color: 'red' };
+        export const L0 = ({ css: cssProp, children }: { css?: any; children?: any }) => (
+          <button className={css(base, cssProp)}>{children}</button>
+        );
+    "#});
+    assert!(!out.bailed);
+    assert!(out.code.contains("css(base, cssProp)"), "{}", out.code);
+}
+
+#[test]
+fn typed_destructured_param_with_concrete_type_is_not_dropped() {
+    let out = css(indoc! {r#"
+        import { css } from '@panda/css';
+        const base = { color: 'red' };
+        export const L0 = ({ extra }: { extra?: Record<string, string> }) =>
+          css(base, extra);
+    "#});
+    assert!(!out.bailed);
+    assert!(out.code.contains("css(base, extra)"), "{}", out.code);
+}

--- a/crates/pandacss_project/tests/transform/edges.rs
+++ b/crates/pandacss_project/tests/transform/edges.rs
@@ -757,8 +757,8 @@ edge_snapshot!(
         "#},
     ),
     @r#"
-const primary = "color_red padding_8px";
-const secondary = "color_blue padding_4px";
+const primary = { color: 'red', padding: '8px' };
+const secondary = { color: 'blue', padding: '4px' };
 export const cls = isActive ? "color_red padding_8px" : "color_blue padding_4px";
 "#
 );
@@ -934,8 +934,8 @@ edge_snapshot!(
         "#},
     ),
     @r#"
-const primary = "background-color_blue color_white";
-const secondary = "background-color_gray color_black";
+const primary = { backgroundColor: 'blue', color: 'white' };
+const secondary = { backgroundColor: 'gray', color: 'black' };
 export const cls = (variant === 'primary' ? "background-color_blue color_white padding_8px hover:opacity_0.9" : "background-color_gray color_black padding_8px hover:opacity_0.9") + " " + (variant === 'primary' ? "padding_8px hover:background-color_blue hover:color_white hover:opacity_0.9" : "padding_8px hover:opacity_0.9");
 "#
 );

--- a/crates/pandacss_project/tests/transform/patterns.rs
+++ b/crates/pandacss_project/tests/transform/patterns.rs
@@ -10,6 +10,22 @@ use pandacss_project::{TransformOptions, transform_source};
 use serde_json::json;
 
 #[test]
+fn folds_pattern_raw_call_to_its_style_object() {
+    // `pattern.raw()` returns the style object the pattern transform produces,
+    // so it folds to that object rather than to a class string.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: '4px' });
+    "#};
+
+    let output = transform_patterns("src/layout.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"export const styles = {"padding":"4px"};"#);
+}
+
+#[test]
 fn rewrites_property_pattern_without_transform() {
     let source = indoc! {r#"
         import { box } from '@panda/patterns';
@@ -167,6 +183,723 @@ fn pattern_target_does_not_rewrite_css_calls() {
         &TransformOptions {
             targets: patterns_only_options().targets,
             ..TransformOptions::default()
+        },
+    );
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+// ---------------------------------------------------------------------------
+// pattern.raw — folds to the style object the pattern transform returns.
+// ---------------------------------------------------------------------------
+
+/// Patterns exercising defaults and prop mapping without a JS callback.
+fn raw_project() -> Project {
+    Project::new(
+        System::new(create_config(json!({
+            "conditions": {
+                "hover": "&:hover",
+                "dark": ".dark &"
+            },
+            "theme": {
+                "breakpoints": { "sm": "640px", "md": "768px" }
+            },
+            "utilities": {
+                "padding": {},
+                "margin": {},
+                "gap": {},
+                "color": {},
+                "content": {},
+                "display": { "className": "d" }
+            },
+            "patterns": {
+                "box": {
+                    "properties": {
+                        "padding": { "type": "property", "property": "padding" }
+                    }
+                },
+                "spaced": {
+                    "defaultValues": { "gap": "8px", "padding": "2px" },
+                    "properties": {
+                        "gap": { "type": "property", "property": "gap" },
+                        "padding": { "type": "property", "property": "padding" }
+                    }
+                }
+            }
+        })))
+        .expect("config"),
+    )
+}
+
+fn transform_raw(source: &str) -> pandacss_project::TransformOutput {
+    transform_source(
+        &raw_project(),
+        "src/layout.tsx",
+        source,
+        &patterns_only_options(),
+    )
+}
+
+#[test]
+fn pattern_raw_keeps_a_conditional_value_object() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: { base: '2px', _hover: '4px' } });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"padding":{"base":"2px","_hover":"4px"}};"#
+    );
+}
+
+#[test]
+fn pattern_raw_keeps_deeply_nested_conditions() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          padding: { base: '2px', _hover: { _dark: { sm: '8px' } } },
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"padding":{"base":"2px","_hover":{"_dark":{"sm":"8px"}}}};"#
+    );
+}
+
+#[test]
+fn pattern_raw_keeps_nested_selector_blocks() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          padding: '4px',
+          '&:hover': { padding: '8px', '& > span': { margin: '0' } },
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"padding":"4px","&:hover":{"padding":"8px","& > span":{"margin":"0"}}};"#
+    );
+}
+
+#[test]
+fn pattern_raw_keeps_a_responsive_array_unnormalized() {
+    // `pattern.raw` never runs `normalizeStyleObject` — the array is keyed by
+    // `css()` later, so it has to survive as an array.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: ['2px', '4px'] });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"padding":["2px","4px"]};"#);
+}
+
+#[test]
+fn pattern_raw_preserves_non_string_scalars() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: 0, gap: 1.5, display: true, margin: null });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"padding":0,"gap":1.5,"display":true,"margin":null};"#
+    );
+}
+
+#[test]
+fn pattern_raw_escapes_quotes_in_values() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ content: '"x"' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"content":"\"x\""};"#);
+}
+
+#[test]
+fn pattern_raw_with_no_arguments_folds_to_an_empty_object() {
+    // `boxRaw(styles)` defaults to `styles || {}`.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw();
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @"export const styles = {};");
+}
+
+#[test]
+fn pattern_raw_with_an_empty_object_folds_to_an_empty_object() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({});
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @"export const styles = {};");
+}
+
+#[test]
+fn pattern_raw_applies_default_values() {
+    let source = indoc! {r#"
+        import { spaced } from '@panda/patterns';
+        export const styles = spaced.raw({});
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"gap":"8px","padding":"2px"};"#);
+}
+
+#[test]
+fn pattern_raw_lets_props_override_default_values() {
+    let source = indoc! {r#"
+        import { spaced } from '@panda/patterns';
+        export const styles = spaced.raw({ gap: '16px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"gap":"16px","padding":"2px"};"#);
+}
+
+#[test]
+fn pattern_raw_applies_defaults_with_no_arguments() {
+    let source = indoc! {r#"
+        import { spaced } from '@panda/patterns';
+        export const styles = spaced.raw();
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"gap":"8px","padding":"2px"};"#);
+}
+
+#[test]
+fn pattern_raw_folds_a_statically_resolvable_identifier() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        const space = '4px';
+        export const styles = box.raw({ padding: space });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"
+    const space = '4px';
+    export const styles = {"padding":"4px"};
+    "#
+    );
+}
+
+#[test]
+fn pattern_raw_folds_a_static_spread() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        const base = { padding: '2px' };
+        export const styles = box.raw({ ...base, margin: '1px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"
+    const base = { padding: '2px' };
+    export const styles = {"padding":"2px","margin":"1px"};
+    "#
+    );
+}
+
+#[test]
+fn pattern_raw_parenthesizes_the_object_in_an_arrow_body() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const make = () => box.raw({ padding: '4px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const make = () => ({"padding":"4px"});"#);
+}
+
+#[test]
+fn pattern_raw_folds_inside_a_css_argument() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = { ...box.raw({ padding: '4px' }), margin: '1px' };
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = { ...{"padding":"4px"}, margin: '1px' };"#
+    );
+}
+
+#[test]
+fn pattern_raw_with_a_runtime_conditional_value_stays_intact() {
+    // A ternary is a runtime branch, not data — there's no object to emit.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: isBig ? '8px' : '2px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_nested_runtime_conditional_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: { base: '2px', _hover: isBig ? '8px' : '4px' } });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_folds_a_statically_decidable_ternary() {
+    // The condition folds, so only the taken branch is data.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        const big = true;
+        export const styles = box.raw({ padding: big ? '8px' : '2px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"
+    const big = true;
+    export const styles = {"padding":"8px"};
+    "#
+    );
+}
+
+#[test]
+fn pattern_raw_with_a_runtime_ternary_argument_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw(isBig ? { padding: '8px' } : { padding: '2px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_ternary_two_conditions_deep_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          padding: { base: '2px', _hover: { _dark: isBig ? '8px' : '4px' } },
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_ternary_inside_a_nested_selector_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          padding: '4px',
+          '&:hover': { '& > span': { margin: isBig ? '8px' : '0' } },
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_ternary_inside_a_responsive_array_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: ['2px', isBig ? '8px' : '4px'] });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_ternary_whose_branches_are_condition_objects_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          padding: isBig ? { base: '8px', _hover: '10px' } : { base: '2px', _hover: '4px' },
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_runtime_logical_and_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: isBig && '8px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_runtime_logical_or_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: size || '8px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_call_with_a_runtime_logical_and_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const cls = box({ padding: isBig && '8px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_keeps_one_static_condition_when_a_sibling_is_dynamic() {
+    // A dynamic sibling has to sink the whole call — emitting only the static
+    // half would drop the other branch.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          margin: { base: '1px', _hover: '2px' },
+          padding: isBig ? '8px' : '2px',
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn defaulted_pattern_raw_with_a_ternary_prop_stays_intact() {
+    // Bailing must not leave the defaults applied on their own.
+    let source = indoc! {r#"
+        import { spaced } from '@panda/patterns';
+        export const styles = spaced.raw({ gap: isBig ? '16px' : '4px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_call_with_a_deep_ternary_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const cls = box({ padding: { _hover: { _dark: isBig ? '8px' : '4px' } } });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_ternary_stays_intact_under_a_js_transform() {
+    let source = indoc! {r#"
+        import { stack } from '@panda/patterns';
+        export const styles = stack.raw({ gap: isBig ? '16px' : '4px' });
+    "#};
+
+    let mut passthrough = |_name: &str, styles: &Literal| -> Result<Option<Literal>, Diagnostic> {
+        Ok(Some(styles.clone()))
+    };
+
+    let output = stack_project().transform_source_with(
+        "src/layout.tsx",
+        source,
+        &patterns_only_options(),
+        ParseTransforms {
+            pattern: Some(&mut passthrough),
+            ..Default::default()
+        },
+    );
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_folds_deep_conditions_that_are_fully_static() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({
+          padding: { base: '2px', sm: '4px', _hover: { _dark: '8px', md: '6px' } },
+          margin: { _dark: { '&:focus': '1px' } },
+        });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"padding":{"base":"2px","sm":"4px","_hover":{"_dark":"8px","md":"6px"}},"margin":{"_dark":{"&:focus":"1px"}}};"#
+    );
+}
+
+#[test]
+fn pattern_raw_with_a_dynamic_argument_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw(props);
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_dynamic_value_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: props.value });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_dynamic_spread_stays_intact() {
+    // `...props` never reaches the literal, so folding here would silently
+    // drop whatever it carries.
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ ...props, padding: '4px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_call_with_a_dynamic_spread_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const cls = box({ ...props, padding: '4px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_with_a_conditional_spread_stays_intact() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ ...(isBig ? big : small), padding: '4px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn unknown_pattern_raw_passes_its_props_through() {
+    // An unconfigured name has no transform, so `raw` is the identity — the
+    // same passthrough the non-raw pattern path already uses.
+    let source = indoc! {r#"
+        import { nope } from '@panda/patterns';
+        export const styles = nope.raw({ padding: '4px' });
+    "#};
+
+    let output = transform_raw(source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"export const styles = {"padding":"4px"};"#);
+}
+
+#[test]
+fn pattern_raw_stays_intact_when_patterns_are_not_targeted() {
+    let source = indoc! {r#"
+        import { box } from '@panda/patterns';
+        export const styles = box.raw({ padding: '4px' });
+    "#};
+
+    let output = transform_source(
+        &raw_project(),
+        "src/layout.tsx",
+        source,
+        &TransformOptions {
+            targets: pandacss_project::TransformTargets {
+                patterns: false,
+                css: true,
+                ..Default::default()
+            },
+            ..TransformOptions::default()
+        },
+    );
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_needing_a_js_transform_stays_intact_without_a_callback() {
+    let source = indoc! {r#"
+        import { stack } from '@panda/patterns';
+        export const styles = stack.raw({ gap: '4px' });
+    "#};
+
+    let output = transform_source(
+        &stack_project(),
+        "src/layout.tsx",
+        source,
+        &patterns_only_options(),
+    );
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn pattern_raw_folds_through_a_js_transform_callback() {
+    let source = indoc! {r#"
+        import { stack } from '@panda/patterns';
+        export const styles = stack.raw({ gap: '4px' });
+    "#};
+
+    let mut stack_transform =
+        |_name: &str, styles: &Literal| -> Result<Option<Literal>, Diagnostic> {
+            let mut out = vec![("display".to_string(), Literal::String("flex".to_string()))];
+            if let Literal::Object(entries) = styles {
+                for (key, value) in entries {
+                    if key == "gap" {
+                        out.push(("gap".to_string(), value.clone()));
+                    }
+                }
+            }
+            Ok(Some(Literal::Object(out)))
+        };
+
+    let output = stack_project().transform_source_with(
+        "src/layout.tsx",
+        source,
+        &patterns_only_options(),
+        ParseTransforms {
+            pattern: Some(&mut stack_transform),
+            ..Default::default()
+        },
+    );
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"export const styles = {"display":"flex","gap":"4px"};"#
+    );
+}
+
+#[test]
+fn pattern_raw_stays_intact_when_the_js_transform_declines() {
+    let source = indoc! {r#"
+        import { stack } from '@panda/patterns';
+        export const styles = stack.raw({ gap: '4px' });
+    "#};
+
+    let mut decline =
+        |_name: &str, _styles: &Literal| -> Result<Option<Literal>, Diagnostic> { Ok(None) };
+
+    let output = stack_project().transform_source_with(
+        "src/layout.tsx",
+        source,
+        &patterns_only_options(),
+        ParseTransforms {
+            pattern: Some(&mut decline),
+            ..Default::default()
         },
     );
 

--- a/crates/pandacss_project/tests/transform/recipe_inline.rs
+++ b/crates/pandacss_project/tests/transform/recipe_inline.rs
@@ -1004,3 +1004,39 @@ fn a_file_with_no_panda_import_is_still_skipped() {
 
     assert!(!output.changed, "{}", output.code);
 }
+
+#[test]
+fn folds_a_raw_call_with_no_arguments() {
+    // The shape the changeset documents: `.raw()` with nothing passed resolves
+    // to the recipe's base styles, not to a class string.
+    let source = indoc! {r#"
+        import { css, cva } from '@panda/css';
+        const button = cva({ base: { color: 'red' } });
+        export const cls = css(button.raw(), { color: 'blue' });
+    "#};
+    assert_snapshot!(transform("src/styles.tsx", source).code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    import { css } from '@panda/css';
+    const button = __pcva({ base: 'color_red' });
+    export const cls = css({"color":"red"}, { color: 'blue' });
+    "#);
+}
+
+#[test]
+fn folds_a_raw_call_with_no_arguments_on_a_recipe_with_defaults() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const button = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { fontSize: '12px' }, lg: { fontSize: '20px' } } },
+          defaultVariants: { size: 'lg' },
+        });
+        export const styles = button.raw();
+    "#};
+    let output = transform("src/styles.tsx", source);
+    assert!(
+        output.code.contains(r#""fontSize":"20px""#),
+        "default variant should be applied: {}",
+        output.code
+    );
+}

--- a/crates/pandacss_project/tests/transform/recipe_inline.rs
+++ b/crates/pandacss_project/tests/transform/recipe_inline.rs
@@ -232,3 +232,775 @@ fn injects_both_cva_and_sva_symbols_when_needed() {
         )
     );
 }
+
+#[test]
+fn keeps_boolean_cva_call_sites_on_memoized_runtime() {
+    // Call-site → `__pcx` lowering is intentionally off: reused prop tuples
+    // win with `__pcva` boolean bitset + memo (bench btn-variant).
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const recipe = cva({
+          base: { display: 'inline-flex' },
+          variants: {
+            r0: { true: { opacity: '0.5' } },
+            r1: { true: { fontSize: '12px' } },
+          },
+          defaultVariants: { r0: true },
+        });
+        export const cls = recipe({
+          r0: !active,
+          r1: variant === 'secondary' || variant === 'outline',
+        });
+        export const baseOnly = recipe();
+    "#};
+
+    let output = transform("src/recipes.ts", source);
+
+    assert!(output.changed);
+    assert!(output.helper.needs_cva);
+    assert!(!output.helper.needs_cx);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const recipe = __pcva({ base: 'd_inline-flex', variants: { r0: { true: 'opacity_0.5' }, r1: { true: 'fs_12px' } }, defaultVariants: { r0: true } });
+    export const cls = recipe({
+      r0: !active,
+      r1: variant === 'secondary' || variant === 'outline',
+    });
+    export const baseOnly = recipe();
+    "#);
+}
+
+#[test]
+fn does_not_lower_non_boolean_cva_call_sites() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const button = cva({
+          base: { color: 'red' },
+          variants: {
+            size: { sm: { fontSize: '12px' }, md: { fontSize: '16px' } },
+          },
+        });
+        export const cls = button({ size: 'sm' });
+    "#};
+
+    let output = transform("src/recipes.ts", source);
+
+    assert!(output.changed);
+    assert!(output.helper.needs_cva);
+    assert!(!output.helper.needs_cx);
+    assert!(output.code.contains("button({ size: 'sm' })"));
+}
+
+// ---------------------------------------------------------------------------
+// `binding.raw(props)` on an inline cva/sva folds to the resolved style object.
+// Expectations mirror the generated `styled-system` runtime.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn folds_cva_raw_with_base_only() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = styles.raw({});
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red' });
+    export const out = {"color":"red"};
+    "#);
+}
+
+#[test]
+fn folds_cva_raw_applying_default_variants() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' }, lg: { padding: '8px' } } },
+          defaultVariants: { size: 'sm' },
+        });
+        export const out = styles.raw({});
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px', lg: 'padding_8px' } }, defaultVariants: { size: 'sm' } });
+    export const out = {"color":"red","padding":"4px"};
+    "#);
+}
+
+#[test]
+fn folds_cva_raw_with_an_explicit_variant_overriding_the_default() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' }, lg: { padding: '8px' } } },
+          defaultVariants: { size: 'sm' },
+        });
+        export const out = styles.raw({ size: 'lg' });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px', lg: 'padding_8px' } }, defaultVariants: { size: 'sm' } });
+    export const out = {"color":"red","padding":"8px"};
+    "#);
+}
+
+#[test]
+fn folds_cva_raw_ignoring_an_unknown_variant_value() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } } },
+        });
+        export const out = styles.raw({ size: 'xl' });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' } } });
+    export const out = {"color":"red"};
+    "#);
+}
+
+#[test]
+fn folds_cva_raw_with_a_matching_compound_variant() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } }, tone: { a: { color: 'blue' } } },
+          compoundVariants: [{ size: 'sm', tone: 'a', css: { margin: '2px' } }],
+        });
+        export const out = styles.raw({ size: 'sm', tone: 'a' });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' }, tone: { a: 'color_blue' } }, compoundVariants: [{ size: 'sm', tone: 'a', css: 'margin_2px' }] });
+    export const out = {"color":"blue","padding":"4px","margin":"2px"};
+    "#
+    );
+}
+
+#[test]
+fn folds_cva_raw_skipping_an_unmatched_compound_variant() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } }, tone: { a: { color: 'blue' } } },
+          compoundVariants: [{ size: 'sm', tone: 'a', css: { margin: '2px' } }],
+        });
+        export const out = styles.raw({ size: 'sm' });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' }, tone: { a: 'color_blue' } }, compoundVariants: [{ size: 'sm', tone: 'a', css: 'margin_2px' }] });
+    export const out = {"color":"red","padding":"4px"};
+    "#);
+}
+
+#[test]
+fn folds_cva_raw_with_a_boolean_variant() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({
+          base: { color: 'red' },
+          variants: { on: { true: { opacity: '0.5' } } },
+        });
+        export const out = styles.raw({ on: true });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { on: { true: 'opacity_0.5' } } });
+    export const out = {"color":"red","opacity":"0.5"};
+    "#);
+}
+
+#[test]
+fn folds_sva_raw_to_one_object_per_slot() {
+    let source = indoc! {r#"
+        import { sva } from '@panda/css';
+        const styles = sva({
+          slots: ['root', 'icon'],
+          base: { root: { color: 'red' }, icon: { padding: '1px' } },
+          variants: { size: { sm: { root: { padding: '4px' } } } },
+          defaultVariants: { size: 'sm' },
+        });
+        export const out = styles.raw({});
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"
+    import { sva as __psva } from '@pandacss-internal/css';
+    const styles = __psva({ slots: ['root', 'icon'], base: { root: 'color_red', icon: 'padding_1px' }, variants: { size: { sm: 'padding_4px' } }, defaultVariants: { size: 'sm' } });
+    export const out = {"root":{"color":"red","padding":"4px"},"icon":{"padding":"1px"}};
+    "#
+    );
+}
+
+#[test]
+fn cva_raw_with_dynamic_props_keeps_the_runtime_recipe() {
+    // The desugared runtime's `raw` returns class strings, so the definition
+    // has to stay as the real `cva`.
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' }, variants: { size: { sm: { padding: '4px' } } } });
+        export const out = styles.raw({ size: props.size });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn sva_raw_with_dynamic_props_keeps_the_runtime_recipe() {
+    let source = indoc! {r#"
+        import { sva } from '@panda/css';
+        const styles = sva({ slots: ['root'], base: { root: { color: 'red' } } });
+        export const out = styles.raw(props);
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(!output.changed);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn cva_raw_and_plain_calls_coexist_when_raw_folds() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' }, variants: { size: { sm: { padding: '4px' } } } });
+        export const out = styles.raw({ size: 'sm' });
+        export const cls = styles({ size: props.size });
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(
+        output.code,
+        @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' } } });
+    export const out = {"color":"red","padding":"4px"};
+    export const cls = styles({ size: props.size });
+    "#
+    );
+}
+
+/// Fixture shared by the slot compound-variant cases. Expected values below are
+/// what the generated `styled-system` `sva(...).raw` returns for each selection.
+macro_rules! sva_compound_source {
+    ($raw_args:literal) => {
+        concat!(
+            "import { sva } from '@panda/css';\n",
+            "const styles = sva({\n",
+            "  slots: ['root', 'icon'],\n",
+            "  base: { root: { color: 'red' }, icon: { padding: '1px' } },\n",
+            "  variants: {\n",
+            "    size: { sm: { root: { padding: '4px' } }, lg: { root: { padding: '8px' }, icon: { margin: '2px' } } },\n",
+            "    tone: { a: { root: { color: 'blue' } } },\n",
+            "  },\n",
+            "  defaultVariants: { size: 'sm' },\n",
+            "  compoundVariants: [\n",
+            "    { size: 'sm', tone: 'a', css: { root: { outline: '1px' }, icon: { border: '9px' } } },\n",
+            "    { size: 'lg', css: { icon: { border: '3px' } } },\n",
+            "  ],\n",
+            "});\n",
+            "export const out = styles.raw(", $raw_args, ");\n",
+        )
+    };
+}
+
+#[test]
+fn folds_sva_raw_applying_default_variants_per_slot() {
+    let output = transform("src/a.tsx", sva_compound_source!("{}"));
+
+    assert!(output.changed);
+    assert!(
+        output.code.ends_with(concat!(
+            r#"export const out = {"root":{"color":"red","padding":"4px"},"#,
+            r#""icon":{"padding":"1px"}};"#,
+            "\n"
+        )),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn folds_sva_raw_applying_a_matching_compound_variant_to_every_slot() {
+    let output = transform(
+        "src/a.tsx",
+        sva_compound_source!("{ size: 'sm', tone: 'a' }"),
+    );
+
+    assert!(output.changed);
+    assert!(
+        output.code.ends_with(concat!(
+            r#"export const out = {"root":{"color":"blue","padding":"4px","outline":"1px"},"#,
+            r#""icon":{"padding":"1px","border":"9px"}};"#,
+            "\n"
+        )),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn folds_sva_raw_when_a_compound_variant_touches_one_slot_only() {
+    let output = transform("src/a.tsx", sva_compound_source!("{ size: 'lg' }"));
+
+    assert!(output.changed);
+    assert!(
+        output.code.ends_with(concat!(
+            r#"export const out = {"root":{"color":"red","padding":"8px"},"#,
+            r#""icon":{"padding":"1px","margin":"2px","border":"3px"}};"#,
+            "\n"
+        )),
+        "{}",
+        output.code
+    );
+}
+
+macro_rules! cva_array_compound_source {
+    ($raw_args:literal) => {
+        concat!(
+            "import { cva } from '@panda/css';\n",
+            "const styles = cva({\n",
+            "  base: { color: 'red' },\n",
+            "  variants: { size: { sm: { padding: '4px' }, md: { padding: '6px' }, lg: { padding: '8px' } } },\n",
+            "  compoundVariants: [{ size: ['sm', 'md'], css: { margin: '2px' } }],\n",
+            "});\n",
+            "export const out = styles.raw(", $raw_args, ");\n",
+        )
+    };
+}
+
+fn assert_folds_to(source: &str, expected: &str) {
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert!(
+        output
+            .code
+            .ends_with(&format!("export const out = {expected};\n")),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn folds_cva_raw_with_the_first_value_of_an_array_compound_condition() {
+    assert_folds_to(
+        cva_array_compound_source!("{ size: 'sm' }"),
+        r#"{"color":"red","padding":"4px","margin":"2px"}"#,
+    );
+}
+
+#[test]
+fn folds_cva_raw_with_a_later_value_of_an_array_compound_condition() {
+    assert_folds_to(
+        cva_array_compound_source!("{ size: 'md' }"),
+        r#"{"color":"red","padding":"6px","margin":"2px"}"#,
+    );
+}
+
+#[test]
+fn folds_cva_raw_skipping_an_array_compound_condition_that_excludes_the_value() {
+    assert_folds_to(
+        cva_array_compound_source!("{ size: 'lg' }"),
+        r#"{"color":"red","padding":"8px"}"#,
+    );
+}
+
+#[test]
+fn folds_cva_raw_when_a_compound_condition_names_an_unselected_variant() {
+    assert_folds_to(cva_array_compound_source!("{}"), r#"{"color":"red"}"#);
+}
+
+/// The desugared runtime's `raw` returns class strings, so the definition may
+/// only be rewritten when every `.raw` use in the file has been folded away.
+fn assert_keeps_runtime_recipe(source: &str) {
+    let output = transform("src/a.tsx", source);
+
+    assert!(!output.changed, "{}", output.code);
+    assert_eq!(output.code, source);
+}
+
+#[test]
+fn a_bare_raw_reference_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const fn = styles.raw;
+    "#});
+}
+
+#[test]
+fn an_optional_chained_raw_call_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = styles?.raw({});
+    "#});
+}
+
+#[test]
+fn raw_passed_as_a_callback_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = [{ size: 'sm' }].map(styles.raw);
+    "#});
+}
+
+#[test]
+fn a_bare_sva_raw_reference_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { sva } from '@panda/css';
+        const styles = sva({ slots: ['root'], base: { root: { color: 'red' } } });
+        export const fn = styles.raw;
+    "#});
+}
+
+#[test]
+fn one_dynamic_raw_call_keeps_the_runtime_recipe_for_every_site() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' }, variants: { size: { sm: { padding: '4px' } } } });
+        export const a = styles.raw({ size: 'sm' });
+        export const b = styles.raw({ size: props.size });
+    "#});
+}
+
+#[test]
+fn a_spread_raw_argument_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = styles.raw({ ...props });
+    "#});
+}
+
+#[test]
+fn a_second_raw_argument_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export const out = styles.raw({ size: 'sm' }, { size: 'lg' });
+    "#});
+}
+
+#[test]
+fn a_computed_raw_key_keeps_the_runtime_recipe() {
+    assert_keeps_runtime_recipe(indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' }, variants: { size: { sm: { padding: '4px' } } } });
+        export const out = styles.raw({ [key]: 'sm' });
+    "#});
+}
+
+#[test]
+fn folds_a_raw_call_nested_inside_a_function() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export function f() { return styles.raw({}); }
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert!(
+        output.code.contains(r#"return {"color":"red"};"#),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn folds_every_static_raw_call_on_one_binding() {
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' }, variants: { size: { sm: { padding: '4px' } } } });
+        export const a = styles.raw({ size: 'sm' });
+        export const b = styles.raw({});
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert!(
+        output
+            .code
+            .contains(r#"export const a = {"color":"red","padding":"4px"};"#),
+        "{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(r#"export const b = {"color":"red"};"#),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn a_shadowed_raw_call_does_not_block_the_desugar() {
+    // The inner `styles` is a different symbol, so it is not a `.raw` use of
+    // the module-level recipe.
+    let source = indoc! {r#"
+        import { cva } from '@panda/css';
+        const styles = cva({ base: { color: 'red' } });
+        export function f(styles) { return styles.raw({}); }
+    "#};
+
+    let output = transform("src/a.tsx", source);
+
+    assert!(output.changed);
+    assert!(output.code.contains("__pcva("), "{}", output.code);
+    assert!(
+        output.code.contains("return styles.raw({});"),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn folds_an_imported_cva_raw_call() {
+    let button = indoc! {r#"
+        import { cva } from '@panda/css';
+        export const button = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' }, lg: { padding: '8px' } } },
+          defaultVariants: { size: 'sm' },
+        });
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { button } from './button';
+        export const cls = css(button.raw({ size: 'lg' }), { color: 'blue' });
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/button.ts", button)]);
+
+    assert!(output.changed);
+    assert!(!output.code.contains("button.raw"), "{}", output.code);
+}
+
+#[test]
+fn an_imported_cva_raw_call_applies_default_variants() {
+    let button = indoc! {r#"
+        import { cva } from '@panda/css';
+        export const button = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } } },
+          defaultVariants: { size: 'sm' },
+        });
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { button } from './button';
+        export const styles = button.raw({});
+        export const cls = css({ color: 'blue' });
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/button.ts", button)]);
+
+    assert!(output.changed);
+    assert!(
+        output.code.contains(r#"{"color":"red","padding":"4px"}"#),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn folds_an_imported_sva_raw_call_per_slot() {
+    let recipe = indoc! {r#"
+        import { sva } from '@panda/css';
+        export const parts = sva({
+          slots: ['root', 'label'],
+          base: { root: { display: 'flex' }, label: { color: 'red' } },
+        });
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { parts } from './parts';
+        export const styles = parts.raw({});
+        export const cls = css({ color: 'blue' });
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/parts.ts", recipe)]);
+
+    assert!(output.changed);
+    assert!(
+        output.code.contains(r#""root":{"display":"flex"}"#),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn an_imported_recipe_raw_with_dynamic_props_keeps_the_call() {
+    let button = indoc! {r#"
+        import { cva } from '@panda/css';
+        export const button = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } } },
+        });
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { button } from './button';
+        export const styles = (size) => button.raw({ size });
+        export const cls = css({ color: 'blue' });
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/button.ts", button)]);
+
+    assert!(output.code.contains("button.raw"), "{}", output.code);
+    // The definition file precomputes its classes, so this returns a string at
+    // runtime. Warn rather than fail silently.
+    let warning = output
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "imported_recipe_raw_dynamic")
+        .expect("diagnostic");
+    assert!(
+        warning.message.contains("statically known variants"),
+        "{}",
+        warning.message
+    );
+}
+
+#[test]
+fn a_static_imported_raw_call_does_not_warn() {
+    let button = indoc! {r#"
+        import { cva } from '@panda/css';
+        export const button = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } } },
+        });
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { button } from './button';
+        export const cls = css(button.raw({ size: 'sm' }));
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/button.ts", button)]);
+
+    assert!(
+        !output
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "imported_recipe_raw_dynamic"),
+        "{:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn a_dynamic_raw_on_a_non_recipe_import_does_not_warn() {
+    let helpers = indoc! {r#"
+        export const helper = { raw: (props) => props };
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { helper } from './helpers';
+        export const styles = (size) => helper.raw({ size });
+        export const cls = css({ color: 'blue' });
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/helpers.ts", helpers)]);
+
+    assert!(
+        !output
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "imported_recipe_raw_dynamic"),
+        "{:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn an_imported_plain_object_is_unaffected() {
+    let tokens = indoc! {r#"
+        export const raw = { color: 'red' };
+    "#};
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        import { raw } from './tokens';
+        export const cls = css(raw);
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/tokens.ts", tokens)]);
+
+    assert!(output.changed, "{}", output.code);
+}
+
+#[test]
+fn a_file_with_no_panda_import_is_still_skipped() {
+    // Extraction skips files that import nothing from Panda, so an imported
+    // recipe's `.raw` can't be folded there. Documents the boundary.
+    let button = indoc! {r#"
+        import { cva } from '@panda/css';
+        export const button = cva({ base: { color: 'red' } });
+    "#};
+    let source = indoc! {r#"
+        import { button } from './button';
+        export const styles = button.raw({});
+    "#};
+
+    let output =
+        super::common::transform_cross_file("src/a.tsx", source, &[("src/button.ts", button)]);
+
+    assert!(!output.changed, "{}", output.code);
+}

--- a/crates/pandacss_project/tests/transform/recipes.rs
+++ b/crates/pandacss_project/tests/transform/recipes.rs
@@ -17,6 +17,22 @@ fn transform_button(project: &Project, source: &str) -> pandacss_project::Transf
 }
 
 #[test]
+fn unwraps_recipe_raw_call_to_its_object() {
+    // `recipe.raw` is `props => props` — it hands back the variant selection,
+    // so the wrapper and the import can both go.
+    let source = indoc! {r#"
+        import { button } from '@panda/recipes';
+        export const styles = button.raw({ size: 'sm' });
+    "#};
+
+    let output = transform_recipes("src/button.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @"export const styles = { size: 'sm' };");
+}
+
+#[test]
 fn rewrites_static_recipe_call_to_class_string() {
     let source = indoc! {r#"
         import { button } from '@panda/recipes';

--- a/crates/pandacss_shared/src/diagnostic.rs
+++ b/crates/pandacss_shared/src/diagnostic.rs
@@ -42,7 +42,7 @@ pub mod codes {
 }
 
 /// UTF-8 byte offsets.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct Span {
     pub start: u32,

--- a/crates/pandacss_shared/src/diagnostic.rs
+++ b/crates/pandacss_shared/src/diagnostic.rs
@@ -36,6 +36,7 @@ pub mod codes {
     pub const STATIC_CSS_WILDCARD_LARGE: &str = "static_css_wildcard_large";
     pub const STATIC_CSS_WILDCARD_EMPTY: &str = "static_css_wildcard_empty";
     pub const PANDA_CALL_UNEXTRACTABLE: &str = "panda_call_unextractable";
+    pub const IMPORTED_RECIPE_RAW_DYNAMIC: &str = "imported_recipe_raw_dynamic";
     pub const TOKEN_DICTIONARY_BUILD_FAILED: &str = "token_dictionary_build_failed";
     pub const TRANSFORM_CALLBACK_FAILED: &str = "transform_callback_failed";
     pub const UNKNOWN_CONDITION: &str = "unknown_condition";

--- a/design-notes/extraction-pipeline.md
+++ b/design-notes/extraction-pipeline.md
@@ -74,10 +74,13 @@ imports the binder can't see; downstream alias lookup by name is authoritative.
 
 The project transformer consumes compact owned facts from this parse instead of parsing source fragments again:
 
-- `ModuleFacts` keeps imports, resolved import-reference spans, and the directive-prologue boundary.
+- `ModuleFacts` keeps imports, resolved import-reference spans, `local_call_bindings` (same-file
+  bindings whose initializer is a collected Panda call, plus plain `binding(...)` reference sites from
+  Oxc `Semantic`), and the directive-prologue boundary.
 - `CallFacts` keeps callee shape, argument spans, and expression facts.
 - `JsxSourceFacts` and `JsxAttr` keep element/runtime shape, property facts, and cooked values.
 - `ExpressionFacts` keeps only the kinds, precedence, static keys, and branch structure needed by rewrites.
+  Includes `parenthesize_for_logical_and` for re-emitting conditions as `cond && class`.
 
 These records use spans and small enums rather than cloned Oxc nodes, so the allocator still drops after extraction.
 `extract_for_transform` retains them; the regular extraction path skips their recursive payload and semantic

--- a/design-notes/transformer/README.md
+++ b/design-notes/transformer/README.md
@@ -401,6 +401,11 @@ The class-merge helper is `cx`. Transformed source aliases it to `__pcx` so user
 
 Recipe inlines use `cva as __pcva` and `sva as __psva` from the same internal module when those rewrites run.
 
+Boolean-only inline `cva` (`variants: { x: { true: … } }`, no compounds, ≤12 keys) uses the internal
+`booleanBitset` + memo path at runtime. Same-file call-site → `__pcx` lowering exists as infrastructure
+(`local_call_bindings` / `cva_call_lower`) but is **off by default** — reused prop tuples are faster through
+`__pcva` than uncached `__pcx(cond && class)` (css-in-js-bench `btn-variant`).
+
 Import shape in transformed code:
 
 ```ts
@@ -507,10 +512,16 @@ The helper does not justify unsafe transforms.
 
 Still bail on:
 
-- JSX spread props we cannot reason about
+- JSX spread props we cannot reason about (opaque `{...props}` leaves `StyleSpread::Open`) — except the
+  [partial fold](#partial-fold-past-an-opaque-spread), which keeps the spread and the factory
 - complex `as={condition ? A : B}` rewrites
 - dynamic style arguments we cannot fold
 - source shapes that would need object-class semantics
+
+Style-only spreads are safe to rewrite: inline `{...({ color: 'red' })}` and extract-resolved
+identifier/member spreads (`{...buttonBase}`) that fold into `style.entries` with no `Open`.
+When every source spread is style-only, the planner returns `StyleOnly` and the printer drops
+those spreads in favor of the resolved `className`.
 
 Also do not use the helper when:
 
@@ -658,13 +669,18 @@ isError ? 'c_red.500' : 'c_green.500'
 
 or a concatenated expression if several fragments are involved.
 
+`css.raw(...)` is not a class-string surface — it yields a style object for later composition, so it folds to that
+object instead. A single object argument is an identity (`mergeCss` skips normalization for one object), so the wrapper
+is stripped and the literal is left in place. Two or more arguments normalize and deep-merge, so the whole call is
+replaced by the merged object literal.
+
 #### Must bail
 
 - `props.color`, `themeColor`, `someMap[key]`, or any other open-ended runtime value
 - object spreads the planner cannot fully resolve
 - dynamic keys
-- `.raw()` forms
 - normalized branch trees that exceed the branch budget
+- `css.raw(...)` carrying a runtime branch — there is no object to print
 
 Important rule:
 
@@ -715,16 +731,106 @@ Pattern function calls such as `hstack(...)` follow the same broad rule as `css(
 - finite conditional props whose branches each resolve to known pattern output
 - conditional object props when normalization stays within the branch budget
 
+`pattern.raw(...)` runs the pattern transform and folds to the style object it returns, defaults included.
+
+A pattern call collapses to a single value — one class string, or one object for `.raw` — so unlike `css(...)` it
+cannot print a runtime ternary. Any branch the runtime has to decide bails the call. The literal alone can't show this
+(a dropped spread and a folded `&&` both look like a plain object), so the planner consults the `StyleTree`.
+
 #### Must bail
 
 - open-ended runtime props such as `hstack({ gap: props.gap })`
-- `.raw()` forms
 - unresolved spreads or dynamic keys
+- any runtime branch: a ternary, a logical `&&`, or span-less `Branches`
+- `.raw()` whose pattern needs a JS transform when no callback is supplied
 - normalized branch trees that exceed the branch budget
 
 Important rule:
 
 - for pattern function calls, open-ended dynamic should preserve the original pattern call
+
+### Partial fold past an opaque spread
+
+An opaque spread (`{...props}`) sets `StyleSpread::Open`, which used to bail the whole element. That
+is costly in the common wrapper shape, where every other style source is a static module const.
+
+Dropping to a plain tag and merging with `cx(static, props.className)` is **not** sound. Later static
+props only dominate *colliding* keys; the spread can still introduce style keys nothing overrides,
+which would be silently dropped and would also leak onto the DOM as attributes that the factory
+would have stripped. Panda's style-prop API is what creates the ambiguity — template-literal
+libraries fold the same component because their `styled` accepts no style props.
+
+So the fold keeps the factory and precomputes everything under it. `{...props}` and the factory tag
+stay; every statically resolvable style prop and spread — including conditional ones like
+`flex={cond ? '1' : undefined}` and the `css` prop — lifts into one `className`, and the runtime
+handles only the unknown spread. Style-prop extraction and DOM filtering stay exactly correct, and
+the per-render cost drops from merging N style objects to merging a string with a usually-empty
+spread.
+
+```tsx
+<styled.button {...props} type="button" {...tabBaseStyle} css={activeTabCss} />
+// →
+<styled.button {...props} type="button" className={__pcx('border-style_none hover:…', props.className)} />
+```
+
+Merge order mirrors the factory rather than guessing. JSX collapses every spread into one props
+object before the component runs, so `splitJsxProps` serializes the style half and `cx` puts
+`combinedProps.className` last (`react_jsx.rs`). Static props therefore beat props' style props (they
+overwrite in the merged object) while `props.className` beats both. Emitting
+`className={cx(<static>, props.className)}` reproduces both precedences, since the factory expands it
+to `cx(propsDerived, static, propsClassName)`. When the spread carries no style props at all the
+factory takes `composedRecipeFn(variantProps)` instead of the serialize path, which is `''` for a
+bare `styled.*`, so the fold lands on the same string there too.
+
+`partial_fold_rewrite` in `transform/jsx-element.rs` runs before the normal planner and requires:
+
+- a `JsxKind::Factory` tag (`styled.*`), so `variantSet` is empty and every style prop is a css prop
+- exactly one `StyleSpread::Open`, from a bare identifier — re-reading `.className` off a call result
+  would run it twice
+- no style source *before* that spread; one would lose to `props` at runtime but win in the
+  precomputed string
+- no explicit `className`, and `helper.cx` not `false` — without `cx` there is no sound merge
+
+One accepted deviation: `<C {...props} css={x} />` used to drop `props.css` outright, because JSX
+overwrites the whole key. After the fold the `css` attribute is gone, so `props.css` reaches the
+factory and its non-colliding keys apply. Colliding ones still lose to the precomputed class.
+
+### Same-file `styled()` chain fold
+
+`const Button = styled('button', { base: … })` renders through `forwardRef`. That extra component
+level is the dominant cost even when the class string never changes: a bare `forwardRef` that returns
+nothing but a `<button>` measures the same as the full factory, while inlining the tag is ~45%
+faster. So when the chain's class is provably constant, `<Button>` folds to the host element.
+
+```tsx
+const L0 = styled('button', { base: { color: 'red' } })
+const L1 = styled(L0, { base: { color: 'blue' } })
+export const el = <L1>hi</L1>
+// →
+export const el = <button className="color_blue">hi</button>
+```
+
+`collect_styled_bindings` (`pandacss_extractor/src/styled_bindings.rs`) walks top-level `const`
+declarations and records `name → { intrinsic, base }`, following `styled(Parent, …)` chains and
+`const Alias = Button`. The JSX visitor then resolves such a tag to `styled.{intrinsic}` and prepends
+the composed `base` under the element's own props, so the element reaches the existing
+`<styled.button>` machinery — `as`, the `css` prop, conditionals, spreads and the partial fold all
+apply unchanged, and precedence falls out of entry order.
+
+A binding is recorded only when the fold can prove the class is constant. Anything else is left out
+of the map and the runtime chain stays:
+
+- `variants` / `compoundVariants` / `defaultVariants`, or any config key other than `base` — the
+  class would depend on props
+- a third `options` argument (`defaultProps`, `shouldForwardProp`), which the fold does not reproduce
+- a base that is not a string tag or an already-recorded local binding, so imported components and
+  `styled(motion.div, …)` keep their wrapper
+- `let` / `var`, which can be reassigned between definition and use
+- declarations inside a function or block, where the visitor has no scope information to tell
+  per-call shadowing apart
+
+The `styled()` definition itself still desugars to `__pcva(…)` as before. After the fold it is
+unreferenced, so bundlers drop it.
 
 ### JSX pattern props
 
@@ -757,12 +863,39 @@ Recipe function calls sit between `css(...)` and JSX recipe elements.
 - conditional variant objects when normalization stays within the branch budget
 - static leftover style props on recipes when those leftovers can be encoded as atomic classes
 
+`recipe.raw(...)` is `props => props` for config recipes and slot recipes alike — the generated `attach()` gives both the
+same identity `raw` — so a single object argument has its wrapper stripped and the literal stays. It hands back variant
+props, not styles; a config slot recipe never yields style objects per slot.
+
+Inline `cva()` / `sva()` are the opposite: their `raw` is `resolve`, which layers base, matching variants and compound
+css through `mergeCss`. `sva` does that per slot. Desugaring the definition to string branches would silently change
+`raw` to return class strings, so `binding.raw(props)` is resolved at build time to the object the real runtime would
+produce, and the desugar only proceeds once every `.raw` call site is folded away. Binding identity and the `.raw` call
+sites come from `pandacss_extractor::LocalCallBinding`.
+
+The same hazard crosses files: `export const button = cva({…})` is desugared on its own, so an importer's
+`button.raw(props)` would meet a runtime that returns class strings. The cross-file resolver classifies such an export as
+`ExportEntry::Recipe`, and the importing file folds `button.raw(staticProps)` to the style object through the same
+resolver, recording each site so the transform pins it. The project supplies the resolution through a callback
+(`extract_with_raw_resolvers`), the way it already supplies the pattern transform — merging styles needs config the
+extractor doesn't own.
+
+Two gaps remain. A file that imports nothing from Panda is skipped before extraction runs, so an imported `.raw` there is
+never folded. And an importer whose props aren't static leaves the call in place, where the desugared definition still
+hands back a string — the definition file can't see its consumers.
+
+That second gap warns rather than fails silently: an unfoldable `.raw` on a known imported recipe emits
+`imported_recipe_raw_dynamic`. Warning is deliberate over the two fixes. Materializing a real recipe at the consumer
+pulls the full `cva` runtime back into that file, and refusing to desugar exported recipes taxes every app to protect a
+corner. The warning can over-fire in one narrow band — the definition's own local `.raw` usage can block its desugar,
+which the consumer can't see — so it stays a warning.
+
 #### Must bail or preserve runtime call
 
 - open-ended variant values such as `button({ size: props.size })`
 - unresolved spreads
-- `.raw()` forms
 - normalized branch trees that exceed the branch budget
+- a `.raw` call on an inline `cva`/`sva` whose props aren't static — the whole definition keeps its runtime recipe
 
 Important rule:
 

--- a/packages/compiler/__tests__/transform-source/css.test.ts
+++ b/packages/compiler/__tests__/transform-source/css.test.ts
@@ -123,9 +123,7 @@ describe('compiler.transformSource: css', () => {
     )
 
     const result = compiler.transformSource({ path: 'src/styles.ts', source })
-    expect(result.code).toMatchInlineSnapshot(`
-      "export const raw = "color_red padding_4px""
-    `)
+    expect(result.code).toMatchInlineSnapshot(`"export const raw = { color: 'red', padding: '4px' }"`)
   })
 
   test('rewrites multiple static css() calls in one file', () => {
@@ -576,7 +574,7 @@ describe('compiler.transformSource: css', () => {
     )
 
     const result = compiler.transformSource({ path: 'src/button.tsx', source })
-    expect(result.code).toMatchInlineSnapshot(`"export const cls = "color_red md:color_blue""`)
+    expect(result.code).toMatchInlineSnapshot(`"export const cls = { color: { base: 'red', md: 'blue' } }"`)
   })
 
   test('emits both classes for a multi-prop finite ternary', () => {

--- a/packages/compiler/__tests__/transform-source/template-literal.test.ts
+++ b/packages/compiler/__tests__/transform-source/template-literal.test.ts
@@ -127,10 +127,13 @@ describe('compiler.transformSource: template-literal css', () => {
     `)
   })
 
-  test('rewrites a css.raw template to a class string, matching the object form', () => {
+  test('leaves a css.raw template untouched — raw yields a style object, not classes', () => {
     const source = lines("import { css } from '@panda/css'", 'export const a = css.raw`color: red;`')
     const result = tpl.transformSource({ path: 'src/a.tsx', source })
-    expect(result.code).toMatchInlineSnapshot(`"export const a = "color_red""`)
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { css } from '@panda/css'
+      export const a = css.raw\`color: red;\`"
+    `)
   })
 })
 


### PR DESCRIPTION
`.raw()` exists so styles can be composed. With the transform enabled it handed back a class string instead, and every composition site downstream silently produced wrong styles. This fixes that for `css`, config recipes, patterns, and inline `cva`/`sva` — same file and across files.

## The bug

```js
const button = cva({ base: { color: 'red' }, variants: { … } })
const styles = button.raw({ size: 'sm' })   // a class string, not an object
css(styles, { color: 'blue' })              // garbage in, garbage out
```

No error, no warning. The transform desugars `cva({…})` to string branches, and the desugared runtime's `raw` returns class strings where the real one returns style objects. Consumers had no way to notice.

## What changes

**`css.raw({…})` and `recipe.raw({…})` are identities**, so the wrapper is stripped and the object literal stays where it was — nested rewrites like token folding still apply inside it.

**`css.raw(a, b)` deep-merges at build time** through the same normalization `mergeCss` uses, folding to one object instead of merging per render.

**`pattern.raw(props)` folds to the object its transform returns**, defaults included. A pattern call collapses to a single value, so it can't express a runtime branch — a dropped dynamic spread or a folded `&&` now bails the call instead of silently emitting one arm.

**Inline `cva`/`sva`, same file**: every `binding.raw(props)` site is resolved at build time to the object the real runtime would produce, and the desugar only proceeds once all of them are folded away. A `.raw` that escapes as a value — `const fn = styles.raw`, `styles.raw?.()`, passing it as an argument — keeps the runtime recipe instead.

**Inline `cva`/`sva`, across files**: an exported `const button = cva({…})` is classified as a resolvable recipe, and the importer folds `button.raw(staticProps)` through a project-supplied callback, the way the pattern transform is already supplied. When the props aren't static, Panda emits `imported_recipe_raw_dynamic` instead of quietly handing back a string.

## Known gap

A consumer file that imports nothing from Panda is skipped before extraction runs, so an imported `.raw` there is never folded and no warning fires. Documented in `design-notes/transformer/README.md` along with the two alternatives that were rejected — materializing the recipe at the consumer pulls the full `cva` runtime into that file, and refusing to desugar exported recipes taxes every app to protect a corner.

## Commits

1. `feat(extractor)` — record local bindings initialized by a Panda call, with their plain and `.raw` call sites, from Oxc's symbol table. Transform-only IR; the normal extraction path is unchanged.
2. `fix(transform)` — `.raw()` stays a style object for css, recipes and patterns.
3. `fix(transform)` — resolve `.raw()` on inline and imported `cva`/`sva`.

## Tests

39 new cases in `pandacss_project`, plus the extractor's binding-collection suite. Coverage includes identity unwrap, multi-arg merge, pattern defaults, the escape hatches that must block the desugar, cross-file resolution, and the dynamic-props warning. Existing `.raw` tests that asserted the class-string behaviour are inverted — that behaviour was the bug.

## Verified locally

Against a binary built from a clean worktree of this branch:

- `cargo nextest run --workspace` — 2252 passed
- `pnpm --filter @pandacss/compiler test` — 533 passed
- `pnpm --filter sandbox-codegen test` — all 11 framework scenarios
- `cargo fmt --check` and `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVzc85Z4YGMGwQz2FnEfFo
