### PR TITLE
fix(cli): stop cwd default from padding help output

### DIFF
--- a/.changeset/cli-help-cwd-default.md
+++ b/.changeset/cli-help-cwd-default.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/cli': patch
+---
+
+Keep `panda --help` readable. The `--cwd` flag no longer prints your resolved working directory as its default, which
+was padding every other option off the right edge of the terminal.

--- a/packages/cli/__tests__/cli-smoke.test.ts
+++ b/packages/cli/__tests__/cli-smoke.test.ts
@@ -44,7 +44,7 @@ describe('cli smoke', () => {
 
       OPTIONS
 
-      \`--cwd="<cwd>"\` Current working directory
+      \`--cwd\` Current working directory
       \`-c, --config\` Path to panda config file
       \`--include=<glob>\` Source file globs to scan, replacing the config include list
       \`-w, --watch\` Watch files and rebuild

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -3,7 +3,7 @@ import type { FlagsInfer, FlagsSchema, Issue, ParseResult, Shape } from './flags
 
 export function baseArgs(): ArgsDef {
   return {
-    cwd: { type: 'string', description: 'Current working directory', default: process.cwd() },
+    cwd: { type: 'string', description: 'Current working directory' },
     config: { type: 'string', description: 'Path to panda config file', alias: 'c' },
   }
 }


### PR DESCRIPTION
## 📝 Description

`panda --help` indents every option by the length of your working directory.

## ⛳️ Current behavior (updates)

`--cwd` declares `process.cwd()` as its default. citty prints the default next to the flag and pads the description
column to the longest entry, so the resolved path sets the width for the whole list. In a deep directory the
descriptions land far off the right edge:

```
OPTIONS

  `--cwd="/Users/you/work/monorepo/apps/web/packages/design-system"`    Current working directory
                                                       `-c, --config`    Path to panda config file
                                                   `--include=<glob>`    Source file globs to scan
```

The help snapshot test already worked around it by collapsing the padding, with a comment calling it
"machine-dependent: keys on cwd length".

## 🚀 New behavior

The flag drops its default, so help lines up again:

```
OPTIONS

                `--cwd`    Current working directory
         `-c, --config`    Path to panda config file
     `--include=<glob>`    Source file globs to scan
```

`--cwd` behaves the same. `resolveCwd()` already fell back to `process.cwd()` when the flag is missing.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Help text only — no change to what any command does.

Test plan:

- [x] `pnpm test packages/cli`
- [x] `panda cssgen --help` from a deep directory, with and without `--cwd`
