### PR TITLE
docs(website): bring the docs content up to date with v2

### DIFF
--- a/website/content/docs/design-systems/avoiding-collisions.mdx
+++ b/website/content/docs/design-systems/avoiding-collisions.mdx
@@ -51,15 +51,20 @@ import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
   presets: ['@acme/marketing-preset', '@acme/product-preset'],
-  hooks: {
-    'preset:resolved': ({ preset, name }) => {
-      if (name === '@acme/marketing-preset' && preset.theme?.recipes?.button) {
-        preset.theme.recipes.marketingButton = preset.theme.recipes.button
-        delete preset.theme.recipes.button
+  plugins: [
+    {
+      name: 'rename-marketing-button',
+      hooks: {
+        'preset:resolved': ({ preset, name }) => {
+          if (name === '@acme/marketing-preset' && preset.theme?.recipes?.button) {
+            preset.theme.recipes.marketingButton = preset.theme.recipes.button
+            delete preset.theme.recipes.button
+          }
+          return preset
+        }
       }
-      return preset
     }
-  }
+  ]
 })
 ```
 

--- a/website/content/docs/design-systems/config-functions.mdx
+++ b/website/content/docs/design-systems/config-functions.mdx
@@ -170,12 +170,10 @@ Function for [plugin](/docs/reference/config#plugins) definitions.
 import { definePlugin } from '@pandacss/dev'
 
 export const plugin = definePlugin({
-  name: 'token-format',
+  name: 'css-report',
   hooks: {
-    'tokens:created': ({ configure }) => {
-      configure({
-        formatTokenName: path => '$' + path.join('-')
-      })
+    'cssgen:done': ({ path, content }) => {
+      console.log(`generated ${content.length} bytes`, path)
     }
   }
 })

--- a/website/content/docs/design-systems/ecosystem-plugins.mdx
+++ b/website/content/docs/design-systems/ecosystem-plugins.mdx
@@ -1,96 +1,56 @@
 ---
-title: Ecosystem Plugins
-description: The plugin packages Panda ships and auto-injects, and how to write your own following the same pattern.
+title: Ecosystem plugins
+description: What a Panda plugin is, when to write one, and how to share hooks as a package.
 ---
 
-A [plugin](/docs/design-systems/hooks#sharing-hooks) is a named bundle of hooks you can distribute as its own package,
-instead of pasting the same `hooks` object into every project's config. Panda already ships three of these as
-separate packages, and the engine wires two of them in for you automatically. This page covers what those three
-plugins do and when you'd write one of your own, not the hook mechanics themselves, see
-[Hooks](/docs/design-systems/hooks) for the full API and how to author a plugin from scratch.
+A plugin is a named bundle of [hooks](/docs/design-systems/hooks) you distribute as its own package, instead of pasting
+the same hooks into every project's config. It's the hooks counterpart to a [preset](/docs/design-systems/presets): a
+preset shares theme and tokens, a plugin shares behavior.
 
-## The plugins Panda ships
+## Framework support is built in
 
-| Package | What it does | How it's enabled |
-| --- | --- | --- |
-| `@pandacss/plugin-vue` | Transforms `.vue` single-file components to a `tsx`-friendly syntax so the parser can extract style calls from them | Automatic, no config needed |
-| `@pandacss/plugin-svelte` | Same idea, for `.svelte` files | Automatic, no config needed |
-| `@pandacss/plugin-lightningcss` | Swaps the CSS optimizer from PostCSS to LightningCSS | Opt-in, set `lightningcss: true` |
-
-All three ship as dependencies of `@pandacss/node`, so they're already installed alongside `@pandacss/dev`, there's
-nothing extra to add to your own `package.json`.
-
-### Vue and Svelte support
-
-Both plugins hook `parser:before`, checking the file extension and handing back a transformed source string:
-
-```ts
-// simplified from packages/plugin-svelte/src/index.ts
-export function pluginSvelte(): PandaPlugin {
-  return {
-    name: '@pandacss/plugin-svelte',
-    hooks: {
-      'parser:before': ({ filePath, content }) => {
-        if (filePath.endsWith('.svelte')) {
-          return svelteToTsx(content)
-        }
-      }
-    }
-  }
-}
-```
-
-The CLI and the PostCSS plugin both auto-inject `pluginVue()` and `pluginSvelte()` before your own config's hooks
-run, which is why the [Vue](/docs/styling/vue) and [Svelte](/docs/styling/svelte) installation pages never mention
-adding a plugin. If you're driving Panda's core APIs directly instead of going through the CLI or the PostCSS plugin,
-you'd need to add these two yourself.
-
-### LightningCSS optimization
-
-By default, Panda optimizes generated CSS with PostCSS. Setting
-[`lightningcss: true`](/docs/reference/config#lightningcss) in your config swaps that for LightningCSS instead, and
-auto-injects `pluginLightningcss()` to do it:
-
-```tsx filename="panda.config.ts"
-import { defineConfig } from '@pandacss/dev'
-
-export default defineConfig({
-  // ...
-  lightningcss: true
-})
-```
-
-Under the hood, this plugin hooks `css:optimize`, the one hook in `PandaHooks` that lets a plugin replace Panda's
-optimizer outright rather than just tweaking its input or output:
-
-```ts
-// simplified from packages/plugin-lightningcss/src/index.ts
-export function pluginLightningcss(): PandaPlugin {
-  return {
-    name: '@pandacss/plugin-lightningcss',
-    hooks: {
-      'css:optimize': ({ css, minify, browserslist }) => {
-        return optimizeLightCss(css, { minify, browserslist })
-      }
-    }
-  }
-}
-```
-
-If you don't already have a [browserslist](https://github.com/browserslist/browserslist) config, Panda looks for one
-in your project once `lightningcss` is enabled, since LightningCSS needs browser targets to know which CSS features
-it can safely emit.
+You don't add a plugin to make Panda read Vue, Svelte, or Astro files. The compiler extracts styles from `.vue`,
+`.svelte`, and `.astro` single-file components directly, so the [Vue](/docs/styling/vue), [Svelte](/docs/styling/svelte),
+and [Astro](/docs/styling/astro) install pages have no plugin to add. If you're upgrading from v1, the separate
+`@pandacss/plugin-vue` and `@pandacss/plugin-svelte` packages are gone — that work moved into the compiler.
 
 ## When to write your own
 
-Most one-off customization belongs in your config's inline `hooks`, not a separate package, see
-[Hooks](/docs/design-systems/hooks) for examples like prefixing token names or stripping unused CSS variables. Reach
-for a real plugin package when you want to share that behavior across multiple projects or teams, the same reason
-you'd reach for a [preset](/docs/design-systems/presets) instead of copy-pasting theme tokens. The three plugins
-above are a working reference for the shape: a `name`, a `hooks` object, and one exported factory function a user
-adds to their own `plugins` array.
+Most one-off customization belongs in an inline plugin in your config, not a separate package — see
+[Hooks](/docs/design-systems/hooks) for examples like transforming source before extraction or reacting to generated
+output. Reach for a published plugin when you want to share that behavior across projects or teams, the same reason you'd
+reach for a preset instead of copy-pasting tokens.
+
+A plugin is a `name` and a `hooks` object. `definePlugin` gives you the types:
+
+```ts filename="my-plugin.ts"
+import { definePlugin } from '@pandacss/dev'
+
+export function myPlugin() {
+  return definePlugin({
+    name: 'my-plugin',
+    hooks: {
+      'parser:before': ({ filePath, content }) => {
+        // transform a file's source before Panda extracts from it
+        return content
+      },
+    },
+  })
+}
+```
+
+Users add the factory to their `plugins` array:
+
+```ts filename="panda.config.ts"
+import { defineConfig } from '@pandacss/dev'
+import { myPlugin } from './my-plugin'
+
+export default defineConfig({
+  plugins: [myPlugin()],
+})
+```
 
 ## See also
 
-- [Hooks](/docs/design-systems/hooks) for the full `PandaHooks` reference and how to author and share a plugin.
-- [Config](/docs/reference/config#lightningcss) for the `lightningcss` option.
+- [Hooks](/docs/design-systems/hooks) for every hook and how to author and share a plugin.
+- [Presets](/docs/design-systems/presets) for sharing theme and tokens the same way.

--- a/website/content/docs/design-systems/federated-microfrontends.mdx
+++ b/website/content/docs/design-systems/federated-microfrontends.mdx
@@ -312,7 +312,7 @@ own build. The collision is identical, and `prefix` is still the fix. It
 just moves to the **consumer's** config, keyed to the remote's identity
 rather than the DS version.
 
-`panda ship` only writes extraction results (which styles are used), not the
+`panda buildinfo` only writes extraction results (which styles are used), not the
 token and recipe **definitions**. So a build-info consumer wires up two
 pieces: the build-info file (via `include`) and the lib's preset (via
 `presets`). The preset supplies the definitions, the build-info file supplies

--- a/website/content/docs/design-systems/forward-props.mdx
+++ b/website/content/docs/design-systems/forward-props.mdx
@@ -43,7 +43,7 @@ attribute. Without `forwardProps`, Panda would consume `size` for styling and ne
 > A forwarded prop becomes a plain prop on the wrapped component: it no longer feeds recipe styling on its own after
 > that point. If you need a prop to both style a slot and reach the component, and you're wrapping a multi-part
 > compound rather than a single element, see [Forwarding props](/docs/styling/jsx-style-context#forwarding-props) in
-> `createStyleContext` instead.
+> `createSlotRecipeContext` instead.
 
 ## When forwardProps isn't enough
 
@@ -61,6 +61,6 @@ can tell your exports apart from the library's own.
 ## See also
 
 - [Wrap headless UI](/docs/design-systems/wrap-headless-ui) covers the equivalent decision for multi-part compounds
-  built with `createStyleContext`, not single-element wrappers.
+  built with `createSlotRecipeContext`, not single-element wrappers.
 - [Track usage in wrapped components](/docs/design-systems/track-usage) covers how Panda's static extraction handles
   a component re-exported or wrapped like this.

--- a/website/content/docs/design-systems/hooks.mdx
+++ b/website/content/docs/design-systems/hooks.mdx
@@ -3,198 +3,198 @@ title: Panda Integration Hooks
 description: Leveraging hooks in Panda to create custom functionality.
 ---
 
-Panda hooks can be used to add new functionality or modify existing behavior during certian parts of the compiler
-lifecycle.
+Panda hooks let you add new functionality or change existing behavior at specific points in the compiler lifecycle.
 
-Hooks are mostly callbacks that can be added to the panda config via the `hooks` property, or installed via `plugins`.
+Hooks are callbacks you attach to named plugins in the `plugins` array. There is no root-level `hooks` object — every
+hook lives on a plugin with a `name` and a `hooks` map.
 
-Here are some examples of what you can do with hooks:
+```ts
+import { defineConfig } from '@pandacss/dev'
 
-- modify the resolved config (`config:resolved`), like strip out tokens or keyframes.
-- modify presets after they are resolved (`preset:resolved`), like removing specific tokens or theme properties from a
-  preset.
-- tweak the design token or classname engine (`tokens:created`, `utility:created`), like prefixing token names, or
-  customizing the hashing function
-- transform a source file to a `tsx` friendly syntax before it's parsed (`parser:before`) so that Panda can
-  automatically extract its styles usage
-- create your own styles parser (`parser:before`, `parser:after`) using the file's content so that Panda could be used
-  with any templating language
-- alter the generated JS and DTS code (`codegen:prepare`)
-- modify the generated CSS (`cssgen:done`), allowing all kinds of customizations like removing the unused CSS variables,
-  etc.
-- restrict `strictTokens` to a specific set of token categories, ex: only affect `colors` and `spacing` tokens and
-  therefore allow any value for `fontSizes` and `lineHeights`
+export default defineConfig({
+  plugins: [
+    {
+      name: 'my-plugin',
+      hooks: {
+        'cssgen:done': ({ content, path }) => {
+          // ...
+        },
+      },
+    },
+  ],
+})
+```
+
+Here are some things you can do with hooks:
+
+- Modify the resolved config (`config:resolved`), like stripping out patterns, tokens, or keyframes.
+- Modify a preset after it's resolved (`preset:resolved`), like removing tokens or theme properties from a preset.
+- Transform a source file into `tsx`-friendly syntax before it's parsed (`parser:before`), so Panda can extract its style
+  usage — this also lets you support templating languages Panda doesn't parse natively.
+- Adjust the generated JS and DTS artifacts before they're written (`codegen:prepare`), or react after they're written
+  (`codegen:done`).
+- Observe the final CSS after it's produced (`cssgen:done`), for reporting or downstream tooling.
 
 ## Examples
 
-### Prefixing token names
-
-This is especially useful when migrating from other css-in-js libraries, [like Stitches.](/docs/styling/stitches)
-
-```ts
-import { defineConfig } from '@pandacss/dev'
-
-export default defineConfig({
-  // ...
-  hooks: {
-    'tokens:created': ({ configure }) => {
-      configure({
-        formatTokenName: path => '$' + path.join('-')
-      })
-    }
-  }
-})
-```
-
-### Customizing the hash function
-
-When using the [`hash: true`](/docs/styling/writing-styles) config property, you can customize the function used to
-hash the classnames.
-
-```ts
-export default defineConfig({
-  // ...
-  hash: true,
-  hooks: {
-    'utility:created': ({ configure }) => {
-      configure({
-        toHash: (paths, toHash) => {
-          const stringConds = paths.join(':')
-          const splitConds = stringConds.split('_')
-          const hashConds = splitConds.map(toHash)
-          return hashConds.join('_')
-        }
-      })
-    }
-  }
-})
-```
-
 ### Modifying the config
 
-Here's an example of how to leveraging the provided `utils` functions in the `config:resolved` hook to remove the
-`stack` pattern from the resolved config.
+Use the `utils` helpers on the `config:resolved` hook to change the resolved config. This example removes the `stack`
+pattern.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
-  // ...
-  hooks: {
-    'config:resolved': ({ config, utils }) => {
-      return utils.omit(config, ['patterns.stack'])
-    }
-  }
+  plugins: [
+    {
+      name: 'remove-stack-pattern',
+      hooks: {
+        'config:resolved': ({ config, utils }) => {
+          return utils.omit(config, ['patterns.stack'])
+        },
+      },
+    },
+  ],
 })
 ```
 
 ### Modifying presets
 
