### PR TITLE
fix(config): surface config load errors against the real file path

### DIFF
--- a/.changeset/config-load-error-message.md
+++ b/.changeset/config-load-error-message.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/config': patch
+---
+
+Report config load failures against the config file instead of a base64 `data:` URL. A missing dependency now reads
+`Cannot find package 'x' imported from …`, and your config is no longer evaluated twice on failure.

--- a/packages/cli/__tests__/cli-smoke.test.ts
+++ b/packages/cli/__tests__/cli-smoke.test.ts
@@ -137,6 +137,17 @@ describe('cli smoke', () => {
     `)
   })
 
+  it('names the config file when a config dependency is missing', () => {
+    dir = createFixture("import 'some-missing-pkg'\nexport default {}\n")
+
+    const result = runCli(['codegen', '--cwd', dir])
+
+    expect(result.exitCode).toBe(1)
+    const output = result.stdout + result.stderr
+    expect(output).toContain("Cannot find package 'some-missing-pkg'")
+    expect(output).not.toContain('data:text/javascript')
+  })
+
   it('returns interactive usage errors as JSON', () => {
     const results = [
       ['--json', ['--json']],

--- a/packages/config/src/bundle.ts
+++ b/packages/config/src/bundle.ts
@@ -3,7 +3,7 @@ import { existsSync, realpathSync } from 'node:fs'
 import { mkdir, unlink, writeFile } from 'node:fs/promises'
 import { builtinModules } from 'node:module'
 import { tmpdir } from 'node:os'
-import { dirname, isAbsolute, join, normalize, relative } from 'node:path'
+import { basename, dirname, isAbsolute, join, normalize, relative } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { RolldownOutput } from 'rolldown'
 import { importMetaUrlPlugin } from './bundle-plugins'
@@ -61,6 +61,8 @@ export async function bundleConfig<T extends Config = Config>(
 async function loadBundledModule(filepath: string, code: string): Promise<Record<string, unknown>> {
   const target = tempTargetFor(filepath)
 
+  let evalError: unknown
+
   if (target) {
     try {
       await mkdir(dirname(target), { recursive: true })
@@ -70,13 +72,24 @@ async function loadBundledModule(filepath: string, code: string): Promise<Record
       } finally {
         void unlink(target).catch(() => undefined)
       }
-    } catch {
-      // fall through to the data: URL loader
+    } catch (error) {
+      // Keep config evaluation errors: they name real paths, unlike the data: URL retry.
+      if (!isUnresolvedTempModule(error, target)) evalError = error
     }
   }
 
   const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
-  return (await import(/* @vite-ignore */ dataUrl)) as Record<string, unknown>
+
+  try {
+    return (await import(/* @vite-ignore */ dataUrl)) as Record<string, unknown>
+  } catch (error) {
+    throw evalError ?? error
+  }
+}
+
+function isUnresolvedTempModule(error: unknown, target: string): boolean {
+  const message = error instanceof Error ? error.message : ''
+  return message.includes('Cannot find module') && message.includes(basename(target))
 }
 
 function tempTargetFor(filepath: string): string | undefined {


### PR DESCRIPTION
## 📝 Description

When your config imports something that isn't installed, Panda prints a base64 blob instead of the missing package.

## ⛳️ Current behavior (updates)

```
error config_load_error Failed to resolve module specifier "@pandacss/dev" from
"data:text/javascript;base64,aW1wb3J0ICJub2RlOm1vZHVsZSI7CmltcG9ydCB7IGRlZmluZUNvbmZpZyB9IGZyb20gIkBwYW5kYWNzcy9kZXYiOwo…":
Invalid relative URL or base scheme is not hierarchical.
  help: Check that the config path exists and can be bundled.
```

Panda bundles your config, writes it to a temp file, and imports that. The `try/catch` around the write was also
catching failures from the import, so any config that throws fell through to a `data:` URL retry. That retry re-runs
the config and reports the failure against the URL, which is where the base64 comes from.

## 🚀 New behavior

```
error config_load_error Cannot find package '@pandacss/dev' imported from
/path/to/project/node_modules/.panda/panda.config.bundled.mtcsqvd2-62ci710ad2.mjs
  help: Check that the config path exists and can be bundled.
```

A config that throws now reports its own error (`boom from config`), and it runs once instead of twice.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

The `data:` URL fallback stays. It's what makes config loading work under vite-node, where importing a file outside the
project root fails. The change is to keep the first error unless it's that fallback case, which is matched by the temp
file's own name.

Test plan:

- [x] `pnpm test packages/config`
- [x] `pnpm test packages/cli` (adds a case that runs the real binary against a config with a missing import)
