### PR TITLE
fix(sandbox): drop the jest-dom import that breaks vue snapshots

### DIFF
--- a/sandbox/codegen/__tests__/frameworks/vue.styled-factory.test.tsx
+++ b/sandbox/codegen/__tests__/frameworks/vue.styled-factory.test.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource vue */
 import { describe, expect, test } from 'vitest'
 import { Box, Stack, styled } from '../../styled-system-vue/jsx'
-import '@testing-library/jest-dom/vitest'
 import { render } from '@testing-library/vue'
 import { buttonWithCompoundVariants } from '../../styled-system-vue/recipes'
 


### PR DESCRIPTION
## 📝 Description

Unit Tests are red on `v2`. `sandbox/codegen` fails on one file, `__tests__/frameworks/vue.styled-factory.test.tsx`, and takes both the runtime and the typecheck pass down with it. One dead import is the cause.

## ⛳️ Current behavior (updates)

All 24 assertions in that file throw the same error:

```
Error: The snapshot state for '.../vue.styled-factory.test.tsx' is not found.
Did you call 'SnapshotClient.setup()'?
```

The file imports `@testing-library/jest-dom/vitest`. It is the only test file in the suite that does, and the only one failing. Under vitest 4 that import wraps `expect` in a proxy the inline-snapshot client can't reach, so `toMatchInlineSnapshot` can't find the state for the file it is running in.

Both halves of `pnpm test` hit it, since `tsx ./cli.ts test` and `tsx ./cli.ts test -t` both execute the test bodies.

## 🚀 New behavior

The import is gone. The file only ever calls `toMatchInlineSnapshot`, 24 times, and that matcher is built into vitest. No jest-dom matcher is used anywhere in it, so nothing else depended on the import.

## 💣 Is this a breaking change (Yes/No):

No. One import removed from one test file. No source, no snapshots touched.

## 📝 Additional Information

`pnpm test` in `sandbox/codegen` now passes end to end — all 11 scenarios in the runtime pass, all 11 again with `-t`, both ending in "All commands succeeded 🎉".

I first fixed this by adding `typecheck.only` to `vitest.config.ts`, which does green the typecheck pass. Then the runtime pass failed on its own, and removing the import turned out to fix both. So the config change went in the bin — this is the whole fix.
