### PR TITLE
feat(transform): fold static JSX past opaque spreads and styled() chains

### DIFF
--- a/.changeset/jsx-partial-fold-opaque-spread.md
+++ b/.changeset/jsx-partial-fold-opaque-spread.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+---
+
+Precompute the static styles of a `styled.*` element that also spreads unknown props. The factory and the spread stay
+so runtime style props still work; everything Panda can see at build time collapses into one `className`.

--- a/.changeset/styled-chain-fold.md
+++ b/.changeset/styled-chain-fold.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fold same-file `styled()` chains to their underlying element when the class string is constant, so
+`<Button>` no longer pays for a `forwardRef` component level at runtime. Chains with variants, an
+options argument, or a non-local base keep the existing runtime behaviour.

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     CssSyntaxKind, Diagnostic, ExpressionFacts, ExtractorConfig, ImportSpecifierKind, JsxKind,
-    Literal, MatchCategory, MatchedImport, Matchers, Span, StyleTree, VisitorContext,
+    Literal, MatchCategory, MatchedImport, Matchers, Span, StyleObject, StyleTree, VisitorContext,
     css_template::css_template_to_style_tree,
     jsx_react_runtime,
     matcher::member_display,
@@ -13,6 +13,7 @@ use crate::{
     },
     span_from_oxc,
     style_tree::{jsx_attributes_to_style_tree, project_literal},
+    styled_bindings::{StyledBinding, StyledBindings, collect_styled_bindings},
 };
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -196,6 +197,7 @@ pub(crate) fn collect_jsx(
         out: &mut out,
         react_runtime,
         style_source_refs: None,
+        styled_bindings: collect_styled_bindings(program, ctx),
         retain_transform_facts,
     };
     extractor.visit_program(program);
@@ -214,6 +216,7 @@ pub(crate) fn collect_jsx_verbose(
         out: &mut out,
         react_runtime,
         style_source_refs: Some(&mut style_source_refs),
+        styled_bindings: collect_styled_bindings(program, ctx),
         retain_transform_facts: false,
     };
     extractor.visit_program(program);
@@ -287,6 +290,7 @@ pub(crate) struct Extractor<'walk, 'ctx, 'cb> {
     out: &'walk mut Vec<ExtractedJsx>,
     react_runtime: jsx_react_runtime::ReactRuntimeImports,
     style_source_refs: Option<&'walk mut Vec<StyleSourceRef>>,
+    styled_bindings: StyledBindings,
     pub(crate) retain_transform_facts: bool,
 }
 
@@ -298,6 +302,9 @@ pub(crate) struct ResolvedTag<'a> {
     /// `true` when resolved via a matched Panda import; `false` for the
     /// name-only `should_match_tag` fallback.
     pub(crate) panda_owned: bool,
+    /// Set when the tag is a local `styled()` chain the fold may collapse to
+    /// its host element.
+    pub(crate) styled: Option<&'a StyledBinding>,
 }
 
 impl Extractor<'_, '_, '_> {
@@ -329,10 +336,30 @@ impl Extractor<'_, '_, '_> {
                         alias: Cow::Borrowed(&matched.alias),
                         emit_empty: true,
                         panda_owned: true,
+                        styled: None,
                     });
                 }
 
                 let tag_name = id.name.as_str();
+                // A local `styled()` chain stands in for `<styled.{tag}>`, so the
+                // fold reaches it with the machinery host factories already use.
+                // Only when the tag resolves to the symbol we recorded — a local
+                // binding may shadow the module-level chain.
+                if let Some(binding) = self.styled_bindings.get(tag_name)
+                    && binding.symbol_id.is_some()
+                    && let Some(resolver) = self.ctx.resolver
+                    && resolver.symbol_for_identifier(id) == binding.symbol_id
+                {
+                    return Some(ResolvedTag {
+                        category: MatchCategory::Jsx,
+                        name: Cow::Owned(format!("styled.{}", binding.intrinsic)),
+                        alias: Cow::Borrowed(tag_name),
+                        emit_empty: true,
+                        panda_owned: true,
+                        styled: Some(binding),
+                    });
+                }
+
                 let is_configured_component = self.ctx.config.jsx.is_component_tag(tag_name);
                 if !is_configured_component
                     && !self
@@ -349,6 +376,7 @@ impl Extractor<'_, '_, '_> {
                     alias: Cow::Borrowed(tag_name),
                     emit_empty: is_configured_component,
                     panda_owned: false,
+                    styled: None,
                 })
             }
             JSXElementName::MemberExpression(member) => {
@@ -386,6 +414,7 @@ impl Extractor<'_, '_, '_> {
                     alias: Cow::Borrowed(root),
                     emit_empty: is_configured_component,
                     panda_owned: false,
+                    styled: None,
                 });
             }
             return None;
@@ -410,6 +439,7 @@ impl Extractor<'_, '_, '_> {
                         alias: Cow::Borrowed(&matched.alias),
                         emit_empty: true,
                         panda_owned: true,
+                        styled: None,
                     });
                 }
 
@@ -423,6 +453,7 @@ impl Extractor<'_, '_, '_> {
                     alias: Cow::Borrowed(&matched.alias),
                     emit_empty: true,
                     panda_owned: true,
+                    styled: None,
                 })
             }
             ImportSpecifierKind::Namespace => {
@@ -441,6 +472,7 @@ impl Extractor<'_, '_, '_> {
                     alias: Cow::Borrowed(&matched.alias),
                     emit_empty: true,
                     panda_owned: true,
+                    styled: None,
                 })
             }
             ImportSpecifierKind::Default => None,
@@ -484,6 +516,7 @@ impl Extractor<'_, '_, '_> {
                         alias: Cow::Borrowed(&matched.alias),
                         emit_empty: true,
                         panda_owned: true,
+                        styled: None,
                     });
                 }
 
@@ -504,6 +537,7 @@ impl Extractor<'_, '_, '_> {
                     alias: Cow::Borrowed(tag_name),
                     emit_empty: is_configured_component,
                     panda_owned: false,
