### PR TITLE
perf(transform): hoist shared classes, and update the design notes

### DIFF
--- a/.changeset/hoist-shared-classes.md
+++ b/.changeset/hoist-shared-classes.md
@@ -1,0 +1,12 @@
+---
+'@pandacss/compiler': patch
+---
+
+Emit a class shared by every branch once instead of repeating it in each one.
+
+```ts
+// before
+export const cls = (wide ? 'd_flex p_8' : 'd_flex p_4') + ' ' + (tall ? 'd_flex m_2' : 'd_flex m_1')
+// after
+export const cls = 'd_flex' + ' ' + (wide ? 'p_8' : 'p_4') + ' ' + (tall ? 'm_2' : 'm_1')
+```

--- a/crates/pandacss_project/src/transform/style_lower.rs
+++ b/crates/pandacss_project/src/transform/style_lower.rs
@@ -180,11 +180,65 @@ pub fn print_class_expr(expr: &ClassExpr) -> String {
                 print_class_expr(no)
             )
         }
-        ClassExpr::Join(parts) => parts
-            .iter()
-            .map(|part| format!("({})", print_class_expr(part)))
-            .collect::<Vec<_>>()
-            .join(" + \" \" + "),
+        ClassExpr::Join(parts) => print_join(parts),
+    }
+}
+
+/// Print `a + " " + b`, except that a part which can be empty carries its own
+/// separator inside each branch — otherwise an empty branch leaves a stray
+/// space in the class attribute.
+fn print_join(parts: &[ClassExpr]) -> String {
+    let mut out = String::new();
+    for (index, part) in parts.iter().enumerate() {
+        if index == 0 {
+            out.push_str(&print_operand(part));
+            continue;
+        }
+        if has_empty_leaf(part) {
+            out.push_str(" + ");
+            out.push_str(&print_operand(&with_leading_separator(part)));
+        } else {
+            out.push_str(" + \" \" + ");
+            out.push_str(&print_operand(part));
+        }
+    }
+    out
+}
+
+fn print_operand(expr: &ClassExpr) -> String {
+    match expr {
+        // A string literal needs no grouping as a `+` operand.
+        ClassExpr::Lit(value) => js_string_literal(value),
+        _ => format!("({})", print_class_expr(expr)),
+    }
+}
+
+fn has_empty_leaf(expr: &ClassExpr) -> bool {
+    match expr {
+        ClassExpr::Lit(value) => value.is_empty(),
+        ClassExpr::Ternary { yes, no, .. } => has_empty_leaf(yes) || has_empty_leaf(no),
+        ClassExpr::Join(parts) => parts.iter().any(has_empty_leaf),
+    }
+}
+
+/// Push a leading space into every non-empty leaf, so an empty branch
+/// contributes nothing at all.
+fn with_leading_separator(expr: &ClassExpr) -> ClassExpr {
+    match expr {
+        ClassExpr::Lit(value) if value.is_empty() => ClassExpr::Lit(String::new()),
+        ClassExpr::Lit(value) => ClassExpr::Lit(format!(" {value}")),
+        ClassExpr::Ternary { test, yes, no } => ClassExpr::Ternary {
+            test: test.clone(),
+            yes: Box::new(with_leading_separator(yes)),
+            no: Box::new(with_leading_separator(no)),
+        },
+        ClassExpr::Join(parts) => {
+            let mut parts = parts.clone();
+            if let Some(first) = parts.first_mut() {
+                *first = with_leading_separator(first);
+            }
+            ClassExpr::Join(parts)
+        }
     }
 }
 
