### PR TITLE
fix(compiler): allow utility values callbacks to return nothing

### DIFF
--- a/.changeset/quiet-utility-values-callbacks.md
+++ b/.changeset/quiet-utility-values-callbacks.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+---
+
+Fix a config load error when a `utility.values` callback returns nothing. Listing `@pandacss/preset-base` on its own
+failed with `Utility values callback ... returned invalid values`, because `translateZ` reads the spacing scale and
+preset-base ships no tokens. The utility now simply has no preset values, and arbitrary values still work.

--- a/packages/compiler-wasm/crate/src/project/transforms.rs
+++ b/packages/compiler-wasm/crate/src/project/transforms.rs
@@ -95,6 +95,10 @@ pub(super) fn resolve_utility_values_callbacks(
                 "Utility values callback `{id}` for `{prop}` threw: {err:?}"
             ))
         })?;
+        if result.is_null() || result.is_undefined() {
+            utility.values = None;
+            continue;
+        }
         utility.values = Some(serde_wasm_bindgen::from_value(result).map_err(|err| {
             JsValue::from_str(&format!(
                 "Utility values callback `{id}` for `{prop}` returned invalid values: {err}"

--- a/packages/compiler/__tests__/callbacks.test.ts
+++ b/packages/compiler/__tests__/callbacks.test.ts
@@ -504,6 +504,42 @@ describe('Compiler callbacks', () => {
     expect(types).not.toContain('export type SpaceValue = "-4"')
   })
 
+  it('keeps the utility usable when the values callback returns nothing', () => {
+    const compiler = createCompilerFromSnapshot(
+      {
+        config: {
+          cwd: '/virtual',
+          outdir: 'styled-system',
+          importMap,
+          jsxFramework: 'react',
+          utilities: {
+            space: {
+              property: 'margin',
+              values: {
+                kind: 'js-callback',
+                id: 'utilities.space.values',
+              },
+            },
+          },
+        },
+        callbacks: {
+          'utility.values': {
+            'utilities.space.values': (theme) => theme('spacing'),
+          },
+        },
+      },
+      { crossFile: false },
+    )
+
+    compiler.parseFileSource(
+      '/virtual/Button.tsx',
+      `import { css } from '@panda/css'
+       css({ space: '4px' })`,
+    )
+
+    expect(compiler.getLayerCss({ layers: ['utilities'] }).css).toContain('margin: 4px')
+  })
+
   it('resolves utility values functions from a config snapshot', () => {
     const compiler = createCompilerFromSnapshot(
       {

--- a/packages/compiler/crate/src/project/transforms.rs
+++ b/packages/compiler/crate/src/project/transforms.rs
@@ -120,6 +120,10 @@ pub(super) fn resolve_utility_values_callbacks(
                     err.reason
                 ))
             })?;
+        if result.is_null() {
+            utility.values = None;
+            continue;
+        }
         utility.values = Some(serde_json::from_value(result).map_err(|err| {
             napi::Error::from_reason(format!(
                 "Utility values callback `{id}` for `{prop}` returned invalid values: {err}"

--- a/website/app/blog/page.tsx
+++ b/website/app/blog/page.tsx
@@ -33,7 +33,8 @@ function formatDate(isoDate: string) {
   })
 }
 
-function formatAuthors(author: string | string[]) {
+function formatAuthors(author: string | string[] | undefined) {
+  if (!author) return ''
   const list = Array.isArray(author) ? author : [author]
   if (list.length <= 1) return list.join('')
   return `${list.slice(0, -1).join(', ')} & ${list[list.length - 1]}`


### PR DESCRIPTION
Reported in #3599.

## 📝 Description

Listing `@pandacss/preset-base` on its own failed to load the config. A `utility.values` callback that returns nothing
is now treated as "no preset values" instead of an error.

## ⛳️ Current behavior (updates)

This config errors:

```ts
export default defineConfig({
  presets: ['@pandacss/preset-base'],
  include: ['./src/**/*.tsx'],
  outdir: 'styled-system',
})
```

```
error config_load_error Utility values callback `utilities.translateZ.values` for `translateZ`
returned invalid values: data did not match any variant of untagged enum UtilityValues
  help: Check that the config path exists and can be bundled.
```

`translateZ` reads the spacing scale, and preset-base ships utilities but no tokens. The callback returns nothing,
deserializing that as utility values fails, and config loading gives up. The help text then sends you to a config file
that was fine.

Leaving `presets` off works, and so does `presets: []`. It only bites if you name `preset-base` and nothing else.

## 🚀 New behavior

The same config builds. A callback returning `null` or `undefined` clears the utility's preset values, so `translateZ`
keeps working with arbitrary values:

```css
.translate-z_4 {
  --translate-z: 4;
}
```

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Fixed in both the NAPI and wasm callback paths, with a compiler test covering a values callback that returns nothing.

Also fixes the docs build, which has been red on `v2` for a few commits. `author` is optional in the velite blog
schema, but the blog index called `formatAuthors(post.author)` outside its `post.author &&` guard, so `next build`
failed to type check. The post page already guarded it.
