### PR TITLE
fix(extractor): refresh changed cross-file modules

### DIFF
--- a/.changeset/refresh-cross-file-cache.md
+++ b/.changeset/refresh-cross-file-cache.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Refresh cached cross-file exports when the resolved module itself changes, is deleted, or is recreated. Long-lived
+compiler sessions no longer reuse stale direct exports when re-extracting an importer.

--- a/crates/pandacss_extractor/src/cross_file.rs
+++ b/crates/pandacss_extractor/src/cross_file.rs
@@ -7,8 +7,9 @@
 //! consumer types (`ExtractorConfig`, `Project`) stay non-generic; the
 //! concrete impl is `ResolverImpl<F>` behind a `Box<dyn CrossFileLookup>`.
 //!
-//! Cache: `path → HashMap<exported_name, ExportEntry>`. Each file parses and
-//! folds once per session, then drops its AST.
+//! Cache: `path → (source hash, HashMap<exported_name, ExportEntry>)`. Each
+//! unchanged file parses and folds once, then drops its AST. A changed source
+//! replaces its cached exports.
 //!
 //! Folds top-level `export const X = <foldable>` values and simple pure
 //! function exports (arrow / function) into an owned descriptor.
@@ -54,6 +55,11 @@ pub struct ExportedRecipe {
 }
 
 type FileExports = FxHashMap<String, ExportEntry>;
+
+struct CachedFileExports {
+    source_hash: u64,
+    exports: FileExports,
+}
 
 fn to_forward_slash(path: &Path) -> PathBuf {
     PathBuf::from(path.to_string_lossy().replace('\\', "/"))
@@ -157,7 +163,7 @@ pub(crate) trait CrossFileLookup: Send + Sync {
 struct ResolverImpl<F: FileSystem + Clone> {
     inner: ResolverGeneric<F>,
     fs: F,
-    cache: Mutex<FxHashMap<PathBuf, FileExports>>,
+    cache: Mutex<FxHashMap<PathBuf, CachedFileExports>>,
     in_flight: Mutex<FxHashSet<(PathBuf, String)>>,
 }
 
@@ -175,13 +181,13 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
     fn extract_exports(
         &self,
         path: &Path,
+        source: &str,
         matchers: Option<&Matchers>,
         tokens: Option<&TokenDictionary>,
-    ) -> Option<FileExports> {
-        let source = <F as oxc_resolver::FileSystem>::read_to_string(&self.fs, path).ok()?;
+    ) -> FileExports {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
-        let parser_return = Parser::new(&allocator, &source, source_type).parse();
+        let parser_return = Parser::new(&allocator, source, source_type).parse();
         let matched = matchers.map_or_else(Vec::new, |matchers| {
             let imports = collect_imports(&parser_return.program);
             match_import_records(&imports, matchers)
@@ -199,13 +205,7 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
         });
 
         // Oxc returns a partial AST on parse errors — walk what we get.
-        Some(collect_exports(
-            &parser_return.program,
-            path,
-            self,
-            &resolver,
-            &matched,
-        ))
+        collect_exports(&parser_return.program, path, self, &resolver, &matched)
     }
 }
 
@@ -244,6 +244,20 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
         };
         let path = to_forward_slash(&resolution.full_path());
 
+        // Validate cached exports against the current source. Never serve the
+        // last successful entry after a read failure.
+        let Ok(source) = <F as oxc_resolver::FileSystem>::read_to_string(&self.fs, &path) else {
+            self.cache
+                .lock()
+                .expect("cross-file cache poisoned")
+                .remove(&path);
+            return CrossFileResolution {
+                entry: None,
+                path: Some(path),
+            };
+        };
+        let source_hash = pandacss_shared::fx_hash(&source);
+
         // A resolved module is a build dependency even if the export doesn't
         // fold — record `path` on every remaining exit.
         if let Some(exports) = self
@@ -251,9 +265,10 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
             .lock()
             .expect("cross-file cache poisoned")
             .get(&path)
+            .filter(|cached| cached.source_hash == source_hash)
         {
             return CrossFileResolution {
-                entry: exports.get(name).cloned(),
+                entry: exports.exports.get(name).cloned(),
                 path: Some(path),
             };
         }
@@ -270,9 +285,7 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
             }
         }
 
-        let exports = self
-            .extract_exports(&path, matchers, tokens)
-            .unwrap_or_default();
+        let exports = self.extract_exports(&path, &source, matchers, tokens);
         self.in_flight
             .lock()
             .expect("cross-file guard poisoned")
