### PR TITLE
fix(compiler): replay utility transforms in design-system build info

### DIFF
--- a/.changeset/design-system-transform-replay.md
+++ b/.changeset/design-system-transform-replay.md
@@ -1,0 +1,16 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix a `designSystem` consumer dropping a library utility's `transform` when replaying its build info, emitting the
+wrong (sometimes invalid) property.
+
+```tsx
+// library built with `panda lib`
+<Box boxSize="4" /> // .size_4 { width: …; height: … }
+
+// consumer via `designSystem` — was `.size_4 { box-size: … }`, now width/height
+```
+
+Transform results now travel in the artifact, so a replayed atom emits the same CSS the library did. Requires
+regenerating the library's build info (`schemaVersion` 6); older artifacts re-extract from source.

--- a/crates/pandacss_project/src/build_info.rs
+++ b/crates/pandacss_project/src/build_info.rs
@@ -12,17 +12,17 @@ use pandacss_encoder::{
     Atom, AtomValue, ConditionList, EncodedRecipesSnapshot, RecipeStyleEntry,
     RecipeStyleGroupSnapshot,
 };
-use pandacss_extractor::ExportInfo;
+use pandacss_extractor::{ExportInfo, Literal};
 use pandacss_shared::ViewTransitionStyle;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::recipes::EncodedRecipes;
-use crate::{FileEntry, ParseFileReport};
+use crate::{FileEntry, ParseFileReport, UtilityStyleKey};
 
 /// Bumped when the on-disk shape changes; a consumer with a different
 /// `SCHEMA_VERSION` falls back to re-extracting the library's source.
-pub const SCHEMA_VERSION: u32 = 5;
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// Synthetic file-key prefix for atoms hydrated from a parent design system.
 /// Excluded from serialized build info so a published artifact carries only
@@ -125,6 +125,8 @@ pub struct BuildAtom {
     /// `!important`. Omitted when false.
     #[serde(default, skip_serializing_if = "is_false")]
     pub i: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s: Option<serde_json::Value>,
 }
 
 /// A bare integer is a string-interned value (the common case); token-derived
@@ -204,6 +206,7 @@ impl Interner {
             v: self.build_value(atom.value()),
             c: atom.conditions().iter().map(|c| self.intern(c)).collect(),
             i: atom.important(),
+            s: None,
         }
     }
 
@@ -213,6 +216,7 @@ impl Interner {
             v: self.build_value(&entry.value),
             c: entry.conditions.iter().map(|c| self.intern(c)).collect(),
             i: entry.important,
+            s: None,
         }
     }
 