-You can use the `preset:resolved` hook to modify presets after they are resolved. This is useful for customizing or
-filtering out parts of a preset.
+Use the `preset:resolved` hook to change a preset after it's resolved. This is useful for filtering out parts of a
+preset.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
-  // ...
-  hooks: {
-    'preset:resolved': ({ utils, preset, name }) => {
-      if (name === '@pandacss/preset-panda') {
-        return utils.omit(preset, ['theme.tokens.colors', 'theme.semanticTokens.colors'])
-      }
-      return preset
-    }
-  }
+  plugins: [
+    {
+      name: 'trim-preset-colors',
+      hooks: {
+        'preset:resolved': ({ utils, preset, name }) => {
+          if (name === '@pandacss/preset-panda') {
+            return utils.omit(preset, ['theme.tokens.colors', 'theme.semanticTokens.colors'])
+          }
+          return preset
+        },
+      },
+    },
+  ],
 })
 ```
 
-### Configuring JSX extraction
+### Transforming a source file before parsing
 
-Use the `matchTag` / `matchTagProp` functions to customize the way Panda extracts your JSX.
+Use `parser:before` to rewrite a file's content before Panda parses it. The hook receives `{ filePath, content }` and
+returns the transformed string. Return nothing to leave the content unchanged.
 
-This can be especially useful when working with libraries that have properties that look like CSS properties but are not
-and should be ignored.
-
-Let's see a Radix UI example where the `Select.Content` component has a `position` property that should be ignored:
-
-```js
-// Here, the `position` property will be extracted because `position` is a valid CSS property, but we don't want that
-<Select.Content position="popper" sideOffset={5}>
-```
+This is how you support source that isn't standard `tsx` — pre-process it into syntax Panda's parser understands, then
+return it.
 
 ```ts
-export default defineConfig({
-  // ...
-  hooks: {
-    'parser:before': ({ configure }) => {
-      configure({
-        // ignore the Select.Content entirely
-        matchTag: tag => tag !== 'Select.Content',
-        // ...or specifically ignore the `position` property
-        matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position'
-      })
-    }
-  }
-})
-```
-
-### Remove unused variables from final css
-
-Here's an example of how to transform the generated css in the `cssgen:done` hook.
-
-```ts file="panda.config.ts"
 import { defineConfig } from '@pandacss/dev'