@@ -282,7 +295,13 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
         self.cache
             .lock()
             .expect("cross-file cache poisoned")
-            .insert(path.clone(), exports);
+            .insert(
+                path.clone(),
+                CachedFileExports {
+                    source_hash,
+                    exports,
+                },
+            );
         CrossFileResolution {
             entry,
             path: Some(path),

--- a/crates/pandacss_extractor/tests/cross_file.rs
+++ b/crates/pandacss_extractor/tests/cross_file.rs
@@ -505,6 +505,37 @@ fn cache_reloads_exports_when_imported_source_changes() {
 }
 
 #[test]
+fn cache_drops_an_export_removed_from_an_existing_module() {
+    let source = indoc::indoc! {r"
+        import { brand } from './tokens';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(source, &[("tokens.ts", "export const brand = 'red';\n")]);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+
+    let before = extract(source, main.to_str().unwrap(), &config);
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const accent = 'blue';\n".to_vec(),
+    );
+    let after = extract(source, main.to_str().unwrap(), &config);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "before": shape(&before),
+        "after": shape(&after),
+    }), @r"
+    before:
+      calls:
+        - name: css
+          data:
+            - color: red
+    after:
+      calls: []
+    ");
+}
+
+#[test]
 fn cache_drops_deleted_exports_and_recovers_after_recreation() {
     let source = indoc::indoc! {r"
         import { brand } from './tokens';

--- a/crates/pandacss_extractor/tests/cross_file.rs
+++ b/crates/pandacss_extractor/tests/cross_file.rs
@@ -470,6 +470,108 @@ fn cache_reuses_across_multiple_extracts() {
     assert_eq!(shape(&a), shape(&b));
 }
 
+#[test]
+fn cache_reloads_exports_when_imported_source_changes() {
+    let source = indoc::indoc! {r"
+        import { brand } from './tokens';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(source, &[("tokens.ts", "export const brand = 'red';\n")]);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+
+    let before = extract(source, main.to_str().unwrap(), &config);
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const brand = 'blue';\n".to_vec(),
+    );
+    let after = extract(source, main.to_str().unwrap(), &config);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "before": shape(&before),
+        "after": shape(&after),
+    }), @r"
+    before:
+      calls:
+        - name: css
+          data:
+            - color: red
+    after:
+      calls:
+        - name: css
+          data:
+            - color: blue
+    ");
+}
+
+#[test]
+fn cache_drops_deleted_exports_and_recovers_after_recreation() {
+    let source = indoc::indoc! {r"
+        import { brand } from './tokens';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(source, &[("tokens.ts", "export const brand = 'red';\n")]);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+    let tokens = PathBuf::from("/proj/tokens.ts");
+
+    let before = extract(source, main.to_str().unwrap(), &config);
+    pandacss_fs::FileSystem::remove_file(&fs, &tokens).unwrap();
+    let deleted = extract(source, main.to_str().unwrap(), &config);
+    fs.add_file(tokens, b"export const brand = 'green';\n".to_vec());
+    let recreated = extract(source, main.to_str().unwrap(), &config);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "before": shape(&before),
+        "deleted": shape(&deleted),
+        "recreated": shape(&recreated),
+    }), @r"
+    before:
+      calls:
+        - name: css
+          data:
+            - color: red
+    deleted:
+      calls: []
+    recreated:
+      calls:
+        - name: css
+          data:
+            - color: green
+    ");
+}
+
+#[test]
+fn cache_reloads_when_a_previously_missing_export_appears() {
+    let source = indoc::indoc! {r"
+        import { brand } from './tokens';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(source, &[("tokens.ts", "export const accent = 'red';\n")]);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+
+    let missing = extract(source, main.to_str().unwrap(), &config);
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const brand = 'blue';\n".to_vec(),
+    );
+    let added = extract(source, main.to_str().unwrap(), &config);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "missing": shape(&missing),
+        "added": shape(&added),
+    }), @r"
+    missing:
+      calls: []
+    added:
+      calls:
+        - name: css
+          data:
+            - color: blue
+    ");
+}
+
 // --- in-memory FS specific tests ----------------------------------------
 
 #[test]

