### PR TITLE
fix(compiler): keep '!' inside string values out of !important

### DIFF
--- a/.changeset/important-inside-string-values.md
+++ b/.changeset/important-inside-string-values.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+---
+
+Keep `!` inside string values. `css({ content: '"hello!"' })` emitted `content: "hello" !important`; only a trailing
+`!` or `!important` marks a declaration important now.

--- a/crates/pandacss_codegen/src/artifacts/helpers/misc.rs
+++ b/crates/pandacss_codegen/src/artifacts/helpers/misc.rs
@@ -350,7 +350,7 @@ pub(super) fn is_important() -> Item {
         "isImportant",
         vec![Param::typed("value", TsType::Ref("unknown".into()))],
         TsType::Bool,
-        r#"return typeof value === "string" ? /\s*!(important)?/i.test(value) : false"#,
+        r#"return typeof value === "string" ? /\s*!(important)?\s*$/i.test(value) : false"#,
         [],
     )
 }
@@ -361,7 +361,7 @@ pub(super) fn without_important() -> Item {
         vec![Param::typed("value", TsType::Ref("T".into()))],
         TsType::Ref("T".into()),
         indoc! {r#"
-            return (typeof value === "string" ? value.replace(/\s*!(important)?/i, "").trim() : value) as T
+            return (typeof value === "string" ? value.replace(/\s*!(important)?\s*$/i, "").trim() : value) as T
         "#}
         .trim(),
         ["T extends string | number | boolean"],

--- a/crates/pandacss_shared/src/important.rs
+++ b/crates/pandacss_shared/src/important.rs
@@ -25,9 +25,11 @@ pub fn split_important(value: &str) -> (Cow<'_, str>, bool) {
 
 /// Byte range to strip for `!important`: the `!` plus leading whitespace
 /// through the keyword. A bare `!` with no keyword still counts (JS parity).
+/// The marker must close the value, so a `!` inside a string (`content: '"hi!"'`)
+/// is left alone.
 fn important_marker(value: &str) -> Option<(usize, usize)> {
     let bytes = value.as_bytes();
-    let bang = bytes.iter().position(|byte| *byte == b'!')?;
+    let bang = bytes.iter().rposition(|byte| *byte == b'!')?;
 
     let mut start = bang;
     while start > 0 && bytes[start - 1].is_ascii_whitespace() {
@@ -37,12 +39,14 @@ fn important_marker(value: &str) -> Option<(usize, usize)> {
     let after_bang = bang + 1;
     let important = "important";
 
-    if value
+    let end = if value
         .get(after_bang..after_bang + important.len())
         .is_some_and(|candidate| candidate.eq_ignore_ascii_case(important))
     {
-        Some((start, after_bang + important.len()))
+        after_bang + important.len()
     } else {
-        Some((start, after_bang))
-    }
+        after_bang
+    };
+
+    value[end..].trim().is_empty().then_some((start, end))
 }

--- a/crates/pandacss_shared/tests/important.rs
+++ b/crates/pandacss_shared/tests/important.rs
@@ -23,3 +23,19 @@ fn returns_borrowed_when_marker_is_absent() {
     assert!(!is_important(value));
     assert!(matches!(without_important(value), Cow::Borrowed("red")));
 }
+
+#[test]
+fn ignores_a_bang_inside_the_value() {
+    let value = r#""hello!""#;
+    assert!(!is_important(value));
+    assert!(matches!(
+        without_important(value),
+        Cow::Borrowed(r#""hello!""#)
+    ));
+
+    assert!(is_important(r#""hello!" !important"#));
+    assert_eq!(
+        without_important(r#""hello!" !important"#).as_ref(),
+        r#""hello!""#
+    );
+}


### PR DESCRIPTION
## 📝 Description

A `!` inside a string value is read as `!important`.

## ⛳️ Current behavior (updates)

```ts
css({ content: '"hello!"' })
```

```css
.content_\"hello\"\! {
  content: "hello" !important;
}
```

The `!` is stripped from the value and the declaration is marked important. Both the Rust side and the generated
`isImportant` helper match the first `!` anywhere in the value, so any string with an exclamation mark is affected —
`content: '"Wow! Yes"'`, a font family, an `attr()` fallback.

## 🚀 New behavior

```css
.content_\"hello\!\" {
  content: "hello!";
}
```

The marker has to close the value. `bgColor: 'red.500!'` and `color: '#fff !important'` are unchanged.

## 💣 Is this a breaking change (Yes/No):

No. Values that were marked important still are.

## 📝 Additional Information

Both sides move together so runtime class names keep matching the emitted CSS: `pandacss_shared::important` and the
`isImportant` / `withoutImportant` helpers in generated code.

Test plan:

- [x] `pnpm rust:test` (2387 tests, no snapshot changes)
- [x] `pnpm test:compiler`
- [x] `pnpm --filter sandbox-codegen codegen && pnpm test sandbox/codegen`
- [x] checked the emitted class and the runtime `css()` output match for `content: '"hello!"'`
