### PR TITLE
docs(website): rewrite Why Panda for v2 and name the alternatives

### DIFF
--- a/website/content/docs/styling/why-panda.mdx
+++ b/website/content/docs/styling/why-panda.mdx
@@ -41,8 +41,8 @@ the tools you're weighing.
   Components. Panda keeps the authoring model and drops the runtime.
 - **On a template-first stack (Rails, Laravel, plain HTML).** No JS component tree needed. Generate a static set of
   utility and recipe classes with [`staticCss`](/docs/design-systems/static) and write them straight in your markup. You
-  trade typed authoring for the same tokens, recipes, and atomic output, and v2 builds that static set far faster than
-  v1.
+  trade typed authoring for the same tokens, recipes, and atomic output, and Panda now builds that static set far faster
+  than before.
 
 ## A quick example
 

--- a/website/content/docs/styling/why-panda.mdx
+++ b/website/content/docs/styling/why-panda.mdx
@@ -1,47 +1,46 @@
 ---
 title: Why Panda
-description: Typed, build-time, zero-runtime styling with real design tokens and recipes — and where it fits next to Tailwind, StyleX, and vanilla-extract.
+description: Typed, build-time, zero-runtime styling with real design tokens and recipes, and where it fits next to Tailwind, StyleX, and vanilla-extract.
 ---
 
-Panda turns the styles you write next to your markup into static, atomic CSS at build time. You get the ergonomics of
-CSS-in-JS — objects, tokens, conditions, autocomplete — with zero runtime: nothing computes styles in the browser, and
-nothing ships to the client but CSS.
+Panda turns the styles you write next to your markup into static, atomic CSS at build time. You author styles as objects
+next to your components, with tokens, conditions, and autocomplete. The build ships only CSS. Nothing computes styles in
+the browser.
 
-## What you get
+## What Panda gives you
 
-- **Zero runtime.** Panda reads your source at build time and resolves it to a static CSS file. No style computation in
-  the browser, no `<head>` injection. It works with React Server Components because there's nothing to run on the
-  server or the client.
-- **Typed at the call site.** Tokens, utilities, and recipe variants are typed from your own config. A misspelled token
-  or an invalid property is a TypeScript error as you type — not a class name that silently does nothing.
-- **A design system, not just utilities.** Tokens and semantic tokens, recipes and slot recipes for component variants,
-  patterns for layout, and presets plus [`panda lib`](/docs/design-systems/building-a-design-system) to share the whole
-  thing across apps.
-- **Atomic CSS that scales.** Each property/value pair becomes one shared class. Your CSS grows with the number of
+- **Zero runtime.** Panda reads your source at build time and writes a static CSS file. No style computation in the
+  browser, no `<head>` injection, and nothing to run under React Server Components.
+- **Typed at the call site.** Tokens, utilities, and recipe variants come from your own config. A misspelled token or an
+  invalid property is a TypeScript error as you type, not a class name that quietly does nothing.
+- **A design system, not just utilities.** Tokens and semantic tokens, recipes and slot recipes for variants, patterns
+  for layout, and presets plus [`panda lib`](/docs/design-systems/building-a-design-system) to share it across apps.
+- **Atomic CSS that scales.** Each property and value becomes one shared class, so your CSS grows with the number of
   distinct styles, not the number of components.
