### PR TITLE
fix(node): keep vue/svelte plugins on config reload

### DIFF
--- a/.changeset/config-reload-keeps-sfc-plugins.md
+++ b/.changeset/config-reload-keeps-sfc-plugins.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/node': patch
+---
+
+Fix styles disappearing after a config change in Vue and Svelte projects. Editing your config rebuilt the context without the built-in Vue/Svelte plugins, so those files stopped producing CSS until you restarted the dev server. The reload now keeps them.

--- a/packages/node/__tests__/config-reload.test.ts
+++ b/packages/node/__tests__/config-reload.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, expect, test } from 'vitest'
+import { loadConfigAndCreateContext } from '../src/config'
+import { PandaContext } from '../src/create-context'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'panda-reload-'))
+  writeFileSync(
+    join(dir, 'App.vue'),
+    `<script setup lang="ts">
+import { css } from '../styled-system/css'
+const cls = css({ color: 'customColor' })
+</script>
+<template><div :class="cls">hi</div></template>`,
+  )
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const writeConfig = (color: string) => {
+  const file = join(dir, 'panda.config.ts')
+  writeFileSync(
+    file,
+    `export default {
+      cwd: ${JSON.stringify(dir)},
+      include: ['*.vue'],
+      outdir: 'styled-system',
+      jsxFramework: 'vue',
+      theme: { extend: { semanticTokens: { colors: { customColor: { value: '${color}' } } } } },
+    }`,
+  )
+  return file
+}
+
+const extractedCssCount = (ctx: PandaContext) => ctx.parseFile(join(dir, 'App.vue'))?.css.size ?? 0
+
+test('config reload keeps extracting styles from vue files', async () => {
+  const configPath = writeConfig('green')
+  const ctx = await loadConfigAndCreateContext({ cwd: dir, configPath })
+
+  expect(extractedCssCount(ctx)).toBe(1)
+
+  writeConfig('red')
+
+  let reloaded: PandaContext | undefined
+  const affecteds = await ctx.diff.reloadConfigAndRefreshContext((conf) => {
+    reloaded = new PandaContext(conf)
+  })
+
+  expect(affecteds.hasConfigChanged).toBe(true)
+  expect(reloaded).toBeDefined()
+  expect(extractedCssCount(reloaded!)).toBe(1)
+})

--- a/packages/node/src/auto-plugins.ts
+++ b/packages/node/src/auto-plugins.ts
@@ -1,0 +1,29 @@
+import { mergeHooks } from '@pandacss/config'
+import { pluginLightningcss } from '@pandacss/plugin-lightningcss'
+import { pluginSvelte } from '@pandacss/plugin-svelte'
+import { pluginVue } from '@pandacss/plugin-vue'
+import type { Config, LoadConfigResult, PandaPlugin } from '@pandacss/types'
+import browserslist from 'browserslist'
+
+const RESOLVED_HOOKS_NAME = '__resolved__'
+
+export function getAutoPlugins(config: Config): PandaPlugin[] {
+  const plugins: PandaPlugin[] = [pluginVue(), pluginSvelte()]
+
+  if (config.lightningcss) {
+    plugins.push(pluginLightningcss())
+  }
+
+  return plugins
+}
+
+export function applyAutoPlugins(conf: LoadConfigResult, cwd: string) {
+  if (conf.config.lightningcss && !conf.config.browserslist) {
+    conf.config.browserslist ||= browserslist.findConfig(cwd)?.defaults
+  }
+
+  const autoPlugins = getAutoPlugins(conf.config)
+
+  conf.hooks = mergeHooks([...autoPlugins, { name: RESOLVED_HOOKS_NAME, hooks: conf.hooks }])
+  conf.config.plugins = [...autoPlugins, ...(conf.config.plugins ?? [])]
+}

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -1,27 +1,8 @@
-import { loadConfig, mergeHooks } from '@pandacss/config'
-import type { Config, PandaPlugin } from '@pandacss/types'
-import { pluginLightningcss } from '@pandacss/plugin-lightningcss'
-import { pluginSvelte } from '@pandacss/plugin-svelte'
-import { pluginVue } from '@pandacss/plugin-vue'
-import browserslist from 'browserslist'
+import { loadConfig } from '@pandacss/config'
+import type { Config } from '@pandacss/types'
+import { applyAutoPlugins } from './auto-plugins'
 import { PandaContext } from './create-context'
 import { loadTsConfig } from './load-tsconfig'
