### PR TITLE
docs(website): rewrite hooks and plugins for v2

### DIFF
--- a/website/content/docs/design-systems/avoiding-collisions.mdx
+++ b/website/content/docs/design-systems/avoiding-collisions.mdx
@@ -51,15 +51,20 @@ import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
   presets: ['@acme/marketing-preset', '@acme/product-preset'],
-  hooks: {
-    'preset:resolved': ({ preset, name }) => {
-      if (name === '@acme/marketing-preset' && preset.theme?.recipes?.button) {
-        preset.theme.recipes.marketingButton = preset.theme.recipes.button
-        delete preset.theme.recipes.button
+  plugins: [
+    {
+      name: 'rename-marketing-button',
+      hooks: {
+        'preset:resolved': ({ preset, name }) => {
+          if (name === '@acme/marketing-preset' && preset.theme?.recipes?.button) {
+            preset.theme.recipes.marketingButton = preset.theme.recipes.button
+            delete preset.theme.recipes.button
+          }
+          return preset
+        }
       }
-      return preset
     }
-  }
+  ]
 })
 ```
 

--- a/website/content/docs/design-systems/config-functions.mdx
+++ b/website/content/docs/design-systems/config-functions.mdx
@@ -170,12 +170,10 @@ Function for [plugin](/docs/reference/config#plugins) definitions.
 import { definePlugin } from '@pandacss/dev'
 
 export const plugin = definePlugin({
-  name: 'token-format',
+  name: 'css-report',
   hooks: {
-    'tokens:created': ({ configure }) => {
-      configure({
-        formatTokenName: path => '$' + path.join('-')
-      })
+    'cssgen:done': ({ path, content }) => {
+      console.log(`generated ${content.length} bytes`, path)
     }
   }
 })

--- a/website/content/docs/design-systems/ecosystem-plugins.mdx
+++ b/website/content/docs/design-systems/ecosystem-plugins.mdx
@@ -1,96 +1,56 @@
 ---
-title: Ecosystem Plugins
-description: The plugin packages Panda ships and auto-injects, and how to write your own following the same pattern.
+title: Ecosystem plugins
+description: What a Panda plugin is, when to write one, and how to share hooks as a package.
 ---
 
-A [plugin](/docs/design-systems/hooks#sharing-hooks) is a named bundle of hooks you can distribute as its own package,
-instead of pasting the same `hooks` object into every project's config. Panda already ships three of these as
-separate packages, and the engine wires two of them in for you automatically. This page covers what those three
-plugins do and when you'd write one of your own, not the hook mechanics themselves, see
-[Hooks](/docs/design-systems/hooks) for the full API and how to author a plugin from scratch.
+A plugin is a named bundle of [hooks](/docs/design-systems/hooks) you distribute as its own package, instead of pasting
+the same hooks into every project's config. It's the hooks counterpart to a [preset](/docs/design-systems/presets): a
+preset shares theme and tokens, a plugin shares behavior.
 
-## The plugins Panda ships
+## Framework support is built in
 
-| Package | What it does | How it's enabled |
-| --- | --- | --- |
-| `@pandacss/plugin-vue` | Transforms `.vue` single-file components to a `tsx`-friendly syntax so the parser can extract style calls from them | Automatic, no config needed |
-| `@pandacss/plugin-svelte` | Same idea, for `.svelte` files | Automatic, no config needed |
-| `@pandacss/plugin-lightningcss` | Swaps the CSS optimizer from PostCSS to LightningCSS | Opt-in, set `lightningcss: true` |
-
-All three ship as dependencies of `@pandacss/node`, so they're already installed alongside `@pandacss/dev`, there's
-nothing extra to add to your own `package.json`.
-
-### Vue and Svelte support
-
-Both plugins hook `parser:before`, checking the file extension and handing back a transformed source string:
-
-```ts
-// simplified from packages/plugin-svelte/src/index.ts
-export function pluginSvelte(): PandaPlugin {
-  return {
-    name: '@pandacss/plugin-svelte',
-    hooks: {
-      'parser:before': ({ filePath, content }) => {
-        if (filePath.endsWith('.svelte')) {
-          return svelteToTsx(content)
-        }
-      }
-    }
-  }
-}
-```
-
-The CLI and the PostCSS plugin both auto-inject `pluginVue()` and `pluginSvelte()` before your own config's hooks
-run, which is why the [Vue](/docs/styling/vue) and [Svelte](/docs/styling/svelte) installation pages never mention
-adding a plugin. If you're driving Panda's core APIs directly instead of going through the CLI or the PostCSS plugin,
-you'd need to add these two yourself.
-
-### LightningCSS optimization
-
-By default, Panda optimizes generated CSS with PostCSS. Setting
-[`lightningcss: true`](/docs/reference/config#lightningcss) in your config swaps that for LightningCSS instead, and
-auto-injects `pluginLightningcss()` to do it:
-
-```tsx filename="panda.config.ts"
-import { defineConfig } from '@pandacss/dev'
-
-export default defineConfig({
-  // ...
-  lightningcss: true
-})
-```
-
-Under the hood, this plugin hooks `css:optimize`, the one hook in `PandaHooks` that lets a plugin replace Panda's
-optimizer outright rather than just tweaking its input or output:
-
-```ts
-// simplified from packages/plugin-lightningcss/src/index.ts
-export function pluginLightningcss(): PandaPlugin {
-  return {
-    name: '@pandacss/plugin-lightningcss',
-    hooks: {
-      'css:optimize': ({ css, minify, browserslist }) => {
-        return optimizeLightCss(css, { minify, browserslist })
-      }
-    }
-  }
-}
-```
-
-If you don't already have a [browserslist](https://github.com/browserslist/browserslist) config, Panda looks for one
-in your project once `lightningcss` is enabled, since LightningCSS needs browser targets to know which CSS features
-it can safely emit.
+You don't add a plugin to make Panda read Vue, Svelte, or Astro files. The compiler extracts styles from `.vue`,
+`.svelte`, and `.astro` single-file components directly, so the [Vue](/docs/styling/vue), [Svelte](/docs/styling/svelte),
+and [Astro](/docs/styling/astro) install pages have no plugin to add. If you're upgrading from v1, the separate
+`@pandacss/plugin-vue` and `@pandacss/plugin-svelte` packages are gone — that work moved into the compiler.
 
 ## When to write your own
 
-Most one-off customization belongs in your config's inline `hooks`, not a separate package, see
-[Hooks](/docs/design-systems/hooks) for examples like prefixing token names or stripping unused CSS variables. Reach
-for a real plugin package when you want to share that behavior across multiple projects or teams, the same reason
-you'd reach for a [preset](/docs/design-systems/presets) instead of copy-pasting theme tokens. The three plugins
-above are a working reference for the shape: a `name`, a `hooks` object, and one exported factory function a user
-adds to their own `plugins` array.
+Most one-off customization belongs in an inline plugin in your config, not a separate package — see
+[Hooks](/docs/design-systems/hooks) for examples like transforming source before extraction or reacting to generated
+output. Reach for a published plugin when you want to share that behavior across projects or teams, the same reason you'd
+reach for a preset instead of copy-pasting tokens.
+
+A plugin is a `name` and a `hooks` object. `definePlugin` gives you the types:
+
+```ts filename="my-plugin.ts"
+import { definePlugin } from '@pandacss/dev'
+
+export function myPlugin() {
+  return definePlugin({
+    name: 'my-plugin',
+    hooks: {
+      'parser:before': ({ filePath, content }) => {
+        // transform a file's source before Panda extracts from it
+        return content
+      },
+    },
+  })
+}
+```
+
+Users add the factory to their `plugins` array:
+
+```ts filename="panda.config.ts"
+import { defineConfig } from '@pandacss/dev'
+import { myPlugin } from './my-plugin'
+
+export default defineConfig({
+  plugins: [myPlugin()],
+})
+```
 
 ## See also
 
-- [Hooks](/docs/design-systems/hooks) for the full `PandaHooks` reference and how to author and share a plugin.
-- [Config](/docs/reference/config#lightningcss) for the `lightningcss` option.
+- [Hooks](/docs/design-systems/hooks) for every hook and how to author and share a plugin.
+- [Presets](/docs/design-systems/presets) for sharing theme and tokens the same way.

--- a/website/content/docs/design-systems/hooks.mdx
+++ b/website/content/docs/design-systems/hooks.mdx
@@ -3,198 +3,198 @@ title: Panda Integration Hooks
 description: Leveraging hooks in Panda to create custom functionality.
 ---
 
-Panda hooks can be used to add new functionality or modify existing behavior during certian parts of the compiler
-lifecycle.
+Panda hooks let you add new functionality or change existing behavior at specific points in the compiler lifecycle.
 
-Hooks are mostly callbacks that can be added to the panda config via the `hooks` property, or installed via `plugins`.
+Hooks are callbacks you attach to named plugins in the `plugins` array. There is no root-level `hooks` object — every
+hook lives on a plugin with a `name` and a `hooks` map.
 
-Here are some examples of what you can do with hooks:
+```ts
+import { defineConfig } from '@pandacss/dev'
 