+                    styled: None,
                 })
             }
             Expression::StringLiteral(s) => {
@@ -517,6 +551,7 @@ impl Extractor<'_, '_, '_> {
                     alias: Cow::Borrowed(tag_name),
                     emit_empty: true,
                     panda_owned: false,
+                    styled: None,
                 })
             }
             Expression::StaticMemberExpression(member) => {
@@ -547,12 +582,18 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
             let emit_empty = resolved.emit_empty;
             let panda_owned = resolved.panda_owned;
 
+            let styled_base = resolved.styled.map(|binding| binding.base.clone());
+            let styled_intrinsic = resolved.styled.map(|binding| binding.intrinsic.clone());
             let style = jsx_attributes_to_style_tree(
                 &element.attributes,
                 self.ctx.resolver,
                 &self.ctx.config.jsx,
                 &tag_name,
             );
+            let style = match (styled_base, style) {
+                (Some(base), style) => prepend_styled_base(base, style),
+                (None, style) => style,
+            };
             let data = style
                 .as_ref()
                 .and_then(project_literal)
@@ -606,7 +647,8 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                 source: if retain {
                     JsxSourceFacts {
                         kind: JsxSourceKind::Element,
-                        factory_intrinsic: factory_intrinsic_from_jsx_name(&element.name),
+                        factory_intrinsic: styled_intrinsic
+                            .or_else(|| factory_intrinsic_from_jsx_name(&element.name)),
                         ..Default::default()
                     }
                 } else {
@@ -686,6 +728,26 @@ fn factory_intrinsic_from_jsx_name(name: &JSXElementName<'_>) -> Option<String> 
         JSXElementName::MemberExpression(member) => Some(member.property.name.to_string()),
         _ => None,
     }
+}
+
+/// Puts a `styled()` chain's `base` underneath the element's own props, which
+/// is the precedence the runtime factory gives them. `None` when the element's
+/// styles are not a plain object, since only then is the ordering well defined.
+fn prepend_styled_base(
+    base: Vec<(String, StyleTree)>,
+    style: Option<StyleTree>,
+) -> Option<StyleTree> {
+    let own = match style {
+        None => StyleObject::default(),
+        Some(StyleTree::Object(object)) => object,
+        Some(_) => return None,
+    };
+    let mut entries = base;
+    entries.extend(own.entries);
+    Some(StyleTree::Object(StyleObject {
+        entries,
+        spreads: own.spreads,
+    }))
 }
 
 pub(crate) fn factory_intrinsic_from_expression(expression: &Expression<'_>) -> Option<String> {

--- a/crates/pandacss_extractor/src/lib.rs
+++ b/crates/pandacss_extractor/src/lib.rs
@@ -29,6 +29,7 @@ mod scope;
 mod source;
 mod source_refs;
 mod style_tree;
+mod styled_bindings;
 mod svelte_adapter;
 mod template_styles;
 mod transform_facts;

--- a/crates/pandacss_extractor/src/style_tree.rs
+++ b/crates/pandacss_extractor/src/style_tree.rs
@@ -78,8 +78,9 @@ pub enum StyleSpread {
         /// Keys overwritten by a later static entry.
         overridden: Vec<String>,
     },
-    /// Opaque object member or spread. Transform bails; encode skips it.
-    Open,
+    /// Opaque object member or spread. Encode skips it; transform needs the
+    /// span to tell which source spread it came from.
+    Open { span: Span },
     /// Dynamic `...(a || b)` or `...(a ?? b)` with a known fallback. Transform
     /// bails; encode merges the fallback.
     OpenWithFallback { fallback: StyleTree },
@@ -89,7 +90,7 @@ impl StyleSpread {
     /// True for rewrite-critical open spreads.
     #[must_use]
     pub const fn is_open(&self) -> bool {
-        matches!(self, Self::Open | Self::OpenWithFallback { .. })
+        matches!(self, Self::Open { .. } | Self::OpenWithFallback { .. })
     }
 }
 
@@ -181,7 +182,7 @@ fn project_object(obj: &StyleObject) -> Option<Literal> {
                     }
                 }
             }
-            StyleSpread::Open => {}
+            StyleSpread::Open { .. } => {}
         }
     }
 
