### PR TITLE
chore(deps): update lru to 0.18.4

### DIFF
--- a/.changeset/update-lru-soundness.md
+++ b/.changeset/update-lru-soundness.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Update the internal transform cache to `lru` 0.18.4, which fixes upstream Rust soundness issues.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,8 +409,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -432,6 +430,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -673,11 +673,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = { version = "1.0.145", features = ["preserve_order"] }
 thiserror = "2.0.17"
 insta = { version = "1.47.2", features = ["yaml"] }
 fast-glob = "1"
-lru = "0.12"
+lru = "0.18.4"
 indoc = "2.0.7"
 itoa = "1.0"
 indexmap = { version = "2.14.0", features = ["serde"] }


### PR DESCRIPTION
## Description

Updates `lru` from 0.12.5 to 0.18.4 in the native and WASM transform caches. This moves both bindings past
[RUSTSEC-2026-0002](https://rustsec.org/advisories/RUSTSEC-2026-0002.html) and
[RUSTSEC-2026-0253](https://rustsec.org/advisories/RUSTSEC-2026-0253.html).

Panda does not call the affected `iter_mut` or `pop` methods, so this is a preventative dependency update.

## Current behavior

Both compiler bindings resolve `lru` 0.12.5, which is affected by the two soundness advisories.

## New behavior

Both bindings resolve `lru` 0.18.4. The existing cache API and behavior are unchanged.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validation:

- Rust 1.93 clippy
- 2,441 Rust tests
- Native compiler build and 601 tests
- WASM node and web builds and 66 tests
- `wasm32-unknown-unknown` check
- `cargo deny check advisories`
- TypeScript typecheck


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the native and WASM transform caches from `lru` 0.12.5 to 0.18.4 to address upstream soundness advisories.
- Updates the workspace dependency and resolved `hashbrown` graph.
- Adds patch changesets for `@pandacss/compiler` and `@pandacss/compiler-wasm`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The dependency upgrade preserves the cache APIs used by both compiler bindings, the lockfile changes are consistent with the new resolution, and the changeset follows repository conventions.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Pins the workspace `lru` dependency to 0.18.4; existing cache call sites remain API-compatible. |
| Cargo.lock | Resolves `lru` 0.18.4 and its updated `hashbrown` dependency graph without introducing an identified changed-code vulnerability. |
| .changeset/update-lru-soundness.md | Correctly records patch releases for both compiler bindings and describes the dependency update. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): update lru to 0.18.4"](https://github.com/chakra-ui/panda/commit/439ba148f1e6bca6eaf20e406cdc505d78b3d546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61029483)</sub>

<!-- /greptile_comment -->