-- modify the resolved config (`config:resolved`), like strip out tokens or keyframes.
-- modify presets after they are resolved (`preset:resolved`), like removing specific tokens or theme properties from a
-  preset.
-- tweak the design token or classname engine (`tokens:created`, `utility:created`), like prefixing token names, or
-  customizing the hashing function
-- transform a source file to a `tsx` friendly syntax before it's parsed (`parser:before`) so that Panda can
-  automatically extract its styles usage
-- create your own styles parser (`parser:before`, `parser:after`) using the file's content so that Panda could be used
-  with any templating language
-- alter the generated JS and DTS code (`codegen:prepare`)
-- modify the generated CSS (`cssgen:done`), allowing all kinds of customizations like removing the unused CSS variables,
-  etc.
-- restrict `strictTokens` to a specific set of token categories, ex: only affect `colors` and `spacing` tokens and
-  therefore allow any value for `fontSizes` and `lineHeights`
+export default defineConfig({
+  plugins: [
+    {
+      name: 'my-plugin',
+      hooks: {
+        'cssgen:done': ({ content, path }) => {
+          // ...
+        },
+      },
+    },
+  ],
+})
+```
+
+Here are some things you can do with hooks:
+
+- Modify the resolved config (`config:resolved`), like stripping out patterns, tokens, or keyframes.
+- Modify a preset after it's resolved (`preset:resolved`), like removing tokens or theme properties from a preset.
+- Transform a source file into `tsx`-friendly syntax before it's parsed (`parser:before`), so Panda can extract its style
+  usage — this also lets you support templating languages Panda doesn't parse natively.
+- Adjust the generated JS and DTS artifacts before they're written (`codegen:prepare`), or react after they're written
+  (`codegen:done`).
+- Observe the final CSS after it's produced (`cssgen:done`), for reporting or downstream tooling.
 
 ## Examples
 
-### Prefixing token names
-
-This is especially useful when migrating from other css-in-js libraries, [like Stitches.](/docs/styling/stitches)
-
-```ts
-import { defineConfig } from '@pandacss/dev'
-
-export default defineConfig({
-  // ...
-  hooks: {
-    'tokens:created': ({ configure }) => {
-      configure({
-        formatTokenName: path => '$' + path.join('-')
-      })
-    }
-  }
-})
-```
-
-### Customizing the hash function
-
-When using the [`hash: true`](/docs/styling/writing-styles) config property, you can customize the function used to
-hash the classnames.
-
-```ts
-export default defineConfig({
-  // ...
-  hash: true,
-  hooks: {
-    'utility:created': ({ configure }) => {
-      configure({
-        toHash: (paths, toHash) => {
-          const stringConds = paths.join(':')
-          const splitConds = stringConds.split('_')
-          const hashConds = splitConds.map(toHash)
-          return hashConds.join('_')
-        }
-      })
-    }
-  }
-})
-```
-
 ### Modifying the config
 
-Here's an example of how to leveraging the provided `utils` functions in the `config:resolved` hook to remove the
-`stack` pattern from the resolved config.
+Use the `utils` helpers on the `config:resolved` hook to change the resolved config. This example removes the `stack`
+pattern.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
-  // ...
-  hooks: {
-    'config:resolved': ({ config, utils }) => {
-      return utils.omit(config, ['patterns.stack'])
-    }
-  }
+  plugins: [
+    {
+      name: 'remove-stack-pattern',
+      hooks: {
+        'config:resolved': ({ config, utils }) => {
+          return utils.omit(config, ['patterns.stack'])
+        },
+      },
+    },
+  ],
 })
 ```
 
 ### Modifying presets
 