@@ -196,7 +197,7 @@ fn project_object(obj: &StyleObject) -> Option<Literal> {
             .iter()
             .all(|(_, v)| project_literal(v).is_none())
             && obj.spreads.iter().all(|s| match s {
-                StyleSpread::Open => true,
+                StyleSpread::Open { .. } => true,
                 StyleSpread::Ternary {
                     consequent,
                     alternate,
@@ -415,11 +416,15 @@ fn object_to_style_tree(
         match prop {
             ObjectPropertyKind::ObjectProperty(prop) => {
                 if prop.method || prop.kind != PropertyKind::Init {
-                    spreads.push(StyleSpread::Open);
+                    spreads.push(StyleSpread::Open {
+                        span: span_from_oxc(prop.span),
+                    });
                     continue;
                 }
                 let Some(key) = property_key_to_string(&prop.key, prop.computed, resolver) else {
-                    spreads.push(StyleSpread::Open);
+                    spreads.push(StyleSpread::Open {
+                        span: span_from_oxc(prop.span),
+                    });
                     continue;
                 };
                 mark_spreads_overridden(&mut spreads, &key);
@@ -446,6 +451,8 @@ fn push_style_spread(
     argument: &Expression<'_>,
     resolver: Option<&Resolver<'_, '_>>,
 ) {
+    // Before `get_inner_expression`, so it lines up with `ExpressionFacts::span`.
+    let open_span = span_from_oxc(argument.span());
     let argument = argument.get_inner_expression();
     match argument {
         Expression::ConditionalExpression(c) => {
@@ -509,7 +516,7 @@ fn push_style_spread(
                         Some(fallback) => {
                             spreads.push(StyleSpread::OpenWithFallback { fallback });
                         }
-                        None => spreads.push(StyleSpread::Open),
+                        None => spreads.push(StyleSpread::Open { span: open_span }),
                     }
                 }
             }
@@ -522,7 +529,7 @@ fn push_style_spread(
                 }
                 spreads.extend(inner.spreads);
             }
-            Some(StyleTree::Open) | None => spreads.push(StyleSpread::Open),
+            Some(StyleTree::Open) | None => spreads.push(StyleSpread::Open { span: open_span }),
             Some(StyleTree::OpenWithFallback(inner)) => {
                 spreads.push(StyleSpread::OpenWithFallback { fallback: *inner });
             }
@@ -559,7 +566,7 @@ fn mark_spreads_overridden(spreads: &mut [StyleSpread], key: &str) {
             StyleSpread::Ternary { overridden, .. } | StyleSpread::And { overridden, .. } => {
                 overridden
             }
-            StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => continue,
+            StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => continue,
         };
         if !overridden.iter().any(|existing| existing == key) {
             overridden.push(key.to_owned());
@@ -694,7 +701,7 @@ fn filter_spread_props(spread: &mut StyleSpread, jsx: &crate::JsxExtractionConfi
         StyleSpread::And { value, .. } | StyleSpread::OpenWithFallback { fallback: value } => {
             filter_object_props(value, jsx, tag_name);
         }
-        StyleSpread::Open => {}
+        StyleSpread::Open { .. } => {}
     }
 }
 
@@ -743,7 +750,7 @@ fn filter_react_runtime_props_in_spread(spread: &mut StyleSpread) {
         StyleSpread::And { value, .. } | StyleSpread::OpenWithFallback { fallback: value } => {
             filter_react_runtime_props_in_tree(value);
         }
-        StyleSpread::Open => {}
+        StyleSpread::Open { .. } => {}
     }
 }
 

--- a/crates/pandacss_extractor/src/styled_bindings.rs
+++ b/crates/pandacss_extractor/src/styled_bindings.rs
@@ -1,0 +1,170 @@
+//! Same-file `const Button = styled('button', { base: … })` chains.
+//!
+//! A `styled()` component renders through `forwardRef`, which costs a whole
+//! extra React component level even when its class string is constant. When the
+//! chain is base-only and rooted in an intrinsic tag, every `<Button>` site can
+//! be folded to the host element, exactly as `<styled.button>` already is.
+//! Anything the fold cannot prove — variants, an options argument, a non-local
+//! base — is simply not recorded, so the runtime chain stays.
+
+use oxc_ast::ast::{
+    BindingPattern, Declaration, Expression, Program, Statement, VariableDeclarationKind,
+};
+use oxc_semantic::SymbolId;
+use rustc_hash::FxHashMap;
+
+use crate::matcher::VisitorContext;
+use crate::{StyleObject, StyleTree, style_tree::expression_to_style_tree};
+
+/// A local binding the JSX visitor may treat as `<styled.{intrinsic}>`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct StyledBinding {
+    /// Symbol of the declaration, so a shadowing local can't be folded as this one.
+    pub symbol_id: Option<SymbolId>,
+    pub intrinsic: String,
+    /// Composed `base` styles, outermost-first, so element props still win.
+    pub base: Vec<(String, StyleTree)>,
+}
+
+pub(crate) type StyledBindings = FxHashMap<String, StyledBinding>;
+
+/// Collects foldable `styled()` bindings from a module's top-level statements.
+///
+/// Top level only: a chain built inside a function or block could differ per
+/// call, and the JSX visitor has no scope information to tell those apart.
+pub(crate) fn collect_styled_bindings(
+    program: &Program<'_>,
+    ctx: &VisitorContext<'_, '_>,
+) -> StyledBindings {
+    let mut bindings = StyledBindings::default();
+    let mut rebindable: Vec<String> = Vec::new();
+
+    for statement in &program.body {
+        let declaration = match statement {
+            Statement::VariableDeclaration(declaration) => declaration,
+            Statement::ExportNamedDeclaration(export) => match export.declaration.as_ref() {
+                Some(Declaration::VariableDeclaration(declaration)) => declaration,
+                _ => continue,
+            },
+            _ => continue,
+        };
+
+        for declarator in &declaration.declarations {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                continue;
+            };
+            // `let`/`var` can be reassigned between definition and use.
+            if declaration.kind != VariableDeclarationKind::Const {
+                rebindable.push(id.name.to_string());
+                continue;
+            }
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let Some(binding) = resolve_binding(init, ctx, &bindings) {
+                bindings.insert(
+                    id.name.to_string(),
+                    StyledBinding {
+                        symbol_id: id.symbol_id.get(),
+                        ..binding
+                    },
+                );
+            }
+        }
+    }
+
+    for name in rebindable {
+        bindings.remove(&name);
+    }
+    bindings
+}
+
+fn resolve_binding(
+    init: &Expression<'_>,
+    ctx: &VisitorContext<'_, '_>,
+    known: &StyledBindings,
+) -> Option<StyledBinding> {
+    match init.get_inner_expression() {
+        // `const Alias = Button`
+        // `const Alias = Button` — the alias gets its own symbol below.
+        Expression::Identifier(id) => known.get(id.name.as_str()).cloned(),
+        Expression::CallExpression(call) => {
+            let Expression::Identifier(callee) = call.callee.get_inner_expression() else {
+                return None;
+            };
+            if !is_styled_factory(callee.name.as_str(), ctx) {
+                return None;
+            }
+            // A third `options` argument carries `defaultProps` /
+            // `shouldForwardProp`, neither of which the fold reproduces.
+            if call.arguments.len() != 2 {
+                return None;
+            }
+
+            let (intrinsic, inherited) = match call
+                .arguments
+                .first()?
+                .as_expression()?
+                .get_inner_expression()
+            {
+                Expression::StringLiteral(tag) => (tag.value.to_string(), Vec::new()),
+                Expression::Identifier(parent) => {
+                    let parent = known.get(parent.name.as_str())?;
+                    (parent.intrinsic.clone(), parent.base.clone())
+                }
+                _ => return None,
+            };
+
+            let config = call.arguments.get(1)?.as_expression()?;
+            let mut base = inherited;
+            base.extend(base_only_entries(config, ctx)?);
+            Some(StyledBinding {
+                symbol_id: None,
+                intrinsic,
+                base,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// True when `name` is the local binding of Panda's imported JSX factory.
+fn is_styled_factory(name: &str, ctx: &VisitorContext<'_, '_>) -> bool {
+    ctx.aliases.get(name).is_some_and(|matched| {
+        ctx.config.matchers.is_jsx_factory(&matched.name)
+            || ctx.config.matchers.is_jsx_factory(&matched.alias)
+    })
+}
+
+/// The `base` entries of a cva config, or `None` when the config carries
+/// anything that stops the class string from being constant.
+fn base_only_entries(
+    config: &Expression<'_>,
+    ctx: &VisitorContext<'_, '_>,
+) -> Option<Vec<(String, StyleTree)>> {
+    let StyleTree::Object(StyleObject { entries, spreads }) =
+        expression_to_style_tree(config, ctx.resolver)?
+    else {
+        return None;
+    };
+    if !spreads.is_empty() {
+        return None;
+    }
+
+    let mut base = Vec::new();
+    for (key, value) in entries {
+        // `variants` / `compoundVariants` / `defaultVariants` make the class
+        // depend on props; anything else is unmodelled by the fold.
+        if key != "base" {
+            return None;
+        }
+        match value {
+            StyleTree::Object(StyleObject {
+                entries,
+                spreads: base_spreads,
+            }) if base_spreads.is_empty() => base = entries,
+            _ => return None,
+        }
+    }
+    Some(base)
+}

--- a/crates/pandacss_project/src/transform/jsx-element.rs
+++ b/crates/pandacss_project/src/transform/jsx-element.rs
@@ -1,14 +1,20 @@
 //! JSX opening-element rewrites.
 
-use pandacss_extractor::{ExtractedJsx, StyleTree};
+use std::fmt::Write as _;
+
+use pandacss_extractor::{
+    ExtractedJsx, JsxExtractionConfig, JsxKind, Literal, StyleObject, StyleSpread, StyleTree,
+    project_literal,
+};
+use pandacss_shared::Span;
 
 use crate::PatternTransformFn;
 use crate::Project;
 
-use super::helper;
+use super::helper::{self, CX_HELPER_LOCAL};
 use super::jsx_parse::{
-    ConditionalSpreadPlan, ConditionalSpreadRewrite, ParsedOpeningElement, SpreadSyntax,
-    plan_conditional_spreads,
+    ConditionalSpreadPlan, ConditionalSpreadRewrite, ParsedAttribute, ParsedOpeningElement,
+    SpreadSyntax, plan_conditional_spreads,
 };
 use super::jsx_shared::{
     ElementTag, data_is_static, plan_opening_class_name, resolve_element_tag,
@@ -30,6 +36,17 @@ pub(super) fn rewrites_for_jsx_opening_element(
 ) -> Vec<Rewrite> {
     let parsed =
         ParsedOpeningElement::from_ast(source, &jsx.attributes, jsx.closing_span.is_none());
+    if let Some(rewrite) = partial_fold_rewrite(
+        project,
+        source,
+        jsx,
+        &parsed,
+        helper_cx,
+        pattern_transform.as_deref_mut(),
+    ) {
+        *needs_cx = true;
+        return vec![rewrite];
+    }
     let Some(spread_plan) = opening_spread_plan(project, source, jsx, &parsed) else {
         return Vec::new();
     };
@@ -138,6 +155,173 @@ fn opening_element_should_skip(
     }
 
     false
+}
+
+/// Precompute the static half of a `styled.*` element that also carries an
+/// opaque spread such as `{...props}`.
+///
+/// The factory and the spread stay, so style-prop splitting and DOM filtering
+/// still happen at runtime for whatever the spread turns out to hold. Every
+/// style source the transform *can* see collapses into one `className`, which
+/// the factory then merges after the spread's own styles — the same precedence
+/// JSX gives them today, since a later attribute overwrites a spread's key.
+fn partial_fold_rewrite(
+    project: &Project,
+    source: &str,
+    jsx: &ExtractedJsx,
+    parsed: &ParsedOpeningElement,
+    helper_cx: HelperCxMode,
+    pattern_transform: Option<&mut PatternTransformFn<'_>>,
+) -> Option<Rewrite> {
+    // The fold merges through `cx`; without it there is no sound way to keep
+    // the spread's own `className`.
+    if jsx.kind != JsxKind::Factory || helper_cx == HelperCxMode::False {
+        return None;
+    }
+    let extractor = project.config().extractor_config();
+    let class_attr = extractor.class_attribute;
+    if parsed
+        .attributes
+        .iter()
+        .any(|attr| attr.name.as_deref() == Some(class_attr))
+    {
+        return None;
+    }
+
+    let StyleTree::Object(object) = jsx.style.as_ref()? else {
+        return None;
+    };
+    let [StyleSpread::Open { span: open_span }] = object.spreads.as_slice() else {
+        return None;
+    };
+    let opaque = opaque_spread_binding(parsed, &extractor.jsx, &jsx.name, class_attr, *open_span)?;
+
+    // Static entries only dominate the spread because they merge after it, so
+    // there is nothing to precompute if the spread has no static half.
+    let folded = StyleTree::Object(StyleObject {
+        entries: object.entries.clone(),
+        spreads: Vec::new(),
+    });
+    if object.entries.is_empty() || style_lower::style_tree_has_open_value(&folded) {
+        return None;
+    }
+
+    let folded_jsx = ExtractedJsx {
+        data: project_literal(&folded).unwrap_or_else(|| Literal::Object(Vec::new())),
+        style: Some(folded.clone()),
+        ..jsx.clone()
+    };
+    let class_name = plan_opening_class_name(
+        project,
+        source,
+        &folded_jsx,
+        parsed,
+        helper_cx,
+        pattern_transform,
+    )?;
+
+    let tag = opening_tag_span(source, jsx.span)?;
+    let mut out = String::from("<");
+    out.push_str(super::resolve::span_slice(source, tag)?);
+    let mut preserved = style_lower::preserved_source_spans(&folded);
+    preserved.push(tag);
+
+    for attr in &parsed.attributes {
+        if attr.span != opaque.span
+            && folds_into_class_name(attr, &extractor.jsx, &jsx.name, class_attr)
+        {
+            continue;
+        }
+        out.push(' ');
+        out.push_str(&attr.raw);
+        preserved.push(attr.span);
+    }
+
+    // `{...props}` with a nullish value is a legal no-op in JSX, so the class
+    // read has to tolerate one.
+    let _ = write!(
+        out,
+        " {class_attr}={{{CX_HELPER_LOCAL}({}, {}?.{class_attr})}}",
+        class_name.expression, opaque.identifier
+    );
+    out.push_str(if parsed.self_closing { " />" } else { ">" });
+
+    Some(Rewrite {
+        start: jsx.span.start,
+        end: jsx.span.end,
+        content: out,
+        preserved,
+    })
+}
+
+struct OpaqueSpread<'a> {
+    span: Span,
+    identifier: &'a str,
+}
+
+/// The source spread that produced `open_span`, when the fold can reason about
+/// it: a bare identifier (so re-reading `.className` is free of side effects)
+/// that no other style source precedes.
+fn opaque_spread_binding<'a>(
+    parsed: &'a ParsedOpeningElement,
+    jsx_config: &JsxExtractionConfig,
+    tag_name: &str,
+    class_attr: &str,
+    open_span: Span,
+) -> Option<OpaqueSpread<'a>> {
+    let mut opaque: Option<OpaqueSpread<'a>> = None;
+    for attr in &parsed.attributes {
+        let expression = attr.spread_expression.as_ref();
+        if expression.is_some_and(|expression| expression.facts.span == open_span) {
+            if opaque.is_some() {
+                return None;
+            }
+            opaque = Some(OpaqueSpread {
+                span: attr.span,
+                identifier: expression?.facts.identifier.as_deref()?,
+            });
+            continue;
+        }
+        // A style source ahead of the spread would lose to it at runtime but
+        // win in the precomputed class string.
+        if opaque.is_none() && folds_into_class_name(attr, jsx_config, tag_name, class_attr) {
+            return None;
+        }
+    }
+    opaque
+}
+
+/// Whether the partial fold absorbs this attribute into the class name.
+fn folds_into_class_name(
+    attr: &ParsedAttribute,
+    jsx_config: &JsxExtractionConfig,
+    tag_name: &str,
+    class_attr: &str,
+) -> bool {
+    if attr.is_spread() {
+        return true;
+    }
+    let Some(name) = attr.name.as_deref() else {
+        return false;
+    };
+    name != class_attr
+        && !should_skip_style_prop(name)
+        && jsx_config.should_extract_prop(tag_name, name)
+}
+
+/// Span of the tag name inside an opening element, e.g. `styled.button`.
+fn opening_tag_span(source: &str, element: Span) -> Option<Span> {
+    let start = element.start.checked_add(1)?;
+    let bytes = source.as_bytes();
+    let mut end = usize::try_from(start).ok()?;
+    while bytes
+        .get(end)
+        .is_some_and(|byte| !matches!(byte, b' ' | b'\t' | b'\n' | b'\r' | b'/' | b'>'))
+    {
+        end += 1;
+    }
+    let end = u32::try_from(end).ok()?;
+    (end > start).then_some(Span { start, end })
 }
 
 /// Plans conditional JSX spread rewrites. Returns `None` when the original

--- a/crates/pandacss_project/src/transform/jsx-parse.rs
+++ b/crates/pandacss_project/src/transform/jsx-parse.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use pandacss_extractor::{
     ExpressionFacts, ExpressionKind, JsxExtractionConfig, LogicalExpressionOperator, ObjectFacts,
-    StyleSpread, StyleTree,
+    StyleObject, StyleSpread, StyleTree,
 };
 
 use super::helper::{ClassNamePrint, ExistingClassName};
@@ -411,7 +411,11 @@ pub(super) fn plan_conditional_spreads<'a>(
             .flatten()
         });
         let Some(parts) = parts else {
-            if is_style_only_object_spread(source, expression, jsx, tag_name, class_attr) {
+            // Static style spreads are already folded into `style.entries` by
+            // extract. Skip them here so they don't shift conditional pairing.
+            if is_style_only_object_spread(source, expression, jsx, tag_name, class_attr)
+                || is_absorbed_resolved_spread(expression, style)
+            {
                 continue;
             }
             return None;
@@ -436,8 +440,10 @@ pub(super) fn plan_conditional_spreads<'a>(
     if style_spreads.next().is_some() {
         return None;
     }
+    // Every source spread was style-only (inline object or extract-resolved
+    // identifier/member). Safe to rewrite — styles already live in entries.
     if count == 0 {
-        return None;
+        return Some(ConditionalSpreadPlan::StyleOnly);
     }
 
     let Some(runtime) = runtime else {
@@ -480,6 +486,31 @@ fn is_style_only_object_spread(
     })
 }
 
+/// Identifier / member spreads that extract folded into `style.entries`.
+///
+/// Opaque spreads (`{...props}`) leave `StyleSpread::Open`. When any Open
+/// remains, we cannot tell which source spread produced it, so bail.
+///
+/// Inline objects are handled by [`is_style_only_object_spread`] — they can
+/// mix runtime props without producing Open.
+fn is_absorbed_resolved_spread(expression: &ParsedExpression, style: &StyleObject) -> bool {
+    if style.spreads.iter().any(|spread| {
+        matches!(
+            spread,
+            StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. }
+        )
+    }) {
+        return false;
+    }
+    if expression.facts.object.is_some()
+        || expression.facts.conditional.is_some()
+        || expression.facts.logical.is_some()
+    {
+        return false;
+    }
+    true
+}
+
 fn spread_arms_are_static(spread: &StyleSpread) -> bool {
     match spread {
         StyleSpread::Ternary {
@@ -496,7 +527,7 @@ fn spread_arms_are_static(spread: &StyleSpread) -> bool {
             !super::style_lower::style_tree_has_rewrite_sites(value)
                 && !super::style_lower::style_tree_has_open_value(value)
         }
-        StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => false,
+        StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => false,
     }
 }
 
@@ -552,7 +583,7 @@ fn conditional_spread_parts(
                 )?,
             })
         }
-        StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => None,
+        StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => None,
     }
 }
 

--- a/crates/pandacss_project/src/transform/style_lower.rs
+++ b/crates/pandacss_project/src/transform/style_lower.rs
@@ -128,7 +128,7 @@ pub(crate) fn style_tree_has_open_value(tree: &StyleTree) -> bool {
         StyleTree::Open | StyleTree::OpenWithFallback(_) => true,
         StyleTree::Object(obj) => {
             obj.spreads.iter().any(|s| match s {
-                StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => true,
+                StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => true,
                 StyleSpread::Ternary {
                     consequent,
                     alternate,
@@ -227,7 +227,7 @@ fn collect_preserved_source_spans(tree: &StyleTree, spans: &mut Vec<Span>) {
                         spans.push(*test);
                         collect_preserved_source_spans(value, spans);
                     }
-                    StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => {}
+                    StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => {}
                 }
             }
             for (_, value) in &object.entries {
@@ -388,7 +388,7 @@ fn collect_sites(
 ) -> CollectOutcome {
     for spread in &obj.spreads {
         match spread {
-            StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => {
+            StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => {
                 return CollectOutcome::Bail;
             }
             StyleSpread::Ternary {
@@ -569,7 +569,7 @@ fn tree_has_open(tree: &StyleTree) -> bool {
         StyleTree::Object(obj) => {
             obj.entries.iter().any(|(_, v)| tree_has_open(v))
                 || obj.spreads.iter().any(|s| match s {
-                    StyleSpread::Open | StyleSpread::OpenWithFallback { .. } => true,
+                    StyleSpread::Open { .. } | StyleSpread::OpenWithFallback { .. } => true,
                     StyleSpread::Ternary {
                         consequent,
                         alternate,

--- a/crates/pandacss_project/tests/transform/jsx.rs
+++ b/crates/pandacss_project/tests/transform/jsx.rs
@@ -610,6 +610,36 @@ fn rewrites_optional_style_prop_with_undefined_alternate() {
 }
 
 #[test]
+fn rewrites_styled_button_with_nested_ternaries_and_undefined_width() {
+    // css-in-js-bench panda-props btn-variant shape: nested value ternaries plus
+    // an optional width that used to bail the whole element on free `undefined`.
+    // Use r## so hex `#…` strings don't terminate the raw literal.
+    let source = indoc! {r##"
+        import { styled } from '@panda/jsx';
+        export const Button = ({ $active, $fullWidth, $variant, children }) => (
+          <styled.button
+            display="inline-flex"
+            backgroundColor={$variant === "ghost" ? "transparent" : $variant === "secondary" ? "#f3f4f6" : !$active ? "#d1d5db" : "#2563eb"}
+            color={$variant === "ghost" ? "#2563eb" : $variant === "secondary" ? "#111827" : !$active ? "#6b7280" : "#ffffff"}
+            width={$fullWidth ? "100%" : undefined}
+          >{children}</styled.button>
+        );
+    "##};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert!(!output.code.contains("styled.button"));
+    assert!(output.code.contains("<button"));
+    assert_snapshot!(output.code, @r#"
+    export const Button = ({ $active, $fullWidth, $variant, children }) => (
+      <button className={($variant === "ghost" ? "bg_transparent d_inline-flex" : $variant === "secondary" ? "bg_#f3f4f6 d_inline-flex" : !$active ? "bg_#d1d5db d_inline-flex" : "bg_#2563eb d_inline-flex") + " " + ($variant === "ghost" ? "color_#2563eb d_inline-flex" : $variant === "secondary" ? "color_#111827 d_inline-flex" : !$active ? "color_#6b7280 d_inline-flex" : "color_#ffffff d_inline-flex") + " " + ($fullWidth ? "d_inline-flex width_100%" : "d_inline-flex")}>{children}</button>
+    );
+    "#);
+}
+
+#[test]
 fn shadowed_undefined_alternate_still_bails_jsx_rewrite() {
     let source = indoc! {r#"
         import { Box } from '@panda/jsx';
@@ -1375,4 +1405,225 @@ fn merges_resolved_class_into_qwik_record_expression() {
 
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"export const el = <div class={[{ 'text-red-500': isError, 'p-4': true }, "color_blue"]} />;"#);
+}
+
+#[test]
+fn rewrites_identifier_spread_with_overriding_ternary_props() {
+    // The `<styled.li>` shape from css-in-js-bench multifile-composition: a
+    // static spread, a ternary that overrides one of its keys, and two more
+    // ternaries whose alternate is `undefined`.
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+
+        const tabListItemStyle = {
+          display: 'block',
+          margin: '0',
+          padding: '0',
+          width: 'min-content',
+          flexShrink: '0',
+          minWidth: '40px',
+        } as const;
+
+        export const Tab = ({ fullWidth }: { fullWidth?: boolean }) => (
+          <styled.li
+            role="presentation"
+            {...tabListItemStyle}
+            display={fullWidth ? 'flex' : 'block'}
+            flex={fullWidth ? '1' : undefined}
+            justifyContent={fullWidth ? 'center' : undefined}
+          />
+        );
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"
+
+    const tabListItemStyle = {
+      display: 'block',
+      margin: '0',
+      padding: '0',
+      width: 'min-content',
+      flexShrink: '0',
+      minWidth: '40px',
+    } as const;
+
+    export const Tab = ({ fullWidth }: { fullWidth?: boolean }) => (
+      <li role="presentation" className={(fullWidth ? "d_flex flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content" : "d_block flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content") + " " + (fullWidth ? "flex_1 flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content" : "flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content") + " " + (fullWidth ? "flex-shrink_0 justify-content_center margin_0 min-width_40px padding_0 width_min-content" : "flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content")} />
+    );
+    "#);
+}
+
+#[test]
+fn folds_static_styles_past_an_opaque_rest_props_spread() {
+    // The `<styled.button>` shape from css-in-js-bench multifile-composition:
+    // an opaque rest-props spread sits *before* every style prop, so the props
+    // it carries lose to them. The factory and the spread stay for runtime
+    // style props; everything else is precomputed.
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+
+        const tabBaseStyle = { borderStyle: 'none' } as const;
+        const normalTabStyle = { height: '40px', color: 'rgba(0, 0, 0, 0.6)' } as const;
+        const activeTabStyle = { color: '#000' } as const;
+        const activeTabCss = { _hover: { borderBottomColor: '#eeb524' } } as const;
+
+        export const Tab = ({ disabled, fullWidth, ...props }) => (
+          <styled.button
+            {...props}
+            type="button"
+            role="tab"
+            disabled={disabled}
+            tabIndex={0}
+            flex={fullWidth ? '1' : undefined}
+            {...tabBaseStyle}
+            {...normalTabStyle}
+            {...activeTabStyle}
+            css={activeTabCss}
+          />
+        );
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"
+    import { cx as __pcx } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+
+    const tabBaseStyle = { borderStyle: 'none' } as const;
+    const normalTabStyle = { height: '40px', color: 'rgba(0, 0, 0, 0.6)' } as const;
+    const activeTabStyle = { color: '#000' } as const;
+    const activeTabCss = { _hover: { borderBottomColor: '#eeb524' } } as const;
+
+    export const Tab = ({ disabled, fullWidth, ...props }) => (
+      <styled.button {...props} type="button" role="tab" disabled={disabled} tabIndex={0} className={__pcx(fullWidth ? "border-style_none color_#000 flex_1 height_40px hover:border-bottom-color_#eeb524" : "border-style_none color_#000 height_40px hover:border-bottom-color_#eeb524", props?.className)} />
+    );
+    "#);
+}
+
+#[test]
+fn partial_fold_keeps_children_and_the_closing_tag() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = (props) => <styled.button {...props} color="red">Go</styled.button>;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @"
+    import { cx as __pcx } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    export const Btn = (props) => <styled.button {...props} className={__pcx('color_red', props?.className)}>Go</styled.button>;
+    ");
+}
+
+#[test]
+fn a_style_prop_before_the_opaque_spread_blocks_the_partial_fold() {
+    // `color="red"` loses to `props.color` at runtime, but a precomputed class
+    // would beat it. Nothing to fold that keeps that order.
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = (props) => <styled.button color="red" {...props} padding="4px" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(!output.changed);
+    assert!(!output.bailed);
+}
+
+#[test]
+fn two_opaque_spreads_block_the_partial_fold() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = (props) => <styled.button {...props} {...rest} color="red" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(!output.changed);
+}
+
+#[test]
+fn a_non_identifier_opaque_spread_blocks_the_partial_fold() {
+    // Re-reading `.className` off a call result would run it twice.
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = () => <styled.button {...getProps()} color="red" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(!output.changed);
+}
+
+#[test]
+fn an_existing_class_name_blocks_the_partial_fold() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = (props) => <styled.button {...props} className="mine" color="red" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(!output.changed);
+}
+
+#[test]
+fn helper_cx_false_blocks_the_partial_fold() {
+    use pandacss_project::HelperCxMode;
+
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = (props) => <styled.button {...props} color="red" />;
+    "#};
+
+    let output = transform_jsx_with_helper("src/app.tsx", source, HelperCxMode::False);
+
+    assert!(!output.changed);
+}
+
+#[test]
+fn partial_fold_uses_the_frameworks_class_attribute() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const Btn = (props) => <styled.button {...props} color="red" />;
+    "#};
+
+    let output = transform_jsx_solid("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @"
+    import { cx as __pcx } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    export const Btn = (props) => <styled.button {...props} class={__pcx('color_red', props?.class)} />;
+    ");
+}
+
+// --- same-file `styled()` chain fold ------------------------------------------
+// A base-only chain rooted in an intrinsic tag has a constant class string, so
+// every `<Chain>` site collapses to the host element and skips a whole
+// `forwardRef` component level at runtime.
+
+#[test]
+fn the_partial_fold_reads_the_spread_class_name_defensively() {
+    // `{...props}` with a nullish value is a legal no-op in JSX, so reading
+    // `.className` off it has to be optional or the element throws.
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export const El = ({ ...props }) => <styled.div {...props} color="red" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(
+        output.code.contains("props?.className"),
+        "expected an optional read, got: {}",
+        output.code
+    );
 }

--- a/crates/pandacss_project/tests/transform/jsx.rs
+++ b/crates/pandacss_project/tests/transform/jsx.rs
@@ -1627,3 +1627,206 @@ fn the_partial_fold_reads_the_spread_class_name_defensively() {
         output.code
     );
 }
+
+#[test]
+fn element_props_win_over_the_chain_base() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', { base: { color: 'red' } });
+        export const el = <Button color="blue" type="submit" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    const Button = styled('button', __pcva({ base: 'color_red' }));
+    export const el = <button type="submit" className="color_blue" />;
+    "#);
+}
+
+#[test]
+fn an_alias_of_a_folded_chain_still_folds() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', { base: { color: 'red' } });
+        const Alias = Button;
+        export const el = <Alias />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    const Button = styled('button', __pcva({ base: 'color_red' }));
+    const Alias = Button;
+    export const el = <button className="color_red" />;
+    "#);
+}
+
+#[test]
+fn folds_a_styled_definition_to_its_intrinsic_tag() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', { base: { color: 'red' } });
+        export const el = <Button>hi</Button>;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    const Button = styled('button', __pcva({ base: 'color_red' }));
+    export const el = <button className="color_red">hi</button>;
+    "#);
+}
+
+#[test]
+fn folds_a_multi_level_chain_with_the_outermost_level_winning() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const L0 = styled('button', { base: { color: 'red', margin: '0' } });
+        const L1 = styled(L0, { base: { color: 'blue' } });
+        const L2 = styled(L1, { base: { color: 'green' } });
+        export const el = <L2>hi</L2>;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    const L0 = styled('button', __pcva({ base: 'color_red margin_0' }));
+    const L1 = styled(L0, { base: { color: 'blue' } });
+    const L2 = styled(L1, { base: { color: 'green' } });
+    export const el = <button className="color_green margin_0">hi</button>;
+    "#);
+}
+
+#[test]
+fn the_as_prop_retargets_a_folded_chain() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', { base: { color: 'red' } });
+        export const el = <Button as="a" href="/home" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert_snapshot!(output.code, @r#"
+    import { cva as __pcva } from '@pandacss-internal/css';
+    import { styled } from '@panda/jsx';
+    const Button = styled('button', __pcva({ base: 'color_red' }));
+    export const el = <a href="/home" className="color_red" />;
+    "#);
+}
+
+#[test]
+fn a_chain_defined_inside_a_function_is_not_folded() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        export function App() {
+          const Button = styled('button', { base: { color: 'red' } });
+          return <Button />;
+        }
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.code.contains(r#"<Button />"#), "{}", output.code);
+}
+#[test]
+fn a_non_local_base_component_blocks_the_chain_fold() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        import { Other } from './other';
+        const Button = styled(Other, { base: { color: 'red' } });
+        export const el = <Button />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.code.contains(r#"<Button />"#), "{}", output.code);
+}
+
+#[test]
+fn a_rebindable_let_declaration_blocks_the_chain_fold() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        let Button = styled('button', { base: { color: 'red' } });
+        export const el = <Button />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.code.contains(r#"<Button />"#), "{}", output.code);
+}
+
+#[test]
+fn an_options_argument_blocks_the_chain_fold() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', { base: { color: 'red' } }, { defaultProps: { type: 'submit' } });
+        export const el = <Button />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.code.contains(r#"<Button />"#), "{}", output.code);
+}
+
+#[test]
+fn variants_block_the_chain_fold() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', {
+          base: { color: 'red' },
+          variants: { size: { sm: { padding: '4px' } } },
+        });
+        export const el = <Button size="sm" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(
+        output.code.contains(r#"<Button size="sm" />"#),
+        "{}",
+        output.code
+    );
+}
+
+#[test]
+fn a_local_binding_shadowing_a_folded_chain_is_left_alone() {
+    // The inner `Button` is an ordinary component, so folding it to the outer
+    // chain's `<button>` would render the wrong element with the wrong styles.
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+        const Button = styled('button', { base: { color: 'red' } });
+        export const Link = () => {
+          const Button = (props) => <a {...props} />;
+          return <Button href="/go">go</Button>;
+        };
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(
+        !output.code.contains("<button"),
+        "shadowed component must not fold to the chain's tag: {}",
+        output.code
+    );
+    // the element keeps its own identity and gains no class from the chain
+    assert!(
+        output.code.contains(r#"<Button href="/go">go</Button>"#),
+        "shadowed element should be untouched: {}",
+        output.code
+    );
+}

--- a/crates/pandacss_project/tests/transform/jsx.rs
+++ b/crates/pandacss_project/tests/transform/jsx.rs
@@ -1,7 +1,8 @@
 use super::common::{
     project_with_jsx, transform_jsx, transform_jsx_patterns, transform_jsx_qwik,
-    transform_jsx_recipes, transform_jsx_solid, transform_jsx_with_project, transform_panda_jsx,
-    transform_panda_jsx_patterns, transform_with_project,
+    transform_jsx_recipes, transform_jsx_solid, transform_jsx_with_helper,
+    transform_jsx_with_project, transform_panda_jsx, transform_panda_jsx_patterns,
+    transform_with_project,
 };
 use indoc::indoc;
 use insta::assert_snapshot;
@@ -595,6 +596,33 @@ fn rewrites_finite_conditional_style_prop_to_ternary_class_name() {
 }
 
 #[test]
+fn rewrites_optional_style_prop_with_undefined_alternate() {
+    let source = indoc! {r#"
+        import { Box } from '@panda/jsx';
+        export const el = <Box width={full ? '100%' : undefined} />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"export const el = <div className={full ? "width_100%" : ""} />;"#);
+}
+
+#[test]
+fn shadowed_undefined_alternate_still_bails_jsx_rewrite() {
+    let source = indoc! {r#"
+        import { Box } from '@panda/jsx';
+        let undefined = dynamic;
+        export const el = <Box width={full ? '100%' : undefined} />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(!output.changed || output.code.contains("<Box"));
+}
+
+#[test]
 fn rewrites_conditional_style_prop_with_static_class_name_peel() {
     let source = indoc! {r#"
         import { Box } from '@panda/jsx';
@@ -725,6 +753,105 @@ fn static_object_spread_does_not_shift_conditional_jsx_spread() {
     assert!(output.changed);
     assert!(!output.bailed);
     assert_snapshot!(output.code, @r#"export const el = <div className={cond ? "color_red padding_1" : "color_red padding_2"} />;"#);
+}
+
+#[test]
+fn rewrites_style_only_inline_object_spread() {
+    let source = indoc! {r#"
+        import { Box } from '@panda/jsx';
+        export const el = <Box {...({ color: 'red' } as const)} />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"export const el = <div className="color_red" />;"#);
+}
+
+#[test]
+fn rewrites_style_only_identifier_spread_and_css_prop() {
+    let source = indoc! {r#"
+        import { styled } from '@panda/jsx';
+
+        const buttonBase = {
+          display: 'inline-flex',
+          alignItems: 'center',
+          fontWeight: '600',
+        } as const;
+
+        const buttonPrimaryCss = {
+          backgroundColor: 'blue.600',
+          color: 'white',
+        } as const;
+
+        export const PrimaryButton = (props: { children?: React.ReactNode }) => (
+          <styled.button type="button" {...buttonBase} css={buttonPrimaryCss}>
+            {props.children}
+          </styled.button>
+        );
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"
+    const buttonBase = {
+      display: 'inline-flex',
+      alignItems: 'center',
+      fontWeight: '600',
+    } as const;
+
+    const buttonPrimaryCss = {
+      backgroundColor: 'blue.600',
+      color: 'white',
+    } as const;
+
+    export const PrimaryButton = (props: { children?: React.ReactNode }) => (
+      <button type="button" className="align-items_center bg_blue.600 color_white d_inline-flex font-weight_600">
+        {props.children}
+      </button>
+    );
+    "#);
+}
+
+#[test]
+fn opaque_identifier_spread_stays_unchanged() {
+    let source = indoc! {r#"
+        import { Box } from '@panda/jsx';
+        export const el = <Box {...props} color="red" />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(!output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"
+    import { Box } from '@panda/jsx';
+    export const el = <Box {...props} color="red" />;
+    "#);
+}
+
+#[test]
+fn identifier_spread_before_conditional_spread_rewrites() {
+    let source = indoc! {r#"
+        import { Box } from '@panda/jsx';
+
+        const base = { color: 'red' } as const;
+
+        export const el = <Box {...base} {...(cond ? { padding: '1' } : { padding: '2' })} />;
+    "#};
+
+    let output = transform_jsx("src/app.tsx", source);
+
+    assert!(output.changed);
+    assert!(!output.bailed);
+    assert_snapshot!(output.code, @r#"
+    const base = { color: 'red' } as const;
+
+    export const el = <div className={cond ? "color_red padding_1" : "color_red padding_2"} />;
+    "#);
 }
 
 #[test]

--- a/design-notes/transformer/README.md
+++ b/design-notes/transformer/README.md
@@ -832,6 +832,43 @@ of the map and the runtime chain stays:
 The `styled()` definition itself still desugars to `__pcva(…)` as before. After the fold it is
 unreferenced, so bundlers drop it.
 
+### Same-file `styled()` chain fold
+
+`const Button = styled('button', { base: … })` renders through `forwardRef`. That extra component
+level is the dominant cost even when the class string never changes: a bare `forwardRef` that returns
+nothing but a `<button>` measures the same as the full factory, while inlining the tag is ~45%
+faster. So when the chain's class is provably constant, `<Button>` folds to the host element.
+
+```tsx
+const L0 = styled('button', { base: { color: 'red' } })
+const L1 = styled(L0, { base: { color: 'blue' } })
+export const el = <L1>hi</L1>
+// →
+export const el = <button className="color_blue">hi</button>
+```
+
+`collect_styled_bindings` (`pandacss_extractor/src/styled_bindings.rs`) walks top-level `const`
+declarations and records `name → { intrinsic, base }`, following `styled(Parent, …)` chains and
+`const Alias = Button`. The JSX visitor then resolves such a tag to `styled.{intrinsic}` and prepends
+the composed `base` under the element's own props, so the element reaches the existing
+`<styled.button>` machinery — `as`, the `css` prop, conditionals, spreads and the partial fold all
+apply unchanged, and precedence falls out of entry order.
+
+A binding is recorded only when the fold can prove the class is constant. Anything else is left out
+of the map and the runtime chain stays:
+
+- `variants` / `compoundVariants` / `defaultVariants`, or any config key other than `base` — the
+  class would depend on props
+- a third `options` argument (`defaultProps`, `shouldForwardProp`), which the fold does not reproduce
+- a base that is not a string tag or an already-recorded local binding, so imported components and
+  `styled(motion.div, …)` keep their wrapper
+- `let` / `var`, which can be reassigned between definition and use
+- declarations inside a function or block — only module-level chains are recorded, and a tag folds
+  only when it resolves to the recorded symbol, so a local binding that shadows one is left alone
+
+The `styled()` definition itself still desugars to `__pcva(…)` as before. After the fold it is
+unreferenced, so bundlers drop it.
+
 ### JSX pattern props
 
 JSX pattern elements such as `<HStack gap="4" />` behave like JSX style props, not like function calls.


### PR DESCRIPTION
Two folds that remove per-render work from JSX, plus the spread fix that unblocks them.

## An element whose spreads are all style-only can be rewritten

A spread the extractor already folded into the element's styles still counted as a runtime spread, so this bailed even though nothing dynamic was left:

```tsx
<styled.div {...tabBaseStyle} css={activeTabCss} />
```

Resolved identifier and member spreads are now recognized, and the element rewrites to a class string.

## The static half of an element with `{...props}` is precomputed

An opaque spread used to bail the whole element, which is costly in the common wrapper shape where everything else is a module const:

```tsx
<styled.button {...props} type="button" {...tabBaseStyle} css={activeTabCss} />
// →
<styled.button {...props} type="button" className={__pcx('border-style_none hover:…', props?.className)} />
```

The factory and the spread stay, so style-prop splitting and DOM filtering still happen for whatever the spread holds. Everything Panda can see collapses into one `className`.

Requires a bare identifier spread, exactly one opaque spread, no style source ahead of it, and no explicit `className` — the conditions under which the factory's precedence is reproducible. The class read is optional-chained, because `{...props}` with a nullish value is a legal no-op in JSX and `props.className` would throw.

## A same-file `styled()` chain folds to its host element

```tsx
const L0 = styled('button', { base: { color: 'red' } })
const L1 = styled(L0, { base: { color: 'blue' } })
export const el = <L1>hi</L1>
// →
export const el = <button className="color_blue">hi</button>
```

`styled()` renders through `forwardRef`, which costs a component level per instance even when the class never changes. When the chain is base-only and rooted in an intrinsic tag, the sites fold and the definition is left for the bundler to drop.

A tag folds **only when it resolves to the symbol the chain declared**, so a local binding that shadows the module-level one is untouched — the same check the imported-tag branch beside it already makes. Variants, an options argument, a non-local base, `let`/`var`, or a declaration inside a function all keep the runtime chain.

## Tests

27 new cases in `pandacss_project`, roughly half of them negative — the shapes that must *not* fold. Two were written for the two judgement calls in this PR specifically:

- a nullish `{...props}` spread still yields `props?.className`
- a local `const Button` shadowing a module-level chain keeps its own identity and gains no class

## Verified locally

Against a binary built from this branch:

- `cargo nextest run --workspace` — 2288 passed
- `pnpm --filter @pandacss/compiler test` — 533 passed
- `pnpm --filter sandbox-codegen test` — all 11 framework scenarios
- `cargo fmt --check` and `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVzc85Z4YGMGwQz2FnEfFo
