### PR TITLE
fix(generator): fix defineParts return type

### DIFF
--- a/.changeset/fix-define-parts-return-type.md
+++ b/.changeset/fix-define-parts-return-type.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/generator': patch
+'@pandacss/dev': patch
+---
+
+Fix the return type of `defineParts` so it reflects the actual runtime output.
+
+Calling the returned function now gives you an object typed with the part `selector`s as keys, and only for the parts you
+actually pass in. Previously it was typed as a `Partial` record keyed by the original part names, which was wrong on both
+counts.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,7 +44,9 @@ export function defineSlotRecipe<S extends string, T extends SlotRecipeVariantRe
 }
 
 export function defineParts<T extends Parts>(parts: T) {
-  return function (config: Partial<Record<keyof T, SystemStyleObject>>): Partial<Record<keyof T, SystemStyleObject>> {
+  return <C extends Partial<Record<keyof T, SystemStyleObject>>>(
+    config: C,
+  ): { [K in keyof C & keyof T as T[K]['selector']]: SystemStyleObject } => {
     return Object.fromEntries(
       Object.entries(config).map(([key, value]) => {
         const part = parts[key]

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,7 +43,7 @@ export function defineSlotRecipe<S extends string, T extends SlotRecipeVariantRe
   return config as SlotRecipeConfig
 }
 
-export function defineParts<T extends Parts>(parts: T) {
+export function defineParts<const T extends Parts>(parts: T) {
   return <C extends Partial<Record<keyof T, SystemStyleObject>>>(
     config: C,
   ): { [K in keyof C & keyof T as T[K]['selector']]: SystemStyleObject } => {

--- a/packages/generator/src/artifacts/types/main.ts
+++ b/packages/generator/src/artifacts/types/main.ts
@@ -32,7 +32,7 @@ export const generateTypesEntry = (ctx: Context, isJsxRequired: boolean) => {
       export function defineAnimationStyles(definition: CompositionStyles['animationStyles']): Panda.AnimationStyles
       export function defineLayerStyles(definition: CompositionStyles['layerStyles']): Panda.LayerStyles
       export function definePattern<T extends PatternProperties>(config: PatternConfig<T>): Panda.PatternConfig
-      export function defineParts<T extends Parts>(parts: T): (config: Partial<Record<keyof T, SystemStyleObject>>) => Partial<Record<keyof T, SystemStyleObject>>
+      export function defineParts<const T extends Parts>(parts: T): <C extends Partial<Record<keyof T, SystemStyleObject>>>(config: C) => { [K in keyof C & keyof T as T[K]['selector']]: SystemStyleObject }
     }
     `,
     index: outdent`

--- a/packages/studio/styled-system/types/global.d.ts
+++ b/packages/studio/styled-system/types/global.d.ts
@@ -16,5 +16,5 @@ declare module '@pandacss/dev' {
   export function defineAnimationStyles(definition: CompositionStyles['animationStyles']): Panda.AnimationStyles
   export function defineLayerStyles(definition: CompositionStyles['layerStyles']): Panda.LayerStyles
   export function definePattern<T extends PatternProperties>(config: PatternConfig<T>): Panda.PatternConfig
-  export function defineParts<T extends Parts>(parts: T): (config: Partial<Record<keyof T, SystemStyleObject>>) => Partial<Record<keyof T, SystemStyleObject>>
+  export function defineParts<const T extends Parts>(parts: T): <C extends Partial<Record<keyof T, SystemStyleObject>>>(config: C) => { [K in keyof C & keyof T as T[K]['selector']]: SystemStyleObject }
 }

--- a/playground/src/dts/@pandacss_dev.d.ts
+++ b/playground/src/dts/@pandacss_dev.d.ts
@@ -7,7 +7,7 @@ declare function defineConfig(config: Config): Config & {
 };
 declare function defineRecipe<T extends RecipeVariantRecord>(config: RecipeConfig<T>): RecipeConfig;
 declare function defineSlotRecipe<S extends string, T extends SlotRecipeVariantRecord<S>>(config: SlotRecipeConfig<S, T>): SlotRecipeConfig;
-declare function defineParts<T extends Parts>(parts: T): (config: Partial<Record<keyof T, SystemStyleObject>>) => Partial<Record<keyof T, SystemStyleObject>>;
+declare function defineParts<T extends Parts>(parts: T): <C extends Partial<Record<keyof T, SystemStyleObject>>>(config: C) => { [K in keyof C & keyof T as T[K]["selector"]]: SystemStyleObject; };
 declare function definePattern<T extends PatternConfig>(config: T): PatternConfig;
 declare function definePreset(preset: Preset): Preset;
 declare function defineKeyframes(keyframes: CssKeyframes): CssKeyframes;

--- a/playground/src/dts/@pandacss_dev.d.ts
+++ b/playground/src/dts/@pandacss_dev.d.ts
@@ -7,7 +7,7 @@ declare function defineConfig(config: Config): Config & {
 };
 declare function defineRecipe<T extends RecipeVariantRecord>(config: RecipeConfig<T>): RecipeConfig;
 declare function defineSlotRecipe<S extends string, T extends SlotRecipeVariantRecord<S>>(config: SlotRecipeConfig<S, T>): SlotRecipeConfig;
-declare function defineParts<T extends Parts>(parts: T): <C extends Partial<Record<keyof T, SystemStyleObject>>>(config: C) => { [K in keyof C & keyof T as T[K]["selector"]]: SystemStyleObject; };
+declare function defineParts<const T extends Parts>(parts: T): <C extends Partial<Record<keyof T, SystemStyleObject>>>(config: C) => { [K in keyof C & keyof T as T[K]["selector"]]: SystemStyleObject; };
 declare function definePattern<T extends PatternConfig>(config: T): PatternConfig;
 declare function definePreset(preset: Preset): Preset;
 declare function defineKeyframes(keyframes: CssKeyframes): CssKeyframes;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #3708

## 📝 Description

Derive the return type from the generic `config` argument (`C`) instead of the static `Parts` type (`T`), and map each key through its `selector`.

The returned type now:

- Only includes keys present in `config` (via `keyof C`)
- Maps each key to its corresponding `selector`, matching the actual runtime output

## ⛳️ Current behavior (updates)

```ts
const styles: Partial<Record<"container" | "item" | "root", SystemStyleObject>>
```

## 🚀 New behavior

```ts
const styles: {
 "& [data-item]": SystemStyleObject;
 "&": SystemStyleObject;
}
```

## 💣 Is this a breaking change (Yes/No):

I think this is a safe change.