-You can use the `preset:resolved` hook to modify presets after they are resolved. This is useful for customizing or
-filtering out parts of a preset.
+Use the `preset:resolved` hook to change a preset after it's resolved. This is useful for filtering out parts of a
+preset.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
-  // ...
-  hooks: {
-    'preset:resolved': ({ utils, preset, name }) => {
-      if (name === '@pandacss/preset-panda') {
-        return utils.omit(preset, ['theme.tokens.colors', 'theme.semanticTokens.colors'])
-      }
-      return preset
-    }
-  }
+  plugins: [
+    {
+      name: 'trim-preset-colors',
+      hooks: {
+        'preset:resolved': ({ utils, preset, name }) => {
+          if (name === '@pandacss/preset-panda') {
+            return utils.omit(preset, ['theme.tokens.colors', 'theme.semanticTokens.colors'])
+          }
+          return preset
+        },
+      },
+    },
+  ],
 })
 ```
 
-### Configuring JSX extraction
+### Transforming a source file before parsing
 
-Use the `matchTag` / `matchTagProp` functions to customize the way Panda extracts your JSX.
+Use `parser:before` to rewrite a file's content before Panda parses it. The hook receives `{ filePath, content }` and
+returns the transformed string. Return nothing to leave the content unchanged.
 
-This can be especially useful when working with libraries that have properties that look like CSS properties but are not
-and should be ignored.
-
-Let's see a Radix UI example where the `Select.Content` component has a `position` property that should be ignored:
-
-```js
-// Here, the `position` property will be extracted because `position` is a valid CSS property, but we don't want that
-<Select.Content position="popper" sideOffset={5}>
-```
+This is how you support source that isn't standard `tsx` — pre-process it into syntax Panda's parser understands, then
+return it.
 
 ```ts
