### PR TITLE
fix(cli): reject non-numeric values for numeric flags

### DIFF
--- a/.changeset/cli-numeric-flags.md
+++ b/.changeset/cli-numeric-flags.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/cli': patch
+---
+
+Fail on non-numeric values for `--max-warnings`, `--watch-debounce`, `--limit`, and `--ui-port`. A typo like
+`--max-warnings=abc` used to be ignored, which silently turned the warning gate off in CI.

--- a/packages/cli/__tests__/cli-smoke.test.ts
+++ b/packages/cli/__tests__/cli-smoke.test.ts
@@ -126,6 +126,17 @@ describe('cli smoke', () => {
     `)
   })
 
+  it('rejects non-numeric values for numeric flags', () => {
+    const result = runCli(['doctor', '--max-warnings', 'abc'])
+
+    expect(result).toMatchObject({ exitCode: 1, stdout: '' })
+    expect(result.stderr).toMatchInlineSnapshot(`
+      "[error] Invalid command options
+      - --max-warnings: expected a number (received "abc")
+      "
+    `)
+  })
+
   it('returns interactive usage errors as JSON', () => {
     const results = [
       ['--json', ['--json']],

--- a/packages/cli/src/flags-schema.ts
+++ b/packages/cli/src/flags-schema.ts
@@ -86,10 +86,10 @@ function parseField(field: Field, value: unknown): { ok: true; value: unknown } 
       return typeof value === 'string'
         ? { ok: true, value }
         : { ok: false, message: `expected string, received ${typeLabel(value)}` }
-    case 'stringOrNumber':
-      return typeof value === 'string' || typeof value === 'number'
-        ? { ok: true, value }
-        : { ok: false, message: `expected string or number, received ${typeLabel(value)}` }
+    case 'stringOrNumber': {
+      const numeric = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+      return Number.isFinite(numeric) ? { ok: true, value } : { ok: false, message: 'expected a number' }
+    }
     case 'stringOrArray':
       return typeof value === 'string' || (Array.isArray(value) && value.every((entry) => typeof entry === 'string'))
         ? { ok: true, value }


### PR DESCRIPTION
## 📝 Description

A typo in `--max-warnings` silently turns the warning gate off instead of failing.

## ⛳️ Current behavior (updates)

`--max-warnings`, `--watch-debounce`, `--limit`, and `--ui-port` accept any string. The value is parsed later with
`Number()`, and a `NaN` is treated as "not set":

```sh
panda cssgen --max-warnings=abc   # exit 0, warnings ignored
```

A CI job that meant `--max-warnings=0` keeps passing on warnings.

## 🚀 New behavior

Non-numeric values are a usage error:

```sh
panda cssgen --max-warnings=abc
# [error] Invalid command options
# - --max-warnings: expected a number (received "abc")
# exit 1
```

Numbers and numeric strings still pass, so `--max-warnings=0` and `--watch-debounce=250` are unchanged.

## 💣 Is this a breaking change (Yes/No):

No, unless you were passing a value that never worked.

## 📝 Additional Information

The check lives in the shared `stringOrNumber` flag kind, so all four numeric flags get it.

Test plan:

- [x] `pnpm test packages/cli` (adds a case for the rejection)