-
-const RESOLVED_HOOKS_NAME = '__resolved__'
-
-/**
- * Built-in plugins that are auto-injected when using the CLI or PostCSS plugin.
- * These provide Vue/Svelte file support and LightningCSS optimization.
- */
-function getAutoPlugins(config: Config): PandaPlugin[] {
-  const plugins: PandaPlugin[] = [pluginVue(), pluginSvelte()]
-
-  if (config.lightningcss) {
-    plugins.push(pluginLightningcss())
-  }
-
-  return plugins
-}
 
 /**
  * Load config and create context with auto-injected plugins.
@@ -41,18 +22,7 @@ export async function loadConfigAndCreateContext(options: { cwd?: string; config
     conf.config.cwd = options.cwd
   }
 
-  if (conf.config.lightningcss && !conf.config.browserslist) {
-    conf.config.browserslist ||= browserslist.findConfig(cwd)?.defaults
-  }
-
-  // Auto-inject built-in plugins (vue, svelte, lightningcss)
-  // Auto plugins run first, then the already-resolved user hooks run after
-  const autoPlugins = getAutoPlugins(conf.config)
-
-  // conf.hooks is already properly merged from user plugins + inline hooks by resolveConfig.
-  // Prepend auto-plugins before it — don't re-process user plugins to avoid double-execution.
-  conf.hooks = mergeHooks([...autoPlugins, { name: RESOLVED_HOOKS_NAME, hooks: conf.hooks }])
-  conf.config.plugins = [...autoPlugins, ...(conf.config.plugins ?? [])]
+  applyAutoPlugins(conf, cwd)
 
   const tsConfResult = await loadTsConfig(conf, cwd)
 

--- a/packages/node/src/diff-engine.ts
+++ b/packages/node/src/diff-engine.ts
@@ -1,6 +1,7 @@
 import { diffConfigs, loadConfig } from '@pandacss/config'
 import { Generator } from '@pandacss/generator'
 import type { Config, LoadConfigResult } from '@pandacss/types'
+import { applyAutoPlugins } from './auto-plugins'
 
 export class DiffEngine {
   private prevConfig: Config | undefined
@@ -18,6 +19,8 @@ export class DiffEngine {
     // attach tsconfig options from previous config
     const { tsconfig, tsconfigFile, tsOptions } = this.ctx.conf
     Object.assign(conf, { tsconfig, tsconfigFile, tsOptions })
+
+    applyAutoPlugins(conf, this.ctx.config.cwd)
 
     return this.refresh(conf, fn)
   }


### PR DESCRIPTION
Closes #3702

## 📝 Description

Config changes keep working in Vue and Svelte projects. Editing your config no longer drops your styles until a restart.

## ⛳️ Current behavior (updates)

In a Vue or Svelte project, change any value in `panda.config.ts` and your styles vanish on save. They come back only after a full page reload, and the next config edit drops them again.

On reload, Panda rebuilds the context from `loadConfig` but skips the auto-injected `pluginVue()` and `pluginSvelte()`. Those register the `parser:before` hook that lets Panda read `.vue`/`.svelte` files. Without it, those files extract zero styles, so every atomic rule is dropped. The tokens layer still regenerates from config, so a `:root` variable updates but nothing references it — the color just disappears.

## 🚀 New behavior

The reload path re-applies the auto plugins, the same way first load does, so `.vue`/`.svelte` files keep extracting after a config change.

The auto-plugin step now lives in `applyAutoPlugins` (`packages/node/src/auto-plugins.ts`), called from both `loadConfigAndCreateContext` and `reloadConfigAndRefreshContext`. Every reload caller (CLI watch, the PostCSS builder, `generate`) goes through the latter, so one change covers them all.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Only SFC frameworks were affected. Plain React and `.tsx` projects need no `parser:before` transform, so they never hit this.

New test at `packages/node/__tests__/config-reload.test.ts` loads a real config, edits it, reloads, and asserts a `.vue` file still extracts its style. It fails before this change and passes after.
