### PR TITLE
docs(website): fix the shorthand vs longhand precedence line for v2

### DIFF
--- a/website/content/docs/styling/writing-styles.mdx
+++ b/website/content/docs/styling/writing-styles.mdx
@@ -580,15 +580,16 @@ const styles: SystemStyleObject = {
 
 ## Property conflicts
 
-When you combine shorthand and longhand properties, Panda will resolve the styles in a predictable way. The shorthand
-property will take precedence over the longhand property.
+When you combine shorthand and longhand properties, Panda resolves them predictably: the longhand wins, whatever order
+you write them in. Panda sorts atomic rules by how broad each property is, so the narrower longhand emits last and
+overrides the shorthand.
 
 ```jsx
 import { css } from '../styled-system/css'
 
 const styles = css({
-  paddingTop: '20px'
-  padding: "10px",
+  paddingTop: '20px',
+  padding: '10px'
 })
 ```
 
@@ -605,6 +606,8 @@ The styles generated at build time will look like this:
   }
 }
 ```
+
+`.pt_20px` emits after `.p_10px`, so the element gets `10px` padding on three sides and `20px` on top.
 
 ## Global vars
 


### PR DESCRIPTION
## 📝 Description

Corrects the shorthand vs longhand precedence line on the Writing Styles page for v2.

## ⛳️ Current behavior (updates)

`writing-styles.mdx` told readers the shorthand property takes precedence over the longhand. In v2 it's the opposite — the longhand wins, whatever order you write them in. The page even contradicted its own example, which shows `padding-top` emitting after `padding`. The example was also missing a comma.

## 🚀 New behavior

Panda sorts atomic rules by how broad each property is, so the narrower longhand lands last and overrides the shorthand — the same rule the v2 border-override behavior follows. This corrects the sentence, fixes the missing comma in the example, and spells out the result so the reader can see why.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Confirmed against the engine: `crates/pandacss_stylesheet/src/sort.rs` ("Longhands rank highest so they override the shorthands"). Docs only, so no changeset.