--- a/design-notes/cross-file-resolution.md
+++ b/design-notes/cross-file-resolution.md
@@ -4,13 +4,18 @@
 
 `CrossFileResolver` lets the same-file `Resolver` follow `import { x } from './tokens'` references and fold the imported
 value. Module resolution itself is delegated to `oxc_resolver` (relative paths, extension probing, tsconfig paths,
-package.json `exports`). The resolver caches per-session so each imported file is parsed and folded exactly once across
-the batch.
+package.json `exports`). The resolver caches per-session. Unchanged imported files are parsed and folded once across the
+batch; changed files replace their cached exports on the next lookup.
 
 ## Cache shape
 
 ```rust
-Mutex<FxHashMap<PathBuf, FxHashMap<String, ExportEntry>>>
+Mutex<FxHashMap<PathBuf, CachedFileExports>>
+
+struct CachedFileExports {
+    source_hash: u64,
+    exports: FxHashMap<String, ExportEntry>,
+}
 
 enum ExportEntry {
     Literal(Literal),
@@ -18,11 +23,15 @@ enum ExportEntry {
 }
 ```
 
-`path → (exported_name → folded literal or pure-fn descriptor)`.
+`path → (source hash, exported_name → folded literal or pure-fn descriptor)`.
 
-Each file is parsed once. Pure function exports are lowered to a closed owned IR **while the AST is live**, then the
-AST is dropped. The cache keeps descriptors, not `Program`s, so the resolver doesn't pin every imported file's
-allocator.
+The resolver reads and hashes the current source before using a cache entry. Matching source hashes avoid another parse
+and fold; changed sources replace the entry. Pure function exports are lowered to a closed owned IR **while the AST is
+live**, then the AST is dropped. The cache keeps descriptors, not `Program`s, so the resolver doesn't pin every imported
+file's allocator.
+
+Source-hash validation is local to the resolved module. Transitive invalidation is a separate host/provenance concern;
+this cache does not own a reverse module graph.
 
 The cache is behind a `Mutex`, not `RefCell`, so the resolver can be shared by `ExtractorConfig` in future
 parallel/bulk-file paths. The public type is `Send + Sync`.
@@ -64,9 +73,10 @@ to the enclosing `ImportDeclaration`:
 Only named import specifiers reach the cross-file path. Default and namespace specifiers return `None` immediately —
 they don't map cleanly to a single named export and our common case is `import { token } from '…'` style.
 
-Inside the loaded file, `collect_exports` builds a per-file `Resolver`. This costs one semantic pass per imported file,
-but the file is cached after that pass and the AST is dropped. That tradeoff buys parity for local aliases, computed
-keys, destructuring, imported values in the exported file, and Panda `.raw()` helpers without keeping AST memory alive.
+Inside the loaded file, `collect_exports` builds a per-file `Resolver`. This costs one semantic pass per imported source
+revision, but unchanged exports are served from the cache and the AST is dropped. That tradeoff buys parity for local
+aliases, computed keys, destructuring, imported values in the exported file, and Panda `.raw()` helpers without keeping
+AST memory alive.
 
 ## Cycle guard
 
@@ -96,9 +106,9 @@ config.
 
 ## I/O failures
 
-`extract_exports` swallows read errors and parse failures, returning an empty exports map. The dictionary still caches
-the empty map so subsequent references to the same module short-circuit. Strict correctness consumers can detect the
-empty case at the call site — the resolver itself stays best-effort, matching the JS extractor's recovery behavior.
+A read failure removes the previous cache entry and returns no export, so a deleted or unreadable file never serves
+stale data. Parse failures use Oxc's partial AST and cache any exports that still fold, matching the JS extractor's
+best-effort recovery behavior. Recreating a previously resolved file refreshes its exports on the next lookup.
 
 ## StyleTree hand-off
 


### PR DESCRIPTION
## Description

`CrossFileResolver` now refreshes cached exports when the resolved module's source changes during a long-lived compiler
session.

## Current behavior

After the first cross-file lookup, the resolver caches folded exports for the rest of the session. Re-extracting an
importer after its resolved module changes, is deleted, or is recreated can reuse the previous exports.

## New behavior

Cache entries include a content hash. Each lookup validates the resolved module's current source before serving cached
exports. Unchanged modules avoid another parse and fold; changed modules replace the entry. A read failure removes the
entry instead of returning stale data.

This change covers the resolved module itself. Transitive provenance and host-driven importer invalidation remain
separate concerns.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Public extractor tests cover:

- a direct export changing
- a previously folded export disappearing from an existing module
- deletion followed by recreation
- a previously missing export appearing in an existing module

Validation on Rust 1.93:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run -p pandacss_extractor --locked` (487 tests)
