### PR TITLE
test: refresh stale buildinfo config-fingerprint snapshots

### DIFF
--- a/crates/pandacss_project/tests/build_info.rs
+++ b/crates/pandacss_project/tests/build_info.rs
@@ -33,7 +33,7 @@ fn build_info_emits_interned_atoms_with_per_module_provenance() {
     assert_yaml_snapshot!(info, @"
     schemaVersion: 5
     panda: ^2.0.0
-    configFingerprint: cfg1-49bac1e44a87696f
+    configFingerprint: cfg1-e34170613f41c279
     strings:
       - color
       - red

--- a/packages/cli/__tests__/buildinfo.test.ts
+++ b/packages/cli/__tests__/buildinfo.test.ts
@@ -51,7 +51,7 @@ describe('buildinfo command', () => {
             "v": 3,
           },
         ],
-        "configFingerprint": "cfg1-49bac1e44a87696f",
+        "configFingerprint": "cfg1-e34170613f41c279",
         "modules": {
           "button.tsx": {
             "atoms": [

--- a/packages/compiler/__tests__/build-info.test.ts
+++ b/packages/compiler/__tests__/build-info.test.ts
@@ -32,7 +32,7 @@ describe('compiler.buildInfo', () => {
       {
         "schemaVersion": 5,
         "panda": "^2.0.0",
-        "configFingerprint": "cfg1-da670b3d66a0f3ee",
+        "configFingerprint": "cfg1-7983b0e78dea7740",
         "strings": [
           "color",
           "red",


### PR DESCRIPTION
## 📝 Description

Refresh three stale `configFingerprint` snapshots so v2 CI goes green again.

## ⛳️ Current behavior (updates)

`view_transitions` was added to the `Theme` struct in `e18eeb3a5`, which changed the serialized config, so `configFingerprint` shifted from `cfg1-49bac1e44a87696f` to `cfg1-e34170613f41c279`. The buildinfo snapshots weren't updated, so these fail on `v2` today — before any PR:

- `crates/pandacss_project/tests/build_info.rs` (Rust `Test` jobs)
- `packages/cli/__tests__/buildinfo.test.ts` (Unit Tests)
- `packages/compiler/__tests__/build-info.test.ts` (Compiler Tests)

Every open v2 PR inherits this red.

## 🚀 New behavior

Snapshots regenerated against a fresh native binding. Only the fingerprint line changed in each; atoms, strings, and module maps are untouched. The fingerprint is a cache key, not CSS output.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

- `cargo nextest run -p pandacss_project build_info…` — pass
- `vitest run buildinfo` (cli) — 8/8 pass
- `vitest run build-info` (compiler) — 22/22 pass
