### PR TITLE
docs(website): rewrite the compiler engine page for the shipped beta

### DIFF
--- a/website/content/docs/styling/compiler-engine.mdx
+++ b/website/content/docs/styling/compiler-engine.mdx
@@ -1,12 +1,21 @@
 ---
 title: The compiler engine
-description: How Panda v2 compiles your styles — a Rust engine built on Oxc, exposed to both Node and the browser.
+description: How Panda compiles your styles — a Rust engine built on Oxc, exposed to both Node and the browser.
 ---
 
-v2's compiler is a Rust engine. It does the same job v1 did — read your source, pull out the styles, emit atomic CSS in
-cascade layers — but it replaces v1's `ts-morph` + PostCSS pipeline with native code built on [Oxc](https://oxc.rs). Your
-styles and your output don't change (see [Upgrading to v2](/docs/styling/upgrading-to-v2) for the handful of deliberate
-CSS differences). What changes is the machine underneath.
+Panda's compiler is a Rust engine built on [Oxc](https://oxc.rs). It reads your source, pulls out the styles, and emits
+atomic CSS in cascade layers — the same model [How Panda works](/docs/styling/how-panda-works) describes, running on
+native code.
+
+If you're coming from an earlier version, the pipeline is what changed:
+
+```
+before   ts-morph walks a TypeScript AST   →   PostCSS generates the CSS
+after    Oxc parses each file once         →   native Rust emits the CSS
+```
+
+Your styles and your output don't change (see [Upgrading to v2](/docs/styling/upgrading-to-v2) for the handful of
+deliberate CSS differences). The machine underneath does.
 
 ## Two bindings, one engine
 
@@ -50,26 +59,25 @@ source → extract → encode → emit → CSS
 Codegen runs alongside this to write the `styled-system` output — the types and helpers you import. A façade crate owns
 the multi-file build and watch state and wires the stages together; it's the single entry point both bindings talk to.
 
-## What's the same, what's faster
+## What you gain
 
-The model is unchanged: static analysis of your source, atomic CSS, cascade layers, tokens, recipes, conditions. You
-write the same Panda.
+You write the same Panda — static analysis of your source, atomic CSS, cascade layers, tokens, recipes, conditions. The
+compiled engine changes what that costs:
 
-What you gain is a compiled engine instead of a JavaScript one — one parse per file and no `ts-morph` AST to build and
-hold — plus a smaller install, since the `ts-morph` / `ts-evaluator` dependency tree is gone. That's the basis for v2's
-performance work.
-
-The diagnostics and lint tooling read the same compiler core rather than reimplementing extraction: see
-[Diagnostics](/docs/reference/diagnostics), the [ESLint & oxlint plugin](/docs/reference/eslint-oxlint-plugin), and
-[Editor & IDE tooling](/docs/reference/editor-tooling).
+- One parse per file, and no `ts-morph` AST to build and hold.
+- A smaller install, since the `ts-morph` / `ts-evaluator` dependency tree is gone.
+- One shared compiler core behind the tooling. Diagnostics and lint read the same extraction the build does, rather than
+  reimplementing it — see [Diagnostics](/docs/reference/diagnostics), the
+  [ESLint & oxlint plugin](/docs/reference/eslint-oxlint-plugin), and
+  [Editor & IDE tooling](/docs/reference/editor-tooling).
 
 ## Still open: CSS optimization
 
-The emitter writes CSS natively and minifies when you set `minify: true`, but full parity with v1's LightningCSS
-minification is still open. If you rely on the last few percent of v1's minified output, check the result before you
+The emitter writes CSS natively and minifies when you set `minify: true`, but full parity with LightningCSS
+minification is still open. If you rely on the last few percent of that minified output, check the result before you
 ship it.
 
 ## See also
 
