### PR TITLE
docs: improve descriptions and formatting in documentation

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -89,28 +89,28 @@ export default function DocsWelcomePage() {
             icon={<LuPaintbrush />}
             title="Styling"
             href="/docs/styling/overview"
-            description="Write styles with css(), style props, conditions, and the styled factory — extracted at build time."
+            description="Write styles with css(), style props, conditions, and the styled factory, extracted at build time"
             cta="Write a style"
           />
           <Card
             icon={<LuLayers />}
             title="Recipes"
             href="/docs/recipes/overview"
-            description="Define component styles with variants and compound variants, compiled to atomic CSS."
+            description="Define component styles with variants and compound variants, compiled to atomic CSS"
             cta="Write a recipe"
           />
           <Card
             icon={<LuPalette />}
             title="Theming"
             href="/docs/theming/tokens"
-            description="Set up design tokens, semantic tokens, and multiple themes that stay type-safe end to end."
+            description="Set up design tokens, semantic tokens, and multiple themes that stay type-safe end to end"
             cta="Define tokens"
           />
           <Card
             icon={<LuBlocks />}
             title="Design Systems"
             href="/docs/design-systems/setup"
-            description="Ship presets and component libraries to npm with a typed system consumers can extend."
+            description="Ship presets and component libraries to npm with a typed system consumers can extend"
             cta="Build a system"
           />
         </Cards>
@@ -137,13 +137,13 @@ export default function DocsWelcomePage() {
             icon={<LuDownload />}
             title="Install Panda"
             href="/docs/get-started/cli"
-            description="Pick your framework and install path — CLI, PostCSS, or bundler plugin."
+            description="Pick your framework and install path - CLI, PostCSS, or bundler plugin"
           />
           <Card
             icon={<LuZap />}
             title="Thinking in Panda"
             href="/docs/get-started/thinking-in-panda"
-            description="The mental model behind tokens, recipes, and build-time styles, in about ten minutes."
+            description="The mental model behind tokens, recipes, and build-time styles, in about ten minutes"
           />
         </Cards>
       </Box>

--- a/website/content/docs/get-started/getting-started.mdx
+++ b/website/content/docs/get-started/getting-started.mdx
@@ -27,6 +27,7 @@ There is more than one way to write it. Every tab below produces the same atomic
       )
     }
     ```
+
   </Tab>
   <Tab>
     ```jsx
@@ -41,6 +42,7 @@ There is more than one way to write it. Every tab below produces the same atomic
       )
     }
     ```
+
   </Tab>
   <Tab>
     ```jsx
@@ -55,6 +57,7 @@ There is more than one way to write it. Every tab below produces the same atomic
       )
     }
     ```
+
   </Tab>
   <Tab>
     ```jsx
@@ -72,12 +75,16 @@ There is more than one way to write it. Every tab below produces the same atomic
       return <div className={card({ size })}>John Doe</div>
     }
     ```
+
   </Tab>
 </Tabs>
 
 ## How it works
 
-Two steps at build time. Nothing in the browser computes styles.
+Panda runs two passes at build time, so the browser never computes styles:
+
+1. **Codegen** reads your config and writes the `styled-system` package you import from.
+2. **Extract** scans your source for those calls and emits only the CSS you used.
 
 ```
   panda.config.ts                 css({ color: 'blue.500' })
