### PR TITLE
fix(compiler): warn on unregistered hydrated design-system utility

### DIFF
--- a/.changeset/hydrate-unregistered-utility-warning.md
+++ b/.changeset/hydrate-unregistered-utility-warning.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/compiler': patch
+---
+
+Warn when a `designSystem` consumer replays a library atom whose utility isn't registered in its own config, usually because the library's preset wasn't merged. The style used to emit silently as the kebab-cased utility name (`boxSize` became `box-size`). Now `panda cssgen`/`codegen` reports it, naming the design system and the utility, so you can add the missing preset.

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -51,7 +51,8 @@ use pandacss_extractor::{
     MatchCategory, extract,
 };
 use pandacss_recipes::{Recipe, SlotRecipe};
-use pandacss_shared::{ViewTransitionStyle, diagnostic_codes};
+use pandacss_shared::css_properties::is_css_property;
+use pandacss_shared::{ViewTransitionStyle, diagnostic_codes, hyphenate_property};
 use pandacss_utility::{ShorthandPolicy, StyleNormalizer, Utility};
 
 /// Key into the utility-transform override map: `(prop, original_value)`. The
@@ -1219,6 +1220,7 @@ impl Project {
             diagnostics.extend(config_diagnostics.iter().cloned());
         }
         diagnostics.extend(hydrated_diagnostics);
+        diagnostics.extend(self.collect_unregistered_hydrated_utility_diagnostics());
 
         ProjectStylesheetSnapshots {
             atoms: self
@@ -1548,6 +1550,34 @@ impl Project {
         }
 
         (overrides, diagnostics)
+    }
+
+    fn collect_unregistered_hydrated_utility_diagnostics(&self) -> Vec<Diagnostic> {
+        let utility = self.config.utility.as_ref();
+        let mut seen: FxHashSet<(&str, &str)> = FxHashSet::default();
+        let mut diagnostics = Vec::new();
+        for (path, entry) in &self.files {
+            let Some(name) = path.strip_prefix(crate::build_info::HYDRATED_FILE_PREFIX) else {
+                continue;
+            };
+            for atom in &entry.atoms {
+                let prop = atom.prop();
+                if utility.is_some_and(|utility| utility.is_known(prop)) || is_css_property(prop) {
+                    continue;
+                }
+                if !seen.insert((name, prop)) {
+                    continue;
+                }
+                diagnostics.push(Diagnostic::warning(
+                    diagnostic_codes::DESIGN_SYSTEM_UTILITY_UNREGISTERED,
+                    format!(
+                        "design system \"{name}\" uses \"{prop}\", which this project's config has no utility for, so its rule emits as \"{}\". Merge \"{name}\"'s preset so \"{prop}\" resolves.",
+                        hyphenate_property(prop)
+                    ),
+                ));
+            }
+        }
+        diagnostics
     }
 
     /// Distinct keys from hydrated atoms whose utility declares a JS transform

--- a/crates/pandacss_project/tests/build_info.rs
+++ b/crates/pandacss_project/tests/build_info.rs
@@ -1343,6 +1343,68 @@ fn a_hydrated_atom_gets_its_transform_recomputed_by_the_consumer() {
     assert_eq!(snapshots.utility_styles.len(), 1);
 }
 