@@ -476,8 +480,27 @@ impl super::Project {
             .map(|(index, atom)| (*atom, index as u32))
             .collect();
 
+        let mut override_lookup: FxHashMap<(&str, &AtomValue), &Literal> = FxHashMap::default();
+        for (path, entry) in &self.files {
+            if path.starts_with(HYDRATED_FILE_PREFIX) {
+                continue;
+            }
+            for ((prop, value), styles) in &entry.utility_styles {
+                override_lookup.insert((prop.as_ref(), value), styles);
+            }
+        }
+
         let mut interner = Interner::default();
-        let build_atoms = atoms.iter().map(|atom| interner.build_atom(atom)).collect();
+        let build_atoms = atoms
+            .iter()
+            .map(|atom| {
+                let mut build = interner.build_atom(atom);
+                if let Some(styles) = override_lookup.get(&(atom.prop(), atom.value())) {
+                    build.s = Some(styles.to_json());
+                }
+                build
+            })
+            .collect();
 
         // Map each group's class name to its combined (base+variants+compounds)
         // index for per-module provenance.
@@ -652,6 +675,7 @@ impl super::Project {
         // corrupt (an out-of-range string index). Refuse to hydrate partial data
         // and let the caller re-extract, same as a schema-version mismatch.
         let mut atoms: FxHashSet<Atom> = FxHashSet::default();
+        let mut utility_styles: FxHashMap<UtilityStyleKey, Literal> = FxHashMap::default();
         for (index, build) in info.atoms.iter().enumerate() {
             let selected = selected_atoms
                 .as_ref()
@@ -661,6 +685,10 @@ impl super::Project {
             }
             match atom_from_build(build, &info.strings) {
                 Some(atom) => {
+                    if let Some(styles) = build.s.as_ref().and_then(Literal::from_json) {
+                        utility_styles
+                            .insert((Box::from(atom.prop()), atom.value().clone()), styles);
+                    }
                     atoms.insert(atom);
                 }
                 None => return false,
@@ -710,7 +738,7 @@ impl super::Project {
                 cacheable: true,
                 atoms,
                 encoded_recipes: EncodedRecipes::new(false),
-                utility_styles: FxHashMap::default(),
+                utility_styles,
                 token_refs,
                 exports: pandacss_extractor::ExportInfo::default(),
                 diagnostics: Vec::new(),

--- a/crates/pandacss_project/tests/build_info.rs
+++ b/crates/pandacss_project/tests/build_info.rs
@@ -31,7 +31,7 @@ fn build_info_emits_interned_atoms_with_per_module_provenance() {
     // `color: red` is shared, so it appears once in `atoms` and is referenced by
     // both modules; `padding`/`margin` are module-local.
     assert_yaml_snapshot!(info, @"
-    schemaVersion: 5
+    schemaVersion: 6
     panda: ^2.0.0
     configFingerprint: cfg1-0130e6407f607c4d
     strings:
@@ -197,6 +197,76 @@ fn hydrate_reproduces_every_atom() {
     assert!(consumer.hydrate("@acme/ds", &info, None));
 
     assert_eq!(sorted_atoms(&consumer), sorted_atoms(&source));
+}
+
+#[test]
+fn hydrate_restores_utility_transform_styles() {
+    use pandacss_project::{
+        Diagnostic, ExtractedLiteral as Literal, ParseTransforms, UtilityTransformFn,
+    };
+
+    let config_overrides = json!({
+        "theme": { "tokens": { "sizes": { "4": { "value": "1rem" } } } },
+        "utilities": {
+            "boxSize": {
+                "className": "size",
+                "values": "sizes",
+                "transform": { "kind": "js-callback", "id": "boxSize" }
+            }
+        }
+    });
+
+    let mut transform = |prop: &str,
+                         resolved: &AtomValue,
+                         _original: &AtomValue|
+     -> Result<Option<Literal>, Diagnostic> {
+        if prop != "boxSize" {
+            return Ok(None);
+        }
+        let value = match resolved {
+            AtomValue::String(value)
+            | AtomValue::Number(value)
+            | AtomValue::Token { value, .. } => value.to_string(),
+            AtomValue::Bool(_) | AtomValue::Null => return Ok(None),
+        };
+        Ok(Some(Literal::Object(vec![
+            ("width".to_owned(), Literal::String(value.clone())),
+            ("height".to_owned(), Literal::String(value)),
+        ])))
+    };
+
+    let mut lib = create_project(config_overrides.clone());
+    lib.parse_file_with(
+        "thing.tsx",
+        "import { css } from '@panda/css'; css({ boxSize: '4' });",
+        ParseTransforms {
+            utility: Some(&mut transform as &mut UtilityTransformFn<'_>),
+            ..Default::default()
+        },
+    );
+
+    let info = lib.build_info("^2.0.0".into());
+    let json = serde_json::to_string(&info).expect("serialize");
+    let restored: BuildInfo = serde_json::from_str(&json).expect("deserialize");
+
+    let mut consumer = create_project(config_overrides.clone());
+    assert!(consumer.hydrate("@acme/ds", &restored, None));
+
+    let config = create_config(config_overrides);
+    let snapshots = consumer.stylesheet_snapshots(&config);
+    let style = snapshots
+        .utility_styles
+        .values()
+        .next()
+        .expect("hydrated boxSize transform styles present");
+    let object = style.to_json();
+    assert_eq!(object["width"], object["height"]);
+    assert!(
+        object
+            .get("width")
+            .is_some_and(serde_json::Value::is_string)
+    );
+    assert_eq!(snapshots.utility_styles.len(), 1);
 }
 
 #[test]

--- a/design-notes/build-info.md
+++ b/design-notes/build-info.md
@@ -31,11 +31,11 @@ recomputed on hydrate.
 
 ```jsonc
 {
-  "schemaVersion": 5,
+  "schemaVersion": 6,
   "panda": "^2.0.0",                               // peer range (collision guard); author-supplied
   "configFingerprint": "cfg1-…",                          // engine fingerprint of output-affecting config
   "strings": ["color", "red", "padding", "4px", "colors.brand", "vt_xxx"], // intern table
-  "atoms": [{ "p": 0, "v": 1 }],                   // [propIdx, valueIdx]; token values use `{ t, v }`
+  "atoms": [{ "p": 0, "v": 1 }],                   // [propIdx, valueIdx]; token values use `{ t, v }`; `s` = JS-transform styles
   "tokenRefs": [4],                                  // string indices for runtime token CSS-var usage
   "recipes": { "base": [...], "variants": [...] }, // interned EncodedRecipesSnapshot groups
   "viewTransitions": [{ "cls": 5, "old": { "opacity": 0 }, "new": { "opacity": 1 } }],
@@ -51,6 +51,13 @@ A value is a bare index (string), `{ t, v }` (token path + resolved value), or `
 px-driving type tag). Full atom/recipe data is kept (not pre-built CSS) so the consumer re-emits with **token identity**
 preserved instead of reducing tokens to opaque CSS values. Top-level `tokenRefs` entries point into `strings`; each
 module's `tokenRefs` entries point into that top-level array, preserving import-based tree-shaking.
+
+**JS utility-`transform` styles ride on the atom (`s`).** A utility with a JS `transform` (e.g. `boxSize` →
+`{ width, height }`) produces styles the Rust engine can't recompute; the producer runs the callback at extraction and
+keeps the result in a side map keyed by the carrier atom's `(prop, value)`. That map isn't derivable from the atom
+alone, so each atom serializes its transform result as `s` (the styles object) and the consumer restores it into the
+same override map on hydrate. Without it a replayed atom falls back to the kebab-cased utility name (`box-size`) — wrong,
+sometimes invalid CSS. Recipe entries need no `s`: their transform is baked into `entries` at extraction.
 
 **Token definitions are not in build info.** The artifact carries token _usage_ (path + producer-resolved value at
 extraction time); the consumer's **tokens layer** still comes from its own config (typically the lib preset merged in

--- a/packages/cli/__tests__/buildinfo.test.ts
+++ b/packages/cli/__tests__/buildinfo.test.ts
@@ -65,7 +65,7 @@ describe('buildinfo command', () => {
           },
         },
         "panda": "^2.0.0",
-        "schemaVersion": 5,
+        "schemaVersion": 6,
         "strings": [
           "background",
           "blue",

--- a/packages/compiler-shared/src/types/compiler.ts
+++ b/packages/compiler-shared/src/types/compiler.ts
@@ -67,6 +67,7 @@ export interface BuildAtom {
   v: number | { t: number; v: number } | { n: number } | boolean | null
   c?: number[]
   i?: boolean
+  s?: Record<string, unknown>
 }
 
 /**

--- a/packages/compiler/__tests__/build-info.test.ts
+++ b/packages/compiler/__tests__/build-info.test.ts
@@ -1,6 +1,7 @@
 import type { BuildInfoArtifact } from '@pandacss/compiler-shared'
 import { describe, expect, it } from 'vitest'
-import { createProject } from './test-utils'
+import { createCompilerFromSnapshot } from '../src'
+import { createProject, importMap } from './test-utils'
 
 // A "library" project that extracts two component modules.
 function libBuildInfo(): BuildInfoArtifact {
@@ -30,7 +31,7 @@ describe('compiler.buildInfo', () => {
     // modules; `padding`/`margin` are module-local.
     expect(libBuildInfo()).toMatchInlineSnapshot(`
       {
-        "schemaVersion": 5,
+        "schemaVersion": 6,
         "panda": "^2.0.0",
         "configFingerprint": "cfg1-343a1d7a20956a6a",
         "strings": [
@@ -233,6 +234,92 @@ describe('compiler.buildInfo', () => {
       "@layer tokens {
         :where(:root, :host) {
           --colors-brand-500: #3b82f6;
+        }
+      }
+      "
+    `)
+  })
+
+  it('replays a JS utility transform (boxSize) into the consumer CSS', () => {
+    const snapshot = (): Parameters<typeof createCompilerFromSnapshot>[0] => ({
+      config: {
+        cwd: '/virtual',
+        outdir: 'styled-system',
+        importMap,
+        jsxFramework: 'react',
+        theme: { tokens: { sizes: { 4: { value: '1rem' } } } },
+        utilities: {
+          boxSize: {
+            className: 'size',
+            values: 'sizes',
+            transform: { kind: 'js-callback', id: 'utilities.boxSize.transform' },
+          },
+        },
+      },
+      callbacks: {
+        'utility.transform': {
+          'utilities.boxSize.transform': (value) => ({ width: value, height: value }),
+        },
+      },
+    })
+
+    const lib = createCompilerFromSnapshot(snapshot(), { crossFile: false })
+    lib.parseFileSource('/virtual/thing.tsx', "import { css } from '@panda/css'\ncss({ boxSize: '4' })")
+    const info = lib.buildInfo.create({ panda: '^2.0.0' })
+
+    const app = createCompilerFromSnapshot(snapshot(), { crossFile: false })
+    expect(app.buildInfo.hydrate(info, { name: '@acme/ds' })).toEqual({
+      ok: true,
+      modules: ['/virtual/thing.tsx'],
+    })
+
+    expect(app.getLayerCss({ layers: ['utilities'] }).css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .size_4 {
+          width: var(--sizes-4);
+          height: var(--sizes-4);
+        }
+      }
+      "
+    `)
+  })
+
+  it('replays a transform whose result nests a condition into the consumer CSS', () => {
+    const snapshot = (): Parameters<typeof createCompilerFromSnapshot>[0] => ({
+      config: {
+        cwd: '/virtual',
+        outdir: 'styled-system',
+        importMap,
+        jsxFramework: 'react',
+        conditions: { hover: '&:hover' },
+        utilities: {
+          debug: {
+            className: 'debug',
+            transform: { kind: 'js-callback', id: 'utilities.debug.transform' },
+          },
+        },
+      },
+      callbacks: {
+        'utility.transform': {
+          'utilities.debug.transform': () => ({ _hover: { border: '2px solid blue' } }),
+        },
+      },
+    })
+
+    const lib = createCompilerFromSnapshot(snapshot(), { crossFile: false })
+    lib.parseFileSource('/virtual/thing.tsx', "import { css } from '@panda/css'\ncss({ debug: true })")
+    const info = lib.buildInfo.create({ panda: '^2.0.0' })
+
+    const app = createCompilerFromSnapshot(snapshot(), { crossFile: false })
+    expect(app.buildInfo.hydrate(info, { name: '@acme/ds' })).toEqual({
+      ok: true,
+      modules: ['/virtual/thing.tsx'],
+    })
+
+    expect(app.getLayerCss({ layers: ['utilities'] }).css).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .debug_true:hover {
+          border: 2px solid blue;
         }
       }
       "

--- a/packages/compiler/__tests__/design-system/codegen.test.ts
+++ b/packages/compiler/__tests__/design-system/codegen.test.ts
@@ -110,7 +110,7 @@ function writeDesignSystemPackage(options: { dir: string; name: string; designSy
     }),
     'dist/panda/preset.mjs': preset,
     'dist/panda/buildinfo.json': json({
-      schemaVersion: 5,
+      schemaVersion: 6,
       panda: '^2.0.0',
       configFingerprint: 'cfg-test',
       strings: [],

--- a/packages/compiler/__tests__/design-system/hydrate.test.ts
+++ b/packages/compiler/__tests__/design-system/hydrate.test.ts
@@ -252,7 +252,7 @@ describe('hydrateDesignSystem (consumer)', () => {
         "severity": "warning",
         "category": "designSystem",
         "file": "buildinfo.json",
-        "message": ""@acme/ds" build info uses schemaVersion 999; expected 5. Re-extracted 1 source file.",
+        "message": ""@acme/ds" build info uses schemaVersion 999; expected 6. Re-extracted 1 source file.",
         "help": [
           "Run \`panda lib\` in "@acme/ds" to rebuild panda/buildinfo.json.",
         ],
@@ -277,7 +277,7 @@ describe('hydrateDesignSystem (consumer)', () => {
         {
           code: 'design_system_buildinfo_stale',
           severity: 'error',
-          message: expect.stringMatching(/uses schemaVersion 999; expected 5\. No fallback source files/),
+          message: expect.stringMatching(/uses schemaVersion 999; expected 6\. No fallback source files/),
         },
       ],
     })
@@ -294,7 +294,7 @@ describe('hydrateDesignSystem (consumer)', () => {
   it('re-extracts when build info is structurally invalid but files are present', async () => {
     cwd = createFixture({
       manifest: { files: ['./button.js'] },
-      buildInfo: { schemaVersion: 5 },
+      buildInfo: { schemaVersion: 6 },
     })
 
     const driver = await createNodeDriver({ cwd })
@@ -375,7 +375,7 @@ describe('hydrateDesignSystem (consumer)', () => {
         },
       }`,
       buildInfo: {
-        schemaVersion: 5,
+        schemaVersion: 6,
         panda: '^2.0.0',
         configFingerprint: 'cfg1-test',
         strings: ['colors.red'],
@@ -1305,7 +1305,7 @@ function createFixture(options: DesignSystemFixture = {}): string {
 
 function validBuildInfo(): Record<string, unknown> {
   return {
-    schemaVersion: 5,
+    schemaVersion: 6,
     panda: '^2.0.0',
     configFingerprint: 'cfg1-test',
     strings: [],


### PR DESCRIPTION
## 📝 Description

A `designSystem` consumer emits the wrong CSS property for any utility with a JS `transform`. A library built with `panda lib` records its extracted styles in `buildinfo.json`, and the consumer replays them instead of re-extracting. That replay dropped the utility's `transform`, so `boxSize="4"` came out as `box-size` instead of `width`/`height` — sometimes a property that doesn't exist.

Reported in [discussion #3599](https://github.com/chakra-ui/panda/discussions/3599#discussioncomment-18000944).

## ⛳️ Current behavior (updates)

Transform results live in a side map that emit swaps in per usage. `buildinfo.json` never carried that map, and hydrate started it empty, so a replayed atom fell back to the kebab-cased utility name.

```css
/* library's own cssgen — correct */
.size_4 { width: var(--sizes-4); height: var(--sizes-4); }

/* consumer via designSystem — wrong */
.size_4 { box-size: var(--sizes-4); }
```

A transform that returns a condition collapses harder: `.debug_true:hover { border: … }` replays as `.debug_true { debug: true }`. Recipes were unaffected — they bake their transform into the serialized entries at extraction.

## 🚀 New behavior

Each atom carries its transform result in the artifact, and hydrate restores it into the same override map emit reads. A replayed atom produces the CSS the library did, nested conditions and all.

```css
/* consumer via designSystem — now matches the library */
.size_4 { width: var(--sizes-4); height: var(--sizes-4); }
```

## 💣 Is this a breaking change (Yes/No):

No. It's a beta wire-format bump: build info goes to `schemaVersion` 6, and a consumer on this version re-extracts an older artifact from source instead of replaying it. Rebuild your library's build info (`panda lib`) after upgrading.

## 📝 Additional Information

Test plan:

- [x] `cargo nextest run -p pandacss_project build_info` — serialize → hydrate round-trip; the transform styles are gone from the hydrated project without the fix
- [x] `pnpm --filter @pandacss/compiler test` — CSS-level replay of `boxSize` and a nested-condition transform through hydrate (both fail with the restore disabled)
- [x] `pnpm --filter @pandacss/cli test buildinfo`
- [x] `pnpm rust:fmt`, `cargo clippy -p pandacss_project -- -D warnings`
