### PR TITLE
docs: note border override cascade order in v2 migration guide

### DIFF
--- a/V2_MIGRATION.md
+++ b/V2_MIGRATION.md
@@ -536,6 +536,30 @@ const Button = withContext('button')
 
 `withRootProvider` is new. Use it for the root of a slot recipe when the root doesn't render a slot of its own.
 
+### Border overrides sort by property, not source order
+
+v2 orders atomic rules by property breadth, deterministically — the same sort every property follows. All the border
+shorthands (`borderWidth` / `borderStyle` / `borderColor` and the per-side `borderTop`, `borderInlineEnd`, … forms) sit
+in one tier, so the all-sides shorthand emits after a narrower per-side one and wins the cascade, no matter which order
+you merged them.
+
+That changes one v1 pattern. Composing an all-sides border with a per-side override no longer opens the side:
+
+```tsx
+// base sets a full border, override tries to drop one side
+cx(css({ borderWidth: '1px', borderStyle: 'solid' }), css({ borderInlineEnd: '0' }))
+// v1: renders an open bracket — the override was declared last
+// v2: renders a closed box — borderWidth re-applies the inline-end side
+```
+
+Reach for the longhand when the override has to win — longhands rank above every shorthand, so they always land last:
+
+```tsx
+cx(css({ borderWidth: '1px', borderStyle: 'solid' }), css({ borderInlineEndWidth: '0' }))
+```
+
+Border is not special-cased here on purpose: padding, margin, and every other property group sort the same way.
+
 ---
 
 ## CLI commands


### PR DESCRIPTION
## 📝 Description

Documents a v1→v2 cascade-order difference for border overrides in `V2_MIGRATION.md`. Docs only — no engine change.

## ⛳️ Current behavior (updates)

v2 orders atomic rules by property breadth, deterministically. All the border shorthands — all-sides `borderWidth` / `borderStyle` / `borderColor` and the per-side `borderTop`, `borderInlineEnd`, … forms — share one tier, so the all-sides shorthand always emits after a narrower per-side one, no matter which order you merged them.

That flips one v1 pattern. Composing a full border with a per-side override no longer opens the side:

```tsx
cx(css({ borderWidth: '1px', borderStyle: 'solid' }), css({ borderInlineEnd: '0' }))
// v1: open bracket — the override was declared last
// v2: closed box — borderWidth re-applies the inline-end side
```

The guide didn't mention this, so a v1 user hitting the closed box had nothing to point them at the fix.

## 🚀 New behavior

Adds a "Border overrides sort by property, not source order" section to the migration guide. It shows the before/after, and the workaround: reach for the longhand when the override has to win, since longhands rank above every shorthand.

```tsx
cx(css({ borderWidth: '1px', borderStyle: 'solid' }), css({ borderInlineEndWidth: '0' }))
```

Border is not special-cased for this. Padding, margin, and every other group sort the same way — carving out a border-only tier would make border the odd one out.

## 💣 Is this a breaking change (Yes/No):

No. Documentation only.

## 📝 Additional Information