@@ -95,17 +102,13 @@ Two steps at build time. Nothing in the browser computes styles.
               class name string + static CSS
 ```
 
-1. **Codegen** reads your config and writes the `styled-system` package you import from.
-2. **Extract** scans your source for those calls and emits only the CSS you used.
-
 Values have to be visible in source. If a style only exists at runtime, see
-[Dynamic Styles](/docs/styling/dynamic-styling). Folder details:
-[Styled System](/docs/reference/styled-system).
+[Dynamic Styles](/docs/styling/dynamic-styling). Folder details: [Styled System](/docs/reference/styled-system).
 
 ## What you get
 
-- **Static analysis:** Panda parses your styles at build time and generates plain CSS files that work in any
-  JavaScript framework.
+- **Static analysis:** Panda parses your styles at build time and generates plain CSS files that work in any JavaScript
+  framework.
 - **Type safety:** Panda combines `csstype` with auto-generated typings, so CSS properties and design tokens are
   type-checked as you write them.
 - **Performance:** styles compile down to atomic CSS ahead of time, so there's no runtime style engine shipped to the

--- a/website/content/docs/get-started/thinking-in-panda.mdx
+++ b/website/content/docs/get-started/thinking-in-panda.mdx
@@ -3,15 +3,16 @@ title: Thinking in Panda
 description: Which Panda API to reach for next, from css() to recipes, slots, and config.
 ---
 
-Panda has one mental model, and everything below is that model at different sizes. Four ideas carry it:
+Panda has one mental model. Whether you're styling a single button or building a design system, these four ideas hold
+true:
 
 - **Styles live next to your markup.** You write them as objects in the same file as the component, not in a separate
-  stylesheet to keep in sync.
-- **Tokens are the vocabulary.** Name intent once (`blue.500`, `md`, `semibold`) and every style refers to the same
-  names.
-- **Atomic CSS that scales.** Each property and value becomes one shared class, so your CSS grows with the number of
-  distinct styles, not the number of components.
-- **Zero runtime.** It all compiles to plain CSS at build time. Nothing computes styles in the browser.
+  stylesheet you have to keep in sync.
+- **Tokens replace raw values.** Name the token once (`blue.500`, `md`, `semibold`) instead of the raw value, and every
+  style refers to the same token.
+- **Atomic CSS scales.** Each property and value becomes one shared class, so your CSS grows with the number of distinct
+  styles, not the number of components.
+- **Ships zero runtime.** It all compiles to plain CSS at build time. Nothing computes styles in the browser.
 
 The only question day to day is which API to reach for as a component grows. Start local. Promote only when the shape of
 the styles forces it. This walk builds a Button, then a Card, and climbs the ladder: `css` → `cva` → `sva` → config.
@@ -20,7 +21,7 @@ Want the case for build-time styles first? Read [Welcome to Panda](/docs/get-sta
 
 ## Step 1: Start with `css()`
 
-Say you need a button, one look, no variants yet. Use `css()` to put the styles right on the element:
+Say you need to style a button that has no variants yet. Use `css()` to put the styles right on the element:
 
 ```tsx
 import { css } from '../styled-system/css'
@@ -142,8 +143,10 @@ export function Button({ size, visual, children }) {
 }
 ```
 
-Promote to a recipe when you have variants to name, not because the component file got long. One element, many looks:
-`cva` is enough.
+Always use a recipe when you have variants to name, not simply because the component file gets long. As long as it's a
+single element, `cva` alone is enough.
+
+If a component has more than one element, reach for `sva` instead, which you'll see in Step 3.
 
 > That "before" example still compiles, unlike Step 1's `` `red.${shade}` ``. A ternary's branches are both literal, so
 > Panda can see them and generates CSS for both. A template literal's interpolation isn't a fixed set of options, so
@@ -154,7 +157,8 @@ Full API: [Recipes](/docs/recipes/atomic-recipe).
 
 ## Step 3: Split into slots when markup has parts
 
-Now let's build a Card. A Card has a `root`, `title`, and a `body`. One `size` prop should style all three together.
+Now let's build a Card. Unlike a button, which has a single element, a Card has a `root`, `title`, and a `body`. One
+`size` prop should style all three together.
 
 `sva` gives you one recipe and a class bag per part:
 
@@ -208,10 +212,10 @@ Full API: [Slot recipes](/docs/recipes/slot-recipes).
 
 ## Step 4: Move to config when it's a system primitive
 
-`cva` and `sva` are fine as long as the recipe stays colocated: it only matters inside this one component's file. Move
-the same `base` / `variants` / `defaultVariants` shape into `defineRecipe` or `defineSlotRecipe` once any of this gets
-true: other apps need to import the component, it ships inside a preset, or you want Panda to generate CSS only for
-the variants your code actually calls, not the full matrix.
+`cva` and `sva` are fine as long as the recipe stays colocated: it only matters inside this one component's file.
+However, move the same `base` / `variants` / `defaultVariants` shape into `defineRecipe` or `defineSlotRecipe`, then
+register it in `panda.config.ts`, once any of this gets true: other apps need to import the component, it ships inside a
+preset, or you want Panda to generate CSS only for the variants your code actually calls, not the full matrix.
 
 Button becomes a config recipe:
 
@@ -317,11 +321,10 @@ const classes = card({ size: 'lg' })
 - Move to `defineRecipe` / `defineSlotRecipe` for design-system components. You get leaner JIT CSS, and you can share
   the recipe through a preset or `panda lib`.
 
-The full comparison table lives here:
-[Recipes overview](/docs/recipes/overview). Config form for parts:
+The full comparison table lives here: [Recipes overview](/docs/recipes/overview). Config form for parts:
 [Config Slot Recipe](/docs/recipes/config-recipe#config-slot-recipe).
 
-## Step 5: Trust the system
+## Trust the system
 
 A few things don't change as you move between `css`, `cva`, `sva`, and config: tokens, cascade layers, and types.
 


### PR DESCRIPTION

## 📝 Description

 - Reworked getting-started.mdx's "How it works" section
  - Rewrote thinking-in-panda.mdx's four core-idea bullets to use parallel, present-tense action verbs 
  - fixed the Step 3 Button-vs-Card comparison

