### PR TITLE
docs(website): drop removed config options and the ship command

### DIFF
--- a/website/content/docs/design-systems/federated-microfrontends.mdx
+++ b/website/content/docs/design-systems/federated-microfrontends.mdx
@@ -312,7 +312,7 @@ own build. The collision is identical, and `prefix` is still the fix. It
 just moves to the **consumer's** config, keyed to the remote's identity
 rather than the DS version.
 
-`panda ship` only writes extraction results (which styles are used), not the
+`panda buildinfo` only writes extraction results (which styles are used), not the
 token and recipe **definitions**. So a build-info consumer wires up two
 pieces: the build-info file (via `include`) and the lib's preset (via
 `presets`). The preset supplies the definitions, the build-info file supplies

--- a/website/content/docs/design-systems/minimal-setup.mdx
+++ b/website/content/docs/design-systems/minimal-setup.mdx
@@ -34,7 +34,8 @@ export default defineConfig({
 
 ## Removing default utilities
 
-Use the `eject: true` property to remove all the default utilities.
+The default utilities come from `@pandacss/preset-base`. To remove them, omit `@pandacss/preset-base` from `presets` (or
+use `presets: []`) — Panda doesn't add it for you.
 
 Panda doesn't automatically know which tokens are valid for which CSS properties, so it is necessary to tell Panda that
 my tokens from the "colors" category are valid for the CSS property "color".
@@ -42,7 +43,7 @@ my tokens from the "colors" category are valid for the CSS property "color".
 ```js
 export default defineConfig({
   // ...
-  eject: true,
+  presets: [],
   utilities: {
     color: {
       values: 'colors'
@@ -86,5 +87,5 @@ export default defineConfig({
 })
 ```
 
-> Note: You don't need to install `@pandacss/preset-base` or `@pandacss/preset-panda`. Panda will automatically resolve
-> them for you.
+> Note: Panda doesn't add `@pandacss/preset-base` or `@pandacss/preset-panda` for you. Install the ones you want and list
+> them in `presets`.

--- a/website/content/docs/design-systems/presets.mdx
+++ b/website/content/docs/design-systems/presets.mdx
@@ -3,8 +3,8 @@ title: Presets
 description: Creating your own reusable preset for utilities and theme
 ---
 
-By default, any configuration you add in your own `panda.config.js` file is smartly merged with the
-[default presets](#which-panda-presets-will-be-included), allowing you to override or extend specific parts of the
+Any configuration you add in your own `panda.config.js` file is smartly merged with the
+[presets you list](#which-panda-presets-will-be-included), allowing you to override or extend specific parts of the
 configuration.
 
 ## When to use a preset
@@ -121,21 +121,22 @@ pnpm add -D @acme/preset
 
 ### Add it to panda.config
 
-Setting `presets` replaces the default `@pandacss/preset-panda`. Include it explicitly if you still want the default
-theme:
+`presets` is the exact list Panda uses — nothing is added for you. List `@pandacss/preset-base` for the default utilities
+and `@pandacss/preset-panda` for the default theme, then add your own:
 
 ```ts filename="panda.config.ts"
 import { defineConfig } from '@pandacss/dev'
+import basePreset from '@pandacss/preset-base'
 import pandaPreset from '@pandacss/preset-panda'
 import { acmePreset } from '@acme/preset'
 
 export default defineConfig({
-  presets: [pandaPreset, acmePreset],
+  presets: [basePreset, pandaPreset, acmePreset],
   include: ['./src/**/*.{js,jsx,ts,tsx}']
 })
 ```
 
-`@pandacss/preset-base` is still included automatically unless you set `eject: true`. See
+`@pandacss/preset-base` gives you the default utilities and patterns, and is included only if you list it, as above. See
 [which presets are included](#which-panda-presets-will-be-included).
 
 ### Extend the preset in the app
@@ -145,7 +146,7 @@ conflicts. See [extend](/docs/styling/extend).
 
 ```ts filename="panda.config.ts"
 export default defineConfig({
-  presets: [pandaPreset, acmePreset],
+  presets: [basePreset, pandaPreset, acmePreset],
   theme: {
     extend: {
       tokens: {
@@ -205,24 +206,27 @@ export default defineConfig({
 })
 ```
 
-## Which panda presets will be included ?
+## Which panda presets will be included?
 
-![Visual helper](/stately-presets-merging.png)
+Panda includes exactly the presets you list in `presets` — nothing is added for you.
 
-- `@pandacss/preset-base`: ALWAYS included if NOT using `eject: true`
+- `@pandacss/preset-base` (default utilities, conditions, and patterns): included only if you list it.
+- `@pandacss/preset-panda` (default tokens, breakpoints, and text styles): included only if you list it.
 
-- `@pandacss/preset-panda`: only included by default if you haven't specified the `presets` config option, otherwise
-  you'll have to include that preset by yourself like so:
+List both when you want the full defaults, then add your own presets:
 
 ```ts
+import basePreset from '@pandacss/preset-base'
 import pandaPreset from '@pandacss/preset-panda'
 import { defineConfig } from '@pandacss/dev'
 
 export default defineConfig({
   // ...
-  presets: [pandaPreset, myCustomPreset]
+  presets: [basePreset, pandaPreset, myCustomPreset]
 })
 ```
+
+For a system with no defaults at all, use `presets: []`.
 
 ## Minimal setup
 

--- a/website/content/docs/design-systems/ship-styled-system.mdx
+++ b/website/content/docs/design-systems/ship-styled-system.mdx
@@ -88,12 +88,13 @@ ship your normal library build alongside it.
 Generate it after building your library:
 
 ```bash
-panda ship --outfile dist/panda.buildinfo.json
+panda buildinfo --outfile dist/panda.buildinfo.json
 ```
 
-> A future major version of Panda renames this command to `panda buildinfo` as part of a broader rewrite of how the
-> build-info format works internally. The file it produces stays named `panda.buildinfo.json` either way, and the
-> `include` step below is expected to keep working the same.
+> Publishing a full library? Prefer `panda lib` — it writes the build info, a preset, and a manifest in one step, and
+> consumers wire it up with the [`designSystem`](/docs/design-systems/consuming-a-design-system) config field instead of
+> `include` + `importMap`. See [Build a design system](/docs/design-systems/building-a-design-system). `panda buildinfo`
+> is the lower-level option when you only want the extraction result.
 
 Then, in the user's config, include the build info file the same way you'd include source:
 

--- a/website/content/docs/styling/extend.mdx
+++ b/website/content/docs/styling/extend.mdx
@@ -129,11 +129,8 @@ import pandaBasePreset from '@pandacss/preset-base'
 const { stack, ...pandaBasePresetPatterns } = pandaBasePreset.patterns
 
 export default defineConfig({
+  // 👇 omit `@pandacss/preset-base` from `presets` so it isn't resolved — Panda doesn't add it for you
   presets: ['@pandacss/preset-panda'], // 👈 we still want the tokens, breakpoints and textStyles from this preset
-
-  // ⚠️ we need to eject to prevent the `@pandacss/preset-base` from being resolved
-  // https://panda-css.com/docs/design-systems/presets#which-panda-presets-will-be-included-
-  eject: true,
   patterns: {
     extend: {
       ...pandaBasePresetPatterns

--- a/website/content/docs/styling/why-panda.mdx
+++ b/website/content/docs/styling/why-panda.mdx
@@ -85,7 +85,6 @@ The generator can be used to create a set of CSS variables for your design token
 
 ```ts filename="panda.config.ts"
 export default defineConfig({
-  emitTokensOnly: true,
   theme: {
     tokens: {
       colors: {


### PR DESCRIPTION
## 📝 Description

Part of splitting up #3730. Removes config options and a CLI command that no longer exist from the preset and design-system pages.

## ⛳️ Current behavior (updates)

- `minimal-setup`, `presets`, and `extend` use `eject: true` to drop `@pandacss/preset-base`, and imply presets are auto-injected.
- `why-panda` shows an `emitTokensOnly: true` example.
- `ship-styled-system` and `federated-microfrontends` use `panda ship`.

## 🚀 New behavior

- `eject` is gone: v2 doesn't auto-inject presets, so a bare system is `presets: []` (or just omit `@pandacss/preset-base`). Preset pages rewritten to the explicit-presets model.
- `emitTokensOnly` example removed.
- `panda ship` → `panda buildinfo`, with a pointer to `panda lib` + `designSystem` for full libraries.

Docs only. Velite content build passes.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Verified `eject`/`emitTokensOnly` are absent from `packages/types/src/config.ts`, that `panda init` scaffolds explicit presets with a `--skip-presets` flag, and that `panda buildinfo`/`panda lib` are the current commands.
