### PR TITLE
docs(website): drop stale not-shipped framing

### DIFF
--- a/website/content/docs/reference/diagnostics.mdx
+++ b/website/content/docs/reference/diagnostics.mdx
@@ -1,28 +1,22 @@
 ---
 title: Diagnostics Reference
-description: The stable diagnostic codes Panda's v2 compiler emits for recoverable config and extraction issues, planned, not yet shipped.
+description: The diagnostic codes Panda's compiler emits for recoverable config and extraction issues.
 ---
-
-> **This page describes a feature that isn't available yet.** It's part of the v2 rewrite covered in
-> [Upgrading to v2](/docs/styling/upgrading-to-v2), still marked as a draft internally, so treat the codes below as
-> directional rather than a reference you can use today. For errors from the current version, see
-> [Debugging](/docs/reference/debugging).
 
 ## What a diagnostic is
 
-Today, a config or extraction problem is either a thrown error or a logged warning, with no stable identifier
-attached to it. The planned diagnostic system gives recoverable issues, ones that don't stop the build, a structured
-shape instead: a stable `code`, a human-readable `message`, a `severity` (`info`, `warning`, or `error`), and where
+The diagnostic system gives recoverable issues, ones that don't stop the build, a structured
+shape: a stable `code`, a human-readable `message`, a `severity` (`info`, `warning`, or `error`), and where
 relevant a source `span` or 1-indexed line/column `location`. Fatal setup failures (a config file that won't load at
 all) still throw, they aren't replaced by this, diagnostics are specifically for issues you can act on without the
 build stopping.
 
-The `code` field is meant to be a stable public API in its own right, useful for tooling (an ESLint rule, a CI check,
+The `code` field is a stable public API in its own right, useful for tooling (an ESLint rule, a CI check,
 an editor integration) to key off, independent of however the human-readable message wording changes over time.
 
-## Planned codes
+## Codes
 
-Grouped by what they're about, not necessarily final or exhaustive:
+Grouped by what they're about, not necessarily exhaustive:
 
 **Config and tokens**
 

--- a/website/content/docs/reference/eslint-oxlint-plugin.mdx
+++ b/website/content/docs/reference/eslint-oxlint-plugin.mdx
@@ -1,26 +1,25 @@
 ---
 title: ESLint & OXLint Plugin
-description: A shared lint rule set for Panda, catching mistakes the compiler itself doesn't error on, planned, not yet shipped.
+description: A shared lint rule set for Panda, catching mistakes the compiler itself doesn't error on.
 ---
 
-> **This page describes a feature that isn't available yet.** It's part of the v2 rewrite covered in
-> [Upgrading to v2](/docs/styling/upgrading-to-v2), still marked as a draft internally, so treat the details below as
-> directional. A package named `@pandacss/eslint-plugin` already exists on npm, but as of this writing it has no
-> public README or rule documentation, so it isn't covered here, check npm directly if you want to inspect it
-> yourself.
+<Callout type="warning">
+  `@pandacss/eslint-plugin` is experimental in the beta. Install it with `@pandacss/eslint-plugin@beta`, and expect
+  the rule set to change while it settles.
+</Callout>
 
 ## Why this needs to be Panda-specific
 
 Generic ESLint rules can't see what Panda's compiler already knows: which values resolve to real tokens, which
 recipe variants actually exist, which conditions are typos. A style object that silently produces no CSS today,
 because a condition key is misspelled or a token reference doesn't resolve, passes both `tsc` and a generic linter
-without a warning. The planned plugin is built directly on Panda's own compiler output instead of pattern-matching
+without a warning. The plugin is built directly on Panda's own compiler output instead of pattern-matching
 source text, so it can catch that class of mistake specifically.
 
 ## One rule set, two entry points
 
 Rather than a separate ESLint package and a separate Oxlint package (which would drift out of sync with each other),
-the plan is one package with two entry points sharing the same rule implementations and the same underlying project
+it's one package with two entry points sharing the same rule implementations and the same underlying project
 metadata (token paths, recipe variants, deprecated entries, resolved import map):
 
 ```txt

--- a/website/content/docs/styling/agent-skills.mdx
+++ b/website/content/docs/styling/agent-skills.mdx
@@ -1,12 +1,12 @@
 ---
 title: Agent Skills
-description: Portable, job-shaped skill packs that teach AI coding agents how to use Panda correctly, planned, not yet shipped.
+description: Portable, job-shaped skill packs that teach AI coding agents how to use Panda correctly.
 ---
 
-> **This page describes a feature that isn't available yet.** It's part of the same v2 effort as
-> [Upgrading to v2](/docs/styling/upgrading-to-v2), still marked as a draft internally, so treat the shape below as
-> directional. If you want AI agent support that works today, see [LLMs.txt](/docs/styling/llms-txt) and
-> [MCP Server](/docs/styling/mcp-server).
+<Callout type="info">
+  Agent Skills are coming soon and aren't published yet, so treat the shape below as a preview. For AI agent support
+  that works today, see [LLMs.txt](/docs/styling/llms-txt) and [MCP Server](/docs/styling/mcp-server).
+</Callout>
 
 ## The problem it's meant to solve
 

--- a/website/content/docs/styling/browser-support.mdx
+++ b/website/content/docs/styling/browser-support.mdx
@@ -37,7 +37,7 @@ For older browsers:
 - Add [autoprefixer](https://github.com/postcss/autoprefixer) in PostCSS when you need vendor prefixes.
 
 ```js
-// postcss.config.js
+// postcss.config.cjs
 module.exports = {
   plugins: ['@pandacss/dev/postcss', 'autoprefixer']
 }

--- a/website/content/docs/theming/studio.mdx
+++ b/website/content/docs/theming/studio.mdx
@@ -3,6 +3,11 @@ title: Using Panda Studio
 description: Document your design system visually using Panda Studio.
 ---
 
+<Callout type="warning">
+  The standalone `@pandacss/studio` Astro app is removed in v2. A lighter, CLI-generated studio is coming, see
+  [Studio in v2](/docs/theming/studio-v2). The page below is kept as a reference for the v1 app.
+</Callout>
+
 ### Panda Studio
 
 Panda Studio is a visual interface for exploring and understanding your entire design system. It provides a read-only


### PR DESCRIPTION
## 📝 Description

Part of splitting up #3730. Removes stale "not shipped yet / proposed internally" framing from pages whose features now ship on the v2 beta.

## ⛳️ Current behavior (updates)

- `diagnostics` and `eslint-oxlint-plugin` open with "this feature isn't available yet," but both ship on beta.
- `theming/studio` documents the removed `@pandacss/studio` Astro app as current.
- `agent-skills` carries "unmerged branch / proposed internally" framing.
- `browser-support` shows `postcss.config.js`.

## 🚀 New behavior

- Diagnostics and the eslint/oxlint plugin rewritten to present tense (the plugin noted as experimental on beta).
- `theming/studio` gets a callout: the Astro app is removed in v2; a lighter CLI studio is coming (link to Studio in v2). The v1 reference stays below.
- `agent-skills` kept honestly as coming soon (no evidence it ships yet), minus the unmerged-branch language.
- `browser-support` example aligned to `postcss.config.cjs`.

Docs only. Velite content build passes.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Confirmed `@pandacss/eslint-plugin` ships on the `beta` tag; found no evidence agent skills ship yet (no skills package or CLI command), so that page stays a coming-soon note rather than claiming availability.
