### PR TITLE
fix(tokens): resolve alpha modifiers, composite values, and gradient units

### DIFF
--- a/.changeset/shadow-token-resolution.md
+++ b/.changeset/shadow-token-resolution.md
@@ -2,11 +2,12 @@
 '@pandacss/compiler': patch
 ---
 
-Fix two shadow token bugs that produced invalid CSS or no output.
+Fix the `{colors.x/alpha}` opacity modifier being ignored outside the `colors` category. In `shadows`, `borders` and
+`gradients` it passed through as raw `colors.x/alpha` text, which browsers drop. It now expands to `color-mix(...)`
+everywhere.
 
-A `{colors.x/alpha}` opacity modifier inside a `shadows` value (or any non-color category, like `borders` and `gradients`) now expands to `color-mix(...)` instead of emitting the raw `colors.x/alpha` text, which the browser dropped.
-
-The composite `Shadow` object form in `semanticTokens` now works:
+Fix the composite object form of a `semanticTokens` value emitting nothing. It was parsed as a conditions map named
+after its own keys. Applies to composite `shadow`, `border` and `asset` values.
 
 ```ts
 semanticTokens: {
@@ -15,5 +16,3 @@ semanticTokens: {
   },
 }
 ```
-
-It used to be read as conditions and emit nothing. The same fix covers composite `border`, `gradient`, and `asset` semantic tokens.

--- a/.changeset/shadow-token-resolution.md
+++ b/.changeset/shadow-token-resolution.md
@@ -1,0 +1,19 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix two shadow token bugs that produced invalid CSS or no output.
+
+A `{colors.x/alpha}` opacity modifier inside a `shadows` value (or any non-color category, like `borders` and `gradients`) now expands to `color-mix(...)` instead of emitting the raw `colors.x/alpha` text, which the browser dropped.
+
+The composite `Shadow` object form in `semanticTokens` now works:
+
+```ts
+semanticTokens: {
+  shadows: {
+    card: { value: { offsetX: '0', offsetY: '2px', blur: '4px', spread: '0', color: '{colors.ink}' } },
+  },
+}
+```
+
+It used to be read as conditions and emit nothing. The same fix covers composite `border`, `gradient`, and `asset` semantic tokens.

