### PR TITLE
docs: correct which property wins in property conflicts

### DIFF
--- a/website/content/docs/concepts/writing-styles.mdx
+++ b/website/content/docs/concepts/writing-styles.mdx
@@ -580,8 +580,8 @@ const styles: SystemStyleObject = {
 
 ## Property conflicts
 
-When you combine shorthand and longhand properties, Panda will resolve the styles in a predictable way. The shorthand
-property will take precedence over the longhand property.
+When you combine shorthand and longhand properties, Panda will resolve the styles in a predictable way. The longhand
+property (`paddingTop`) will take precedence over the shorthand property (`padding`).
 
 ```jsx
 import { css } from '../styled-system/css'


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

The sentence said the shorthand takes precedence, but Panda emits the longhand rule after the shorthand rule, as the sample output on the page shows, so the longhand wins.

Taking the shorthand definition from https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties 

## ⛳️ Current behavior (updates)

shorthand vs longhand is unclear, does not match example code or behavior

## 🚀 New behavior

shorthand is clarified

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