-- [How Panda works](/docs/styling/how-panda-works) for the extraction model this keeps.
-- [Upgrading to v2](/docs/styling/upgrading-to-v2) for what else changes in v2.
+- [How Panda works](/docs/styling/how-panda-works) for the extraction model this runs.
+- [Upgrading to v2](/docs/styling/upgrading-to-v2) for what else changes.

--- a/website/content/docs/styling/compiler-engine.mdx
+++ b/website/content/docs/styling/compiler-engine.mdx
@@ -1,35 +1,75 @@
 ---
-title: The Compiler Engine
-description: A short overview of Panda v2's Rust-based compiler, replacing the current PostCSS/ts-morph pipeline. Not yet shipped.
+title: The compiler engine
+description: How Panda v2 compiles your styles — a Rust engine built on Oxc, exposed to both Node and the browser.
 ---
 
-> **This page describes a feature that isn't available yet, and it's the least stable page in this section.** The v2
-> compiler's internal design has already changed shape more than once, so treat everything below as a snapshot, not
-> a spec. See [Upgrading to v2](/docs/styling/upgrading-to-v2) for the broader context.
+v2's compiler is a Rust engine. It does the same job v1 did — read your source, pull out the styles, emit atomic CSS in
+cascade layers — but it replaces v1's `ts-morph` + PostCSS pipeline with native code built on [Oxc](https://oxc.rs). Your
+styles and your output don't change (see [Upgrading to v2](/docs/styling/upgrading-to-v2) for the handful of deliberate
+CSS differences). What changes is the machine underneath.
 