-- **A fast compiler.** Panda extracts and emits with a Rust engine built on [Oxc](https://oxc.rs) — native for your
-  build, WebAssembly for the browser. See [The compiler engine](/docs/styling/compiler-engine).
-- **Modern CSS.** Cascade layers, CSS variables, `:where`/`:is`, and container queries in the generated output.
+- **A Rust compiler.** Panda extracts with an engine built on [Oxc](https://oxc.rs): one parse per file, no TypeScript
+  program in the hot path. Native for your build, WebAssembly for the browser. See
+  [the compiler engine](/docs/styling/compiler-engine).
+- **Modern CSS.** Cascade layers, CSS variables, `:where` and `:is`, and container queries in the output.
 
-Run it through the CLI, the PostCSS plugin, or a Vite/webpack/Rollup plugin — Panda doesn't depend on any one bundler.
+Run it through the CLI, the PostCSS plugin, or a Vite, webpack, or Rollup plugin. Panda doesn't depend on any one
+bundler.
 
 ## Where Panda fits
 
-Most people find Panda at one moment: the styling approach that got them started stops scaling. Here's how Panda sits
-next to the tools you're probably weighing.
+Most people find Panda at one moment: the approach that got them started stops scaling. Here's where Panda sits next to
+the tools you're weighing.
 
-- **Coming from Tailwind.** You've hit class-name soup — long `class="..."` strings your editor can't check, no
-  colocated variants, and a typo that just no-ops. Panda keeps the speed of utilities, but they're typed object keys and
-  token values, and variants live in [recipes](/docs/styling/recipes) instead of strings. See
-  [migrating from Tailwind](/docs/styling/tailwind).
+- **Coming from Tailwind.** You've hit class-name soup: long `class="..."` strings your editor can't check, no colocated
+  variants, a typo that just no-ops. Panda keeps the speed of utilities, but they're typed object keys and token values,
+  and variants live in [recipes](/docs/styling/recipes). See [migrating from Tailwind](/docs/styling/tailwind).
 - **Comparing build-time CSS-in-JS.** StyleX and vanilla-extract are the other typed, zero-runtime options. All three
-  extract to static atomic CSS, so the real difference is scope: Panda ships the design-system layer — recipes, slot
-  recipes, patterns, semantic tokens, presets — as first-class APIs, where StyleX and vanilla-extract leave you to build
-  variants and layout primitives by hand. See [migrating from StyleX](/docs/styling/stylex).
+  extract to static atomic CSS, so the difference is scope: Panda ships the design-system layer (recipes, slot recipes,
+  patterns, semantic tokens, presets) as built-in APIs, where the others leave you to build variants and layout by hand.
+  See [migrating from StyleX](/docs/styling/stylex).
 - **Leaving runtime CSS-in-JS.** emotion and styled-components compute styles in the browser and struggle under Server
-  Components. Panda keeps the familiar authoring model and drops the runtime cost.
+  Components. Panda keeps the authoring model and drops the runtime.
 
-## A quick taste
+## A quick example
 
 ```tsx
 import { css } from '../styled-system/css'
@@ -59,22 +58,22 @@ function Profile() {
 }
 ```
 
-`stack` and `circle` are patterns; `blue.500`, `md`, and `xl` are tokens from your theme. All of it is typed, and all of
-it compiles to atomic CSS with no runtime.
+`stack` and `circle` are patterns; `md` and `xl` are tokens from your theme. It's all typed, and it all compiles to
+atomic CSS with no runtime.
 
 ## When not to use Panda
 
-Panda earns its place when you have a design system to express — tokens, variants, themes — and a build step to run it.
+Panda earns its place when you have a design system to express, tokens, variants, themes, and a build step to run it.
 It's the wrong fit if:
 
 - You're writing plain HTML and CSS with no build step.
-- You're on a template-first server framework (PHP, Rails views) with little JavaScript.
+- You're on a template-first server framework like PHP or Rails views, with little JavaScript.
 - You need an absolute zero-tooling setup.
 
 Modern CSS keeps getting better. If you don't need tokens, variants, or type-safety, you may not need a tool at all.
 
-## Next
+## Where to go next
 
-- [Get started](/docs/styling/getting-started) — install Panda and generate your first styles.
-- [Thinking in Panda](/docs/styling/thinking-in-panda) — which API to reach for as a component grows.
-- [How Panda works](/docs/styling/how-panda-works) — the build-time model, start to finish.
+- [Get started](/docs/styling/getting-started): install Panda and generate your first styles.
+- [Thinking in Panda](/docs/styling/thinking-in-panda): which API to reach for as a component grows.
+- [How Panda works](/docs/styling/how-panda-works): the build-time model, start to finish.

--- a/website/content/docs/styling/why-panda.mdx
+++ b/website/content/docs/styling/why-panda.mdx
@@ -39,6 +39,10 @@ the tools you're weighing.
   See [migrating from StyleX](/docs/styling/stylex).
 - **Leaving runtime CSS-in-JS.** emotion and styled-components compute styles in the browser and struggle under Server
   Components. Panda keeps the authoring model and drops the runtime.
+- **On a template-first stack (Rails, Laravel, plain HTML).** No JS component tree needed. Generate a static set of
+  utility and recipe classes with [`staticCss`](/docs/design-systems/static) and write them straight in your markup. You
+  trade typed authoring for the same tokens, recipes, and atomic output, and v2 builds that static set far faster than
+  v1.
 
 ## A quick example
 
@@ -63,12 +67,8 @@ atomic CSS with no runtime.
 
 ## When not to use Panda
 
-Panda earns its place when you have a design system to express, tokens, variants, themes, and a build step to run it.
-It's the wrong fit if:
-
-- You're writing plain HTML and CSS with no build step.
-- You're on a template-first server framework like PHP or Rails views, with little JavaScript.
-- You need an absolute zero-tooling setup.
+Panda needs a build step to turn your styles into CSS. It's the wrong fit if you want zero tooling: plain HTML and CSS,
+or a setup with no build at all.
 
 Modern CSS keeps getting better. If you don't need tokens, variants, or type-safety, you may not need a tool at all.
 

--- a/website/content/docs/styling/why-panda.mdx
+++ b/website/content/docs/styling/why-panda.mdx
@@ -1,142 +1,80 @@
 ---
 title: Why Panda
-description: From the endless list of CSS-in-JS libraries, why should you choose Panda?
+description: Typed, build-time, zero-runtime styling with real design tokens and recipes — and where it fits next to Tailwind, StyleX, and vanilla-extract.
 ---
 
-Runtime CSS-in-JS and style props are powerful features that allow developers to build dynamic UI components that are
-composable, predictable, and easy to use. However, it comes at the cost of performance and runtime.
+Panda turns the styles you write next to your markup into static, atomic CSS at build time. You get the ergonomics of
+CSS-in-JS — objects, tokens, conditions, autocomplete — with zero runtime: nothing computes styles in the browser, and
+nothing ships to the client but CSS.
 
-## Backstory
+## What you get
 
-With the release of Server Components and the rise of server-first frameworks, most existing runtime CSS-in-JS styling
-solutions (like emotion, styled-components) either can't work reliably, or can't work anymore. This new paradigm is a
-huge win for performance, development, and user experience, however, it poses a new "Innovate or Die" challenge for
-CSS-in-JS libraries.
+- **Zero runtime.** Panda reads your source at build time and resolves it to a static CSS file. No style computation in
+  the browser, no `<head>` injection. It works with React Server Components because there's nothing to run on the
+  server or the client.
+- **Typed at the call site.** Tokens, utilities, and recipe variants are typed from your own config. A misspelled token
+  or an invalid property is a TypeScript error as you type — not a class name that silently does nothing.
+- **A design system, not just utilities.** Tokens and semantic tokens, recipes and slot recipes for component variants,
+  patterns for layout, and presets plus [`panda lib`](/docs/design-systems/building-a-design-system) to share the whole
+  thing across apps.
+- **Atomic CSS that scales.** Each property/value pair becomes one shared class. Your CSS grows with the number of
+  distinct styles, not the number of components.
+- **A fast compiler.** Panda extracts and emits with a Rust engine built on [Oxc](https://oxc.rs) — native for your
+  build, WebAssembly for the browser. See [The compiler engine](/docs/styling/compiler-engine).
+- **Modern CSS.** Cascade layers, CSS variables, `:where`/`:is`, and container queries in the generated output.
 
-> **Fun Fact:** Most CSS-in-JS libraries have a pinned issue on their GitHub repo about "Next app dir" or/and "Server
-> Components" 😅, making the challenge even more obvious.
+Run it through the CLI, the PostCSS plugin, or a Vite/webpack/Rollup plugin — Panda doesn't depend on any one bundler.
 
-So, the question is, **is CSS-in-JS dead?** The answer is **no, but it needs to evolve!**
+## Where Panda fits
 
-## The new era of CSS-in-JS
+Most people find Panda at one moment: the styling approach that got them started stops scaling. Here's how Panda sits
+next to the tools you're probably weighing.
 
-Panda is a new CSS-in-JS engine that aims to solve the challenges of CSS-in-JS in the server-first era. It provides
-styling primitives to create, organize, and manage CSS styles in a type-safe and readable manner.
+- **Coming from Tailwind.** You've hit class-name soup — long `class="..."` strings your editor can't check, no
+  colocated variants, and a typo that just no-ops. Panda keeps the speed of utilities, but they're typed object keys and
+  token values, and variants live in [recipes](/docs/styling/recipes) instead of strings. See
+  [migrating from Tailwind](/docs/styling/tailwind).
+- **Comparing build-time CSS-in-JS.** StyleX and vanilla-extract are the other typed, zero-runtime options. All three
+  extract to static atomic CSS, so the real difference is scope: Panda ships the design-system layer — recipes, slot
+  recipes, patterns, semantic tokens, presets — as first-class APIs, where StyleX and vanilla-extract leave you to build
+  variants and layout primitives by hand. See [migrating from StyleX](/docs/styling/stylex).
+- **Leaving runtime CSS-in-JS.** emotion and styled-components compute styles in the browser and struggle under Server
+  Components. Panda keeps the familiar authoring model and drops the runtime cost.
 
-- **Static Analysis:** Panda uses static analysis to parse and analyze your styles at build time, and generate CSS files
-  that can be used in any JavaScript framework.
+## A quick taste
 
-- **PostCSS:** After static analysis, Panda uses a set of PostCSS plugins to convert the parsed data to atomic css at
-  build time. **This makes Panda compatible with any framework that supports PostCSS.**
-
-- **Codegen:** Panda generates a lightweight runtime JS code that is used to author styles. **Think of it as an
-  optimized function that joins key-value pairs of an object**. It doesn't generate styles in the browser nor inject
-  styles in the `<head>`.
-
-- **Type-Safety:** Panda combines `csstype` and auto-generated typings to provide type-safety for css properties and
-  design tokens.
-
-- **Performance:** Panda uses a unique approach to generate atomic CSS files that are optimized for performance and
-  readability.
-
-- **Developer Experience:** Panda provides a great developer experience with a rich set of features like recipes,
-  patterns, design tokens, JSX style props, and more.
-
-- **Modern CSS**: Panda uses modern CSS features like cascade layers, css variables, modern selectors like `:where` and
-  `:is` in generated styles.
-
-## When to use Panda?
-
-### Styling engine
-
-If you're building a JavaScript application with a framework that supports PostCSS, Panda is a great choice for you.
-
-```jsx
+```tsx
 import { css } from '../styled-system/css'
 import { circle, stack } from '../styled-system/patterns'
 
-function App() {
+function Profile() {
   return (
-    <div
-      className={stack({
-        direction: 'row',
-        p: '4',
-        rounded: 'md',
-        shadow: 'lg',
-        bg: 'white'
-      })}
-    >
-      <div className={circle({ size: '5rem', overflow: 'hidden' })}>
-        <img src="https://via.placeholder.com/150" alt="avatar" />
+    <div className={stack({ direction: 'row', gap: '4', p: '4', rounded: 'md', bg: 'white' })}>
+      <div className={circle({ size: '12', overflow: 'hidden' })}>
+        <img src="/avatar.png" alt="" />
       </div>
-      <div className={css({ mt: '4', fontSize: 'xl', fontWeight: 'semibold' })}>John Doe</div>
-      <div className={css({ mt: '2', fontSize: 'sm', color: 'gray.600' })}>john@doe.com</div>
+      <div className={css({ fontSize: 'xl', fontWeight: 'semibold', color: 'gray.900' })}>John Doe</div>
     </div>
   )
 }
 ```
 
-> If your framework doesn't support PostCSS, you can use the [Panda CLI](/docs/styling/cli)
+`stack` and `circle` are patterns; `blue.500`, `md`, and `xl` are tokens from your theme. All of it is typed, and all of
+it compiles to atomic CSS with no runtime.
 
-### Token generator
+## When not to use Panda
 
-Panda has first-class support for design tokens. It provides a way to express raw and semantic tokens for your project.
-The generator can be used to create a set of CSS variables for your design tokens.
+Panda earns its place when you have a design system to express — tokens, variants, themes — and a build step to run it.
+It's the wrong fit if:
 
-```ts filename="panda.config.ts"
-export default defineConfig({
-  theme: {
-    tokens: {
-      colors: {
-        gray50: { value: '#F9FAFB' },
-        gray100: { value: '#F3F4F6' }
-      }
-    },
-    semanticTokens: {
-      colors: {
-        primary: { value: '{colors.gray50}' },
-        success: {
-          value: { _light: '{colors.green500}', _dark: '{colors.green200}' }
-        }
-      }
-    }
-  }
-})
-```
+- You're writing plain HTML and CSS with no build step.
+- You're on a template-first server framework (PHP, Rails views) with little JavaScript.
+- You need an absolute zero-tooling setup.
 
-Running the `panda codegen` will generate
+Modern CSS keeps getting better. If you don't need tokens, variants, or type-safety, you may not need a tool at all.
 
-```css filename="styled-system/tokens/index.css"
-:root {
-  --colors-gray50: #f9fafb;
-  --colors-gray100: #f3f4f6;
-  --colors-primary: var(--colors-gray50);
-  --colors-success: var(--colors-green500);
-}
+## Next
 
-[data-theme='dark'] {
-  --colors-primary: var(--colors-gray50);
-  --colors-success: var(--colors-green200);
-}
-```
-
-Then you have a set of css variables that you can use in your project.
-
-```css
-@import '../styled-system/tokens/index.css';
-
-.card {
-  background-color: var(--colors-gray50);
-}
-```
-
-## When not to use Panda?
-
-Panda isn't the right fit for your project if:
-
-- You're building with HTML and CSS.
-- You're using a template-based framework like PHP.
-- You're looking for an absolute zero JS solution.
-
-In these scenarios, we recommend that you use vanilla CSS (which is getting awesome by the day), or other utility based
-CSS libraries.
+- [Get started](/docs/styling/getting-started) — install Panda and generate your first styles.
+- [Thinking in Panda](/docs/styling/thinking-in-panda) — which API to reach for as a component grows.
+- [How Panda works](/docs/styling/how-panda-works) — the build-time model, start to finish.


### PR DESCRIPTION
## 📝 Description

Rewrite the "Why Panda" page for v2. 

## ⛳️ Current behavior (updates)

The page is stale v1. It says Panda runs on "a set of PostCSS plugins" (v2 is a Rust/Oxc engine), leads with "is CSS-in-JS dead?" and frames the whole pitch against emotion and styled-components, and never mentions StyleX, vanilla-extract, or Tailwind — the tools a reader is actually choosing between. Type-safety, the clearest differentiator, is one understated bullet.

## 🚀 New behavior

Leads with what Panda is today — typed, build-time, zero-runtime styling with real tokens and recipes on a fast compiler — then a "Where Panda fits" section that names the alternatives and says plainly where Panda sits:

- **Tailwind** → keeps utility speed, drops class-name soup; utilities are typed, variants live in recipes.
- **StyleX / vanilla-extract** → same zero-runtime atomic CSS; Panda adds the design-system layer (recipes, slot recipes, patterns, semantic tokens, presets) as first-class APIs.
- **emotion / styled-components** → same authoring model, no runtime cost.

Keeps a short code taste and a modernized "when not to use Panda." 

Docs only. The velite content build passes; all internal links resolve to existing pages.

## 💣 Is this a breaking change (Yes/No):

No.