-export default defineConfig({
-  // ...
-  hooks: {
-    'parser:before': ({ configure }) => {
-      configure({
-        // ignore the Select.Content entirely
-        matchTag: tag => tag !== 'Select.Content',
-        // ...or specifically ignore the `position` property
-        matchTagProp: (tag, prop) => tag === 'Select.Content' && prop !== 'position'
-      })
-    }
-  }
-})
-```
-
-### Remove unused variables from final css
-
-Here's an example of how to transform the generated css in the `cssgen:done` hook.
-
-```ts file="panda.config.ts"
 import { defineConfig } from '@pandacss/dev'
-import { removeUnusedCssVars } from './remove-unused-css-vars'
-import { removeUnusedKeyframes } from './remove-unused-keyframes'
 
 export default defineConfig({
-  // ...
-  hooks: {
-    'cssgen:done': ({ artifact, content }) => {
-      if (artifact === 'styles.css') {
-        return removeUnusedCssVars(removeUnusedKeyframes(content))
-      }
-    }
-  }
+  plugins: [
+    {
+      name: 'strip-directives',
+      hooks: {
+        'parser:before': ({ filePath, content }) => {
+          if (!filePath.endsWith('.astro')) return
+          return content.replace(/^---[\s\S]*?---/, '')
+        },
+      },
+    },
+  ],
 })
 ```
 
-Get the snippets for the removal logic from our Github Sandbox in the
-[remove-unused-css-vars](https://github.com/chakra-ui/panda/blob/main/sandbox/vite-ts/remove-unused-css-vars.ts) and
-[remove-unused-keyframes](https://github.com/chakra-ui/panda/blob/main/sandbox/vite-ts/remove-unused-keyframes.ts)
-files.
+To scope a hook to specific files, pass an object with a `filter` and a `handler` instead of a bare function:
 
-> Note: Using this means you can't use the JS function [`token.var`](/docs/styling/dynamic-styling#using-tokenvar) (or
-> [token(xxx)](/docs/styling/dynamic-styling#using-token) where `xxx` is the path to a
-> [semanticToken](/docs/theming/tokens#semantic-tokens)) from `styled-system/tokens` as the CSS variables will be
-> removed based on the usage found in the generated CSS
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'scoped-parser',
+      hooks: {
+        'parser:before': {
+          filter: { id: '**/*.{jsx,tsx}' },
+          handler: ({ content }) => content,
+        },
+      },
+    },
+  ],
+})
+```
+
+### Observing the final CSS
+
+`cssgen:done` runs after the final CSS is produced, for the CLI, Vite, and PostCSS. It's observe-only — the hook
+receives `{ artifact, content, path?, … }` and its return value is ignored, so you can't rewrite the CSS here.
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'css-report',
+      hooks: {
+        'cssgen:done': ({ artifact, content, path }) => {
+          if (artifact === 'styles.css') {
+            console.log(`Generated ${content.length} bytes at ${path}`)
+          }
+        },
+      },
+    },
+  ],
+})
+```
+
+To strip unused tokens or keyframes from the final CSS, use the top-level `optimize` config instead of a hook:
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+
+export default defineConfig({
+  optimize: {
+    removeUnusedTokens: true,
+    removeUnusedKeyframes: true,
+  },
+})
+```
+
+For any other CSS transform, run PostCSS after Panda.
+
+> Note: With `removeUnusedTokens`, you can't rely on the JS function
+> [`token.var`](/docs/styling/dynamic-styling#using-tokenvar) (or [token(xxx)](/docs/styling/dynamic-styling#using-token)
+> where `xxx` is a [semanticToken](/docs/theming/tokens#semantic-tokens) path) from `styled-system/tokens`, because the
+> CSS variables are removed based on the usage found in the generated CSS.
 
 ## Sharing hooks
 
-Hooks can be shared as a snippet or as a `plugin`. Plugins are currently simple objects that contain a `name` associated
-with a `hooks` object with the same structure as the `hooks` object in the config.
+Hooks are shared as plugins. A plugin is a plain object with a `name` and a `hooks` object.
 
-> Plugins differ from `presets` as they can't be extended, but they will be called in sequence in the order they are
-> defined in the `plugins` array, with the user's config called last.
+Plugins differ from `presets` in that they can't be extended, but they run in sequence in the order they appear in the
+`plugins` array, with the user's own config called last.
 
 ```ts
 import { defineConfig } from '@pandacss/dev'
 
+const myPlugin = {
+  name: 'strip-stack',
+  hooks: {
+    'config:resolved': ({ config, utils }) => {
+      return utils.omit(config, ['patterns.stack'])
+    },
+  },
+}
+
 export default defineConfig({
-  // ...
-  plugins: [
-    {
-      name: 'token-format',
-      hooks: {
-        'tokens:created': ({ configure }) => {
-          configure({
-            formatTokenName: path => '$' + path.join('-')
-          })
-        }
-      }
-    }
-  ]
+  plugins: [myPlugin],
 })
 ```
 
@@ -203,55 +203,90 @@ export default defineConfig({
 ```ts
 export interface PandaHooks {
   /**
-   * Called when the config is resolved, after all the presets are loaded and merged.
-   * This is the first hook called, you can use it to tweak the config before the context is created.
+   * Called after authored presets are merged, before defaults and serialization.
    */
-  'config:resolved': (args: ConfigResolvedHookArgs) => MaybeAsyncReturn<void | ConfigResolvedHookArgs['config']>
+  'config:resolved': (args: ConfigResolvedHookArgs) => MaybeAsyncReturn<void | Config>
   /**
-   * Called when a preset is resolved, allowing you to modify it before it's merged into the config.
+   * Called when an authored preset is resolved, before all configs are merged.
    */
-  'preset:resolved': (args: PresetResolvedHookArgs) => MaybeAsyncReturn<void | PresetResolvedHookArgs['preset']>
+  'preset:resolved': (args: PresetResolvedHookArgs) => MaybeAsyncReturn<void | Config>
   /**
-   * Called when the token engine has been created
+   * Called after reading file content but before parsing it.
+   * Use this to transform non-standard source into TSX-friendly syntax.
    */
-  'tokens:created': (args: TokenCreatedHookArgs) => MaybeAsyncReturn
+  'parser:before': (args: ParserResultBeforeHookArgs) => MaybeAsyncReturn<string | void>
   /**
-   * Called when the classname engine has been created
+   * Called before generated files are written by a JS host.
    */
-  'utility:created': (args: UtilityCreatedHookArgs) => MaybeAsyncReturn
+  'codegen:prepare': (args: CodegenPrepareHookArgs) => void | CodegenPrepareArtifact[]
   /**
-   * Called when the Panda context has been created and the API is ready to be used.
+   * Called after generated files are written by a JS host.
    */
-  'context:created': (args: ContextCreatedHookArgs) => void
+  'codegen:done': (args: CodegenDoneHookArgs) => void
   /**
-   * Called when the config file or one of its dependencies (imports) has changed.
+   * Called after final CSS is produced by a JS host (observe-only; no rewrite).
+   * Fires for CLI, Vite, and PostCSS string sinks. Use `optimize` or PostCSS to mutate CSS.
    */
-  'config:change': (args: ConfigChangeHookArgs) => MaybeAsyncReturn
-  /**
-   * Called after reading the file content but before parsing it.
-   * You can use this hook to transform the file content to a tsx-friendly syntax so that Panda's parser can parse it.
-   * You can also use this hook to parse the file's content on your side using a custom parser, in this case you don't have to return anything.
-   */
-  'parser:before': (args: ParserResultBeforeHookArgs) => string | void
-  /**
-   * Called after the file styles are extracted and processed into the resulting ParserResult object.
-   * You can also use this hook to add your own extraction results from your custom parser to the ParserResult object.
-   */
-  'parser:after': (args: ParserResultAfterHookArgs) => void
-  /**
-   * Called right before writing the codegen files to disk.
-   * You can use this hook to tweak the codegen files before they are written to disk.
-   */
-  'codegen:prepare': (args: CodegenPrepareHookArgs) => MaybeAsyncReturn<Artifact[]>
-  /**
-   * Called after the codegen is completed
-   */
-  'codegen:done': (args: CodegenDoneHookArgs) => MaybeAsyncReturn
-  /**
-   * Called right before adding the design-system CSS (global, static, preflight, tokens, keyframes) to the final CSS
-   * Called right before writing/injecting the final CSS (styles.css) that contains the design-system CSS and the parser CSS
-   * You can use it to tweak the CSS content before it's written to disk or injected through the postcss plugin.
-   */
-  'cssgen:done': (args: CssgenDoneHookArgs) => string | void
+  'cssgen:done': (args: CssgenDoneHookArgs) => void
+}
+```
+
+Each hook can be a plain function or an object with a `filter` and a `handler`, which is useful for scoping
+`parser:before` to specific files:
+
+```ts
+export type PandaHook<Handler> = Handler | { filter?: HookFilter; handler: Handler }
+```
+
+The argument types are:
+
+```ts
+export interface ConfigResolvedHookArgs {
+  config: Config
+  path: string
+  dependencies: string[]
+  utils: ConfigResolvedHookUtils
+}
+
+export interface PresetResolvedHookArgs {
+  preset: Config
+  name: string
+  utils: ConfigResolvedHookUtils
+}
+
+export interface ConfigResolvedHookUtils {
+  omit<T extends object>(obj: T, paths: string[]): T
+  pick<T extends object>(obj: T, paths: string[]): Partial<T>
+  traverse(obj: unknown, callback: (item: TraverseItem) => void, options?: TraverseOptions): void
+}
+
+export interface ParserResultBeforeHookArgs {
+  filePath: string
+  content: string
+  original?: string
+}
+
+export interface CodegenPrepareHookArgs {
+  artifacts: CodegenPrepareArtifact[]
+  outdir: string
+  cwd?: string
+}
+
+export interface CodegenDoneHookArgs {
+  files: string[]
+  outdir: string
+  cwd?: string
+}
+
+export interface CssgenDoneHookArgs {
+  artifact: 'styles.css' | 'styles.layer' | 'styles.split'
+  content: string
+  /** Absolute path when written to disk; omitted for string sinks (Vite/PostCSS). */
+  path?: string
+  outfile?: string
+  outdir?: string
+  cwd?: string
+  manifest?: CssgenDoneManifest
+  layerRanges?: CssgenDoneLayerRanges
 }
 ```

--- a/website/content/docs/styling/stitches.mdx
+++ b/website/content/docs/styling/stitches.mdx
@@ -297,8 +297,8 @@ const styles = css({
 })
 ```
 
-Notice that in Panda, you don't need to use the `$` prefix to access the tokens. If you really want to use the `$`
-prefix, you can either update the name of the token:
+Notice that in Panda, you don't need to use the `$` prefix to access the tokens. If you really want the `$` prefix,
+name the token with it:
 
 ```diff
 export default defineConfig({
@@ -307,23 +307,6 @@ export default defineConfig({
 -      gray100: { value: 'hsl(206,22%,99%)' },
 +      $gray100: { value: 'hsl(206,22%,99%)' },
     },
-  }
-})
-```
-
-Or you can tweak the token engine to format them with the `$` prefix:
-
-```ts
-import { defineConfig } from '@pandacss/dev'
-
-export default defineConfig({
-  // ...
-  hooks: {
-    'tokens:created': ({ configure }) => {
-      configure({
-        formatTokenName: path => '$' + path.join('-')
-      })
-    }
   }
 })
 ```


### PR DESCRIPTION
## 📝 Description

Part of splitting up #3730. Brings the hooks and plugins docs in line with the v2 hook system.

## ⛳️ Current behavior (updates)

- The hooks page teaches five removed hooks (`tokens:created`, `utility:created`, `context:created`, `config:change`, `parser:after`), the removed `parser:before.configure(...)` JSX-match API, and the old root-level `hooks` config.
- Ecosystem plugins is built on the removed `@pandacss/plugin-*` packages and the `css:optimize` hook.
- `avoiding-collisions`, `config-functions`, and the Stitches guide use root `hooks` / removed hooks.

## 🚀 New behavior

- Hooks attach to named plugins (`plugins: [{ name, hooks }]`); only the six v2 hooks remain (`config:resolved`, `preset:resolved`, `parser:before`, `codegen:prepare`, `codegen:done`, `cssgen:done`). `cssgen:done` is observe-only.
- Ecosystem plugins rewritten: framework support (Vue/Svelte/Astro) is built into the compiler, and a plugin is a hook bundle via `definePlugin`.
- Collision and config-function examples moved onto the plugins model; the Stitches `$`-prefix section keeps only the token-rename approach.

Docs only. Velite content build passes.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Hook set and signatures verified against `packages/types/src/hooks.ts`; framework adapters live in `crates/pandacss_extractor` (`vue_adapter.rs`, `svelte_adapter.rs`, `astro_adapter.rs`).
