### PR TITLE
fix(compiler): config recipes crash with template-literal syntax

### DIFF
--- a/.changeset/template-literal-recipe-conditions.md
+++ b/.changeset/template-literal-recipe-conditions.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix config recipes throwing at import time with `syntax: 'template-literal'`. The recipe runtime imported `breakpointKeys` from the conditions file, which the template-literal build didn't export, so any `defineRecipe` failed to load.

--- a/crates/pandacss_codegen/src/artifacts/conditions/conditions_literal.rs
+++ b/crates/pandacss_codegen/src/artifacts/conditions/conditions_literal.rs
@@ -2,11 +2,16 @@ use crate::{CodegenContext, ImportDecl, Item, ItemNode, Module, RuntimeImport};
 
 #[must_use]
 pub fn module(ctx: CodegenContext<'_>) -> Module {
+    let breakpoint_keys = serde_json::to_string(&ctx.config.theme.breakpoint_names())
+        .expect("breakpoints should serialize");
     Module::new()
         .with_import(ImportDecl::value(
             ["withoutSpace"],
             &ctx.runtime_import(RuntimeImport::Helpers, "../helpers"),
         ))
+        .with_item(Item::runtime(ItemNode::RawStmt(format!(
+            "export const breakpointKeys = {breakpoint_keys}"
+        ))))
         .with_item(Item::runtime(ItemNode::RawStmt(
             CONDITIONS_LITERAL_RUNTIME.into(),
         )))

--- a/crates/pandacss_codegen/tests/conditions_artifact.rs
+++ b/crates/pandacss_codegen/tests/conditions_artifact.rs
@@ -208,8 +208,10 @@ fn template_literal_syntax_emits_selector_only_conditions() {
     assert_eq!(paths(conditions), vec!["css/conditions.mjs"]);
     assert_eq!(
         file(conditions, "css/conditions.mjs"),
-        indoc! {r"
+        indoc! {r#"
         import { withoutSpace } from '../helpers.mjs';
+
+        export const breakpointKeys = ["base"]
 
         export const isCondition = (val) => condRegex.test(val)
 
@@ -229,7 +231,7 @@ fn template_literal_syntax_emits_selector_only_conditions() {
             return 0
           })
         }
-        "}
+        "#}
         .trim()
     );
 }


### PR DESCRIPTION
## What

Config recipes crash at import time when a project uses `syntax: 'template-literal'`.

Any `defineRecipe` produces a `recipes` runtime that imports `breakpointKeys` from the generated conditions file, but the template-literal build of that file never exported `breakpointKeys`. So the module fails to evaluate:

```
The requested module '../css/conditions.js' does not provide an export named 'breakpointKeys'
```

The import throws before any component runs, so any page touching a recipe goes down with it. And since `cva` isn't emitted in template-literal mode, config recipes are the only recipe path there — this breaks recipes entirely for those projects.

## Fix

Export `breakpointKeys` from the template-literal conditions module too, from the same `theme.breakpoint_names()` source the default build already uses. The recipe runtime's import now resolves in both modes.

## Before / after

```jsx
// panda.config: syntax: 'template-literal', recipes: { button }
import { button } from './styled-system/recipes'

// before → throws on import, page fails to load
// after  → button({ visual: 'yellow' }) === "button button--visual_yellow"
```

## Testing

- Reproduced against a template-literal sandbox, then confirmed the recipe loads and returns the expected non-atomic classes.
- Updated the template-literal conditions test to assert the export (regression guard).
- `cargo fmt --check` and `cargo clippy -D warnings` clean; all 140 `pandacss_codegen` tests pass.