@@ -323,9 +377,84 @@ pub fn lower_style_tree(
     }
 
     if exprs.len() == 1 {
-        LowerResult::Expr(exprs.pop().expect("one expr"))
-    } else {
-        LowerResult::Expr(ClassExpr::Join(exprs))
+        return LowerResult::Expr(exprs.pop().expect("one expr"));
+    }
+
+    let mut parts = Vec::with_capacity(exprs.len() + 1);
+    if let Some(shared) = hoist_shared_classes(&mut exprs) {
+        parts.push(ClassExpr::Lit(shared));
+    }
+    parts.append(&mut exprs);
+    LowerResult::Expr(ClassExpr::Join(parts))
+}
+
+/// Every site encodes the object's static base alongside its own branch, so a
+/// class list with N sites repeats that base N times at runtime. Class order
+/// doesn't affect the cascade, so tokens present in every branch of every site
+/// are pulled out and emitted once.
+///
+/// Only worth doing for multiple sites: with one site the base appears twice in
+/// the source but only once in the rendered string.
+fn hoist_shared_classes(exprs: &mut [ClassExpr]) -> Option<String> {
+    let mut shared: Option<Vec<String>> = None;
+    for expr in exprs.iter() {
+        let mut bail = false;
+        for_each_leaf(expr, &mut |leaf| {
+            if bail {
+                return;
+            }
+            match &mut shared {
+                None => shared = Some(leaf.split_whitespace().map(str::to_owned).collect()),
+                Some(shared) => shared
+                    .retain(|token| leaf.split_whitespace().any(|candidate| candidate == token)),
+            }
+            bail = shared.as_ref().is_some_and(Vec::is_empty);
+        });
+        if bail {
+            return None;
+        }
+    }
+
+    let shared = shared.filter(|shared| !shared.is_empty())?;
+    for expr in exprs.iter_mut() {
+        for_each_leaf_mut(expr, &mut |leaf| {
+            let kept: Vec<&str> = leaf
+                .split_whitespace()
+                .filter(|token| !shared.iter().any(|s| s == token))
+                .collect();
+            *leaf = kept.join(" ");
+        });
+    }
+    Some(shared.join(" "))
+}
+
+fn for_each_leaf<'a>(expr: &'a ClassExpr, visit: &mut impl FnMut(&'a str)) {
+    match expr {
+        ClassExpr::Lit(value) => visit(value),
+        ClassExpr::Ternary { yes, no, .. } => {
+            for_each_leaf(yes, visit);
+            for_each_leaf(no, visit);
+        }
+        ClassExpr::Join(parts) => {
+            for part in parts {
+                for_each_leaf(part, visit);
+            }
+        }
+    }
+}
+
+fn for_each_leaf_mut(expr: &mut ClassExpr, visit: &mut impl FnMut(&mut String)) {
+    match expr {
+        ClassExpr::Lit(value) => visit(value),
+        ClassExpr::Ternary { yes, no, .. } => {
+            for_each_leaf_mut(yes, visit);
+            for_each_leaf_mut(no, visit);
+        }
+        ClassExpr::Join(parts) => {
+            for part in parts {
+                for_each_leaf_mut(part, visit);
+            }
+        }
     }
 }
 

--- a/crates/pandacss_project/tests/transform/advanced.rs
+++ b/crates/pandacss_project/tests/transform/advanced.rs
@@ -210,7 +210,7 @@ advanced_snapshot!(
         "#};
         transform("src/styles.tsx", source)
     },
-    @r#"export const cls = (a ? "color_red" : "color_blue") + " " + (b ? "padding_1" : "");"#
+    @r#"export const cls = (a ? "color_red" : "color_blue") + (b ? " padding_1" : "");"#
 );
 
 advanced_snapshot!(
@@ -227,7 +227,7 @@ advanced_snapshot!(
         "#};
         transform("src/styles.tsx", source)
     },
-    @r#"export const cls = (a ? "color_red margin-top_1" : "color_blue margin-top_1") + " " + (b ? "margin-top_1 padding_1" : "margin-top_1 padding_2");"#
+    @r#"export const cls = "margin-top_1" + " " + (a ? "color_red" : "color_blue") + " " + (b ? "padding_1" : "padding_2");"#
 );
 
 #[test]

--- a/crates/pandacss_project/tests/transform/conditional.rs
+++ b/crates/pandacss_project/tests/transform/conditional.rs
@@ -309,7 +309,7 @@ conditional_snapshot!(
         });
     "#,
     true,