--- a/.changeset/shadow-token-resolution.md
+++ b/.changeset/shadow-token-resolution.md
@@ -16,3 +16,7 @@ semanticTokens: {
   },
 }
 ```
+
+Fix composite `gradients` emitting bare numbers where CSS needs a unit. A stop `position` now serializes as a percentage
+(`100%`, was `100px`) and a numeric `placement` as an angle (`45deg`, was `45`, which browsers rejected outright).
+Gradients using either form will render differently.

--- a/crates/pandacss_config/src/theme.rs
+++ b/crates/pandacss_config/src/theme.rs
@@ -369,8 +369,8 @@ pub struct TokenEntry<T> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SemanticValue<T> {
-    Conditions(IndexMap<String, SemanticValue<T>>),
     Value(T),
+    Conditions(IndexMap<String, SemanticValue<T>>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/pandacss_stylesheet/tests/tokens.rs
+++ b/crates/pandacss_stylesheet/tests/tokens.rs
@@ -67,6 +67,36 @@ fn emits_primitive_and_semantic_token_vars() {
 }
 
 #[test]
+fn emits_shadow_alpha_modifier_and_composite_token_vars() {
+    let config = config(serde_json::json!({
+        "theme": {
+            "tokens": {
+                "colors": { "ink": { "value": "#000000" } }
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "embeddedAlpha": { "value": "3px 3px 0 {colors.ink/10}" },
+                    "composite": {
+                        "value": { "offsetX": "3px", "offsetY": "3px", "blur": "0", "spread": "0", "color": "{colors.ink}" }
+                    }
+                }
+            }
+        }
+    }));
+    let css = compile_output(&config, "", StylesheetOptions::default())
+        .get_layer_css(&[StylesheetLayer::Tokens]);
+    assert_snapshot!(css, @"
+    @layer tokens {
+      :where(:root, :host) {
+        --colors-ink: #000000;
+        --shadows-embedded-alpha: 3px 3px 0 color-mix(in oklab, var(--colors-ink) 10%, transparent);
+        --shadows-composite: 3px 3px 0 0 var(--colors-ink);
+      }
+    }
+    ");
+}
+
+#[test]
 fn optimize_tokens_keeps_only_referenced_vars() {
     let config = config(serde_json::json!({
         "optimize": { "removeUnusedTokens": true },

--- a/crates/pandacss_tokens/src/from_config.rs
+++ b/crates/pandacss_tokens/src/from_config.rs
@@ -533,12 +533,7 @@ fn expand_token_references(builder: &mut TokenDictionaryBuilder) -> Result<(), T
         }
 
         let value = Arc::clone(&tokens[index].value);
-        let expanded = expand_references(
-            value.as_ref(),
-            tokens,
-            &by_path,
-            tokens[index].category == TokenCategory::Colors,
-        )?;
+        let expanded = expand_references(value.as_ref(), tokens, &by_path)?;
         if let Some(expanded) = expanded {
             tokens[index].original_value = Some(value);
             tokens[index].value = Arc::from(expanded);
@@ -793,7 +788,6 @@ fn expand_references(
     value: &str,
     tokens: &[Token],
     by_path: &FxHashMap<Arc<str>, usize>,
-    allow_color_mix: bool,
 ) -> Result<Option<String>, TokenError> {
     let mut out = String::with_capacity(value.len());
     let mut rest = value;
@@ -809,14 +803,12 @@ fn expand_references(
             return Ok((out != value).then_some(out));
         };
         let key = after_start[..end].trim();
-        let replacement = if allow_color_mix && key.contains('/') {
+        let replacement = if let Some(index) = by_path.get(key) {
+            Cow::Borrowed(tokens[*index].var.as_ref())
+        } else if key.contains('/') {
             Cow::Owned(color_mix(key, tokens, by_path)?)
         } else {
-            Cow::Borrowed(
-                by_path
-                    .get(key)
-                    .map_or(key, |index| tokens[*index].var.as_ref()),
-            )
+            Cow::Borrowed(key)
         };
         out.push_str(&replacement);
         changed = true;

--- a/crates/pandacss_tokens/src/transform.rs
+++ b/crates/pandacss_tokens/src/transform.rs
@@ -101,7 +101,16 @@ impl TokenValueString for GradientValue {
         match self {
             Self::String(value) => value.clone(),
             Self::Gradient(value) => {
-                let placement = value.placement.to_token_string();
+                // A bare number only reads as an angle, and CSS drops the whole
+                // declaration when the unit is missing.
+                let placement = match &value.placement {
+                    StringOrNumber::Number(angle) => {
+                        let mut placement = number_to_js_string(*angle);
+                        placement.push_str("deg");
+                        placement
+                    }
+                    StringOrNumber::String(placement) => placement.clone(),
+                };
                 let mut out = String::new();
                 out.push_str(&value.r#type);
                 out.push_str("-gradient(");
@@ -124,7 +133,7 @@ impl TokenValueString for GradientValue {
                             out.push_str(&stop.color);
                             out.push(' ');
                             push_number_to_js_string(&mut out, stop.position);
-                            out.push_str("px");
+                            out.push('%');
                         }
                     }
                 }
@@ -167,8 +176,7 @@ fn shadow_to_string(value: &Shadow) -> String {
         offset_x.len() + offset_y.len() + blur.len() + spread.len() + value.color.len() + 12,
     );
     if value.inset.unwrap_or(false) {
-        // Double space is intentional: JS writes "inset " then joins with spaces.
-        out.push_str("inset  ");
+        out.push_str("inset ");
     }
     out.push_str(&offset_x);
     out.push(' ');

--- a/crates/pandacss_tokens/tests/from_config.rs
+++ b/crates/pandacss_tokens/tests/from_config.rs
@@ -279,7 +279,7 @@ fn from_config_transforms_composite_token_values() {
     colors.red: "#f00"
     easings.smooth: "cubic-bezier(0.4, 0, 0.2, 1)"
     fonts.body: "Inter, sans-serif"
-    gradients.brand: "linear-gradient(to right, var(--colors-red) 0px, blue 100px)"
+    gradients.brand: "linear-gradient(to right, var(--colors-red) 0%, blue 100%)"
     shadows.ring: "0px 1px 2px 0px rgb(0 0 0 / 0.1), 0px 0px 0px 1px var(--colors-red)"
     shadows.sm: 4px 10px 4px 0px var(--colors-red)
     "##);
@@ -544,14 +544,45 @@ fn from_config_serializes_shadow_arrays_and_inset_semantic_tokens() {
         .expect("token dictionary")
         .expect("non-empty dictionary");
 
-    // The doubled space after `inset` matches v1's `["inset ", …].join(" ")`.
     assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
     colors.colorPalette: var(--colors-color-palette)
     colors.ink: "#000000"
     colors.snow: "#ffffff"
-    shadows.inner: inset  0 1px 2px 0 var(--colors-ink)
+    shadows.inner: inset 0 1px 2px 0 var(--colors-ink)
     shadows.layered: "0 1px 2px 0 var(--colors-ink), 0 4px 8px 0 var(--colors-snow)"
     shadows.strings: "0 1px 2px var(--colors-ink), 0 4px 8px var(--colors-snow)"
+    "##);
+}
+
+/// Composite values accept bare numbers where CSS needs a unit. A stop position
+/// is a percentage along the gradient and a numeric placement is an angle;
+/// emitting either unitless gives a gradient that renders wrong, or not at all.
+#[test]
+fn from_config_gives_numeric_gradient_values_their_css_unit() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "gradients": {
+                    "angled": { "value": { "type": "linear", "placement": 45, "stops": ["red", "blue"] } },
+                    "positioned": { "value": { "type": "linear", "placement": "to right", "stops": [
+                        { "color": "red", "position": 0 },
+                        { "color": "blue", "position": 100 },
+                    ] } },
+                    "keyword": { "value": { "type": "radial", "placement": "circle at center", "stops": ["red", "blue"] } },
+                },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
+    gradients.angled: "linear-gradient(45deg, red, blue)"
+    gradients.keyword: "radial-gradient(circle at center, red, blue)"
+    gradients.positioned: "linear-gradient(to right, red 0%, blue 100%)"
     "##);
 }
 

--- a/crates/pandacss_tokens/tests/from_config.rs
+++ b/crates/pandacss_tokens/tests/from_config.rs
@@ -331,6 +331,96 @@ fn from_config_expands_color_mix_references() {
 }
 
 #[test]
+fn from_config_expands_alpha_modifier_reference_in_non_color_categories() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "colors": { "ink": { "value": "#000000" } },
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "embeddedAlpha": { "value": "3px 3px 0 {colors.ink/10}" },
+                    "embeddedPlain": { "value": "3px 3px 0 {colors.ink}" },
+                },
+                "borders": {
+                    "embeddedAlpha": { "value": "1px solid {colors.ink/10}" },
+                },
+                "gradients": {
+                    "embeddedAlpha": { "value": "linear-gradient(to right, {colors.ink/10}, transparent)" },
+                },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
+    borders.embeddedAlpha: "1px solid color-mix(in oklab, var(--colors-ink) 10%, transparent)"
+    colors.colorPalette: var(--colors-color-palette)
+    colors.ink: "#000000"
+    gradients.embeddedAlpha: "linear-gradient(to right, color-mix(in oklab, var(--colors-ink) 10%, transparent), transparent)"
+    shadows.embeddedAlpha: "3px 3px 0 color-mix(in oklab, var(--colors-ink) 10%, transparent)"
+    shadows.embeddedPlain: 3px 3px 0 var(--colors-ink)
+    "##);
+}
+
+#[test]
+fn from_config_resolves_slash_keyed_token_reference_over_color_mix() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "sizes": { "1/2": { "value": "50%" } },
+            },
+            "semanticTokens": {
+                "sizes": { "half": { "value": "{sizes.1/2}" } },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r#"
+    sizes.1/2: 50%
+    sizes.half: "var(--sizes-1\\/2)"
+    "#);
+}
+
+#[test]
+fn from_config_serializes_composite_shadow_semantic_token() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "colors": { "ink": { "value": "#000000" } },
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "composite": {
+                        "value": { "offsetX": "3px", "offsetY": "3px", "blur": "0", "spread": "0", "color": "{colors.ink}" },
+                    },
+                },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
+    colors.colorPalette: var(--colors-color-palette)
+    colors.ink: "#000000"
+    shadows.composite: 3px 3px 0 0 var(--colors-ink)
+    "##);
+}
+
+#[test]
 fn from_config_uses_css_var_prefix_and_hash_options() {
     let config: UserConfig = serde_json::from_value(json!({
         "prefix": {

--- a/crates/pandacss_tokens/tests/from_config.rs
+++ b/crates/pandacss_tokens/tests/from_config.rs
@@ -420,6 +420,141 @@ fn from_config_serializes_composite_shadow_semantic_token() {
     "##);
 }
 
+/// `border` and `asset` share the composite path with `shadows`. Without the
+/// `SemanticValue` variant order they deserialize as conditions, producing
+/// `borders.card@color` / `assets.grid@type` instead of one serialized value.
+#[test]
+fn from_config_serializes_composite_border_and_asset_semantic_tokens() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "colors": { "ink": { "value": "#000000" } },
+            },
+            "semanticTokens": {
+                "borders": {
+                    "card": { "value": { "color": "{colors.ink}", "width": "1px", "style": "solid" } },
+                },
+                "gradients": {
+                    "sweep": { "value": { "type": "linear", "placement": "to right", "stops": ["{colors.ink}", "transparent"] } },
+                },
+                "assets": {
+                    "grid": { "value": { "type": "svg", "value": "<svg/>" } },
+                },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
+    assets.grid: "url(\"data:image/svg+xml,%3csvg/%3e\")"
+    borders.card: 1px solid var(--colors-ink)
+    colors.colorPalette: var(--colors-color-palette)
+    colors.ink: "#000000"
+    gradients.sweep: "linear-gradient(to right, var(--colors-ink), transparent)"
+    "##);
+}
+
+/// `SemanticValue` tries the value before the conditions map, so a composite
+/// object is no longer mistaken for conditions. This is the other direction:
+/// a real conditions map whose branches are composites must still split into
+/// per-condition tokens for every category that has a composite form.
+#[test]
+fn from_config_keeps_conditions_for_composite_semantic_tokens() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "colors": { "ink": { "value": "#000000" }, "snow": { "value": "#ffffff" } },
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "card": { "value": {
+                        "base": { "offsetX": "0", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "{colors.ink}" },
+                        "_dark": { "offsetX": "0", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "{colors.snow}" },
+                    } },
+                },
+                "borders": {
+                    "card": { "value": {
+                        "base": { "color": "{colors.ink}", "width": "1px", "style": "solid" },
+                        "_dark": { "color": "{colors.snow}", "width": "2px", "style": "dashed" },
+                    } },
+                },
+                "gradients": {
+                    "sweep": { "value": {
+                        "base": { "type": "linear", "placement": "to right", "stops": ["{colors.ink}", "transparent"] },
+                        "_dark": { "type": "linear", "placement": "to left", "stops": ["{colors.snow}", "transparent"] },
+                    } },
+                },
+                "assets": {
+                    "grid": { "value": {
+                        "base": { "type": "svg", "value": "<svg/>" },
+                        "_dark": { "type": "url", "value": "https://example.test/grid.png" },
+                    } },
+                },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
+    assets.grid: "url(\"data:image/svg+xml,%3csvg/%3e\")"
+    assets.grid@_dark: "url(\"https://example.test/grid.png\")"
+    borders.card: 1px solid var(--colors-ink)
+    borders.card@_dark: 2px dashed var(--colors-snow)
+    colors.colorPalette: var(--colors-color-palette)
+    colors.ink: "#000000"
+    colors.snow: "#ffffff"
+    gradients.sweep: "linear-gradient(to right, var(--colors-ink), transparent)"
+    gradients.sweep@_dark: "linear-gradient(to left, var(--colors-snow), transparent)"
+    shadows.card: 0 1px 2px 0 var(--colors-ink)
+    shadows.card@_dark: 0 1px 2px 0 var(--colors-snow)
+    "##);
+}
+
+/// Shadow arrays and the `inset` flag also flow through the composite path.
+#[test]
+fn from_config_serializes_shadow_arrays_and_inset_semantic_tokens() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "colors": { "ink": { "value": "#000000" }, "snow": { "value": "#ffffff" } },
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "layered": { "value": [
+                        { "offsetX": "0", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "{colors.ink}" },
+                        { "offsetX": "0", "offsetY": "4px", "blur": "8px", "spread": "0", "color": "{colors.snow}" },
+                    ] },
+                    "strings": { "value": ["0 1px 2px {colors.ink}", "0 4px 8px {colors.snow}"] },
+                    "inner": { "value": { "offsetX": "0", "offsetY": "1px", "blur": "2px", "spread": "0", "color": "{colors.ink}", "inset": true } },
+                },
+            },
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    // The doubled space after `inset` matches v1's `["inset ", …].join(" ")`.
+    assert_yaml_snapshot!(snapshot_token_values(&dict), @r##"
+    colors.colorPalette: var(--colors-color-palette)
+    colors.ink: "#000000"
+    colors.snow: "#ffffff"
+    shadows.inner: inset  0 1px 2px 0 var(--colors-ink)
+    shadows.layered: "0 1px 2px 0 var(--colors-ink), 0 4px 8px 0 var(--colors-snow)"
+    shadows.strings: "0 1px 2px var(--colors-ink), 0 4px 8px var(--colors-snow)"
+    "##);
+}
+
 #[test]
 fn from_config_uses_css_var_prefix_and_hash_options() {
     let config: UserConfig = serde_json::from_value(json!({

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -52,10 +52,12 @@ export interface Shadow {
 
 export interface Gradient {
   type: 'linear' | 'radial'
+  /** A keyword (`to right`, `circle at center`) or an angle in degrees. */
   placement: string | number
   stops:
     | Array<{
         color: string
+        /** Distance along the gradient, as a percentage (`0` to `100`). */
         position: number
       }>
     | Array<string>

--- a/website/content/docs/theming/tokens.mdx
+++ b/website/content/docs/theming/tokens.mdx
@@ -227,6 +227,9 @@ type Gradient =
     }
 ```
 
