### PR TITLE
fix(compiler): inline keyframe names in animationName types

### DIFF
--- a/.changeset/keyframes-animation-name-types.md
+++ b/.changeset/keyframes-animation-name-types.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix `animationName` rejecting every keyframe name under `strictTokens`. Generated types now inline the keyframe names
+(`KeyframesValue = "spin" | "fadeIn" | …`) instead of pointing at a `keyframes` token category that never existed, so
+`css({ animationName: 'spin' })` type-checks without the `[spin]` escape hatch.

--- a/crates/pandacss_codegen/src/artifacts/types.rs
+++ b/crates/pandacss_codegen/src/artifacts/types.rs
@@ -60,6 +60,7 @@ pub fn files(ctx: CodegenContext<'_>, options: GenerateOptions) -> Vec<ArtifactF
         &system_module(
             &ctx.types.conditions,
             &ctx.types.utilities,
+            &ctx.types.keyframes.keys,
             ctx.types.options,
         ),
         options,
@@ -272,9 +273,14 @@ fn tokens_module(data: &TokenTypeData) -> Module {
 
 fn value_alias_parts(
     data: &UtilityTypeData,
+    keyframes: &[String],
     options: pandacss_config::TypegenOptions,
 ) -> Vec<String> {
     let strict = options.strict_tokens || options.strict_property_values;
+
+    let mut keyframe_names = keyframes.to_vec();
+    keyframe_names.sort_unstable();
+    keyframe_names.dedup();
 
     // Color-opacity / important modifiers are only reachable from strict aliases.
     let escape_hatch = if strict {
@@ -304,11 +310,12 @@ fn value_alias_parts(
         if !needed_aliases.contains(alias.name.as_str()) {
             continue;
         }
+        let alias_parts = expand_keyframe_parts(&alias.parts, &keyframe_names);
         parts.push(format!(
             "export type {} = {}",
             alias.name,
             value_alias_type(
-                &alias.parts,
+                &alias_parts,
                 options,
                 strict_entries.get(alias.name.as_str()).copied()
             )
@@ -316,6 +323,25 @@ fn value_alias_parts(
     }
 
     parts
+}
+
+fn expand_keyframe_parts(parts: &[ValueTypePart], keyframe_names: &[String]) -> Vec<ValueTypePart> {
+    if !parts.iter().any(
+        |part| matches!(part, ValueTypePart::TokenCategory(category) if category == "keyframes"),
+    ) {
+        return parts.to_vec();
+    }
+
+    let mut expanded = Vec::with_capacity(parts.len() + keyframe_names.len());
+    for part in parts {
+        match part {
+            ValueTypePart::TokenCategory(category) if category == "keyframes" => {
+                expanded.extend(keyframe_names.iter().cloned().map(ValueTypePart::Literal));
+            }
+            other => expanded.push(other.clone()),
+        }
+    }
+    expanded
 }
 
 /// Maps each utility value alias to its native CSS property entry, for default-mode `strict_props` inheritance.
@@ -629,6 +655,7 @@ fn css_datatype_type_parts() -> Vec<String> {
 fn system_module(
     conditions: &ConditionTypeData,
     data: &UtilityTypeData,
+    keyframes: &[String],
     options: pandacss_config::TypegenOptions,
 ) -> Module {
     let jsx_style_props = options.jsx_style_props;
@@ -641,7 +668,7 @@ fn system_module(
         "export type Assign<T, U> = {\n  [K in keyof T]: K extends keyof U ? U[K] : T[K]\n} & U".into(),
     ];
     parts.extend(condition_type_parts(conditions, options));
-    parts.extend(value_alias_parts(data, options));
+    parts.extend(value_alias_parts(data, keyframes, options));
     parts.extend(vec![
         r#"export type AtRuleType = "media" | "layer" | "container" | "supports" | "page" | "scope" | "starting-style""#.into(),
         "export type Selector = `${string}&` | `&${string}` | `@${AtRuleType}${string}`".into(),

--- a/crates/pandacss_project/tests/codegen.rs
+++ b/crates/pandacss_project/tests/codegen.rs
@@ -307,3 +307,42 @@ fn generates_affected_artifacts_by_dependency() {
 
     assert_snapshot!(format!("{ids:?}"), @"[Patterns, Themes, Types, Tokens, Conditions]");
 }
+
+#[test]
+fn keyframes_typegen_inlines_names_and_stays_out_of_tokens() {
+    let config = create_config(json!({
+        "strictTokens": true,
+        "theme": {
+            "keyframes": {
+                "probeKf": { "from": { "opacity": 0 }, "to": { "opacity": 1 } }
+            }
+        },
+        "utilities": {
+            "animationName": { "values": "keyframes" }
+        }
+    }));
+    let system = System::new(config.clone()).expect("valid project config");
+    let project = Project::new(system);
+
+    let artifact = project
+        .generate_artifact(&config, ArtifactId::Types, GenerateOptions::default(), None)
+        .expect("types artifact");
+    let system_code = &artifact
+        .files
+        .iter()
+        .find(|file| file.path == "types/system.d.mts")
+        .expect("system file")
+        .code;
+    let tokens_code = &artifact
+        .files
+        .iter()
+        .find(|file| file.path == "types/tokens.d.mts")
+        .expect("tokens file")
+        .code;
+
+    assert!(system_code.contains(
+        r#"export type KeyframesValue = WithEscapeHatch<CssGlobals | "probeKf" | CssVars>"#
+    ));
+    assert!(!tokens_code.contains("keyframes"));
+    assert!(!tokens_code.contains("probeKf"));
+}


### PR DESCRIPTION
## 📝 Description

Under `strictTokens`, `css({ animationName: 'spin' })` failed to type-check. Every keyframe name needed the `'[spin]'` escape hatch, which typed fine unbracketed on v1. Reported in [#3599](https://github.com/chakra-ui/panda/discussions/3599#discussioncomment-17933445).

## ⛳️ Current behavior (updates)

The generated `KeyframesValue` pointed at a `keyframes` token category:

```ts
// styled-system/types/system.d.ts
export type KeyframesValue = WithEscapeHatch<CssGlobals | TokenValue<"keyframes"> | CssVars>
```

But `keyframes` is not a token category — keyframe names live outside the token dictionary and never enter the `Tokens` interface. `TokenValue<"keyframes">` maps a missing key to `never`, so the only non-escape-hatch options left were `CssGlobals | CssVars`:

```ts
css({ animationName: 'spin' })     // ❌ '"spin"' is not assignable to ConditionalValue<KeyframesValue>
css({ animationName: '[spin]' })   // only this worked
```

The keyframe names were already collected into the type data — they just weren't wired into the alias.

## 🚀 New behavior

Keyframe names are inlined as a literal union at type emission, matching v1's `UtilityValues["animationName"]`:

```ts
export type KeyframesValue = WithEscapeHatch<CssGlobals | "spin" | "fadeIn" | CssVars>

css({ animationName: 'spin' })          // ✅
css({ animationName: 'notAKeyframe' })  // ❌ still rejected — names stay type-checked
```

Keyframes stay out of `tokens.d.ts`, so `token('keyframes.spin')` isn't wrongly offered. The utility keeps its `keyframes` category sentinel, so language-service autocomplete still lists keyframe names with `kind: 'keyframe'`.

Verified end to end with the reporter's repro: `panda codegen` then `tsc` with `skipLibCheck: false` passes, valid names accepted and unknown ones rejected.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

- Fix lives in `pandacss_codegen` (`expand_keyframe_parts`), fed by keyframe names that already flowed into `TypeData`.
- Covered by an end-to-end codegen test plus the existing tooling-autocomplete suite (`config-style-object`).
