### PR TITLE
fix(compiler): reconcile deleted files on rescan

### DIFF
--- a/.changeset/fix-driver-rescan-removals.md
+++ b/.changeset/fix-driver-rescan-removals.md
@@ -1,0 +1,8 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-shared': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Fix `Driver.parseFiles()` retaining atoms from source files removed since the previous scan. Full-project rescans now
+reconcile scan- and watcher-owned files, including recovery from dropped watcher events.

--- a/packages/compiler-shared/src/driver.ts
+++ b/packages/compiler-shared/src/driver.ts
@@ -99,7 +99,7 @@ export interface Driver {
   reload(): Promise<DiffConfigResult>
   /** Source paths matching the config includes/excludes. Does not parse. */
   scan(options?: ScanOptions): string[]
-  /** Scan, then parse every discovered source file via the engine fs. */
+  /** Parse scanned sources, reconciling removals only for a default full-project scan. */
   parseFiles(options?: ScanOptions): ParseFileReport[]
   /** Route one watcher event into the engine. `false` = unknown path / no-op. */
   applyChange(change: SourceChange): boolean
@@ -169,6 +169,7 @@ export function selectArtifacts(
 export abstract class BaseDriver implements Driver {
   #compiler: Compiler
   #introspect: Introspection | undefined
+  #scanOwnedFiles = new Set<string>()
 
   protected constructor(compiler: Compiler) {
     this.#compiler = compiler
@@ -178,6 +179,7 @@ export abstract class BaseDriver implements Driver {
   protected setCompiler(compiler: Compiler): void {
     this.#compiler = compiler
     this.#introspect = undefined
+    this.#scanOwnedFiles.clear()
   }
 
   get compiler(): Compiler {
@@ -218,7 +220,38 @@ export abstract class BaseDriver implements Driver {
   }
 
   parseFiles(options?: ScanOptions): ParseFileReport[] {
-    return this.#compiler.parseFiles(this.#compiler.scan(options))
+    const paths = this.#compiler.scan(options)
+
+    // Only the default scan is an authoritative view of every config-owned
+    // source. A scan with include/exclude/cwd overrides may intentionally be a
+    // subset, so it must not evict files outside that targeted scan.
+    const isFullProjectScan =
+      options?.include === undefined && options?.exclude === undefined && options?.cwd === undefined
+    if (isFullProjectScan) {
+      const active = new Set(paths)
+      for (const path of this.#scanOwnedFiles) {
+        if (!active.has(path)) this.#compiler.removeFile(path)
+      }
+    }
+
+    const reports = this.#compiler.parseFiles(paths)
+    if (isFullProjectScan) {
+      this.#scanOwnedFiles = new Set(paths)
+    } else {
+      for (const path of paths) this.#scanOwnedFiles.add(path)
+    }
+    return reports
+  }
+
+  /** Record source ownership after a host watcher change. */
+  protected trackSourceChange(change: SourceChange, applied: boolean): boolean {
+    if (!this.#compiler.isSourceFile(change.path)) return applied
+    if (change.kind === 'unlink') {
+      this.#scanOwnedFiles.delete(change.path)
+    } else if (applied) {
+      this.#scanOwnedFiles.add(change.path)
+    }
+    return applied
   }
 
   applyChanges(changes: SourceChange[]): boolean[] {

--- a/packages/compiler-wasm/__tests__/browser-driver.test.ts
+++ b/packages/compiler-wasm/__tests__/browser-driver.test.ts
@@ -52,6 +52,54 @@ describe('createBrowserDriver', () => {
     expect(driver.cssgen().css).toContain('blue')
   })
 
+  it('reconciles staged sources removed since the previous parseFiles scan', async () => {
+    const source = "import { css } from '@panda/css'; css({ color: 'red' })"
+    const driver = await createBrowserDriver({
+      snapshot,
+      sources: {
+        '/proj/A.tsx': source,
+        '/proj/B.tsx': "import { css } from '@panda/css'; css({ color: 'blue' })",
+      },
+    })
+    const explicit = '/proj/virtual.tsx'
+    const explicitSource = "import { css } from '@panda/css'; css({ color: 'green' })"
+    driver.compiler.parseFileSource(explicit, explicitSource)
+    driver.parseFiles()
+
+    expect(driver.compiler.getFile(explicit)).not.toBeNull()
+    expect(driver.cssgen().css).toContain('green')
+    expect(driver.parseFiles({ include: ['A.tsx'] })).toHaveLength(1)
+    expect(driver.compiler.getFile('/proj/B.tsx')).not.toBeNull()
+    expect(driver.cssgen().css).toContain('blue')
+
+    expect(
+      driver.applyChange({
+        path: '/proj/added.tsx',
+        kind: 'add',
+        content: "import { css } from '@panda/css'; css({ color: 'purple' })",
+      }),
+    ).toBe(true)
+    expect(driver.cssgen().css).toContain('purple')
+
+    driver.compiler.fs.removeFile?.('/proj/B.tsx')
+    driver.compiler.fs.removeFile?.('/proj/added.tsx')
+
+    expect(driver.parseFiles()).toHaveLength(1)
+    expect(driver.compiler.getFile('/proj/B.tsx')).toBeNull()
+    expect(driver.compiler.getFile('/proj/added.tsx')).toBeNull()
+    const incrementalCss = driver.cssgen().css
+    expect(incrementalCss).toContain('red')
+    expect(incrementalCss).not.toContain('blue')
+    expect(incrementalCss).not.toContain('purple')
+    expect(incrementalCss).toContain('green')
+    expect(driver.compiler.getFile(explicit)).not.toBeNull()
+
+    const cold = await createBrowserDriver({ snapshot, sources: { '/proj/A.tsx': source } })
+    cold.compiler.parseFileSource(explicit, explicitSource)
+    cold.parseFiles()
+    expect(incrementalCss).toBe(cold.cssgen().css)
+  })
+
   it('embeds the user pattern transform in generated artifacts', async () => {
     const driver = await createBrowserDriver({ snapshot })
     const patterns = driver.artifacts().find((artifact) => artifact.id === 'patterns')

--- a/packages/compiler-wasm/src/driver.ts
+++ b/packages/compiler-wasm/src/driver.ts
@@ -76,7 +76,7 @@ class BrowserDriver extends BaseDriver {
   }
 
   applyChange(change: SourceChange): boolean {
-    const changed = this.#applySourceChange(change)
+    const changed = this.trackSourceChange(change, this.#applySourceChange(change))
     const refreshed = this.refreshAffectedFiles()
     return changed || refreshed
   }

--- a/packages/compiler/__tests__/node-driver.test.ts
+++ b/packages/compiler/__tests__/node-driver.test.ts
@@ -7,6 +7,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -230,6 +231,60 @@ describe('createNodeDriver', () => {
       expect(driver.cssgen().css).toContain('outline-color: blue-outline')
     } finally {
       rmSync(watchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reconciles files removed since the previous parseFiles scan', async () => {
+    const rescanDir = mkdtempSync(join(tmpdir(), 'panda-driver-rescan-'))
+    try {
+      writeFileTree(rescanDir, {
+        'panda.config.ts': `export default {
+          include: ['**/*.tsx'],
+          importMap: { css: ['@panda/css'] },
+        }`,
+        'a.tsx': "import { css } from '@panda/css'; css({ color: 'red' })",
+        'b.tsx': "import { css } from '@panda/css'; css({ color: 'blue' })",
+      })
+      const driver = await createNodeDriver({ cwd: rescanDir })
+      const explicit = join(rescanDir, 'virtual.tsx')
+      const explicitSource = "import { css } from '@panda/css'; css({ color: 'green' })"
+      driver.compiler.parseFileSource(explicit, explicitSource)
+
+      expect(driver.parseFiles()).toHaveLength(2)
+      expect(driver.compiler.getFile(explicit)).not.toBeNull()
+      expect(driver.cssgen().css).toContain('red')
+      expect(driver.cssgen().css).toContain('blue')
+      expect(driver.cssgen().css).toContain('green')
+
+      expect(driver.parseFiles({ include: ['a.tsx'] })).toHaveLength(1)
+      expect(driver.compiler.getFile(join(rescanDir, 'b.tsx'))).not.toBeNull()
+      expect(driver.cssgen().css).toContain('blue')
+
+      const added = join(rescanDir, 'added.tsx')
+      writeFileSync(added, "import { css } from '@panda/css'; css({ color: 'purple' })")
+      expect(driver.applyChange({ path: added, kind: 'add' })).toBe(true)
+      expect(driver.cssgen().css).toContain('purple')
+
+      const removed = join(rescanDir, 'b.tsx')
+      unlinkSync(removed)
+      unlinkSync(added)
+
+      expect(driver.parseFiles()).toHaveLength(1)
+      expect(driver.compiler.getFile(removed)).toBeNull()
+      expect(driver.compiler.getFile(added)).toBeNull()
+      const incrementalCss = driver.cssgen().css
+      expect(incrementalCss).toContain('red')
+      expect(incrementalCss).not.toContain('blue')
+      expect(incrementalCss).not.toContain('purple')
+      expect(incrementalCss).toContain('green')
+      expect(driver.compiler.getFile(explicit)).not.toBeNull()
+
+      const cold = await createNodeDriver({ cwd: rescanDir })
+      cold.compiler.parseFileSource(explicit, explicitSource)
+      cold.parseFiles()
+      expect(incrementalCss).toBe(cold.cssgen().css)
+    } finally {
+      rmSync(rescanDir, { recursive: true, force: true })
     }
   })
 

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -280,7 +280,7 @@ export class NodeDriver extends BaseDriver {
   }
 
   private applySourceChange(change: SourceChange, admission: 'project' | 'design-system'): boolean {
-    const changed = this.admitSourceChange(change, admission)
+    const changed = this.trackSourceChange(change, this.admitSourceChange(change, admission))
     const refreshed = this.refreshAffectedFiles()
     return this.recordSourceChange(changed || refreshed)
   }


### PR DESCRIPTION
## Description

A full `Driver.parseFiles()` rescan now removes configured source files that are no longer returned by `scan()`. This
allows recovery rescans to converge after watcher events are dropped.

## Current behavior (updates)

If a source file is deleted and its unlink event is missed, `parseFiles()` reparses the files still on disk but leaves
the deleted file in the compiler project. Its CSS remains until the compiler is recreated.

## New behavior

Before parsing a default full-project scan, `BaseDriver` removes sources previously discovered by a scan or watcher
event when they are absent from the new scan. Removal uses the compiler's existing `removeFile()` lifecycle.

Scans with `include`, `exclude`, or `cwd` overrides remain additive. Explicit compiler inputs and hydrated build-info
entries are not scan-owned and are not removed.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Native and WASM tests cover:

- a missed unlink followed by a full rescan
- targeted scans preserving files outside the selected subset
- explicit inputs outside the configured source set
- incremental CSS matching a fresh compiler with the same final inputs

Validation:

- `pnpm --filter @pandacss/compiler exec vitest run __tests__/node-driver.test.ts --maxWorkers=1`
- `pnpm --filter @pandacss/compiler-wasm test`
- `pnpm --filter @pandacss/compiler-shared test`
- `pnpm --filter @pandacss/cli exec vitest run __tests__/watch.test.ts --maxWorkers=1`
- `pnpm typecheck`
