### PR TITLE
fix(config): do not validate literal colors as token references

### DIFF
--- a/.changeset/literal-color-ref.md
+++ b/.changeset/literal-color-ref.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+---
+
+Stop reporting a literal color inside a token reference as a missing token. `{#000/64}` and `{rgb(0 0 0)/64}` already
+resolve to a `color-mix()`; only real token paths are validated now.

--- a/crates/pandacss_config/src/validate.rs
+++ b/crates/pandacss_config/src/validate.rs
@@ -697,6 +697,12 @@ fn is_token_reference(value: &str) -> bool {
     value.contains('{') && value.contains('}')
 }
 
+/// `{#000/64}` and `{rgb(0 0 0)/64}` are literal colors the resolver mixes as-is,
+/// not token paths — reporting them as missing tokens is a false positive.
+fn is_literal_value(reference: &str) -> bool {
+    reference.starts_with('#') || reference.contains('(')
+}
+
 /// Every `{token.path}` reference in a serialized value, `/opacity` suffix stripped.
 fn references(value: &str) -> BTreeSet<String> {
     let mut refs = BTreeSet::new();
@@ -707,7 +713,7 @@ fn references(value: &str) -> BTreeSet<String> {
             break;
         };
         let reference = after_start[..end].trim();
-        if !reference.is_empty() {
+        if !reference.is_empty() && !is_literal_value(reference) {
             refs.insert(
                 reference
                     .split_once('/')

--- a/crates/pandacss_config/tests/validation.rs
+++ b/crates/pandacss_config/tests/validation.rs
@@ -236,3 +236,32 @@ fn reports_invalid_container_configuration() {
       severity: warning
     "#);
 }
+
+#[test]
+fn does_not_report_a_literal_color_with_an_alpha_modifier() {
+    let diagnostics = validate_config_value(&json!({
+        "validation": "warn",
+        "theme": {
+            "tokens": {
+                "colors": { "black": { "value": "#09090B" } }
+            },
+            "semanticTokens": {
+                "shadows": {
+                    "hex": { "value": "0 0 0 1px {#000/64}" },
+                    "functional": { "value": "0 0 0 1px {rgb(0 0 0)/64}" },
+                    "named": { "value": "0 0 0 1px {black/64}" }
+                }
+            }
+        }
+    }));
+
+    let missing: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "config_token_missing_reference")
+        .map(|diagnostic| diagnostic.message.clone())
+        .collect();
+
+    assert_yaml_snapshot!(missing, @r#"
+    - "Missing token: `black` used in `theme.semanticTokens.shadows.named`"
+    "#);
+}


### PR DESCRIPTION
## 📝 Description

A literal color inside a token reference is reported as a missing token, even though it resolves fine.

## ⛳️ Current behavior (updates)

```ts
semanticTokens: {
  shadows: { xl: { value: '0px 16px 24px {#000/64}' } }
}
```

```
warning config_token_missing_reference Missing token: `#000` used in `theme.semanticTokens.shadows.xl`
```

The CSS is correct — `color-mix(in oklab, #000 64%, transparent)`. Validation collects everything inside `{}` as a
token path, so a literal color gets looked up and reported when it isn't found.

You hit this writing an alpha modifier against a raw color instead of a token, which is the right thing to write when
you want that exact color rather than whatever the token holds.

## 🚀 New behavior

No diagnostic. `{#000/64}` and `{rgb(0 0 0)/64}` are treated as values, not paths.

A bare name still warns — `{black/64}` is indistinguishable from a typo'd token, and it is usually a real mistake:

```
warning config_token_missing_reference Missing token: `black` used in `theme.semanticTokens.shadows.xl`
```

## 💣 Is this a breaking change (Yes/No):

No. CSS output is unchanged; this only removes a false diagnostic.

## 📝 Additional Information

The check is deliberately narrow — a `#` prefix or a `(` in the reference. Anything that could plausibly be a token
name keeps its validation.

Test plan:

- [x] `cargo nextest run -p pandacss_config` (adds hex, functional, and bare-name cases)
- [x] `pnpm rust:test` (2388 tests)
- [x] rebuilt the binding and confirmed the emitted `color-mix()` is byte-identical, warning gone