-import { removeUnusedCssVars } from './remove-unused-css-vars'
-import { removeUnusedKeyframes } from './remove-unused-keyframes'
 
 export default defineConfig({
-  // ...
-  hooks: {
-    'cssgen:done': ({ artifact, content }) => {
-      if (artifact === 'styles.css') {
-        return removeUnusedCssVars(removeUnusedKeyframes(content))
-      }
-    }
-  }
+  plugins: [
+    {
+      name: 'strip-directives',
+      hooks: {
+        'parser:before': ({ filePath, content }) => {
+          if (!filePath.endsWith('.astro')) return
+          return content.replace(/^---[\s\S]*?---/, '')
+        },
+      },
+    },
+  ],
 })
 ```
 
-Get the snippets for the removal logic from our Github Sandbox in the
-[remove-unused-css-vars](https://github.com/chakra-ui/panda/blob/main/sandbox/vite-ts/remove-unused-css-vars.ts) and
-[remove-unused-keyframes](https://github.com/chakra-ui/panda/blob/main/sandbox/vite-ts/remove-unused-keyframes.ts)
-files.
+To scope a hook to specific files, pass an object with a `filter` and a `handler` instead of a bare function:
 
-> Note: Using this means you can't use the JS function [`token.var`](/docs/styling/dynamic-styling#using-tokenvar) (or
-> [token(xxx)](/docs/styling/dynamic-styling#using-token) where `xxx` is the path to a
-> [semanticToken](/docs/theming/tokens#semantic-tokens)) from `styled-system/tokens` as the CSS variables will be
-> removed based on the usage found in the generated CSS
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'scoped-parser',
+      hooks: {
+        'parser:before': {
+          filter: { id: '**/*.{jsx,tsx}' },
+          handler: ({ content }) => content,
+        },
+      },
+    },
+  ],
+})
+```
+
+### Observing the final CSS
+
+`cssgen:done` runs after the final CSS is produced, for the CLI, Vite, and PostCSS. It's observe-only — the hook
+receives `{ artifact, content, path?, … }` and its return value is ignored, so you can't rewrite the CSS here.
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'css-report',
+      hooks: {
+        'cssgen:done': ({ artifact, content, path }) => {
+          if (artifact === 'styles.css') {
+            console.log(`Generated ${content.length} bytes at ${path}`)
+          }
+        },
+      },
+    },
+  ],
+})
+```
+
+To strip unused tokens or keyframes from the final CSS, use the top-level `optimize` config instead of a hook:
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  optimize: {
+    removeUnusedTokens: true,
+    removeUnusedKeyframes: true,
+  },
+})
+```
+
+For any other CSS transform, run PostCSS after Panda.
+
+> Note: With `removeUnusedTokens`, you can't rely on the JS function
+> [`token.var`](/docs/styling/dynamic-styling#using-tokenvar) (or [token(xxx)](/docs/styling/dynamic-styling#using-token)
+> where `xxx` is a [semanticToken](/docs/theming/tokens#semantic-tokens) path) from `styled-system/tokens`, because the
+> CSS variables are removed based on the usage found in the generated CSS.
 
 ## Sharing hooks
 
-Hooks can be shared as a snippet or as a `plugin`. Plugins are currently simple objects that contain a `name` associated
-with a `hooks` object with the same structure as the `hooks` object in the config.
+Hooks are shared as plugins. A plugin is a plain object with a `name` and a `hooks` object.
 
-> Plugins differ from `presets` as they can't be extended, but they will be called in sequence in the order they are
-> defined in the `plugins` array, with the user's config called last.
+Plugins differ from `presets` in that they can't be extended, but they run in sequence in the order they appear in the
+`plugins` array, with the user's own config called last.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
 
+const myPlugin = {
+  name: 'strip-stack',
+  hooks: {
+    'config:resolved': ({ config, utils }) => {
+      return utils.omit(config, ['patterns.stack'])
+    },
+  },
+}
+
 export default defineConfig({
-  // ...
-  plugins: [
-    {
-      name: 'token-format',
-      hooks: {
-        'tokens:created': ({ configure }) => {
-          configure({
-            formatTokenName: path => '$' + path.join('-')
-          })
-        }
-      }
-    }
-  ]
+  plugins: [myPlugin],
 })
 ```
 
@@ -203,55 +203,90 @@ export default defineConfig({
 ```ts
 export interface PandaHooks {
   /**
-   * Called when the config is resolved, after all the presets are loaded and merged.
-   * This is the first hook called, you can use it to tweak the config before the context is created.
+   * Called after authored presets are merged, before defaults and serialization.
    */
-  'config:resolved': (args: ConfigResolvedHookArgs) => MaybeAsyncReturn<void | ConfigResolvedHookArgs['config']>
+  'config:resolved': (args: ConfigResolvedHookArgs) => MaybeAsyncReturn<void | Config>
   /**
-   * Called when a preset is resolved, allowing you to modify it before it's merged into the config.
+   * Called when an authored preset is resolved, before all configs are merged.
    */
-  'preset:resolved': (args: PresetResolvedHookArgs) => MaybeAsyncReturn<void | PresetResolvedHookArgs['preset']>
+  'preset:resolved': (args: PresetResolvedHookArgs) => MaybeAsyncReturn<void | Config>
   /**
-   * Called when the token engine has been created
+   * Called after reading file content but before parsing it.
+   * Use this to transform non-standard source into TSX-friendly syntax.
    */
-  'tokens:created': (args: TokenCreatedHookArgs) => MaybeAsyncReturn
+  'parser:before': (args: ParserResultBeforeHookArgs) => MaybeAsyncReturn<string | void>
   /**
-   * Called when the classname engine has been created
+   * Called before generated files are written by a JS host.
    */
-  'utility:created': (args: UtilityCreatedHookArgs) => MaybeAsyncReturn
+  'codegen:prepare': (args: CodegenPrepareHookArgs) => void | CodegenPrepareArtifact[]
   /**
-   * Called when the Panda context has been created and the API is ready to be used.
+   * Called after generated files are written by a JS host.
    */
-  'context:created': (args: ContextCreatedHookArgs) => void
+  'codegen:done': (args: CodegenDoneHookArgs) => void
   /**
-   * Called when the config file or one of its dependencies (imports) has changed.
+   * Called after final CSS is produced by a JS host (observe-only; no rewrite).
+   * Fires for CLI, Vite, and PostCSS string sinks. Use `optimize` or PostCSS to mutate CSS.
    */
-  'config:change': (args: ConfigChangeHookArgs) => MaybeAsyncReturn
-  /**
-   * Called after reading the file content but before parsing it.
-   * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
-   * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
-   */
-  'parser:before': (args: ParserResultBeforeHookArgs) => string | void
-  /**
-   * Called after the file styles are extracted and processed into the resulting ParserResult object.
-   * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
-   */
-  'parser:after': (args: ParserResultAfterHookArgs) => void
-  /**
-   * Called right before writing the codegen files to disk.
-   * You can use this hook to tweak the codegen files before they are written to disk.
-   */
-  'codegen:prepare': (args: CodegenPrepareHookArgs) => MaybeAsyncReturn<Artifact[]>
-  /**
-   * Called after the codegen is completed
-   */
-  'codegen:done': (args: CodegenDoneHookArgs) => MaybeAsyncReturn
-  /**
-   * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
-   * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
-   * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
-   */
-  'cssgen:done': (args: CssgenDoneHookArgs) => string | void
+  'cssgen:done': (args: CssgenDoneHookArgs) => void
+}
+```
+
+Each hook can be a plain function or an object with a `filter` and a `handler`, which is useful for scoping
+`parser:before` to specific files:
+
+```ts
+export type PandaHook<Handler> = Handler | { filter?: HookFilter; handler: Handler }
+```
+
+The argument types are:
+
+```ts
+export interface ConfigResolvedHookArgs {
+  config: Config
+  path: string
+  dependencies: string[]
+  utils: ConfigResolvedHookUtils
+}
+
+export interface PresetResolvedHookArgs {
+  preset: Config
+  name: string
+  utils: ConfigResolvedHookUtils
+}
+
+export interface ConfigResolvedHookUtils {
+  omit<T extends object>(obj: T, paths: string[]): T
+  pick<T extends object>(obj: T, paths: string[]): Partial<T>
+  traverse(obj: unknown, callback: (item: TraverseItem) => void, options?: TraverseOptions): void
+}
+
+export interface ParserResultBeforeHookArgs {
+  filePath: string
+  content: string
+  original?: string
+}
+
+export interface CodegenPrepareHookArgs {
+  artifacts: CodegenPrepareArtifact[]
+  outdir: string
+  cwd?: string
+}
+
+export interface CodegenDoneHookArgs {
+  files: string[]
+  outdir: string
+  cwd?: string
+}
+
+export interface CssgenDoneHookArgs {
+  artifact: 'styles.css' | 'styles.layer' | 'styles.split'
+  content: string
+  /** Absolute path when written to disk; omitted for string sinks (Vite/PostCSS). */
+  path?: string
+  outfile?: string
+  outdir?: string
+  cwd?: string
+  manifest?: CssgenDoneManifest
+  layerRanges?: CssgenDoneLayerRanges
 }
 ```

--- a/website/content/docs/design-systems/minimal-setup.mdx
+++ b/website/content/docs/design-systems/minimal-setup.mdx
@@ -34,7 +34,8 @@ export default defineConfig({
 
 ## Removing default utilities
 
-Use the `eject: true` property to remove all the default utilities.
+The default utilities come from `@pandacss/preset-base`. To remove them, omit `@pandacss/preset-base` from `presets` (or
+use `presets: []`) — Panda doesn't add it for you.
 
 Panda doesn't automatically know which tokens are valid for which CSS properties, so it is necessary to tell Panda that
 my tokens from the "colors" category are valid for the CSS property "color".
@@ -42,7 +43,7 @@ my tokens from the "colors" category are valid for the CSS property "color".
 ```js
 export default defineConfig({
   // ...
-  eject: true,
+  presets: [],
   utilities: {
     color: {
       values: 'colors'
@@ -86,5 +87,5 @@ export default defineConfig({
 })
 ```
 
-> Note: You don't need to install `@pandacss/preset-base` or `@pandacss/preset-panda`. Panda will automatically resolve
-> them for you.
+> Note: Panda doesn't add `@pandacss/preset-base` or `@pandacss/preset-panda` for you. Install the ones you want and list
+> them in `presets`.

--- a/website/content/docs/design-systems/overview.mdx
+++ b/website/content/docs/design-systems/overview.mdx
@@ -25,7 +25,7 @@ The rest of this section walks through building a component library on Panda, in
   <Card
     arrow
     title="Wrap headless UI"
-    description="Use createStyleContext to turn Ark UI or Radix primitives into styled, distributable components"
+    description="Use createSlotRecipeContext to turn Ark UI or Radix primitives into styled, distributable components"
     href="/docs/design-systems/wrap-headless-ui"
   />
   <Card

--- a/website/content/docs/design-systems/presets.mdx
+++ b/website/content/docs/design-systems/presets.mdx
@@ -3,8 +3,8 @@ title: Presets
 description: Creating your own reusable preset for utilities and theme
 ---
 
-By default, any configuration you add in your own `panda.config.js` file is smartly merged with the
-[default presets](#which-panda-presets-will-be-included), allowing you to override or extend specific parts of the
+Any configuration you add in your own `panda.config.js` file is smartly merged with the
+[presets you list](#which-panda-presets-will-be-included), allowing you to override or extend specific parts of the
 configuration.
 
 ## When to use a preset
@@ -121,21 +121,22 @@ pnpm add -D @acme/preset
 
 ### Add it to panda.config
 
-Setting `presets` replaces the default `@pandacss/preset-panda`. Include it explicitly if you still want the default
-theme:
+`presets` is the exact list Panda uses — nothing is added for you. List `@pandacss/preset-base` for the default utilities
+and `@pandacss/preset-panda` for the default theme, then add your own:
 
 ```ts filename="panda.config.ts"
 import { defineConfig } from '@pandacss/dev'
+import basePreset from '@pandacss/preset-base'
 import pandaPreset from '@pandacss/preset-panda'
 import { acmePreset } from '@acme/preset'
 
 export default defineConfig({
-  presets: [pandaPreset, acmePreset],
+  presets: [basePreset, pandaPreset, acmePreset],
   include: ['./src/**/*.{js,jsx,ts,tsx}']
 })
 ```
 
-`@pandacss/preset-base` is still included automatically unless you set `eject: true`. See
+`@pandacss/preset-base` gives you the default utilities and patterns, and is included only if you list it, as above. See
 [which presets are included](#which-panda-presets-will-be-included).
 
 ### Extend the preset in the app
@@ -145,7 +146,7 @@ conflicts. See [extend](/docs/styling/extend).
 
 ```ts filename="panda.config.ts"
 export default defineConfig({
-  presets: [pandaPreset, acmePreset],
+  presets: [basePreset, pandaPreset, acmePreset],
   theme: {
     extend: {
       tokens: {
@@ -205,24 +206,27 @@ export default defineConfig({
 })
 ```
 
-## Which panda presets will be included ?
+## Which panda presets will be included?
 
-![Visual helper](/stately-presets-merging.png)
+Panda includes exactly the presets you list in `presets` — nothing is added for you.
 
-- `@pandacss/preset-base`: ALWAYS included if NOT using `eject: true`
+- `@pandacss/preset-base` (default utilities, conditions, and patterns): included only if you list it.
+- `@pandacss/preset-panda` (default tokens, breakpoints, and text styles): included only if you list it.
 
-- `@pandacss/preset-panda`: only included by default if you haven't specified the `presets` config option, otherwise
-  you'll have to include that preset by yourself like so:
+List both when you want the full defaults, then add your own presets:
 
 ```ts
+import basePreset from '@pandacss/preset-base'
 import pandaPreset from '@pandacss/preset-panda'
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
   // ...
-  presets: [pandaPreset, myCustomPreset]
+  presets: [basePreset, pandaPreset, myCustomPreset]
 })
 ```
+
+For a system with no defaults at all, use `presets: []`.
 
 ## Minimal setup
 

--- a/website/content/docs/design-systems/ship-styled-system.mdx
+++ b/website/content/docs/design-systems/ship-styled-system.mdx
@@ -88,12 +88,13 @@ ship your normal library build alongside it.
 Generate it after building your library:
 
 ```bash
-panda ship --outfile dist/panda.buildinfo.json
+panda buildinfo --outfile dist/panda.buildinfo.json
 ```
 
-> A future major version of Panda renames this command to `panda buildinfo` as part of a broader rewrite of how the
-> build-info format works internally. The file it produces stays named `panda.buildinfo.json` either way, and the
-> `include` step below is expected to keep working the same.
+> Publishing a full library? Prefer `panda lib` — it writes the build info, a preset, and a manifest in one step, and
+> consumers wire it up with the [`designSystem`](/docs/design-systems/consuming-a-design-system) config field instead of
+> `include` + `importMap`. See [Build a design system](/docs/design-systems/building-a-design-system). `panda buildinfo`
+> is the lower-level option when you only want the extraction result.
 
 Then, in the user's config, include the build info file the same way you'd include source:
 

--- a/website/content/docs/design-systems/track-usage.mdx
+++ b/website/content/docs/design-systems/track-usage.mdx
@@ -49,7 +49,7 @@ export const cardRecipe = defineSlotRecipe({
 ```
 
 This is the same rule covered in [Config Recipes](/docs/styling/jsx-style-context#config-recipes) for components
-built with `createStyleContext`, it applies just as much to a plain `styled()` wrapper with a non-matching name.
+built with `createSlotRecipeContext`, it applies just as much to a plain `styled()` wrapper with a non-matching name.
 
 ## When the value is genuinely dynamic
 
@@ -64,5 +64,5 @@ CSS reaches users in the first place.
 
 The flip side: sometimes Panda tracks a prop you don't want it to, most often when wrapping a headless library whose
 props happen to share a name with a CSS property (Radix UI's `Select.Content` has a `position` prop that isn't a CSS
-position, for example). Use the `matchTag` / `matchTagProp` hooks to exclude those tags or props explicitly. See
-[Configuring JSX extraction](/docs/design-systems/hooks#configuring-jsx-extraction) for the exact setup.
+position, for example). Excluding a specific tag or prop from extraction isn't configurable in the current engine — it's
+a known gap. If it causes a real problem, [open an issue](https://github.com/chakra-ui/panda/issues).

--- a/website/content/docs/design-systems/troubleshooting.mdx
+++ b/website/content/docs/design-systems/troubleshooting.mdx
@@ -28,7 +28,7 @@ export default defineConfig({
 ## Types like StyleContextProvider or a recipe's variant type aren't exported
 
 If users hit a type error saying something your library re-exports from the shared `styled-system` package
-isn't exported, for example a `createStyleContext`-generated provider type, or a recipe's variant type, check two
+isn't exported, for example a `createSlotRecipeContext`-generated provider type, or a recipe's variant type, check two
 things before assuming it's a Panda issue:
 
 1. **The `styled-system` package's own `exports` map.** Every conditional export needs `types` listed first, before

--- a/website/content/docs/design-systems/wrap-headless-ui.mdx
+++ b/website/content/docs/design-systems/wrap-headless-ui.mdx
@@ -1,18 +1,19 @@
 ---
 title: Wrap headless UI
-description: Use createStyleContext to turn a headless UI library like Ark UI into styled, distributable components.
+description: Use createSlotRecipeContext to turn a headless UI library like Ark UI into styled, distributable components.
 ---
 
 Most component libraries aren't built from raw DOM elements, they wrap a headless UI library like
-[Ark UI](https://ark-ui.com) or Radix UI for behavior and accessibility, then add styling on top. `createStyleContext`
-is the tool for that: it's covered in full at [JSX Style Context](/docs/styling/jsx-style-context), this page is
+[Ark UI](https://ark-ui.com) or Radix UI for behavior and accessibility, then add styling on top.
+`createSlotRecipeContext` is the tool for that: it's covered in full at
+[JSX Style Context](/docs/styling/jsx-style-context), this page is
 about applying it when the components you're wrapping and shipping aren't your own.
 
 ## Why not just style each part
 
 A compound component like `Accordion` has a root, several items, triggers, and panels, all sharing one slot recipe.
 Styling each part with a plain `css()` call works, but every user would need to know which slot recipe variant
-applies to which part, and repeat that wiring themselves. `createStyleContext` does that wiring once, in your
+applies to which part, and repeat that wiring themselves. `createSlotRecipeContext` does that wiring once, in your
 library, and hands the user a set of already-styled components.
 
 ## Wrapping a headless root
@@ -24,7 +25,7 @@ from its context. Match `withProvider` and `withContext` to that shape:
 // components/ui/accordion.tsx
 import { Accordion as ArkAccordion } from '@ark-ui/react/accordion'
 import { sva } from '../styled-system/css'
-import { createStyleContext } from '../styled-system/jsx'
+import { createSlotRecipeContext } from '../styled-system/jsx'
 
 const accordion = sva({
   slots: ['root', 'item', 'itemTrigger', 'itemContent'],
@@ -34,7 +35,7 @@ const accordion = sva({
   }
 })
 
-const { withProvider, withContext } = createStyleContext(accordion)
+const { withProvider, withContext } = createSlotRecipeContext(accordion)
 
 export const Accordion = {
   Root: withProvider(ArkAccordion.Root, 'root'),
@@ -57,7 +58,7 @@ library than in an app, since users see the exported name, not your internal rec
 
 ## Let users opt out
 
-Every component built with `createStyleContext` accepts an `unstyled` prop, on the root to strip all slot styles, or
+Every component built with `createSlotRecipeContext` accepts an `unstyled` prop, on the root to strip all slot styles, or
 on a single slot to strip just that one. Document this for your users explicitly. It's often the only supported
 way to fully override a slot's structure without fighting your recipe's specificity, and library authors sometimes
 forget to mention it exists. See [unstyled prop](/docs/styling/jsx-style-context#unstyled-prop) for the exact

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -1,138 +1,242 @@
 ---
 title: CLI Reference
 description:
-  You can use the Command-Line Interface (CLI) provided by Panda to develop, build, and preview your project from a
-  terminal window.
+  Use the Panda command-line interface to scaffold a project, generate your styled-system and CSS, and inspect what your
+  project uses.
 ---
 
-Use Panda's Command-Line Interface (CLI) to develop, build, and preview your project from a terminal.
+Use the `panda` CLI to scaffold a project, generate your styled-system and CSS, and inspect what your project uses.
+
+The commands are:
+
+| Command           | What it does                                                            |
+| ----------------- | ---------------------------------------------------------------------- |
+| `panda init`      | Scaffold `panda.config.ts` and run the first codegen                   |
+| `panda dev`       | Watch files and rebuild the system and CSS on change                   |
+| `panda build`     | Generate the system and CSS once (bare `panda` runs this)              |
+| `panda check`     | Check generated files without writing (use in CI)                      |
+| `panda codegen`   | Generate the `styled-system` output only                              |
+| `panda cssgen`    | Generate CSS only                                                      |
+| `panda analyze`   | Report token, recipe, and utility usage across your sources            |
+| `panda doctor`    | Validate your setup and print a project summary                        |
+| `panda debug`     | Dump resolved config and per-file extraction for bug reports           |
+| `panda lib`       | Publish a design system other apps can consume                        |
+| `panda buildinfo` | Write a portable `panda.buildinfo.json` only                          |
+
+## Shared flags
+
+Most commands accept these flags.
+
+| Flag                    | Description                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| `--cwd <dir>`           | Current working directory                                                            |
+| `--config, -c <path>`   | Path to the Panda config file                                                        |
+| `--json`                | Print the result as JSON (for scripts)                                               |
+| `--format <format>`     | Diagnostic output format: `human`, `pretty`, `json`, or `github`                     |
+| `--log-level <level>`   | Output level: `silent`, `error`, `warn`, `info`, or `debug`                          |
+| `--max-warnings <n>`    | Fail when warning diagnostics exceed this count                                      |
+| `--logfile <file>`      | Write human output to a log file                                                     |
+| `--no-color`            | Disable ANSI colors (or set the `NO_COLOR` environment variable)                     |
+| `--profile`             | Capture compiler timings — see [Profiling a slow build](#profiling-a-slow-build)     |
+| `--trace`               | Enable compiler tracing                                                              |
+| `--trace-output <fmt>`  | Trace output: `fmt` or `chrome-json`                                                 |
+| `--trace-file <file>`   | Trace output file for `chrome-json` tracing                                          |
+
+Commands that scan your source files (`dev`, `build`, `check`, `cssgen`, `analyze`, `debug`, `lib`, `buildinfo`) also take `--include`:
+
+| Flag                | Description                                                                       |
+| ------------------- | -------------------------------------------------------------------------------- |
+| `--include <glob>`  | Source globs to scan, replacing the config `include` list (repeat or comma-separate) |
+
+Commands that watch (`dev`, `build`, `codegen`, `cssgen`, `lib`) also take:
+
+| Flag                     | Description                            |
+| ------------------------ | -------------------------------------- |
+| `--watch, -w`            | Watch files and rebuild on change      |
+| `--watch-debounce <ms>`  | Debounce watch rebuilds, in milliseconds |
+
+`panda init` is the exception: it doesn't take `--watch`, `--max-warnings`, or the tracing flags.
+
+---
 
 ## init
 
-Initialize Panda in a project. This process will:
-
-- Create a `panda.config.ts` file in your project with the default settings and presets.
-- Emit CSS utilities for your project in the specified `output` directory.
+Scaffold Panda in a project. It creates `panda.config.ts` with the default presets, installs those presets, updates
+`.gitignore`, and runs the first codegen into your `outdir`.
 
 ```bash
 pnpm panda init
 
-# Initialize with interactive mode
+# Run the setup wizard
 pnpm panda init --interactive
 
-# Initialize with PostCSS config
+# Also emit a PostCSS config file
 pnpm panda init --postcss
 ```
 
-| Flag                          | Description                                                   | Related                                                       |
-| ----------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
-| `--interactive, -i`           | Whether to run the interactive mode                           | -                                                             |
-| `--force, -f`                 | Whether to overwrite existing files                           | -                                                             |
-| `--postcss, -p`               | Whether to emit a [postcss](https://postcss.org/) config file | -                                                             |
-| `--config, -c <path>`         | Path to Panda config file                                     | [`config`](/docs/reference/config)                           |
-| `--cwd <dir>`                 | Path to current working directory                             | -                                                             |
-| `--silent`                    | Whether to suppress all output                                | -                                                             |
-| `--no-gitignore`              | Whether to update gitignore with the output directory         | -                                                             |
-| `--no-codegen`                | Whether to run the codegen process                            | -                                                             |
-| `--out-extension <ext>`       | The extension of the generated js files (default: 'mjs')      | [`config.outExtension`](/docs/reference/config#outextension) |
-| `--outdir <dir>`              | The output directory for the generated files                  | [`config.outdir`](/docs/reference/config#outdir)             |
-| `--jsx-framework <framework>` | The jsx framework to use                                      | [`config.jsxFramework`](/docs/reference/config#jsxframework) |
-| `--syntax <syntax>`           | The css syntax preference                                     | [`config.syntax`](/docs/reference/config#syntax)             |
-| `--strict-tokens`             | Set strictTokens to true                                      | [`config.strictTokens`](/docs/reference/config#stricttokens) |
-| `--logfile <file>`            | Outputs logs to a file                                        | [Debugging](/docs/reference/debugging)                           |
+| Flag                          | Description                                                       | Related                                                       |
+| ----------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------ |
+| `--interactive, -i`           | Run the setup wizard                                             | -                                                            |
+| `--force, -f`                 | Overwrite an existing config file                               | -                                                            |
+| `--postcss, -p`               | Emit a [PostCSS](https://postcss.org/) config file             | -                                                            |
+| `--outdir <dir>`              | Output directory for generated files                            | [`config.outdir`](/docs/reference/config#outdir)             |
+| `--out-extension <ext>`       | Generated runtime file extension: `ts`, `js`, or `mjs`         | [`config.outExtension`](/docs/reference/config#outextension) |
+| `--jsx-framework <framework>` | JSX framework: `react`, `preact`, `vue`, `solid`, or `qwik`    | [`config.jsxFramework`](/docs/reference/config#jsxframework) |
+| `--jsx-style-props <mode>`    | JSX style props: `all`, `minimal`, or `none`                   | -                                                            |
+| `--syntax <syntax>`           | CSS syntax: `object-literal` or `template-literal`             | [`config.syntax`](/docs/reference/config#syntax)             |
+| `--strict-tokens`             | Set `strictTokens` to `true`                                   | [`config.strictTokens`](/docs/reference/config#stricttokens) |
+| `--skip-presets`              | Skip adding and installing the default presets                 | -                                                            |
+| `--no-gitignore`              | Don't update `.gitignore` with the output directory            | -                                                            |
+| `--no-codegen`                | Don't run codegen after setup                                  | -                                                            |
+
+`panda init` also accepts the [shared flags](#shared-flags), except `--watch`, `--max-warnings`, and the tracing flags.
 
 ---
 
-## panda
+## dev
 
-Run the extract process to generate static CSS from your project.
+Watch your source files and rebuild the system and CSS on every change. This is `panda build --watch` under one name.
 
-By default it will scan and generate CSS for the entire project depending on your include and exclude options from your
-config file.
+```bash
+pnpm panda dev
+
+# Restrict the scan to specific files
+pnpm panda dev --include "./src/**/*.tsx"
+```
+
+| Flag                 | Description                                                    | Related                                            |
+| -------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| `--outdir <dir>`     | Output directory for generated files                         | [`config.outdir`](/docs/reference/config#outdir)   |
+| `--outfile, -o <file>` | Output file for extracted CSS                              | -                                                  |
+| `--splitting`        | Emit split CSS files (one per layer and recipe)             | -                                                  |
+| `--clean`            | Clean the output directory before generating                | [`config.clean`](/docs/reference/config#clean)     |
+| `--polyfill`         | Polyfill cascade layers with `:not(#\\#)` for older browsers | [`config.polyfill`](/docs/reference/config#polyfill) |
+
+`panda dev` also accepts the [shared flags](#shared-flags), `--include`, and `--watch-debounce`.
+
+---
+
+## build
+
+Generate the system and CSS once. This is the default — bare `panda` runs `panda build`.
+
+By default it scans and generates CSS for the whole project, following the `include` and `exclude` options in your
+config.
 
 ```bash
 pnpm panda
-# You can also scan a specific file or folder
-# using the optional glob argument
-pnpm panda src/components/Button.tsx
-pnpm panda "./src/components/**"
+
+# Same thing, spelled out
+pnpm panda build
+
+# Scan a subset of files
+pnpm panda build --include "./src/components/**"
+
+# Split output into separate files per layer and recipe
+pnpm panda build --splitting
 ```
 
-| Flag                    | Description                                                            | Related                                                           |
-| ----------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `--outdir, -o [dir]`    | The output directory for the generated CSS utilities                   | [`config.outdir`](/docs/reference/config#outdir)                 |
-| `--minify, -m`          | Whether to minify the generated CSS                                    | [`config.minify`](/docs/reference/config#minify)                 |
-| `--watch, -w`           | Whether to watch for changes in the project                            | [`config.watch`](/docs/reference/config#watch)                   |
-| `--poll`                | Whether to poll for file changes                                       | [`config.poll`](/docs/reference/config#poll)                     |
-| `--config, -c <path>`   | The path to the config file                                            | [`config`](/docs/reference/config.md)                            |
-| `--cwd <path>`          | The current working directory                                          | [`config.cwd`](/docs/reference/config#cwd)                       |
-| `--preflight`           | Whether to emit the preflight or reset CSS                             | [`config.preflight`](/docs/reference/config#preflight)           |
-| `--silent`              | Whether to suppress all output                                         | [`config.logLevel`](/docs/reference/config#log-level)            |
-| `--exclude, -e <files>` | Files to exclude from the extract process                              | [`config`](/docs/reference/config.md)                            |
-| `--clean`               | Whether to clean the output directory before emitting                  | [`config.clean`](/docs/reference/config#clean)                   |
-| `--hash`                | Whether to hash the output classnames                                  | [`config.hash`](/docs/reference/config#hash)                     |
-| `--lightningcss`        | Use `lightningcss` instead of `postcss` for css optimization           | [`config.lightningcss`](/docs/reference/config#lightningcss)     |
-| `--polyfill`            | Polyfill CSS @layers at-rules for older browsers                       | [`config.polyfill`](/docs/reference/config#polyfill)             |
-| `--emitTokensOnly`      | Whether to only emit the `tokens` directory                            | [`config.emitTokensOnly`](/docs/reference/config#emittokensonly) |
-| `--cpu-prof`            | Generate a `panda-{command}-{timestamp}.cpuprofile` file for profiling | [Debugging](/docs/reference/debugging)                               |
-| `--logfile <file>`      | Outputs logs to a file                                                 | [Debugging](/docs/reference/debugging)                               |
+| Flag                   | Description                                                    | Related                                            |
+| ---------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| `--watch, -w`          | Watch files and rebuild on change                           | -                                                  |
+| `--outdir <dir>`       | Output directory for generated files                        | [`config.outdir`](/docs/reference/config#outdir)   |
+| `--outfile, -o <file>` | Output file for extracted CSS                              | -                                                  |
+| `--splitting`          | Emit split CSS files (one per layer and recipe)             | -                                                  |
+| `--clean`              | Clean the output directory before generating                | [`config.clean`](/docs/reference/config#clean)     |
+| `--polyfill`           | Polyfill cascade layers with `:not(#\\#)` for older browsers | [`config.polyfill`](/docs/reference/config#polyfill) |
+| `--check`              | Check generated files without writing                       | -                                                  |
+
+`panda build` also accepts the [shared flags](#shared-flags), `--include`, and `--watch-debounce`.
+
+---
+
+## check
+
+Check that generated files are up to date without writing anything. It exits non-zero if the output is missing or stale,
+so use it in CI to catch a `styled-system` that drifted from your config or source.
+
+```bash
+pnpm panda check
+```
+
+| Flag                   | Description                                                    | Related                                            |
+| ---------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| `--outdir <dir>`       | Output directory to check                                    | [`config.outdir`](/docs/reference/config#outdir)   |
+| `--outfile, -o <file>` | CSS file to check                                           | -                                                  |
+| `--splitting`          | Check split CSS output instead of a single file             | -                                                  |
+| `--polyfill`           | Account for the cascade-layer polyfill when checking        | [`config.polyfill`](/docs/reference/config#polyfill) |
+
+`panda check` also accepts the [shared flags](#shared-flags) and `--include`.
 
 ---
 
 ## codegen
 
-Generate new CSS utilities for your project based on the configuration file.
+Generate the `styled-system` output only, based on your config. This skips the source scan and CSS extraction — use it
+when you only need the generated functions and types.
 
 ```bash
 pnpm panda codegen
 
-# Clean output directory before generating
+# Clean the output directory first
 pnpm panda codegen --clean
 
-# Watch for config changes
+# Rebuild when the config changes
 pnpm panda codegen --watch
 ```
 
-| Flag                  | Description                                                            | Related                                                |
-| --------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------ |
-| `--silent`            | Whether to suppress all output                                         | [`config.logLevel`](/docs/reference/config#log-level) |
-| `--clean`             | Whether to clean the output directory before emitting                  | [`config.clean`](/docs/reference/config#clean)        |
-| `--config, -c <path>` | Path to Panda config file                                              | [`config`](/docs/reference/config.md)                 |
-| `--watch, -w`         | Whether to watch for changes in the project                            | [`config.watch`](/docs/reference/config#watch)        |
-| `--poll, -p`          | Whether to poll for file changes                                       | [`config.poll`](/docs/reference/config#poll)          |
-| `--cwd <path>`        | Current working directory                                              | [`config.cwd`](/docs/reference/config#cwd)            |
-| `--cpu-prof`          | Generate a `panda-{command}-{timestamp}.cpuprofile` file for profiling | [Debugging](/docs/reference/debugging)                    |
-| `--logfile <file>`    | Outputs logs to a file                                                 | [Debugging](/docs/reference/debugging)                    |
+| Flag              | Description                                  | Related                                          |
+| ----------------- | -------------------------------------------- | ------------------------------------------------ |
+| `--watch, -w`     | Watch the config and rebuild on change      | -                                                |
+| `--outdir <dir>`  | Output directory for generated files        | [`config.outdir`](/docs/reference/config#outdir) |
+| `--clean`         | Clean the output directory before generating | [`config.clean`](/docs/reference/config#clean)   |
+| `--check`         | Check generated files without writing        | -                                                |
+
+`panda codegen` also accepts the [shared flags](#shared-flags) and `--watch-debounce`.
+
+---
 
 ## cssgen
 
-Generate the CSS from files.
+Generate CSS from your source files only. This skips codegen — use it when your `styled-system` already exists.
 
 ```bash
-panda cssgen
+pnpm panda cssgen
 
-# Generate CSS for specific type
-panda cssgen tokens
+# Only usage CSS (recipes and utilities), no reset/base/tokens
+pnpm panda cssgen --minimal
 
-# Generate CSS for specific glob
-panda cssgen "src/**/*.css"
-
-# Generate CSS files split into separate files per layer and recipe
-panda cssgen --splitting
+# Split output into separate files per layer and recipe
+pnpm panda cssgen --splitting
 ```
 
-When using the `cssgen` command, you can pass a `{type}` argument to generate only a specific type of CSS. The supported
-types are: `preflight`, `tokens`, `static`, `global`, `keyframes`.
+| Flag                   | Description                                                    | Related                                            |
+| ---------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
+| `--watch, -w`          | Watch files and rebuild on change                           | -                                                  |
+| `--outfile, -o <file>` | Output file for extracted CSS (default `./styled-system/styles.css`) | -                                          |
+| `--minimal`            | Emit usage CSS only (recipes and utilities)                 | -                                                  |
+| `--minify, -m`         | Minify the emitted CSS (overrides `config.minify`)         | [`config.minify`](/docs/reference/config#minify)   |
+| `--splitting`          | Emit split CSS files (one per layer and recipe)            | -                                                  |
+| `--polyfill`           | Polyfill cascade layers with `:not(#\\#)` for older browsers | [`config.polyfill`](/docs/reference/config#polyfill) |
+| `--check`              | Check that the CSS is up to date without writing            | -                                                  |
 
-### CSS Splitting
+`panda cssgen` also accepts the [shared flags](#shared-flags), `--include`, and `--watch-debounce`.
 
-The `--splitting` flag enables CSS code splitting, which generates separate CSS files for different parts of your design
-system instead of a single monolithic CSS file. This is useful for:
+### CSS output for monorepos
 
-- **Selective loading** - Load only the CSS you need for specific pages
-- **Easier debugging** - Identify which layer or recipe contributes to the final CSS
+`--minimal` emits a package's usage CSS (recipes and utilities) without duplicating reset, base, and tokens. Emit the
+full stylesheet once from the app or root:
 
-When using `--splitting`, Panda will generate the following structure:
+1. **App or root:** `panda build` or `panda cssgen` for the full stylesheet.
+2. **Per package:** `panda cssgen --minimal` for local usage CSS.
+3. **Published libraries:** [`panda lib`](#lib), then consumers wire it in with `designSystem`.
+
+### Splitting CSS into files
+
+`--splitting` writes separate CSS files instead of one stylesheet, so you can load only the CSS a page needs or trace
+which layer or recipe produced a rule.
+
+With `--splitting`, Panda emits this structure:
 
 ```
 styled-system/
@@ -148,11 +252,11 @@ styled-system/
     │   ├── card.css        # Individual recipe: card
     │   └── ...             # Other recipes as separate files
     └── themes/
-        └── dark.css        # Theme-specific tokens (not auto-imported)
+        ├── dark.css        # Theme-specific tokens (not auto-imported)
         └── light.css       # Theme-specific tokens (not auto-imported)
 ```
 
-The main `styles.css` file contains the `@layer` declarations and imports all the layer files (but not the themes):
+The main `styles.css` declares the layers and imports each layer file (but not the themes):
 
 ```css
 /* styled-system/styles.css */
@@ -165,7 +269,7 @@ The main `styles.css` file contains the `@layer` declarations and imports all th
 @import './styles/utilities.css';
 ```
 
-You can then choose how to import these files:
+You then choose how to import them:
 
 ```css
 /* Option 1: Import everything (default) */
@@ -183,221 +287,158 @@ You can then choose how to import these files:
 @import './styled-system/styles/themes/oceanic.css';
 ```
 
-| Flag                   | Description                                                                            | Related                                                       |
-| ---------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `--outfile, -o <file>` | Output file for extracted css, default to './styled-system/styles.css'                 | -                                                             |
-| `--silent`             | Whether to suppress all output                                                         | [`config.logLevel`](/docs/reference/config#log-level)        |
-| `--minify, -m`         | Whether to minify the generated CSS                                                    | [`config.minify`](/docs/reference/config#minify)             |
-| `--clean`              | Whether to clean the output directory before emitting                                  | [`config.clean`](/docs/reference/config#clean)               |
-| `--config, -c <path>`  | Path to Panda config file                                                              | [`config`](/docs/reference/config.md)                        |
-| `--watch, -w`          | Whether to watch for changes in the project                                            | [`config.watch`](/docs/reference/config#watch)               |
-| `--minimal`            | Skip generating CSS for theme tokens, preflight, keyframes, static and global css      | -                                                             |
-| `--splitting`          | Emit CSS as separate files per layer (reset, global, tokens, utilities) and per recipe | -                                                             |
-| `--poll, -p`           | Whether to poll for file changes                                                       | [`config.poll`](/docs/reference/config#poll)                 |
-| `--cwd <path>`         | Current working directory                                                              | [`config.cwd`](/docs/reference/config#cwd)                   |
-| `--lightningcss`       | Use `lightningcss` instead of `postcss` for css optimization                           | [`config.lightningcss`](/docs/reference/config#lightningcss) |
-| `--polyfill`           | Polyfill CSS @layers at-rules for older browsers                                       | [`config.polyfill`](/docs/reference/config#polyfill)         |
-| `--cpu-prof`           | Generate a `panda-{command}-{timestamp}.cpuprofile` file for profiling                 | [Debugging](/docs/reference/debugging)                           |
-| `--logfile <file>`     | Outputs logs to a file                                                                 | [Debugging](/docs/reference/debugging)                           |
-
-## studio
-
-Realtime documentation for your design tokens.
-
-```bash
-pnpm panda studio
-
-# Build static studio site
-pnpm panda studio --build
-
-# Preview built studio
-pnpm panda studio --preview
-
-# Use custom port
-pnpm panda studio --port 3000
-```
-
-| Flag                  | Description                       | Related                                     |
-| --------------------- | --------------------------------- | ------------------------------------------- |
-| `--build`             | Build                             | -                                           |
-| `--preview`           | Preview                           | -                                           |
-| `--port <port>`       | Use custom port                   | -                                           |
-| `--host`              | Expose to custom host             | -                                           |
-| `--config, -c <path>` | Path to Panda config file         | [`config`](/docs/reference/config.md)      |
-| `--cwd <path>`        | Current working directory         | [`config.cwd`](/docs/reference/config#cwd) |
-| `--outdir <dir>`      | Output directory for static files | -                                           |
-| `--base <path>`       | Base path of project              | -                                           |
-
-## spec
-
-Generate spec files for your theme (useful for documentation).
-
-```bash
-pnpm panda spec
-
-# Generate specs in custom directory
-pnpm panda spec --outdir ./theme-specs
-```
-
-| Flag                  | Description                     | Related                                                |
-| --------------------- | ------------------------------- | ------------------------------------------------------ |
-| `--silent`            | Whether to suppress all output  | [`config.logLevel`](/docs/reference/config#log-level) |
-| `--outdir <dir>`      | Output directory for spec files | -                                                      |
-| `--config, -c <path>` | Path to Panda config file       | [`config`](/docs/reference/config.md)                 |
-| `--cwd <path>`        | Current working directory       | [`config.cwd`](/docs/reference/config#cwd)            |
-
-> The spec output represents your entire design system, everything available in your Panda setup. If you want to
-> understand which tokens or recipes your app is actually using, you should use the
-> [Panda Analyze](/docs/reference/cli#analyze), not the spec.
+---
 
 ## analyze
 
-Analyze design token and recipe usage.
-
-By default, it will analyze your project based on the `include` and `exclude` config options.
+Report which tokens, recipes, utilities, patterns, and keyframes your project uses. By default it scans the whole
+project, following your `include` and `exclude` options.
 
 ```bash
 pnpm panda analyze
 
-# analyze a specific file
-pnpm panda analyze src/components/Button.tsx
+# Scope the report
+pnpm panda analyze --scope tokens
+pnpm panda analyze --scope recipes
 
-# analyze a specific glob
-pnpm panda analyze "src/components/**"
+# Write a JSON report
+pnpm panda analyze --outfile analyze.json
 
-# analyze only token usage
-pnpm panda analyze --scope token
+# Write a static HTML report
+pnpm panda analyze --report ./analyze-report
 
-# analyze only recipe usage
-pnpm panda analyze --scope recipe
+# Open an interactive UI
+pnpm panda analyze --ui
 ```
 
-| Flag                   | Description                                  | Related                                                |
-| ---------------------- | -------------------------------------------- | ------------------------------------------------------ |
-| `--outfile <filepath>` | Output analyze report in given JSON filepath | -                                                      |
-| `--silent`             | Whether to suppress all output               | [`config.logLevel`](/docs/reference/config#log-level) |
-| `--scope <type>`       | Select analysis scope (token or recipe)      | -                                                      |
-| `--config, -c <path>`  | Path to Panda config file                    | [`config`](/docs/reference/config.md)                 |
-| `--cwd <path>`         | Current working directory                    | [`config.cwd`](/docs/reference/config#cwd)            |
+| Flag                | Description                                                                                | Related |
+| ------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| `--scope <scope>`   | Scope the report: `all`, `tokens`, `recipes`, `utilities`, `patterns`, or `keyframes` (`token`/`recipe` are aliases) | -       |
+| `--limit <n>`       | Maximum rows per section in the terminal report                                           | -       |
+| `--outfile <path>`  | Write the report as JSON to this path                                                     | -       |
+| `--report <dir>`    | Write a static HTML report to this directory                                              | -       |
+| `--ui`              | Start an interactive report UI that refreshes on change                                   | -       |
+| `--ui-host <host>`  | Host for the report UI server                                                             | -       |
+| `--ui-port <port>`  | Port for the report UI server                                                             | -       |
+
+`panda analyze` also accepts the [shared flags](#shared-flags), `--include`, and `--watch-debounce` (UI refresh debounce).
+
+---
+
+## doctor
+
+Validate your setup and print a project summary — config path, source count, generated artifacts, conditions, token
+categories, and utilities. It reports any config or diagnostic errors and exits non-zero when it finds them. This
+replaces the v1 `inspect`, `validate`, and `info` commands.
+
+```bash
+pnpm panda doctor
+
+# Machine-readable output for scripts
+pnpm panda doctor --json
+```
+
+`panda doctor` accepts the [shared flags](#shared-flags).
+
+---
 
 ## debug
 
-Debug design token extraction & CSS generated from files in glob.
-
-More details in [Debugging](/docs/reference/debugging) docs.
+Dump the resolved config and per-file extraction results, useful for bug reports. More detail in the
+[Debugging](/docs/reference/debugging) docs.
 
 ```bash
 pnpm panda debug
 
-# Debug a specific file
-pnpm panda debug src/components/Button.tsx
-
-# Output to stdout without writing files
+# Print to stdout without writing files
 pnpm panda debug --dry
 
-# Only output resolved config
+# Only dump the resolved config
 pnpm panda debug --only-config
 ```
 
-| Flag                  | Description                                                            | Related                                                   |
-| --------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- |
-| `--silent`            | Whether to suppress all output                                         | -                                                         |
-| `--dry`               | Output debug files in stdout without writing to disk                   | -                                                         |
-| `--outdir <dir>`      | Output directory for debug files, defaults to `../styled-system/debug` | -                                                         |
-| `--only-config`       | Should only output the config file, default to 'false'                 | -                                                         |
-| `--config, -c <path>` | Path to Panda config file                                              | [`config`](/docs/reference/config.md)                    |
-| `--cwd <path>`        | Current working directory                                              | [`config.cwd`](/docs/reference/config#cwd)               |
-| `--cpu-prof`          | Generate a `panda-{command}-{timestamp}.cpuprofile` file for profiling | [Debugging](/docs/reference/debugging#performance-profiling) |
-| `--logfile <file>`    | Outputs logs to a file                                                 | [Debugging](/docs/reference/debugging)                       |
+| Flag             | Description                                                                | Related |
+| ---------------- | ------------------------------------------------------------------------- | ------- |
+| `--outdir <dir>` | Debug output directory (default `<styled-system>/debug`)                  | -       |
+| `--dry`          | Print the dump to stdout instead of writing files                        | -       |
+| `--only-config`  | Only dump the resolved config, skip per-file extraction                  | -       |
 
-## ship
+`panda debug` also accepts the [shared flags](#shared-flags) and `--include`. `--profile` writes files to disk, so it
+can't be combined with `--dry`.
 
-Ship extract result from files in glob.
+---
 
-By default it will extract from the entire project depending on your include and exclude options from your config file.
+## lib
 
-```bash
-pnpm panda ship
-# You can also analyze a specific file or folder
-# using the optional glob argument
-pnpm panda ship src/components/Button.tsx
-pnpm panda ship "./src/components/**"
-```
+Publish a design system so other apps share your tokens, recipes, and CSS without re-scanning your source. It writes
+machine artifacts under `panda/` and syncs your package `exports`. This replaces the v1 `ship` command.
 
-| Flag                   | Description                                                                                 | Related                                                |
-| ---------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `--outfile <filepath>` | Output path for the JSON build info file, default to './styled-system/panda.buildinfo.json' | -                                                      |
-| `--silent`             | Whether to suppress all output                                                              | [`config.logLevel`](/docs/reference/config#log-level) |
-| `--minify, -m`         | Whether to minify the generated JSON                                                        | -                                                      |
-| `--config, -c <path>`  | Path to Panda config file                                                                   | [`config`](/docs/reference/config.md)                 |
-| `--cwd <path>`         | Current working directory                                                                   | [`config.cwd`](/docs/reference/config#cwd)            |
-| `--watch, -w`          | Whether to watch for changes in the project                                                 | [`config.watch`](/docs/reference/config#watch)        |
-| `--poll, -p`           | Whether to poll for file changes                                                            | [`config.poll`](/docs/reference/config#poll)          |
-
-## emit-pkg
-
-Emit package.json with entrypoints, can be used to create a workspace package dedicated to the
-[`config.outdir`](/docs/reference/config#outdir), in combination with
-[`config.importMap`](/docs/reference/config#importmap)
+See [Building a design system](/docs/design-systems/building-a-design-system) and
+[Consuming a design system](/docs/design-systems/consuming-a-design-system) for the full workflow.
 
 ```bash
-pnpm panda emit-pkg
+pnpm panda lib
 
-# Specify output directory
-pnpm panda emit-pkg --outdir styled-system
+# Built-only package: set the re-extract fallback globs yourself
+pnpm panda lib --files './**/*.{js,mjs}'
+
+# Stamp an explicit peer Panda range
+pnpm panda lib --panda '^2.0.0'
 ```
 
-| Flag             | Description                                          | Related                                                |
-| ---------------- | ---------------------------------------------------- | ------------------------------------------------------ |
-| `--outdir <dir>` | The output directory for the generated CSS utilities | [`config.outdir`](/docs/reference/config#outdir)      |
-| `--base <path>`  | The base directory of the package.json entrypoints   | -                                                      |
-| `--silent`       | Whether to suppress all output                       | [`config.logLevel`](/docs/reference/config#log-level) |
-| `--cwd <path>`   | Current working directory                            | [`config.cwd`](/docs/reference/config#cwd)            |
+| Flag              | Description                                                                                     | Related |
+| ----------------- | ---------------------------------------------------------------------------------------------- | ------- |
+| `--outdir, -o <dir>` | Output directory for the artifacts (default `dist`)                                        | -       |
+| `--panda <range>` | Peer Panda version range to stamp (defaults to your `@pandacss/dev` peer, or the running major) | -       |
+| `--files <globs>` | Re-extract fallback globs for consumers, relative to the output dir (repeat or comma-separate) | -       |
+| `--minify, -m`    | Minify the generated build-info JSON                                                           | -       |
 
-## mcp
+`panda lib` also accepts the [shared flags](#shared-flags), `--include`, and `--watch` / `--watch-debounce`.
 
-Start the MCP (Model Context Protocol) server for AI assistants. This exposes your design system to AI tools like
-Claude, Cursor, VS Code Copilot, and more.
+---
+
+## buildinfo
+
+Write a portable `panda.buildinfo.json` only. Prefer [`panda lib`](#lib) for shipping a library — this command is the
+lower-level piece for cases where you just need the build-info artifact.
 
 ```bash
-pnpm panda mcp
+pnpm panda buildinfo
 
-# With custom config path
-pnpm panda mcp --config ./panda.config.ts
-
-# Specify working directory
-pnpm panda mcp --cwd ./my-project
+# Custom output path
+pnpm panda buildinfo --outfile ./dist/panda.buildinfo.json
 ```
 
-| Flag                  | Description               | Related                                     |
-| --------------------- | ------------------------- | ------------------------------------------- |
-| `--config, -c <path>` | Path to Panda config file | [`config`](/docs/reference/config.md)      |
-| `--cwd <path>`        | Current working directory | [`config.cwd`](/docs/reference/config#cwd) |
+| Flag                   | Description                                                                                | Related |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ------- |
+| `--outfile, -o <path>` | Output path (default `./<outdir>/panda.buildinfo.json`)                                   | -       |
+| `--panda <range>`      | Peer Panda version range to stamp (defaults to the running Panda's major)                 | -       |
+| `--minify, -m`         | Minify the generated JSON                                                                  | -       |
 
-> Note: This command is typically started automatically by AI clients. See the [MCP Server guide](/docs/styling/mcp-server)
-> for setup instructions.
+`panda buildinfo` also accepts the [shared flags](#shared-flags) and `--include`.
 
-## init-mcp
+---
 
-Initialize MCP configuration for AI clients. This creates the necessary configuration files for AI assistants to connect
-to the Panda MCP server.
+## Profiling a slow build
+
+Add `--profile` to any command to capture where time goes, including time inside the Rust engine:
 
 ```bash
-# Interactive mode - select clients from a list
-pnpm panda init-mcp
-
-# Configure specific clients
-pnpm panda init-mcp --client claude,cursor
-
-# Specify working directory
-pnpm panda init-mcp --cwd ./my-project
+panda build --profile
 ```
 
-| Flag               | Description                               | Related                                     |
-| ------------------ | ----------------------------------------- | ------------------------------------------- |
-| `--client <names>` | AI clients to configure (comma-separated) | -                                           |
-| `--cwd <path>`     | Current working directory                 | [`config.cwd`](/docs/reference/config#cwd) |
+It writes two files:
 
-Supported clients: `claude`, `cursor`, `vscode`, `windsurf`, `codex`
+- `.panda/trace.json` — open it in `chrome://tracing` or [ui.perfetto.dev](https://ui.perfetto.dev)
+- `.panda/timings.json` — per-span totals and the slowest files
 
-See the [MCP Server guide](/docs/styling/mcp-server) for detailed usage and available tools.
+## MCP server
+
+The MCP (Model Context Protocol) server is no longer a `panda` subcommand. It ships as its own package, so you run it
+directly:
+
+```bash
+npx -y @pandacss/mcp
+```
+
+See the [MCP Server guide](/docs/styling/mcp-server) for setup and available tools.

--- a/website/content/docs/reference/config.mdx
+++ b/website/content/docs/reference/config.mdx
@@ -13,39 +13,24 @@ export default defineConfig({
 })
 ```
 
-> These are the current, real config options. Several are expected to change in Panda's next major version, see
-> [Upgrading to v2](/docs/styling/upgrading-to-v2) for what's already known about that.
-
 ## Output css options
 
 ### presets
 
-**Type**: `string[]`
+**Type**: `(string | Preset | Promise<Preset>)[]`
 
-**Default**: `['@pandacss/preset-base', '@pandacss/preset-panda']`
+**Default**: `[]`
 
-The set of reusable and shareable configuration presets.
+The set of reusable and shareable configuration presets. Presets are explicit — Panda does not auto-inject any preset.
+For the default utilities, tokens, and conditions, add `@pandacss/preset-base` and `@pandacss/preset-panda` yourself
+(`panda init` scaffolds this for you). Without them you get a bare system.
 
-By default, any preset you add will be smartly merged with the default configuration, with your own configuration acting
-as a set of overrides and extensions.
+Each preset you add is smartly merged with your config, with your own config acting as a set of overrides and
+extensions.
 
 ```json
 {
   "presets": ["@pandacss/preset-base", "@pandacss/preset-panda"]
-}
-```
-
-### eject
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to opt-out of the defaults config presets: [`@pandacss/preset-base`, `@pandacss/preset-panda`]
-
-```json
-{
-  "eject": true
 }
 ```
 
@@ -116,25 +101,12 @@ table.extension {
 }
 ```
 
-### emitTokensOnly
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to only emit the `tokens` directory
-
-```json
-{
-  "emitTokensOnly": false
-}
-```
-
 ### prefix
 
-**Type**: `string`
+**Type**: `string | { cssVar?: string; className?: string }`
 
-The namespace prefix for the generated css classes and css variables.
+The namespace prefix for the generated css classes and css variables. Pass a string to prefix both, or an object to set
+the css variable and class name prefixes separately.
 
 Ex: when using a prefix of `panda-`
 
@@ -315,29 +287,38 @@ Then the result looks like this:
 }
 ```
 
-## File system options
+### optimize
 
-### gitignore
+**Type**: `OptimizeOptions`
 
-**Type**: `boolean`
+**Default**: `{}`
 
-**Default**: `true`
-
-Whether to update the .gitignore file.
+CSS emission optimizations. Every optimization is opt-in.
 
 ```json
 {
-  "gitignore": true
+  "optimize": {
+    "removeUnusedTokens": true,
+    "removeUnusedKeyframes": true,
+    "smartCompoundVariants": true,
+    "treeshakeDesignSystem": true,
+    "propertyFallback": true
+  }
 }
 ```
 
-Will add the following to your `.gitignore` file:
+- `removeUnusedTokens` — remove unused token declarations based on extracted project usage.
+- `removeUnusedKeyframes` — remove unused keyframes based on extracted project usage.
+- `smartCompoundVariants` — narrow compound variant CSS to the variant combinations you actually use, instead of
+  emitting every permutation.
+- `treeshakeDesignSystem` — hydrate only the build-info modules for the design-system exports your app imports. Namespace
+  and side-effect imports still hydrate everything.
+- `propertyFallback` — also seed `@property` registrations as plain declarations, for engines that ignore `@property`
+  (Safari &lt; 16.4, Firefox &lt; 128) and would otherwise drop declarations that read an unregistered variable.
 
-```txt
-# Panda
-styled-system
-styled-system-static
-```
+`removeUnusedTokens` and `removeUnusedKeyframes` replace the cleanup people used to do in a `cssgen:done` hook.
+
+## File system options
 
 ### cwd
 
@@ -350,20 +331,6 @@ The current working directory.
 ```json
 {
   "cwd": "src"
-}
-```
-
-### clean
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to clean the output directory before generating the css.
-
-```json
-{
-  "clean": false
 }
 ```
 
@@ -446,6 +413,21 @@ Check out [Shared styled-system in a monorepo](/docs/design-systems/shared-style
 using multiple `importMap` roots, or the [Component Library](/docs/design-systems/overview) guide for the
 external-package case.
 
+### designSystem
+
+**Type**: `string`
+
+Consume a published design system. Point this at the package and Panda resolves its manifest, merges its preset, and
+applies its build info — you don't set `importMap` or list build info in `include`.
+
+```json
+{
+  "designSystem": "@acme/design-system"
+}
+```
+
+Check out [Consuming a design system](/docs/design-systems/consuming-a-design-system) for the full workflow.
+
 ### include
 
 **Type**: `string[]`
@@ -491,62 +473,32 @@ Explicit list of config related files that should trigger a context reload on ch
 }
 ```
 
-### watch
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to watch for changes and regenerate the css.
-
-```json
-{
-  "watch": false
-}
-```
-
-### poll
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to use polling instead of filesystem events when watching.
-
-```json
-{
-  "poll": false
-}
-```
-
 ### outExtension
 
-**Type**: `'mjs' | 'js'`
+**Type**: `'ts' | 'js' | 'mjs'`
 
-**Default**: `mjs`
+**Default**: `js`
 
 File extension for generated javascript files.
 
 ```json
 {
-  "outExtension": "mjs"
+  "outExtension": "js"
 }
 ```
 
-### forceConsistentTypeExtension
+### forceImportExtension
 
 **Type**: `boolean`
 
 **Default**: `false`
 
-Whether to force consistent type extensions for generated typescript .d.ts files.
-
-If set to `true` and `outExtension` is set to `mjs`, the generated typescript `.d.ts` files will have the extension
-`.d.mts`.
+Whether generated import specifiers include the runtime file extension. When `outExtension` is `mjs`, this also emits
+`.d.mts` instead of `.d.ts`.
 
 ```json
 {
-  "forceConsistentTypeExtension": true
+  "forceImportExtension": true
 }
 ```
 
@@ -580,34 +532,6 @@ const Container = styled.div`
   background-color: gainsboro;
   padding: 10px 15px;
 `
-```
-
-### lightningcss
-
-**Type**: `boolean`
-
-**Default**: `false`
-
-Whether to use `lightningcss` instead of `postcss` for css optimization.
-
-```json
-{
-  "lightningcss": true
-}
-```
-
-### browserslist
-
-**Type**: `string[]`
-
-**Default**: `[]`
-
-Browserslist query to target specific browsers. Only used when `lightningcss` is set to `true`.
-
-```json
-{
-  "browserslist": ["last 2 versions", "not dead", "not < 2%"]
-}
 ```
 
 ### polyfill
@@ -924,6 +848,46 @@ Global font face definitions.
 Check out the [Custom Fonts](/docs/theming/fonts#global-font-face) guide for more information on how to use the
 `globalFontface` option.
 
+### globalVars
+
+**Type**: `Extendable<GlobalVarsDefinition>`
+
+**Default**: `{}`
+
+The global CSS variables for your project. A plain string emits the variable directly; an object registers it with
+`@property`, and only reaches the output if the stylesheet reads or writes it.
+
+```json
+{
+  "globalVars": {
+    "--some-color": "red",
+    "--button-color": {
+      "syntax": "<color>",
+      "inherits": false,
+      "initialValue": "blue"
+    }
+  }
+}
+```
+
+### globalPositionTry
+
+**Type**: `Extendable<GlobalPositionTry>`
+
+**Default**: `{}`
+
+Global `@position-try` fallbacks for anchor positioning, keyed by the fallback name.
+
+```json
+{
+  "globalPositionTry": {
+    "--bottom": {
+      "top": "anchor(bottom)"
+    }
+  }
+}
+```
+
 ## JSX options
 
 ### jsxFramework
@@ -990,23 +954,6 @@ Ex with 'none':
 
 ## Documentation options
 
-### studio
-
-**Type**: `Partial<Studio>`
-
-**Default**: `{ title: 'Panda', logo: '🐼' }`
-
-Used to customize the design system studio
-
-```json
-{
-  "studio": {
-    "logo": "🐼",
-    "title": "Panda"
-  }
-}
-```
-
 ### log level
 
 **Type**: `'debug' | 'info' | 'warn' | 'error' | 'silent'`
@@ -1041,22 +988,14 @@ The validation strictness to use when validating the config.
 
 ## Other options
 
-### Hooks
-
-**Type**: `PandaHooks`
-
-Panda provides a set of callbacks that you can hook into for more advanced use cases. Check the
-[Hooks](/docs/design-systems/hooks) docs for more information.
-
-### Plugins
+### plugins
 
 **Type**: `PandaPlugin[]`
 
-Plugins are currently simple objects that contain a `name` and a `hooks` object with the same structure as the `hooks`
-object in the config.
+Plugins are simple objects that contain a `name` and a `hooks` object. Hooks live on plugins — there is no root-level
+`hooks` config option. Check the [Hooks](/docs/design-systems/hooks) docs for the full list of callbacks.
 
-They will be called in sequence in the order they are defined in the `plugins` array, with the user's config called
-last.
+Plugins are called in sequence in the order they are defined in the `plugins` array, with the user's config called last.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
@@ -1065,12 +1004,10 @@ export default defineConfig({
   // ...
   plugins: [
     {
-      name: 'token-format',
+      name: 'local',
       hooks: {
-        'tokens:created': ({ configure }) => {
-          configure({
-            formatTokenName: path => '$' + path.join('-')
-          })
+        'cssgen:done': ({ content, path }) => {
+          report({ bytes: content.length, path })
         }
       }
     }

--- a/website/content/docs/reference/debugging.mdx
+++ b/website/content/docs/reference/debugging.mdx
@@ -142,15 +142,15 @@ extracted.
 
 ## Performance profiling
 
-If Panda is taking too long to process your files, you can use the `--cpu-prof` with the `panda`, `panda cssgen`,
-`panda codegen` and `panda debug` commands to generate a flamegraph of the whole process, which will allow you (or us as
-maintainers) to see which part of the process is taking the most time.
+If Panda is taking too long to process your files, add `--profile` to any command (`panda`, `panda cssgen`,
+`panda codegen`, `panda debug`) to profile the whole run, including time spent in the Rust engine. This lets you (or us
+as maintainers) see which part of the process is taking the most time.
 
-This will generate a `panda-{command}-{timestamp}.cpuprofile` file in the current working directory, which can be opened
-in tools like [Speedscope](https://www.speedscope.app/)
+This writes a `.panda/trace.json` file — open it in `chrome://tracing` or [ui.perfetto.dev](https://ui.perfetto.dev) — along
+with a `.panda/timings.json` summary.
 
 ```bash
-pnpm panda --cpu-prof
+pnpm panda --profile
 ```
 
 ## FAQ

--- a/website/content/docs/reference/diagnostics.mdx
+++ b/website/content/docs/reference/diagnostics.mdx
@@ -1,28 +1,22 @@
 ---
 title: Diagnostics Reference
-description: The stable diagnostic codes Panda's v2 compiler emits for recoverable config and extraction issues, planned, not yet shipped.
+description: The diagnostic codes Panda's compiler emits for recoverable config and extraction issues.
 ---
-
-> **This page describes a feature that isn't available yet.** It's part of the v2 rewrite covered in
-> [Upgrading to v2](/docs/styling/upgrading-to-v2), still marked as a draft internally, so treat the codes below as
-> directional rather than a reference you can use today. For errors from the current version, see
-> [Debugging](/docs/reference/debugging).
 
 ## What a diagnostic is
 
-Today, a config or extraction problem is either a thrown error or a logged warning, with no stable identifier
-attached to it. The planned diagnostic system gives recoverable issues, ones that don't stop the build, a structured
-shape instead: a stable `code`, a human-readable `message`, a `severity` (`info`, `warning`, or `error`), and where
+The diagnostic system gives recoverable issues, ones that don't stop the build, a structured
+shape: a stable `code`, a human-readable `message`, a `severity` (`info`, `warning`, or `error`), and where
 relevant a source `span` or 1-indexed line/column `location`. Fatal setup failures (a config file that won't load at
 all) still throw, they aren't replaced by this, diagnostics are specifically for issues you can act on without the
 build stopping.
 
-The `code` field is meant to be a stable public API in its own right, useful for tooling (an ESLint rule, a CI check,
+The `code` field is a stable public API in its own right, useful for tooling (an ESLint rule, a CI check,
 an editor integration) to key off, independent of however the human-readable message wording changes over time.
 
-## Planned codes
+## Codes
 
-Grouped by what they're about, not necessarily final or exhaustive:
+Grouped by what they're about, not necessarily exhaustive:
 
 **Config and tokens**
 

--- a/website/content/docs/reference/eslint-oxlint-plugin.mdx
+++ b/website/content/docs/reference/eslint-oxlint-plugin.mdx
@@ -1,26 +1,25 @@
 ---
 title: ESLint & OXLint Plugin
-description: A shared lint rule set for Panda, catching mistakes the compiler itself doesn't error on, planned, not yet shipped.
+description: A shared lint rule set for Panda, catching mistakes the compiler itself doesn't error on.
 ---
 
-> **This page describes a feature that isn't available yet.** It's part of the v2 rewrite covered in
-> [Upgrading to v2](/docs/styling/upgrading-to-v2), still marked as a draft internally, so treat the details below as
-> directional. A package named `@pandacss/eslint-plugin` already exists on npm, but as of this writing it has no
-> public README or rule documentation, so it isn't covered here, check npm directly if you want to inspect it
-> yourself.
+<Callout type="warning">
+  `@pandacss/eslint-plugin` is experimental in the beta. Install it with `@pandacss/eslint-plugin@beta`, and expect
+  the rule set to change while it settles.
+</Callout>
 
 ## Why this needs to be Panda-specific
 
 Generic ESLint rules can't see what Panda's compiler already knows: which values resolve to real tokens, which
 recipe variants actually exist, which conditions are typos. A style object that silently produces no CSS today,
 because a condition key is misspelled or a token reference doesn't resolve, passes both `tsc` and a generic linter
-without a warning. The planned plugin is built directly on Panda's own compiler output instead of pattern-matching
+without a warning. The plugin is built directly on Panda's own compiler output instead of pattern-matching
 source text, so it can catch that class of mistake specifically.
 
 ## One rule set, two entry points
 
 Rather than a separate ESLint package and a separate Oxlint package (which would drift out of sync with each other),
-the plan is one package with two entry points sharing the same rule implementations and the same underlying project
+it's one package with two entry points sharing the same rule implementations and the same underlying project
 metadata (token paths, recipe variants, deprecated entries, resolved import map):
 
 ```txt

--- a/website/content/docs/styling/agent-skills.mdx
+++ b/website/content/docs/styling/agent-skills.mdx
@@ -1,12 +1,12 @@
 ---
 title: Agent Skills
-description: Portable, job-shaped skill packs that teach AI coding agents how to use Panda correctly, planned, not yet shipped.
+description: Portable, job-shaped skill packs that teach AI coding agents how to use Panda correctly.
 ---
 
-> **This page describes a feature that isn't available yet.** It's part of the same v2 effort as
-> [Upgrading to v2](/docs/styling/upgrading-to-v2), still marked as a draft internally, so treat the shape below as
-> directional. If you want AI agent support that works today, see [LLMs.txt](/docs/styling/llms-txt) and
-> [MCP Server](/docs/styling/mcp-server).
+<Callout type="info">
+  Agent Skills are coming soon and aren't published yet, so treat the shape below as a preview. For AI agent support
+  that works today, see [LLMs.txt](/docs/styling/llms-txt) and [MCP Server](/docs/styling/mcp-server).
+</Callout>
 
 ## The problem it's meant to solve
 

--- a/website/content/docs/styling/browser-support.mdx
+++ b/website/content/docs/styling/browser-support.mdx
@@ -37,7 +37,7 @@ For older browsers:
 - Add [autoprefixer](https://github.com/postcss/autoprefixer) in PostCSS when you need vendor prefixes.
 
 ```js
-// postcss.config.js
+// postcss.config.cjs
 module.exports = {
   plugins: ['@pandacss/dev/postcss', 'autoprefixer']
 }

--- a/website/content/docs/styling/extend.mdx
+++ b/website/content/docs/styling/extend.mdx
@@ -129,11 +129,8 @@ import pandaBasePreset from '@pandacss/preset-base'
 const { stack, ...pandaBasePresetPatterns } = pandaBasePreset.patterns
 
 export default defineConfig({
+  // 👇 omit `@pandacss/preset-base` from `presets` so it isn't resolved — Panda doesn't add it for you
   presets: ['@pandacss/preset-panda'], // 👈 we still want the tokens, breakpoints and textStyles from this preset
-
-  // ⚠️ we need to eject to prevent the `@pandacss/preset-base` from being resolved
-  // https://panda-css.com/docs/design-systems/presets#which-panda-presets-will-be-included-
-  eject: true,
   patterns: {
     extend: {
       ...pandaBasePresetPatterns

--- a/website/content/docs/styling/jsx-style-context.mdx
+++ b/website/content/docs/styling/jsx-style-context.mdx
@@ -9,14 +9,14 @@ headless UI libraries like Ark UI, and Radix UI.
 ## Atomic Slot Recipe
 
 - Create a slot recipe using the `sva` function
-- Pass the slot recipe to the `createStyleContext` function
+- Pass the slot recipe to the `createSlotRecipeContext` function
 - Use the `withProvider` and `withContext` functions to create compound components
 
 ```tsx
 // components/ui/card.tsx
 
 import { sva } from 'styled-system/css'
-import { createStyleContext } from 'styled-system/jsx'
+import { createSlotRecipeContext } from 'styled-system/jsx'
 
 const card = sva({
   slots: ['root', 'label'],
@@ -35,7 +35,7 @@ const card = sva({
   }
 })
 
-const { withProvider, withContext } = createStyleContext(card)
+const { withProvider, withContext } = createSlotRecipeContext(card)
 
 const Root = withProvider('div', 'root')
 const Label = withContext('label', 'label')
@@ -64,18 +64,18 @@ export default function App() {
 
 ## Config Slot Recipe
 
-The `createStyleContext` function can also be used with slot recipes defined in the `panda.config.ts` file.
+The `createSlotRecipeContext` function can also be used with slot recipes defined in the `panda.config.ts` file.
 
-- Pass the config recipe to the `createStyleContext` function
+- Pass the config recipe to the `createSlotRecipeContext` function
 - Use the `withProvider` and `withContext` functions to create compound components
 
 ```tsx
 // components/ui/card.tsx
 
 import { card } from '../styled-system/recipes'
-import { createStyleContext } from 'styled-system/jsx'
+import { createSlotRecipeContext } from 'styled-system/jsx'
 
-const { withProvider, withContext } = createStyleContext(card)
+const { withProvider, withContext } = createSlotRecipeContext(card)
 
 const Root = withProvider('div', 'root')
 const Label = withContext('label', 'label')
@@ -102,9 +102,10 @@ export default function App() {
 }
 ```
 
-## createStyleContext
+## createSlotRecipeContext
 
-This function is a factory function that returns three functions: `withRootProvider`, `withProvider`, and `withContext`.
+Use this for a slot recipe (`sva` or `defineSlotRecipe`) with multiple parts. It's a factory function that returns three
+functions: `withRootProvider`, `withProvider`, and `withContext`.
 
 ### withRootProvider
 
@@ -150,8 +151,8 @@ const AvatarFallback = withContext(Avatar.Fallback, 'fallback')
 
 ### unstyled prop
 
-Every component created with `createStyleContext` supports the `unstyled` prop to disable styling. It is useful when you
-want to opt-out of the recipe styles.
+Every component created with `createSlotRecipeContext` supports the `unstyled` prop to disable styling. It is useful when
+you want to opt-out of the recipe styles.
 
 - When applied the root component, will disable all styles
 - When applied to a child component, will disable the styles for that specific slot
@@ -170,11 +171,27 @@ want to opt-out of the recipe styles.
 </AvatarRoot>
 ```
 
+## createRecipeContext
+
+Use this for a single-element config recipe (`cva` or `defineRecipe`) that has no slots. It returns a single
+`withContext` function, and `withContext` takes just the element or component, with no slot name.
+
+```tsx
+import { button } from '../styled-system/recipes'
+import { createRecipeContext } from 'styled-system/jsx'
+
+const { withContext } = createRecipeContext(button)
+
+export const Button = withContext('button')
+```
+
+The component accepts the recipe's variant props and forwards them to drive the styling.
+
 ## Guides
 
 ### Config Recipes
 
-The rules of config recipes still applies when using `createStyleContext`. Ensure the name of the final component
+The rules of config recipes still applies when using `createSlotRecipeContext`. Ensure the name of the final component
 matches the name of the recipe.
 
 > If you want to use a custom name, you can configure the recipe's `jsx` property in the `panda.config.ts` file.
@@ -183,7 +200,7 @@ matches the name of the recipe.
 // recipe name is "card"
 import { card } from '../styled-system/recipes'
 
-const { withRootProvider, withContext } = createStyleContext(card)
+const { withRootProvider, withContext } = createSlotRecipeContext(card)
 
 const Root = withRootProvider('div')
 const Header = withContext('header', 'header')
@@ -202,7 +219,7 @@ export const Card = {
 Use `defaultProps` option to provide default props to the component.
 
 ```tsx
-const { withContext } = createStyleContext(card)
+const { withContext } = createSlotRecipeContext(card)
 
 export const CardHeader = withContext('header', 'header', {
   defaultProps: {
@@ -228,7 +245,7 @@ const tabs = sva({
   }
 })
 
-const { withProvider } = createStyleContext(tabs)
+const { withProvider } = createSlotRecipeContext(tabs)
 
 function TabsRoot({ orientation, ...rest }: TabsRootProps) {
   // `orientation` is available here, so we can mirror it as an aria attribute

--- a/website/content/docs/styling/performance-optimization.mdx
+++ b/website/content/docs/styling/performance-optimization.mdx
@@ -10,16 +10,16 @@ fixes.
 
 ## Measure before you tune
 
-Don't guess which phase is slow. Panda's CLI can generate a flamegraph for any command:
+Don't guess which phase is slow. Add `--profile` to any Panda command to profile the whole run, including time spent in
+the Rust engine:
 
 ```bash
-panda --cpu-prof
+panda --profile
 ```
 
-This produces a `.cpuprofile` file you can open in [Speedscope](https://www.speedscope.app/) to see exactly which
-phase, config resolution, file parsing, CSS generation, is actually taking the time. See
-[Debugging](/docs/reference/debugging#performance-profiling) for the full flag list across `codegen`, `cssgen`, and
-`debug`.
+This writes a `.panda/trace.json` file you can open in `chrome://tracing` or [ui.perfetto.dev](https://ui.perfetto.dev)
+to see exactly which phase, config resolution, file parsing, CSS generation, is actually taking the time (plus a
+`.panda/timings.json` summary). See [Debugging](/docs/reference/debugging#performance-profiling) for details.
 
 ## Build time: scope what gets scanned
 
@@ -56,6 +56,6 @@ size of what TypeScript has to check on every style call.
 
 - [How Panda works](/docs/styling/how-panda-works) for why there's no runtime cost to weigh against these build/IDE
   costs in the first place.
-- [Debugging](/docs/reference/debugging) for `--cpu-prof`, `panda debug`, and `PANDA_DEBUG`.
+- [Debugging](/docs/reference/debugging) for `--profile`, `panda debug`, and `PANDA_DEBUG`.
 - [Static CSS Generation](/docs/design-systems/static) and [Federated Micro-Frontends](/docs/design-systems/federated-microfrontends)
   for scaling considerations once you're shipping to multiple apps, not just optimizing one.

--- a/website/content/docs/styling/slot-recipes.mdx
+++ b/website/content/docs/styling/slot-recipes.mdx
@@ -250,10 +250,10 @@ const Checkbox = (props: CheckboxVariants) => {
 ### Styling JSX Compound Components
 
 Compound components are a great way to create reusable components for better composition. Slot recipes play nicely with
-this pattern and requires a context provider for the component.
+this pattern through a context provider for the component.
 
 > **Note:** This is an advanced topic and you don't need to understand it to use slot recipes. If you use React, be
-> aware that context require adding 'use client' to the top of the file.
+> aware that context requires adding 'use client' to the top of the file.
 
 Let's say you want to design a Checkbox component that can be used like this:
 
@@ -264,55 +264,15 @@ Let's say you want to design a Checkbox component that can be used like this:
 </Checkbox>
 ```
 
-First, create a shared context for ths styles
-
-```jsx filename="style-context.tsx"
-'use client'
-import { createContext, forwardRef, useContext } from 'react'
-
-export const createStyleContext = recipe => {
-  const StyleContext = createContext(null)
-
-  const withProvider = (Component, part) => {
-    const Comp = forwardRef((props, ref) => {
-      const [variantProps, rest] = recipe.splitVariantProps(props)
-      const styles = recipe(variantProps)
-      return (
-        <StyleContext.Provider value={styles}>
-          <Component ref={ref} className={styles?.[part ?? '']} {...rest} />
-        </StyleContext.Provider>
-      )
-    })
-    Comp.displayName = Component.displayName || Component.name
-    return Comp
-  }
-
-  const withContext = (Component, part) => {
-    if (!part) return Component
-
-    const Comp = forwardRef((props, ref) => {
-      const styles = useContext(StyleContext)
-      return <Component ref={ref} className={styles?.[part ?? '']} {...props} />
-    })
-    Comp.displayName = Component.displayName || Component.name
-    return Comp
-  }
-
-  return { withProvider, withContext }
-}
-```
-
-> Note: For the TypeScript version of this file, refer to
-> [create-style-context.tsx](https://github.com/cschroeter/park-ui/blob/main/website/src/lib/create-style-context.tsx)
-> in Park UI
-
-Then, use the context to create compound components connected to the recipe
+Panda ships `createSlotRecipeContext` in `styled-system/jsx`. Pass it your slot recipe and it returns `withProvider` and
+`withContext` to wire each part to the right slot:
 
 ```jsx filename="Checkbox.tsx"
-import { createStyleContext } from './style-context'
+'use client'
+import { createSlotRecipeContext } from '../styled-system/jsx'
 import { checkbox } from './checkbox.recipe'
 
-const { withProvider, withContext } = createStyleContext(checkbox)
+const { withProvider, withContext } = createSlotRecipeContext(checkbox)
 
 //                                  👇🏻 points to the root slot
 const Root = withProvider('label', 'root')
@@ -323,6 +283,9 @@ const Label = withContext('span', 'label')
 
 const Checkbox = { Root, Control, Label }
 ```
+
+For the full API — `withRootProvider`, forwarding props, and the `unstyled` prop — see
+[JSX Style Context](/docs/styling/jsx-style-context).
 
 ## Config Slot Recipe
 
@@ -653,7 +616,7 @@ It pairs well with [ZagJs](https://zagjs.com/) and [Ark-UI](https://ark-ui.com/)
 Let's refactor the previous example to use parts instead of slots:
 
 ```ts
-import { defineParts, definetRecipe } from '@pandacss/dev'
+import { defineParts, defineRecipe } from '@pandacss/dev'
 
 const parts = defineParts({
   root: { selector: '& [data-part="root"]' },

--- a/website/content/docs/styling/stitches.mdx
+++ b/website/content/docs/styling/stitches.mdx
@@ -297,8 +297,8 @@ const styles = css({
 })
 ```
 
-Notice that in Panda, you don't need to use the `$` prefix to access the tokens. If you really want to use the `$`
-prefix, you can either update the name of the token:
+Notice that in Panda, you don't need to use the `$` prefix to access the tokens. If you really want the `$` prefix,
+name the token with it:
 
 ```diff
 export default defineConfig({
@@ -307,23 +307,6 @@ export default defineConfig({
 -      gray100: { value: 'hsl(206,22%,99%)' },
 +      $gray100: { value: 'hsl(206,22%,99%)' },
     },
-  }
-})
-```
-
-Or you can tweak the token engine to format them with the `$` prefix:
-
-```ts
-import { defineConfig } from '@pandacss/dev'
-
-export default defineConfig({
-  // ...
-  hooks: {
-    'tokens:created': ({ configure }) => {
-      configure({
-        formatTokenName: path => '$' + path.join('-')
-      })
-    }
   }
 })
 ```

--- a/website/content/docs/styling/style-props.mdx
+++ b/website/content/docs/styling/style-props.mdx
@@ -321,7 +321,7 @@ const App = () => <Input size={4} />
 
 > **Note:** A forwarded prop becomes a plain HTML prop, so it no longer feeds recipe styling. To keep a prop styling
 > _and_ pass it to your component, see [forwarding props](/docs/styling/jsx-style-context#forwarding-props) in
-> `createStyleContext`.
+> `createSlotRecipeContext`.
 
 ### Unstyled prop
 

--- a/website/content/docs/styling/why-panda.mdx
+++ b/website/content/docs/styling/why-panda.mdx
@@ -85,7 +85,6 @@ The generator can be used to create a set of CSS variables for your design token
 
 ```ts filename="panda.config.ts"
 export default defineConfig({
-  emitTokensOnly: true,
   theme: {
     tokens: {
       colors: {

--- a/website/content/docs/theming/studio.mdx
+++ b/website/content/docs/theming/studio.mdx
@@ -3,6 +3,11 @@ title: Using Panda Studio
 description: Document your design system visually using Panda Studio.
 ---
 
+<Callout type="warning">
+  The standalone `@pandacss/studio` Astro app is removed in v2. A lighter, CLI-generated studio is coming, see
+  [Studio in v2](/docs/theming/studio-v2). The page below is kept as a reference for the v1 app.
+</Callout>
+
 ### Panda Studio
 
 Panda Studio is a visual interface for exploring and understanding your entire design system. It provides a read-only


### PR DESCRIPTION
## 📝 Description

A content sweep of docs pages that still taught v1 APIs, config options, and CLI commands. Follows the two v2 doc PRs (#3728, #3729) and applies the same rule: describe Panda in present tense, with a before/after only where a real v1→v2 change matters.

Every claim was checked against the source (`packages/types/src/config.ts`, `packages/types/src/hooks.ts`, `packages/cli/src/`), not just find-and-replaced.

## ⛳️ Current behavior (updates)

Several pages document things that no longer exist in v2:
- `createStyleContext` (removed) across 8 pages.
- The CLI reference lists `panda studio`, `spec`, `ship`, `inspect`/`validate`/`info` and `--lightningcss`, `--emitTokensOnly`, `--cpu-prof`, `--silent`/`--quiet`/`--verbose`.
- The config reference documents `eject`, `emitTokensOnly`, `lightningcss`, `browserslist`.
- The hooks page teaches five removed hooks (`tokens:created`, `utility:created`, `context:created`, `config:change`, `parser:after`) and the old root-level `hooks` config.
- Ecosystem plugins is built on removed `@pandacss/plugin-*` packages and the `css:optimize` hook.
- Diagnostics, the eslint/oxlint plugin, and the studio page carry stale "not shipped" / v1-Astro-app framing.

## 🚀 New behavior

- `createStyleContext` → `createRecipeContext` / `createSlotRecipeContext` (28 occurrences), with a new `createRecipeContext` section.
- **CLI reference** rewritten to the real 11-command v2 surface, with a Shared flags section and a "Profiling a slow build" section (`--profile`, `--log-level`).
- **Config reference** rewritten: removed options dropped; `optimize`, `designSystem`, `forceImportExtension` documented.
- **Hooks** rewritten to the six v2 hooks on the `plugins` model; `cssgen:done` is observe-only.
- **Ecosystem plugins** rewritten: framework support is built in, plugins are hook bundles via `definePlugin`.
- `panda ship` → `panda buildinfo` / `panda lib`; `--cpu-prof` → `--profile`.
- Marked the removed Astro studio and dropped the stale "not shipped" framing.

Docs only. The velite content build passes; agent skills stays flagged as coming soon (no evidence it ships yet), and prop-level extraction exclusion is called out as a current gap since the v1 `matchTag` hook was removed with no replacement.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Verified against: `packages/types/src/config.ts` and `hooks.ts` (option/hook sets), `packages/cli/src/cli-main.ts` + `commands/*` + `args.ts` (commands and flags), the native framework adapters in `crates/pandacss_extractor`, and the `beta` dist-tag on npm.