+#[test]
+fn hydrating_a_utility_the_consumer_never_merged_warns() {
+    use pandacss_project::{
+        Diagnostic, ExtractedLiteral as Literal, ParseTransforms, UtilityTransformFn,
+    };
+
+    let lib_overrides = json!({
+        "utilities": {
+            "boxSize": {
+                "className": "size",
+                "transform": { "kind": "js-callback", "id": "boxSize" }
+            }
+        }
+    });
+
+    let mut transform = |prop: &str,
+                         resolved: &AtomValue,
+                         _original: &AtomValue|
+     -> Result<Option<Literal>, Diagnostic> {
+        if prop != "boxSize" {
+            return Ok(None);
+        }
+        let value = match resolved {
+            AtomValue::String(value)
+            | AtomValue::Number(value)
+            | AtomValue::Token { value, .. } => value.to_string(),
+            AtomValue::Bool(_) | AtomValue::Null => return Ok(None),
+        };
+        Ok(Some(Literal::Object(vec![
+            ("width".to_owned(), Literal::String(value.clone())),
+            ("height".to_owned(), Literal::String(value)),
+        ])))
+    };
+
+    let mut lib = create_project(lib_overrides.clone());
+    lib.parse_file_with(
+        "thing.tsx",
+        "import { css } from '@panda/css'; css({ boxSize: '4', color: 'red' });",
+        ParseTransforms {
+            utility: Some(&mut transform as &mut UtilityTransformFn<'_>),
+            ..Default::default()
+        },
+    );
+    let info = lib.build_info("^2.0.0".into());
+
+    let mut consumer = create_project(json!({}));
+    assert!(consumer.hydrate("@acme/ds", &info, None));
+
+    let config = create_config(json!({}));
+    let diagnostics = consumer.stylesheet_snapshots(&config).diagnostics.clone();
+    let unregistered: Vec<&str> = diagnostics
+        .iter()
+        .filter(|d| d.code == "design_system_utility_unregistered")
+        .map(|d| d.message.as_str())
+        .collect();
+
+    assert_eq!(unregistered.len(), 1, "one warning, got {diagnostics:?}");
+    assert!(unregistered[0].contains("boxSize"), "{}", unregistered[0]);
+    assert!(unregistered[0].contains("box-size"), "{}", unregistered[0]);
+    assert!(!unregistered[0].contains("color"), "{}", unregistered[0]);
+}
+
 /// Shared fixture for the hydrated-transform tests: a `boxSize` utility whose
 /// JS transform expands to `width`/`height`.
 fn box_size_config() -> serde_json::Value {

--- a/crates/pandacss_shared/src/diagnostic.rs
+++ b/crates/pandacss_shared/src/diagnostic.rs
@@ -20,6 +20,7 @@ pub mod codes {
     pub const CONFIG_TOKEN_UNKNOWN_REFERENCE: &str = "config_token_unknown_reference";
     pub const DEPRECATED_TOKEN_USED: &str = "deprecated_token_used";
     pub const DEPRECATED_UTILITY_USED: &str = "deprecated_utility_used";
+    pub const DESIGN_SYSTEM_UTILITY_UNREGISTERED: &str = "design_system_utility_unregistered";
     pub const INVALID_COLOR_OPACITY_MODIFIER: &str = "invalid_color_opacity_modifier";
     pub const JS_PARSE_ERROR: &str = "js_parse_error";
     pub const LAYER_NAME_COLLISION: &str = "layer_name_collision";

--- a/design-notes/build-info.md
+++ b/design-notes/build-info.md
@@ -69,6 +69,11 @@ atoms also key off conditions), and the producer's resolved `var(--…)` baked i
 their transform is applied to the carrier atom's conditions at extraction and baked into `entries`, so they need
 nothing at hydrate time.
 
+Recompute only works when the consumer actually merged the library's preset. If it didn't, the utility is unknown and
+the atom emits as the kebab-cased name (`box-size`). `Project::collect_unregistered_hydrated_utility_diagnostics` catches
+that: a hydrated prop that's neither a known utility nor a CSS property raises `design_system_utility_unregistered`, so
+the silent fallback surfaces as a warning instead.
+
 Runtime `token()` / `token.var()` calls that require a CSS variable are carried separately in `tokenRefs`. They may not
 produce an atom or recipe—for example, an exported `token.var('colors.brand')` value—but still seed `removeUnusedTokens`
 after hydration. Primitive `token()` calls that inline a non-variable value are intentionally not retained.


### PR DESCRIPTION
## 📝 Description

Follow-up to `10014b4a8`, which recomputes a hydrated utility's `transform` on the consumer. That only works if the consumer merged the library's preset. If it didn't, the utility is unknown and the atom emits silently as `box-size`. This warns instead.

Sage flagged it on #3718: "a consumer that never merges the preset emits `box-size` silently. Neither approach catches it."

## ⛳️ Current behavior (updates)

`panda cssgen` reports `diagnostics: 0` and writes `.size_4 { box-size: var(--sizes-4) }` — invalid CSS, no warning.

## 🚀 New behavior

A hydrated atom whose prop is neither a known utility nor a CSS property raises `design_system_utility_unregistered`, naming the design system and the missing preset. Real CSS properties (`color`) never warn, so it only flags utility names the consumer can't resolve.

## 💣 Is this a breaking change (Yes/No):

No. Adds a warning; CSS output is unchanged.

## 📝 Additional Information

- [x] `cargo nextest run -p pandacss_project` — warns for a hydrated `boxSize` without the utility, not for a co-hydrated `color`
- [x] `pnpm --filter @pandacss/compiler test design-system build-info` (546 pass)
- [x] `pnpm rust:fmt`, `cargo clippy -p pandacss_project -p pandacss_shared -- -D warnings`
