### PR TITLE
fix(extractor): reach files that only import a recipe

### DIFF
--- a/.changeset/reach-recipe-consumers.md
+++ b/.changeset/reach-recipe-consumers.md
@@ -1,0 +1,11 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix `.raw()` on an imported recipe being left alone in files that import nothing else from Panda.
+
+```ts
+import { button } from './recipes' // the only import
+
+const styles = button.raw() // was a class string, now { color: 'red' }
+```

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -19,8 +19,10 @@ use crate::{
 };
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Comment, Program};
+use oxc_ast_visit::Visit as _;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use rustc_hash::FxHashSet;
 use serde::Serialize;
 
 /// A folded `imported.raw(props)` call on an inline `cva`/`sva` exported from
@@ -357,7 +359,16 @@ fn run_extract<'cb>(
         exports
     };
 
-    if should_skip_extraction(&matched, config) {
+    // A file with no Panda imports can still consume one: `button.raw(...)` on
+    // a recipe imported from another module. The definition file desugars
+    // independently, so skipping here would leave the call reading a class
+    // string. Only relevant when the project supplied a recipe resolver.
+    let would_skip = should_skip_extraction(&matched, config);
+    let consumes_imported_recipe = would_skip
+        && recipe_raw_resolve.is_some()
+        && calls_raw_on_an_imported_binding(&parser_return.program, &imports);
+
+    if would_skip && !consumes_imported_recipe {
         let module = if retain_transform_facts {
             ModuleFacts {
                 imports,
@@ -403,27 +414,26 @@ fn run_extract<'cb>(
     };
     let ctx = VisitorContext::new(&matched, config).with_resolver(&resolver);
 
-    let (calls, call_diagnostics, mut token_refs, mut style_source_refs) = if should_collect_calls(
-        &matched, config,
-    ) {
-        let span = tracing::trace_span!(target: "extract", "extract_calls", call_count = tracing::field::Empty);
-        let _entered = span.enter();
-        let result = if verbose {
-            collect_calls_verbose(&parser_return.program, &ctx, &line_index)
+    let (calls, call_diagnostics, mut token_refs, mut style_source_refs) =
+        if consumes_imported_recipe || should_collect_calls(&matched, config) {
+            let span = tracing::trace_span!(target: "extract", "extract_calls", call_count = tracing::field::Empty);
+            let _entered = span.enter();
+            let result = if verbose {
+                collect_calls_verbose(&parser_return.program, &ctx, &line_index)
+            } else {
+                let (calls, diagnostics, token_refs) = collect_calls_with_token_refs(
+                    &parser_return.program,
+                    &ctx,
+                    &line_index,
+                    retain_transform_facts,
+                );
+                (calls, diagnostics, token_refs, Vec::new())
+            };
+            span.record("call_count", result.0.len());
+            result
         } else {
-            let (calls, diagnostics, token_refs) = collect_calls_with_token_refs(
-                &parser_return.program,
-                &ctx,
-                &line_index,
-                retain_transform_facts,
-            );
-            (calls, diagnostics, token_refs, Vec::new())
+            (Vec::new(), Vec::new(), Vec::new(), Vec::new())
         };
-        span.record("call_count", result.0.len());
-        result
-    } else {
-        (Vec::new(), Vec::new(), Vec::new(), Vec::new())
-    };
 
     let mut jsx = if should_collect_jsx(config) {
         let span = tracing::trace_span!(target: "extract", "extract_jsx", jsx_count = tracing::field::Empty);
@@ -594,6 +604,51 @@ fn after_line_terminator(start: u32, source: &str) -> u32 {
         cursor
     };
     u32::try_from(end).unwrap_or(start)
+}
+
+/// True when the file calls `.raw(...)` on a binding it imported.
+///
+/// Deliberately syntactic: no resolution, no filesystem. A false positive
+/// costs one file's extraction, which then finds nothing.
+fn calls_raw_on_an_imported_binding(program: &Program<'_>, imports: &[ImportRecord]) -> bool {
+    let locals: FxHashSet<&str> = imports
+        .iter()
+        .filter(|record| !record.type_only)
+        .flat_map(|record| record.specifiers.iter())
+        .filter(|specifier| !specifier.type_only)
+        .map(|specifier| specifier.local.as_str())
+        .collect();
+    if locals.is_empty() {
+        return false;
+    }
+
+    let mut finder = ImportedRawCallFinder {
+        locals: &locals,
+        found: false,
+    };
+    finder.visit_program(program);
+    finder.found
+}
+
+struct ImportedRawCallFinder<'a> {
+    locals: &'a FxHashSet<&'a str>,
+    found: bool,
+}
+
+impl<'a> oxc_ast_visit::Visit<'a> for ImportedRawCallFinder<'_> {
+    fn visit_call_expression(&mut self, call: &oxc_ast::ast::CallExpression<'a>) {
+        if !self.found
+            && let oxc_ast::ast::Expression::StaticMemberExpression(member) =
+                call.callee.get_inner_expression()
+            && member.property.name == "raw"
+            && let oxc_ast::ast::Expression::Identifier(object) =
+                member.object.get_inner_expression()
+            && self.locals.contains(object.name.as_str())
+        {
+            self.found = true;
+        }
+        oxc_ast_visit::walk::walk_call_expression(self, call);
+    }
 }
 
 fn should_collect_calls(matched: &[MatchedImport], config: &ExtractorConfig) -> bool {

--- a/crates/pandacss_project/tests/transform/recipe_inline.rs
+++ b/crates/pandacss_project/tests/transform/recipe_inline.rs
@@ -987,25 +987,6 @@ fn an_imported_plain_object_is_unaffected() {
 }
 
 #[test]
-fn a_file_with_no_panda_import_is_still_skipped() {
-    // Extraction skips files that import nothing from Panda, so an imported
-    // recipe's `.raw` can't be folded there. Documents the boundary.
-    let button = indoc! {r#"
-        import { cva } from '@panda/css';
-        export const button = cva({ base: { color: 'red' } });
-    "#};
-    let source = indoc! {r#"
-        import { button } from './button';
-        export const styles = button.raw({});
-    "#};
-
-    let output =
-        super::common::transform_cross_file("src/a.tsx", source, &[("src/button.ts", button)]);
-
-    assert!(!output.changed, "{}", output.code);
-}
-
-#[test]
 fn folds_a_raw_call_with_no_arguments() {
     // The shape the changeset documents: `.raw()` with nothing passed resolves
     // to the recipe's base styles, not to a class string.
@@ -1037,6 +1018,56 @@ fn folds_a_raw_call_with_no_arguments_on_a_recipe_with_defaults() {
     assert!(
         output.code.contains(r#""fontSize":"20px""#),
         "default variant should be applied: {}",
+        output.code
+    );
+}
+
+// --- a consumer that imports the recipe but nothing from Panda ---
+
+#[test]
+fn folds_a_raw_call_in_a_file_that_imports_no_panda_api() {
+    // The component only imports the recipe. Panda skips files with no Panda
+    // imports, which is exactly how this call used to survive unfolded — and
+    // the desugared definition's `raw` hands back a class string.
+    let source = indoc! {r#"
+        import { button } from './recipes';
+        export const styles = button.raw({ size: 'sm' });
+    "#};
+    let recipes = indoc! {r#"
+        import { cva } from '@panda/css';
+        export const button = cva({
+          base: { color: 'red' },
+          variants: { size: { sm: { fontSize: '12px' } } },
+        });
+    "#};
+
+    let output =
+        super::common::transform_cross_file("main.tsx", source, &[("recipes.ts", recipes)]);
+
+    assert!(output.changed, "the raw call should fold: {}", output.code);
+    assert!(
+        output.code.contains(r#""fontSize":"12px""#),
+        "expected resolved styles, got: {}",
+        output.code
+    );
+}
+
+#[test]
+fn leaves_a_file_with_no_panda_api_and_no_raw_call_alone() {
+    // The fast path that skips unrelated files has to survive.
+    let source = indoc! {r#"
+        import { helper } from './helper';
+        export const value = helper(1);
+    "#};
+    let helper = indoc! {r#"
+        export const helper = (n) => n + 1;
+    "#};
+
+    let output = super::common::transform_cross_file("main.tsx", source, &[("helper.ts", helper)]);
+
+    assert!(
+        !output.changed,
+        "unrelated file should be untouched: {}",
         output.code
     );
 }

--- a/design-notes/transformer/README.md
+++ b/design-notes/transformer/README.md
@@ -880,11 +880,15 @@ resolver, recording each site so the transform pins it. The project supplies the
 (`extract_with_raw_resolvers`), the way it already supplies the pattern transform — merging styles needs config the
 extractor doesn't own.
 
-Two gaps remain. A file that imports nothing from Panda is skipped before extraction runs, so an imported `.raw` there is
-never folded. And an importer whose props aren't static leaves the call in place, where the desugared definition still
+A consumer often imports the recipe and nothing else from Panda, which the no-Panda-imports fast path would skip. So the
+skip test also asks whether the file calls `.raw(...)` on a binding it imported — a syntactic check over the AST already
+parsed, with no resolution and no filesystem. A false positive costs that one file's extraction, which then finds
+nothing. Everything else still skips.
+
+One gap remains: an importer whose props aren't static leaves the call in place, where the desugared definition still
 hands back a string — the definition file can't see its consumers.
 
-That second gap warns rather than fails silently: an unfoldable `.raw` on a known imported recipe emits
+That gap warns rather than fails silently: an unfoldable `.raw` on a known imported recipe emits
 `imported_recipe_raw_dynamic`. Warning is deliberate over the two fixes. Materializing a real recipe at the consumer
 pulls the full `cva` runtime back into that file, and refusing to desugar exported recipes taxes every app to protect a
 corner. The warning can over-fire in one narrow band — the definition's own local `.raw` usage can block its desugar,


### PR DESCRIPTION
Closes the gap #3697 documented. A component that imports a recipe and nothing else from Panda was skipped entirely, so its `.raw()` call kept reading a class string — silently, in an ordinary shape.

```ts
// Card.tsx — the only import
import { button } from './recipes'

const styles = button.raw() // was "color_red", now { color: 'red' }
```

## Why it was skipped

Panda skips any file that imports nothing from Panda. That fast path is what keeps it quick over `node_modules` and unrelated code, and it's why this file was never opened. The definition file desugars on its own, without knowing who consumes it, so nothing corrected the call.

## The fix

The skip test now also asks: does this file call `.raw(...)` on a binding it imported?

That's a syntactic question over an AST that is already parsed — no module resolution, no filesystem, no import graph. It runs **only** for files that were about to be skipped, so a file with Panda imports pays nothing. A false positive costs that one file's extraction, which then finds nothing and moves on.

Everything downstream already existed: once the file is extracted, the cross-file recipe resolution from #3697 folds the call, or warns if the props aren't static.

## What was considered instead

- **Follow imports to see if a file is Panda-related.** One level isn't enough — barrel files re-export — so it needs the full transitive closure, which means resolving and parsing a large share of the project to decide what to skip.
- **A module graph, TypeScript-style.** The right long-term shape, and it subsumes this. But `transform_source` is per-file and stateless — the bundler owns the file loop — so there's no build pass to hang it on, and it partly rebuilds what v2 dropped for speed. Worth doing when two or three cross-file features need it, not for one gap.

## Tests

- a consumer importing only the recipe folds its `.raw()` call
- a file with no Panda imports and no `.raw()` call is still skipped — this guards the fast path
- the old test that documented the gap is removed; it asserted the behaviour this fixes

## Verified locally

- `cargo nextest run --workspace` — 2260 passed
- `pnpm --filter @pandacss/compiler test` — 533 passed
- `pnpm --filter sandbox-codegen test` — all 11 framework scenarios
- `cargo fmt --check` and `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVzc85Z4YGMGwQz2FnEfFo