+`placement` is either a keyword (`to right`, `circle at center`) or a number, which is read as an angle in degrees. A
+stop `position` is a percentage along the gradient, from `0` to `100`.
+
 ```jsx
 const theme = {
   tokens: {
@@ -240,11 +243,24 @@ const theme = {
           placement: 'to right',
           stops: ['red', 'blue']
         }
+      },
+      // angled placement, with positioned stops
+      angled: {
+        value: {
+          type: 'linear',
+          placement: 45,
+          stops: [
+            { color: 'red', position: 0 },
+            { color: 'blue', position: 100 }
+          ]
+        }
       }
     }
   }
 }
 ```
+
+The `angled` token above emits `linear-gradient(45deg, red 0%, blue 100%)`.
 
 ### Sizes
 


### PR DESCRIPTION
## 📝 Description

Fixes a set of token bugs that silently produced invalid CSS or no output. All of them reported `diagnostics: 0`, so the only symptom was a missing or wrong style at runtime.

Reported in [discussion #3599](https://github.com/chakra-ui/panda/discussions/3599#discussioncomment-18003609).

## ⛳️ Current behavior (updates)

**1. The `{colors.x/alpha}` opacity modifier is dropped outside the `colors` category.** Reference expansion only ran `color-mix` for color tokens, so the same reference in `shadows` (or `borders`, `gradients`) emitted the raw path text — invalid CSS the browser discards.

```css
--colors-embedded:        color-mix(in oklab, var(--colors-ink) 10%, transparent);  /* ok */
--shadows-embedded-alpha: 3px 3px 0 colors.ink/10;                                  /* dropped */
```

**2. The composite object form of a `semanticTokens` value emits nothing.** `SemanticValue` is an untagged enum that tried the conditions map before the value, so `{ offsetX, offsetY, blur, spread, color }` was read as conditions named `offsetX`, `blur`, … — no CSS variable, and the JS token map kept a stray field.

The same fault hit composite `border` and `asset` values, which deserialized into bogus `borders.card@color` / `assets.grid@type` tokens. Composite `gradient` was unaffected: its `stops` field is an array, so it never matched the conditions map.

**3. Composite gradients emit bare numbers where CSS needs a unit.** A stop `position` serialized as `100px`, anchoring the stop 100 pixels from the start instead of at the end, so the gradient depended on element width. A numeric `placement` serialized as `45`, which is not a valid angle, so the browser dropped the declaration and nothing rendered.

```css
--gradients-angled: linear-gradient(45, red, blue);              /* dropped */
--gradients-brand:  linear-gradient(to right, red 0px, blue 100px);  /* renders wrong */
```

## 🚀 New behavior

The alpha modifier expands wherever a `{ref/alpha}` reference appears. Composite objects serialize instead of being read as conditions. Numeric gradient values carry their unit.

```css
--shadows-embedded-alpha: 3px 3px 0 color-mix(in oklab, var(--colors-ink) 10%, transparent);
--shadows-card:           0 2px 4px 0 var(--colors-ink);
--gradients-angled:       linear-gradient(45deg, red, blue);
--gradients-brand:        linear-gradient(to right, red 0%, blue 100%);
```

Reference expansion now resolves a real token path before treating a `/` as an alpha modifier, so a slash-keyed token (`{sizes.1/2}`) is no longer mistaken for one.

Composite shadows also drop the doubled space after `inset`. v1 produced it by joining an `"inset "` literal with spaces; CSS ignores the difference.

`Gradient.placement` and the stop `position` had no documented unit or range, which is what made `100px` and a unitless `45` look reasonable. Both are now specified in `packages/types` and the tokens docs.

## 💣 Is this a breaking change (Yes/No):

No, in the sense that every spelling here worked in v1 or produced broken CSS. But gradients built from composite stops or a numeric placement **will render differently**: `100px` becomes `100%`, and `45` becomes `45deg` where nothing rendered before.

## 📝 Additional Information

Test plan:

- [x] `cargo nextest run -p pandacss_tokens` — alpha modifier in shadows/borders/gradients, slash-keyed references, composite shadow/border/asset, conditions preserved for every composite category, shadow arrays and `inset`, numeric gradient units
- [x] `cargo nextest run -p pandacss_stylesheet tokens` — the emitted `--shadows-*` custom properties
- [x] `cargo nextest run --workspace` — 2,329 passing, no regression from the `SemanticValue` variant reorder
- [x] `pnpm rust:fmt`, `pnpm rust:clippy`

Each test was verified to fail with the corresponding fix reverted.
