### PR TITLE
feat(config): suggest the qualified path for a bare token reference

### DIFF
--- a/.changeset/token-ref-suggestion.md
+++ b/.changeset/token-ref-suggestion.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+---
+
+Name the fix when a token reference is missing its category. `{black/64}` now warns with
+`Did you mean {colors.black}?` instead of only reporting that `black` is missing.

--- a/crates/pandacss_config/src/validate.rs
+++ b/crates/pandacss_config/src/validate.rs
@@ -528,10 +528,22 @@ fn validate_token_references(tokens: &TokenData, diagnostics: &mut Vec<Diagnosti
 
             let Some(value) = tokens.value_at_path.get(&current_path) else {
                 let config_key = tokens.type_by_path.get(path).copied().unwrap_or("tokens");
-                diagnostics.push(warn(
+                let mut diagnostic = warn(
                     diagnostic_codes::CONFIG_TOKEN_MISSING_REFERENCE,
                     format!("Missing token: `{current_path}` used in `theme.{config_key}.{path}`"),
-                ));
+                );
+                let candidates = qualified_candidates(tokens, &current_path);
+                if !candidates.is_empty() {
+                    let suggestion = candidates
+                        .iter()
+                        .map(|candidate| format!("`{{{candidate}}}`"))
+                        .collect::<Vec<_>>()
+                        .join(" or ");
+                    diagnostic = diagnostic.with_help(format!(
+                        "Did you mean {suggestion}? A reference is a full path from the token root, so it needs its category."
+                    ));
+                }
+                diagnostics.push(diagnostic);
                 continue;
             };
 
@@ -563,6 +575,26 @@ fn validate_token_references(tokens: &TokenData, diagnostics: &mut Vec<Diagnosti
             }
         }
     }
+}
+
+/// Category-qualified paths for a bare reference like `{black}`. More than
+/// [`MAX_SUGGESTIONS`] candidates is too vague to be worth naming.
+fn qualified_candidates(tokens: &TokenData, path: &str) -> Vec<String> {
+    const MAX_SUGGESTIONS: usize = 2;
+
+    let suffix = format!(".{path}");
+    let candidates: Vec<String> = tokens
+        .value_at_path
+        .keys()
+        .filter(|candidate| candidate.ends_with(&suffix))
+        .cloned()
+        .collect();
+
+    if candidates.len() > MAX_SUGGESTIONS {
+        return Vec::new();
+    }
+
+    candidates
 }
 
 /// Path to every token leaf (a `value` key, or a non-object). Reuses one `path` buffer.

--- a/crates/pandacss_config/tests/validation.rs
+++ b/crates/pandacss_config/tests/validation.rs
@@ -236,3 +236,114 @@ fn reports_invalid_container_configuration() {
       severity: warning
     "#);
 }
+
+#[test]
+fn suggests_the_qualified_path_for_a_bare_reference() {
+    let diagnostics = validate_config_value(&json!({
+        "validation": "warn",
+        "theme": {
+            "tokens": {
+                "colors": { "black": { "value": "#09090B" } }
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "xl": { "value": "0px 16px 24px {black/64}" }
+                }
+            }
+        }
+    }));
+
+    let missing: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "config_token_missing_reference")
+        .map(|diagnostic| (diagnostic.message.clone(), diagnostic.help.clone()))
+        .collect();
+
+    assert_yaml_snapshot!(missing, @r#"
+    - - "Missing token: `black` used in `theme.semanticTokens.shadows.xl`"
+      - - "Did you mean `{colors.black}`? A reference is a full path from the token root, so it needs its category."
+    "#);
+}
+
+#[test]
+fn lists_both_categories_when_a_bare_name_is_defined_twice() {
+    let diagnostics = validate_config_value(&json!({
+        "validation": "warn",
+        "theme": {
+            "tokens": {
+                "colors": { "black": { "value": "#09090B" } },
+                "fontWeights": { "black": { "value": 900 } }
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "xl": { "value": "0px 16px 24px {black/64}" }
+                }
+            }
+        }
+    }));
+
+    let help: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "config_token_missing_reference")
+        .map(|diagnostic| diagnostic.help.clone())
+        .collect();
+
+    assert_yaml_snapshot!(help, @r#"
+    - - "Did you mean `{colors.black}` or `{fontWeights.black}`? A reference is a full path from the token root, so it needs its category."
+    "#);
+}
+
+#[test]
+fn lists_both_candidates_for_a_name_defined_in_two_categories() {
+    let diagnostics = validate_config_value(&json!({
+        "validation": "warn",
+        "theme": {
+            "tokens": {
+                "colors": { "muted": { "value": "#888" } },
+                "shadows": { "muted": { "value": "0 0 0 1px #888" } }
+            },
+            "semanticTokens": {
+                "borders": {
+                    "subtle": { "value": "1px solid {muted}" }
+                }
+            }
+        }
+    }));
+
+    let help: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "config_token_missing_reference")
+        .map(|diagnostic| diagnostic.help.clone())
+        .collect();
+
+    assert_yaml_snapshot!(help, @r#"
+    - - "Did you mean `{colors.muted}` or `{shadows.muted}`? A reference is a full path from the token root, so it needs its category."
+    "#);
+}
+
+#[test]
+fn skips_the_suggestion_when_too_many_categories_match() {
+    let diagnostics = validate_config_value(&json!({
+        "validation": "warn",
+        "theme": {
+            "tokens": {
+                "colors": { "muted": { "value": "#888" } },
+                "shadows": { "muted": { "value": "0 0 0 1px #888" } },
+                "borders": { "muted": { "value": "1px solid #888" } }
+            },
+            "semanticTokens": {
+                "borders": {
+                    "subtle": { "value": "1px solid {muted}" }
+                }
+            }
+        }
+    }));
+
+    let help: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "config_token_missing_reference")
+        .map(|diagnostic| diagnostic.help.clone())
+        .collect();
+
+    assert_eq!(help, vec![None]);
+}


### PR DESCRIPTION
## 📝 Description

When a token reference is missing its category, Panda says what's missing but not what to write instead.

## ⛳️ Current behavior (updates)

```
warning config_token_missing_reference Missing token: `black` used in `theme.semanticTokens.shadows.xl`
```

References resolve by full path from the token root, so a bare `{black}` never resolves — not across categories, not
even inside its own. The value falls through as literal text. `{black/64}` becomes the CSS named color `black`, which
renders, so the page looks fine and the token is quietly ignored.

This comes up when porting a theme written for another system. Chakra's default theme has 8 of these.

## 🚀 New behavior

```
warning config_token_missing_reference Missing token: `black` used in `theme.semanticTokens.shadows.xl`
  help: Did you mean `{colors.black}` or `{fontWeights.black}`? A reference is a full path from the token root, so it
  needs its category.
```

Panda already knows which categories define that name. It lists them, up to two. More than that is too vague to be
worth guessing, so it stays quiet.

## 💣 Is this a breaking change (Yes/No):

No. Same code, same message, same severity — an added `help` line.

## 📝 Additional Information

This is the first Rust-side diagnostic to carry `help`. The field was already plumbed through the NAPI boundary and
the CLI renderer; nothing needed wiring.

Test plan:

- [x] `cargo nextest run -p pandacss_config` (adds three cases: one match, two matches, too many)
- [x] `pnpm rust:test` (2391 tests)
- [x] `pnpm test:compiler`
- [x] ran it against the real config with presets loaded, where `black` matches both `colors` and `fontWeights`