-    @r#"export const cls = (wide ? "color_red d_flex padding_8px" : "color_red d_flex padding_4px") + " " + (tall ? "color_red d_flex margin_2px" : "color_red d_flex margin_1px");"#
+    @r#"export const cls = "color_red d_flex" + " " + (wide ? "padding_8px" : "padding_4px") + " " + (tall ? "margin_2px" : "margin_1px");"#
 );
 
 conditional_snapshot!(
@@ -353,3 +353,27 @@ conditional_snapshot!(
     "#,
     unchanged
 );
+
+#[test]
+fn a_conditional_with_nothing_to_add_leaves_no_stray_space() {
+    // Hoisting the shared classes can empty one branch. If the separator
+    // stayed outside the ternary, every element without the optional class
+    // would carry a trailing space in its class attribute.
+    let source = indoc! {r#"
+        import { css } from '@panda/css';
+        export const cls = css({
+          display: 'flex',
+          width: wide ? '100%' : undefined,
+          margin: tall ? '2px' : '1px',
+        });
+    "#};
+
+    let output = transform("src/styles.tsx", source);
+
+    assert!(
+        !output.code.contains(r#"" " + (wide ? " "#),
+        "separator should move inside the branch: {}",
+        output.code
+    );
+    assert_snapshot!(output.code, @r#"export const cls = "d_flex" + (wide ? " width_100%" : "") + " " + (tall ? "margin_2px" : "margin_1px");"#);
+}

--- a/crates/pandacss_project/tests/transform/edges.rs
+++ b/crates/pandacss_project/tests/transform/edges.rs
@@ -185,7 +185,7 @@ edge_snapshot!(
     ),
     @r#"
 export const el = (
-  <div className={(isMobile ? "button button--size_sm" : "button button--size_lg") + " " + (isPrimary ? "button button--size_md button--visual_solid" : "button button--size_md button--visual_outline")} />
+  <div className={"button" + " " + (isMobile ? "button--size_sm" : "button--size_lg") + " " + (isPrimary ? "button--size_md button--visual_solid" : "button--size_md button--visual_outline")} />
 );
 "#
 );
@@ -936,7 +936,7 @@ edge_snapshot!(
     @r#"
 const primary = { backgroundColor: 'blue', color: 'white' };
 const secondary = { backgroundColor: 'gray', color: 'black' };
-export const cls = (variant === 'primary' ? "background-color_blue color_white padding_8px hover:opacity_0.9" : "background-color_gray color_black padding_8px hover:opacity_0.9") + " " + (variant === 'primary' ? "padding_8px hover:background-color_blue hover:color_white hover:opacity_0.9" : "padding_8px hover:opacity_0.9");
+export const cls = "padding_8px hover:opacity_0.9" + " " + (variant === 'primary' ? "background-color_blue color_white" : "background-color_gray color_black") + (variant === 'primary' ? " hover:background-color_blue hover:color_white" : "");
 "#
 );
 

--- a/crates/pandacss_project/tests/transform/jsx.rs
+++ b/crates/pandacss_project/tests/transform/jsx.rs
@@ -634,7 +634,7 @@ fn rewrites_styled_button_with_nested_ternaries_and_undefined_width() {
     assert!(output.code.contains("<button"));
     assert_snapshot!(output.code, @r#"
     export const Button = ({ $active, $fullWidth, $variant, children }) => (
-      <button className={($variant === "ghost" ? "bg_transparent d_inline-flex" : $variant === "secondary" ? "bg_#f3f4f6 d_inline-flex" : !$active ? "bg_#d1d5db d_inline-flex" : "bg_#2563eb d_inline-flex") + " " + ($variant === "ghost" ? "color_#2563eb d_inline-flex" : $variant === "secondary" ? "color_#111827 d_inline-flex" : !$active ? "color_#6b7280 d_inline-flex" : "color_#ffffff d_inline-flex") + " " + ($fullWidth ? "d_inline-flex width_100%" : "d_inline-flex")}>{children}</button>
+      <button className={"d_inline-flex" + " " + ($variant === "ghost" ? "bg_transparent" : $variant === "secondary" ? "bg_#f3f4f6" : !$active ? "bg_#d1d5db" : "bg_#2563eb") + " " + ($variant === "ghost" ? "color_#2563eb" : $variant === "secondary" ? "color_#111827" : !$active ? "color_#6b7280" : "color_#ffffff") + ($fullWidth ? " width_100%" : "")}>{children}</button>
     );
     "#);
 }
@@ -1451,7 +1451,7 @@ fn rewrites_identifier_spread_with_overriding_ternary_props() {
     } as const;
 
     export const Tab = ({ fullWidth }: { fullWidth?: boolean }) => (
-      <li role="presentation" className={(fullWidth ? "d_flex flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content" : "d_block flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content") + " " + (fullWidth ? "flex_1 flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content" : "flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content") + " " + (fullWidth ? "flex-shrink_0 justify-content_center margin_0 min-width_40px padding_0 width_min-content" : "flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content")} />
+      <li role="presentation" className={"flex-shrink_0 margin_0 min-width_40px padding_0 width_min-content" + " " + (fullWidth ? "d_flex" : "d_block") + (fullWidth ? " flex_1" : "") + (fullWidth ? " justify-content_center" : "")} />
     );
     "#);
 }

--- a/design-notes/README.md
+++ b/design-notes/README.md
@@ -53,6 +53,8 @@ Some topics span several notes. Keep the detailed contract in one place and link
 - [StyleTree](./style-tree.md) — span-backed transform IR for `css()` / JSX conditionals; `project_literal` for encode.
 - [Cross-file resolution](./cross-file-resolution.md) — `CrossFileResolver`, cache shape (`Literal` | `PureFn`), cycle
   guard.
+- [Cross-file questions](./cross-file-questions.md) — forward questions use the lazy resolver; reverse or whole-program
+  ones ask the bundler at `buildEnd` rather than building a second module graph.
 - [JSX tag matching](./jsx-tag-matching.md) — `jsxMatchTag`: declarative successor to v1 `matchTag`/`matchTagProp`;
   match/ignore JSX tags by name, pattern, or import source, plus per-rule prop control. Why it's data, not a callback.
 - [Recipe variant dynamic diagnostics](./recipe-variant-diagnostics.md) — `recipe_variant_dynamic`: warn when config

--- a/design-notes/codegen-design.md
+++ b/design-notes/codegen-design.md
@@ -346,6 +346,27 @@ The graph emits the full `ArtifactId` set today, including:
 Remaining work is mostly polish: import-map-aware package entrypoints and using the tracked recipe/pattern names to
 scope watch-mode writes more narrowly.
 
+## Keeping the generated runtime tree-shakeable
+
+A bundler only drops a `/* @__PURE__ */` call when it initializes a **plain identifier**. Destructuring the result pins
+everything the call returns, in every bundle that imports anything from the module.
+
+That is why `css/index` binds each piece of the serializer on its own:
+
+```ts
+const cssContext = /* @__PURE__ */ createCssContext()
+const serializeCss = /* @__PURE__ */ createSerializeCss(cssContext)
+export const mergeCss = /* @__PURE__ */ createMergeCss(cssContext)
+```
+
+and not `const { serializeCss, mergeCss } = createCssRuntime(ctx)`, which pins the serializer everywhere.
+
+A pure call is also only droppable when its arguments are, so a wrapped factory needs the annotation on both:
+`Object.assign(/* @__PURE__ */ memo(fn), { … })`.
+
+`sandbox/codegen/__tests__/tree-shaking.test.ts` bundles the generated output with rollup and asserts that a
+`mergeCss`-only entry drops `serializeCss`. It fails against the destructured shape.
+
 ## Design Principles
 
 - Keep public config simple until a second real use case forces more shape.

--- a/design-notes/cross-file-questions.md
+++ b/design-notes/cross-file-questions.md
@@ -1,0 +1,58 @@
+# Cross-file questions
+
+## Summary
+
+Panda answers two different kinds of cross-file question, and they need different machinery. Getting this wrong leads to
+rebuilding a module graph Panda does not own.
+
+**Forward questions** — "what value does this import give me?" — are answered lazily by `CrossFileResolver`: resolve the
+specifier, parse the module, fold what it exports, cache the descriptors, drop the AST. One edge, on demand. Works in
+every context: the CLI, the PostCSS plugin, and bundler plugins.
+
+**Reverse or whole-program questions** — "who consumes this recipe?", "which variants are reachable through wrapper
+components?", "which files must re-run when this definition changes?" — cannot be answered from one file. Ask the host
+bundler; do not build a second graph.
+
+## Why not build our own graph
+
+TypeScript builds a whole-program graph because types are global — a type can be declared anywhere and merged across
+files. ts-morph inherits that, which is how v1 answered cross-file questions. v2 dropped it deliberately (no TypeScript
+program in the hot path) because Panda's question is narrower: a value along one specific edge.
+
+Building a Panda-owned graph in the transform path costs three things:
+
+- the bundler already owns file discovery, ordering and invalidation, and `transform_source` is called per file
+- a graph walked from the project root follows imports the bundler tree-shakes away, so it ends up larger than the
+  actual build, and every file in it is a second parse
+- two invalidation systems that must agree, where disagreement is a correctness bug rather than slowness
+
+## What the host already has
+
+Rolldown builds exactly this graph in Rust on Oxc — `ModuleTable`, `ImportRecord` for forward edges, `ImporterRecord`
+for reverse ones, indexed by arena `ModuleIdx`. Rollup, Vite and Rolldown all expose it to plugins:
+
+- `this.getModuleInfo(id)` → `importedIds`, `importers`, `dynamicallyImportedIds`, `dynamicImporters`
+- `this.getModuleIds()` → every module in the graph
+
+One constraint: `importers` starts empty and fills as the build discovers modules. It is only complete after `buildEnd`,
+so reverse queries belong there, not in `transform`.
+
+`packages/vite` uses none of this today — only `moduleGraph.getModuleById` and `invalidateModule` for HMR.
+
+## The CLI path
+
+`panda cssgen` has no host graph, but Panda globs the file set itself there, so it can build a cheap edge map when a
+feature needs one. Any feature built on host-graph queries has to degrade for this path.
+
+## Worked example
+
+A component that imports only a recipe used to be skipped, because Panda skips files that import nothing from Panda — so
+`button.raw()` there kept reading a class string. The fix was not a graph. The skip test also asks whether the file
+calls `.raw(...)` on a binding it imported: syntactic, over an AST already parsed, no resolution. Reach for the graph
+when a question is genuinely reverse, not when a local check will do.
+
+## Related
+
+- [cross-file-resolution](./cross-file-resolution.md)
+- [extraction-pipeline](./extraction-pipeline.md)
+- [performance-budget](./performance-budget.md)

--- a/design-notes/jsx-tag-matching.md
+++ b/design-notes/jsx-tag-matching.md
@@ -196,6 +196,13 @@ The only genuinely new field is a **tag blocklist**: `tag_blocklist: FxHashSet<S
 `JsxExtractionConfig`, so `from` rules slot into the same path rather than a parallel one (see
 [Extraction pipeline](./extraction-pipeline.md), [Cross-file resolution](./cross-file-resolution.md)).
 
+## Interaction with local `styled()` chains
+
+A module-level `const Button = styled('button', …)` resolves as `<styled.button>` **before** any `jsxMatchTag` rule is
+consulted, so the chain fold reaches it. When `ignore: true` lands it has to gate that branch too, or
+`{ tag: 'Button', ignore: true }` is silently overridden for a local chain. The fold already requires the tag to resolve
+to the symbol the chain declared, so the hook point exists.
+
 ## Out of scope
 
 **Recipe variant tree-shaking through wrapper components** (#3522 item 12). When `MyRedButton = (p) => <Button {...p}/>`

--- a/design-notes/style-tree.md
+++ b/design-notes/style-tree.md
@@ -24,7 +24,7 @@ pub enum StyleTree {
     Ternary { test: Span, consequent: Box<StyleTree>, alternate: Box<StyleTree> },
     And { test: Span, value: Box<StyleTree> },
     Branches(Vec<StyleTree>), // span-less (cross-file / Literal::Conditional)
-    Open,
+    Open { span: Span },
     OpenWithFallback(Box<StyleTree>),
 }
 ```
@@ -36,7 +36,8 @@ pub enum StyleTree {
 - **`Branches`** — encode expands all arms (`Literal::Conditional`). Transform cannot rewrite them without a local
   condition span. Used for cross-file imports and `Literal` rehydration.
 - **`Open`** — transform cannot rewrite it, and encode has no fallback. Used for unresolvable arms, computed properties,
-  methods, accessors, and opaque spreads. `project_literal(Open)` returns `None`, so encode skips the property.
+  methods, accessors, and opaque spreads. `project_literal(Open)` returns `None`, so encode skips the property. Carries
+  the span of the source spread that produced it, which is how the partial fold tells one `{...props}` from another.
 - **`OpenWithFallback`** — transform cannot rewrite it, but encode can use a known fallback. Used for dynamic left
   operands of `||` and `??`, and duplicate properties with an unresolved value. `project_literal(inner)` returns the
   fallback.

--- a/design-notes/transformer/README.md
+++ b/design-notes/transformer/README.md
@@ -401,10 +401,11 @@ The class-merge helper is `cx`. Transformed source aliases it to `__pcx` so user
 
 Recipe inlines use `cva as __pcva` and `sva as __psva` from the same internal module when those rewrites run.
 
-Boolean-only inline `cva` (`variants: { x: { true: … } }`, no compounds, ≤12 keys) uses the internal
-`booleanBitset` + memo path at runtime. Same-file call-site → `__pcx` lowering exists as infrastructure
-(`local_call_bindings` / `cva_call_lower`) but is **off by default** — reused prop tuples are faster through
-`__pcva` than uncached `__pcx(cond && class)` (css-in-js-bench `btn-variant`).
+Boolean-only inline `cva` (`variants: { x: { true: … } }`, no compounds, ≤12 keys) dispatches through the internal
+`booleanBitset`; anything else compound-free goes through the mixed-radix `variantTable`. Lowering call sites to
+`__pcx(cond && class)` instead was measured and rejected — a reused prop tuple resolves faster through the memoized
+table than through an uncached `cx` (css-in-js-bench `btn-variant`). `local_call_bindings` remains, because the
+`.raw()` interlock needs it.
 
 Import shape in transformed code:
 

--- a/design-notes/transformer/test-matrix.md
+++ b/design-notes/transformer/test-matrix.md
@@ -133,7 +133,7 @@ These are the direct successors to the earlier prototype's `buildClassNameAttr(.
 ## Snapshot tests: bailout behavior
 
 - dynamic `css` arg bails
-- `.raw()` forms bail
+- `.raw()` forms fold to the style object they resolve to
 - JSX spread props bail
 - complex `as={condition ? A : B}` bail
 - dynamic token path bails
@@ -226,12 +226,12 @@ If conditional flattening stays in scope:
 - `cva` compound variants
 - callable `cva` result shape
 - `cva.variantMap` and `variantKeys`
-- `cva.raw()` bail
+- `cva.raw()` folds to resolved styles
 - `cva.splitVariantProps`
 - `sva()` helper output shape
 - slot keys on result
 - `sva.variantMap`
-- `sva.raw()` bail
+- `sva.raw()` folds to resolved styles per slot
 
 ## Integration tests: common host contract
 

--- a/packages/compiler/__tests__/transform-source/jsx.test.ts
+++ b/packages/compiler/__tests__/transform-source/jsx.test.ts
@@ -429,7 +429,7 @@ describe('compiler.transformSource: jsx', () => {
 
     const result = styledJsxCompiler.transformSource({ path: 'src/app.tsx', source })
     expect(result.code).toMatchInlineSnapshot(
-      `"export const el = <div className={(isError ? "color_red padding_4" : "color_blue padding_4") + " " + (isDark ? "bg_black padding_4" : "bg_white padding_4")} />"`,
+      `"export const el = <div className={"padding_4" + " " + (isError ? "color_red" : "color_blue") + " " + (isDark ? "bg_black" : "bg_white")} />"`,
     )
   })
 


### PR DESCRIPTION
Last of the series. One optimization, plus the documentation the previous five PRs owed.

## A class shared by every branch is emitted once

Each conditional site carried the object's static base, so a class list with N sites repeated that base N times in the rendered string.

```ts
// before
export const cls =
  (wide ? 'd_flex p_8' : 'd_flex p_4') + ' ' + (tall ? 'd_flex m_2' : 'd_flex m_1')
// after
export const cls = 'd_flex' + ' ' + (wide ? 'p_8' : 'p_4') + ' ' + (tall ? 'm_2' : 'm_1')
```

Class order doesn't affect the cascade — that's stylesheet order — so the tokens in every branch of every site are hoisted out. Shorter strings to build per render, and shorter class attributes in SSR output.

Hoisting can empty a branch, so a part that may be empty now carries its own separator inside each branch:

```ts
'd_flex' + (wide ? ' width_100%' : '')   // not:  'd_flex' + ' ' + (wide ? 'width_100%' : '')
```

Without that, every element without the optional class renders with a trailing space in `class`. A test pins it.

## Documentation

Five notes were left stale by the earlier PRs:

- **style-tree** — `Open` carries the span of the spread that produced it, which is how the partial fold tells one `{...props}` from another
- **test-matrix** — `.raw()` folds to styles now; it used to say the forms bail
- **codegen-design** — why each `@__PURE__` call binds its own const, and the rollup test that fails against the destructured shape
- **jsx-tag-matching** — a local `styled()` chain resolves before any `jsxMatchTag` rule, so `ignore: true` has to gate that branch when it lands
- **transformer** — call-site `__pcx` lowering was measured and rejected; `cva_call_lower` is not carried as dead code

Plus a new note, **cross-file-questions**, recording a decision that came up repeatedly during this series: forward questions ("what does this import give me") use the lazy `CrossFileResolver`; reverse or whole-program ones ("who consumes this recipe") ask the bundler at `buildEnd`. Rolldown already builds that graph in Rust on Oxc, and Rollup exposes it to plugins — a second one duplicates discovery, parses files the build excludes, and needs its own invalidation. The note also records that `importers` is incomplete during `transform`, and that the CLI path has no host graph.

## Verified locally

- `cargo nextest run --workspace` — 2289 passed
- `pnpm --filter @pandacss/compiler test` — 533 passed
- `pnpm --filter sandbox-codegen test` — all 11 framework scenarios
- `cargo fmt --check` and `clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVzc85Z4YGMGwQz2FnEfFo