-[How Panda works](/docs/styling/how-panda-works) describes today's pipeline: `ts-morph` walks your source as a
-TypeScript AST, and PostCSS turns the result into CSS. v2 replaces that with a Rust engine, exposed to JavaScript
-through two bindings, `@pandacss/compiler` (native, Node) and `@pandacss/compiler-wasm` (browser/WASM, for editor
-and playground contexts that can't run native code).
+## Two bindings, one engine
 
-The core entry point is a single `createCompiler(config)` call that returns a long-lived, stateful compiler, not a
-one-shot function. The expensive part, compiling your config into matchers, utilities, conditions, and a token
-dictionary, happens once, and the same instance is reused across every file you parse and every rebuild. Source
-files then flow through roughly six phases: construction, ingestion (reading matched files), extraction (parsing
-with [Oxc](https://oxc.rs/) and matching your style calls), encoding (turning usage into atomic style records),
-emission (turning those into actual CSS rules and layers), and output. As of this writing the CSS optimization phase
-specifically has no native implementation yet, that's one of several pieces still open.
+The engine is a set of Rust crates. Two bindings wrap it, so the same code runs in both places:
 
-## Why this matters even before it ships
+- **`@pandacss/compiler`** — a native binding (NAPI). The CLI and the Vite, webpack, and Rollup plugins use it.
+- **`@pandacss/compiler-wasm`** — the same engine compiled to WASM, for the browser. The playground and editor tooling
+  run on it.
 
-The extraction and CSS-generation model itself, static analysis of your source, atomic CSS output organized into
-cascade layers, isn't changing. What changes is what runs underneath it: a compiled Rust engine instead of a
-JavaScript one, which is the basis for v2's performance goals. See the diagnostics and lint tooling planned around
-it: [Diagnostics Reference](/docs/reference/diagnostics), [ESLint & OXLint Plugin](/docs/reference/eslint-oxlint-plugin),
-and [Editor & IDE Tooling](/docs/reference/editor-tooling), all three are meant to share this same compiler core
-rather than reimplementing extraction logic separately.
+Both talk to a filesystem trait rather than `node:fs` directly, which is what lets the engine compile to WASM at all.
+Node and browser builds produce the same CSS.
+
+## One long-lived compiler
+
+The entry point is `createCompiler(config)`. It returns a stateful compiler you hold onto, not a one-shot function.
+
+The expensive work — turning your config into utilities, conditions, recipes, and a resolved token dictionary — happens
+once, when you create the compiler. The same instance is reused for every file you parse and every rebuild. You feed it
+files as they change (`parseFile`, `parseFiles`, `parseFileSource`) and ask it for CSS; the config isn't recompiled each
+time.
+
+That's what makes `panda dev` cheap: the watcher re-parses only the files that changed and re-emits, against config
+state that's already in memory.
+
+## The pipeline: extract, encode, emit
+
+Data flows one way. Each stage is a separate crate, and dependencies point in the direction of the arrows — nothing
+downstream reaches back up.
+
+```
+source → extract → encode → emit → CSS
+```
+
+- **Extract.** Oxc parses each source file once and matches your style calls — `css()`, `cva()`, patterns, JSX style
+  props, and the rest. One parse per file, no TypeScript program in the hot path. Static values (including local
+  `const`s and imports from other files) are folded here.
+- **Encode.** Matched usage becomes atomic style records — one property/value/condition per atom, deduplicated.
+- **Emit.** Atoms, recipes, and your static CSS become real CSS rules, grouped into `@layer`s and written natively. No
+  PostCSS pass.
+
+Codegen runs alongside this to write the `styled-system` output — the types and helpers you import. A façade crate owns
+the multi-file build and watch state and wires the stages together; it's the single entry point both bindings talk to.
+
+## What's the same, what's faster
+
+The model is unchanged: static analysis of your source, atomic CSS, cascade layers, tokens, recipes, conditions. You
+write the same Panda.
+
+What you gain is a compiled engine instead of a JavaScript one — one parse per file and no `ts-morph` AST to build and
+hold — plus a smaller install, since the `ts-morph` / `ts-evaluator` dependency tree is gone. That's the basis for v2's
+performance work.
+
+The diagnostics and lint tooling read the same compiler core rather than reimplementing extraction: see
+[Diagnostics](/docs/reference/diagnostics), the [ESLint & oxlint plugin](/docs/reference/eslint-oxlint-plugin), and
+[Editor & IDE tooling](/docs/reference/editor-tooling).
+
+## Still open: CSS optimization
+
+The emitter writes CSS natively and minifies when you set `minify: true`, but full parity with v1's LightningCSS
+minification is still open. If you rely on the last few percent of v1's minified output, check the result before you
+ship it.
 
 ## See also
 
-- [How Panda works](/docs/styling/how-panda-works) for the current, shipped pipeline this replaces.
-- [Upgrading to v2](/docs/styling/upgrading-to-v2) for what else changes.
+- [How Panda works](/docs/styling/how-panda-works) for the extraction model this keeps.
+- [Upgrading to v2](/docs/styling/upgrading-to-v2) for what else changes in v2.


### PR DESCRIPTION
## 📝 Description

Rewrite the compiler engine page. It read as "a feature that isn't available yet… the least stable page in this section," but the v2 compiler is what the beta ships. This describes how the engine actually works, checked against the code.

## ⛳️ Current behavior (updates)

The page frames the Rust compiler as unshipped and unstable ("treat everything below as a snapshot, not a spec"), and sketches the pipeline as "roughly six phases." That framing is stale now that v2 is a published beta.

## 🚀 New behavior

- Two bindings over one engine — `@pandacss/compiler` (native) and `@pandacss/compiler-wasm` (browser), both over a filesystem trait so Node and browser produce the same CSS.
- `createCompiler(config)` as a long-lived, stateful compiler: config compiles once, files re-parse on change.
- The real one-way pipeline — extract (Oxc), encode (atoms), emit (native CSS in layers) — with codegen alongside.
- One honest gap kept: `minify: true` works, but full parity with v1's LightningCSS minification is still open.

Docs only. The velite content build passes.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Grounded in `design-notes/crate-layering.md` (the `extract → encode → emit` tiering), `packages/compiler/src/index.ts` (`createCompiler`), and the crate layout under `crates/`.
