### PR TITLE
fix(project): retry unresolved cross-file imports on add

### DIFF
--- a/.changeset/fix-unresolved-cross-file-adds.md
+++ b/.changeset/fix-unresolved-cross-file-adds.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Re-extract files with unresolved cross-file imports when the missing module is created during watch mode.

--- a/crates/pandacss_extractor/src/cross_file.rs
+++ b/crates/pandacss_extractor/src/cross_file.rs
@@ -31,7 +31,8 @@ use crate::literal::expression_to_literal;
 use crate::pure_fn::{OwnedPureFn, lower_callable_expr, lower_function};
 use crate::{
     MatchCategory, MatchedImport, Matchers, TokenDictionary, collect_imports,
-    imports::module_export_name, match_import_records, scope::Resolver,
+    extract::UnresolvedCrossFileDependency, imports::module_export_name, match_import_records,
+    scope::Resolver,
 };
 
 /// Folded named export: style literal, pure callable, or inline recipe.
@@ -55,12 +56,15 @@ type FileExports = FxHashMap<String, ExportEntry>;
 
 /// Modules read while folding and the hash seen; `None` = unreadable.
 type Provenance = Vec<(PathBuf, Option<u64>)>;
+type UnresolvedDependencies = Vec<(PathBuf, String)>;
 
 struct CachedFileExports {
     source_hash: u64,
     exports: FileExports,
     /// Modules folded while collecting this file's exports. A hash miss busts this entry.
     deps: Provenance,
+    /// Failed nested resolutions. A newly resolvable request invalidates this entry.
+    unresolved: UnresolvedDependencies,
 }
 
 fn to_forward_slash(path: &Path) -> PathBuf {
@@ -134,6 +138,17 @@ impl CrossFileResolver {
     pub fn dependency_key(&self, path: &Path) -> Option<PathBuf> {
         self.inner.dependency_key(path)
     }
+
+    /// Whether any previously unresolved dependency can now be resolved.
+    #[must_use]
+    pub fn any_resolvable(&self, dependencies: &[UnresolvedCrossFileDependency]) -> bool {
+        self.inner.any_resolvable(dependencies)
+    }
+
+    /// Clear cached filesystem lookups before retrying unresolved dependencies.
+    pub fn clear_resolution_cache(&self) {
+        self.inner.clear_resolution_cache();
+    }
 }
 
 /// Folded export plus resolved path. `path` is a build dep even when the export does not fold.
@@ -142,6 +157,7 @@ pub(crate) struct CrossFileResolution {
     pub(crate) path: Option<PathBuf>,
     pub(crate) source_hash: Option<u64>,
     pub(crate) provenance: Provenance,
+    pub(crate) unresolved: UnresolvedDependencies,
 }
 
 impl CrossFileResolution {
@@ -151,6 +167,17 @@ impl CrossFileResolution {
             path: None,
             source_hash: None,
             provenance: Vec::new(),
+            unresolved: Vec::new(),
+        }
+    }
+
+    fn unresolved(from_file: &Path, specifier: &str) -> Self {
+        Self {
+            entry: None,
+            path: None,
+            source_hash: None,
+            provenance: Vec::new(),
+            unresolved: vec![(from_file.to_path_buf(), specifier.to_owned())],
         }
     }
 
@@ -165,7 +192,13 @@ impl CrossFileResolution {
             path: Some(path),
             source_hash,
             provenance,
+            unresolved: Vec::new(),
         }
+    }
+
+    fn with_unresolved(mut self, unresolved: UnresolvedDependencies) -> Self {
+        self.unresolved = unresolved;
+        self
     }
 }
 
@@ -182,6 +215,10 @@ pub(crate) trait CrossFileLookup: Send + Sync {
     fn resolve_path(&self, from_file: &Path, specifier: &str) -> Option<PathBuf>;
 
     fn dependency_key(&self, path: &Path) -> Option<PathBuf>;
+
+    fn any_resolvable(&self, dependencies: &[UnresolvedCrossFileDependency]) -> bool;
+
+    fn clear_resolution_cache(&self);
 
     fn cache_len(&self) -> usize;
 }
@@ -210,7 +247,7 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
         source: &str,
         matchers: Option<&Matchers>,
         tokens: Option<&TokenDictionary>,
-    ) -> (FileExports, Provenance) {
+    ) -> (FileExports, Provenance, UnresolvedDependencies) {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
         let parser_return = Parser::new(&allocator, source, source_type).parse();
@@ -237,7 +274,12 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
             .into_iter()
             .map(|dep| (PathBuf::from(dep.path), dep.source_hash))
             .collect();
-        (exports, deps)
+        let unresolved = resolver
+            .take_unresolved_cross_file_deps()
+            .into_iter()
+            .map(|dep| (PathBuf::from(dep.from_file), dep.specifier))
+            .collect();
+        (exports, deps, unresolved)
     }
 
     // PERF(port): one read + hash per nested dep on every cache hit.
@@ -248,6 +290,18 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
                 .map(|source| pandacss_shared::fx_hash(&source))
                 == *expected
         })
+    }
+
+    fn unresolved_still_missing(&self, deps: &UnresolvedDependencies) -> bool {
+        deps.iter()
+            .all(|(from_file, specifier)| !self.is_resolvable(from_file, specifier))
+    }
+
+    fn is_resolvable(&self, from_file: &Path, specifier: &str) -> bool {
+        let Some(directory) = from_file.parent() else {
+            return false;
+        };
+        self.inner.resolve(directory, specifier).is_ok()
     }
 }
 
@@ -276,6 +330,22 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
         Some(to_forward_slash(&parent.join(path.file_name()?)))
     }
 
+    fn any_resolvable(&self, dependencies: &[UnresolvedCrossFileDependency]) -> bool {
+        let resolver = ResolverGeneric::<F>::new_with_file_system(
+            self.fs.clone(),
+            self.inner.options().clone(),
+        );
+        dependencies.iter().any(|dep| {
+            Path::new(&dep.from_file)
+                .parent()
+                .is_some_and(|directory| resolver.resolve(directory, &dep.specifier).is_ok())
+        })
+    }
+
+    fn clear_resolution_cache(&self) {
+        self.inner.clear_cache();
+    }
+
     fn resolve_named_export(
         &self,
         from_file: &Path,
@@ -288,7 +358,7 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
             return CrossFileResolution::none();
         };
         let Ok(resolution) = self.inner.resolve(directory, specifier) else {
-            return CrossFileResolution::none();
+            return CrossFileResolution::unresolved(from_file, specifier);
         };
         let path = to_forward_slash(&resolution.full_path());
 
@@ -309,13 +379,19 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
                 if cached.source_hash != source_hash {
                     return None;
                 }
-                Some((cached.exports.get(name).cloned(), cached.deps.clone()))
+                Some((
+                    cached.exports.get(name).cloned(),
+                    cached.deps.clone(),
+                    cached.unresolved.clone(),
+                ))
             })
         };
-        if let Some((entry, deps)) = cached
+        if let Some((entry, deps, unresolved)) = cached
             && self.provenance_fresh(&deps)
+            && self.unresolved_still_missing(&unresolved)
         {
-            return CrossFileResolution::at_path(path, Some(source_hash), entry, deps);
+            return CrossFileResolution::at_path(path, Some(source_hash), entry, deps)
+                .with_unresolved(unresolved);
         }
 
         // Cycle guard: `a.ts ↔ b.ts` would otherwise overflow the stack.
@@ -327,7 +403,7 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
             }
         }
 
-        let (exports, deps) = self.extract_exports(&path, &source, matchers, tokens);
+        let (exports, deps, unresolved) = self.extract_exports(&path, &source, matchers, tokens);
         self.in_flight
             .lock()
             .expect("cross-file guard poisoned")
@@ -343,9 +419,11 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
                     source_hash,
                     exports,
                     deps: deps.clone(),
+                    unresolved: unresolved.clone(),
                 },
             );
         CrossFileResolution::at_path(path, Some(source_hash), entry, deps)
+            .with_unresolved(unresolved)
     }
 
     fn cache_len(&self) -> usize {

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -83,6 +83,13 @@ pub struct CrossFileDependency {
     pub source_hash: Option<u64>,
 }
 
+/// A cross-file import that did not resolve during extraction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnresolvedCrossFileDependency {
+    pub from_file: String,
+    pub specifier: String,
+}
+
 /// Lean extraction result for the production hot path — strips `imports`
 /// and `matched` so callers don't pay serialization cost for fields they
 /// don't use.
@@ -104,6 +111,9 @@ pub struct ExtractUsage {
     /// re-export / imported-alias modules. Project-side only.
     #[serde(skip)]
     pub dependencies: Vec<CrossFileDependency>,
+    /// Failed cross-file resolutions to retry after the filesystem changes.
+    #[serde(skip)]
+    pub unresolved_dependencies: Vec<UnresolvedCrossFileDependency>,
     /// Original-parse module and symbol facts used by source transforms.
     #[serde(skip)]
     pub module: ModuleFacts,
@@ -213,6 +223,7 @@ fn extract_usage(outcome: ExtractResult) -> ExtractUsage {
         token_refs: outcome.token_refs,
         exports: outcome.exports,
         dependencies: outcome.dependencies,
+        unresolved_dependencies: outcome.unresolved_dependencies,
         module: outcome.module,
         imported_recipe_raw_calls: outcome.imported_recipe_raw_calls,
     }
@@ -305,6 +316,7 @@ struct ExtractResult {
     style_source_refs: Vec<StyleSourceRef>,
     exports: ExportInfo,
     dependencies: Vec<CrossFileDependency>,
+    unresolved_dependencies: Vec<UnresolvedCrossFileDependency>,
     imported_recipe_raw_calls: Vec<ImportedRecipeRawCall>,
 }
 
@@ -407,6 +419,7 @@ fn run_extract<'cb>(
             style_source_refs: Vec::new(),
             exports,
             dependencies: Vec::new(),
+            unresolved_dependencies: Vec::new(),
             imported_recipe_raw_calls: Vec::new(),
         };
     }
@@ -492,6 +505,7 @@ fn run_extract<'cb>(
     token_refs.extend(resolver.take_token_refs());
     let token_refs = dedupe_token_refs(token_refs);
     let dependencies = resolver.take_cross_file_deps();
+    let unresolved_dependencies = resolver.take_unresolved_cross_file_deps();
     let imported_recipe_raw_calls = resolver.take_imported_recipe_raw_calls();
     let module = if retain_transform_facts {
         let local_call_bindings = if calls.is_empty() {
@@ -525,6 +539,7 @@ fn run_extract<'cb>(
         style_source_refs,
         exports,
         dependencies,
+        unresolved_dependencies,
         imported_recipe_raw_calls,
     }
 }

--- a/crates/pandacss_extractor/src/lib.rs
+++ b/crates/pandacss_extractor/src/lib.rs
@@ -41,9 +41,9 @@ pub use design_system_imports::{
 };
 pub use extract::{
     CrossFileDependency, ExtractDebugResult, ExtractUsage, ExtractVerboseResult,
-    ImportBindingFacts, ImportedRecipeRawCall, ModuleFacts, TokenRef, analyze_module, extract,
-    extract_debug, extract_for_transform, extract_for_transform_with_recipe_resolver,
-    extract_verbose, extract_with_raw_resolvers,
+    ImportBindingFacts, ImportedRecipeRawCall, ModuleFacts, TokenRef,
+    UnresolvedCrossFileDependency, analyze_module, extract, extract_debug, extract_for_transform,
+    extract_for_transform_with_recipe_resolver, extract_verbose, extract_with_raw_resolvers,
 };
 pub use imports::{
     ImportKind, ImportRecord, ImportScanResult, ImportSpecifier, ImportSpecifierKind,

--- a/crates/pandacss_extractor/src/scope.rs
+++ b/crates/pandacss_extractor/src/scope.rs
@@ -19,11 +19,11 @@ use oxc_ast::ast::{
 use oxc_semantic::{Semantic, SemanticBuilder, SymbolFlags, SymbolId};
 use oxc_span::GetSpan;
 use pandacss_tokens::{TokenCategory, TokenDictionary};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::cross_file::{CrossFileLookup, ExportEntry};
-use crate::extract::CrossFileDependency;
+use crate::extract::{CrossFileDependency, UnresolvedCrossFileDependency};
 use crate::literal::expression_to_literal;
 use crate::matcher::{MatchCategory, MatchedImport, Matchers};
 use crate::pure_fn::{
@@ -72,6 +72,8 @@ pub(crate) struct Resolver<'a, 'cb> {
     /// Cross-file modules read during this file's extraction (nested re-export /
     /// imported-alias modules included), with the source hash folded.
     cross_file_deps: RefCell<FxHashMap<PathBuf, Option<u64>>>,
+    /// Cross-file requests that did not resolve during this extraction.
+    unresolved_cross_file_deps: RefCell<FxHashSet<(PathBuf, String)>>,
     pattern_raw_transform: Option<&'cb PatternRawTransformCell<'cb>>,
     recipe_raw_resolve: Option<&'cb RecipeRawResolveCell<'cb>>,
 }
@@ -160,6 +162,7 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
             token_refs: RefCell::default(),
             imported_recipe_raw_calls: RefCell::default(),
             cross_file_deps: RefCell::default(),
+            unresolved_cross_file_deps: RefCell::default(),
             pattern_raw_transform,
             recipe_raw_resolve,
         }
@@ -194,6 +197,22 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
         deps
     }
 
+    pub(crate) fn take_unresolved_cross_file_deps(&self) -> Vec<UnresolvedCrossFileDependency> {
+        let mut deps = std::mem::take(&mut *self.unresolved_cross_file_deps.borrow_mut())
+            .into_iter()
+            .map(|(from_file, specifier)| UnresolvedCrossFileDependency {
+                from_file: from_file.to_string_lossy().into_owned(),
+                specifier,
+            })
+            .collect::<Vec<_>>();
+        deps.sort_by(|a, b| {
+            a.from_file
+                .cmp(&b.from_file)
+                .then_with(|| a.specifier.cmp(&b.specifier))
+        });
+        deps
+    }
+
     pub(crate) fn record_cross_file_resolution(
         &self,
         resolution: &crate::cross_file::CrossFileResolution,
@@ -205,6 +224,9 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
         for (path, source_hash) in &resolution.provenance {
             deps.insert(path.clone(), *source_hash);
         }
+        self.unresolved_cross_file_deps
+            .borrow_mut()
+            .extend(resolution.unresolved.iter().cloned());
     }
 
     pub(crate) fn semantic(&self) -> &Semantic<'a> {

--- a/crates/pandacss_extractor/tests/cross_file.rs
+++ b/crates/pandacss_extractor/tests/cross_file.rs
@@ -365,7 +365,16 @@ fn unresolvable_specifier_drops_outer_call() {
         &[],
     );
     let src = String::from_utf8(oxc_resolver::FileSystem::read(&fs, &main).unwrap()).unwrap();
-    assert_yaml_snapshot!(shape(&run(&fs, &main, &src)), @"calls: []");
+    let result = run(&fs, &main, &src);
+
+    assert_yaml_snapshot!(shape(&result), @"calls: []");
+    assert_eq!(
+        result.unresolved_dependencies,
+        vec![pandacss_extractor::UnresolvedCrossFileDependency {
+            from_file: "/proj/main.tsx".to_owned(),
+            specifier: "./does-not-exist".to_owned(),
+        }]
+    );
 }
 
 #[test]

--- a/crates/pandacss_project/src/build_info.rs
+++ b/crates/pandacss_project/src/build_info.rs
@@ -719,6 +719,7 @@ impl super::Project {
                 diagnostics: Vec::new(),
                 report: ParseFileReport::default(),
             },
+            &[],
         );
         true
     }

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -49,7 +49,7 @@ use pandacss_config::UserConfig;
 use pandacss_encoder::{Atom, Encoder, compare_atoms_by_emit_order};
 use pandacss_extractor::{
     CrossFileDependency, CrossFileResolver, ExportInfo, ExtractedCall, ExtractedJsx, JsxKind,
-    LineIndex, Literal, MatchCategory, extract,
+    LineIndex, Literal, MatchCategory, UnresolvedCrossFileDependency, extract,
 };
 use pandacss_recipes::{Recipe, SlotRecipe};
 use pandacss_shared::css_properties::is_css_property;
@@ -155,6 +155,8 @@ pub struct Project {
     parse_epoch: u64,
     /// Reverse index: cross-file module path → importer → source hash it folded.
     importers: FxHashMap<String, FxHashMap<Arc<str>, Option<u64>>>,
+    /// Failed cross-file requests keyed by the project file that attempted them.
+    unresolved_importers: FxHashMap<Arc<str>, Vec<UnresolvedCrossFileDependency>>,
     /// Drained by the host, which re-parses through its transform-aware path.
     affected_files: FxHashSet<Arc<str>>,
     /// Recipes keyed by `(file, span)` so re-parsing a path drops every
@@ -255,6 +257,7 @@ impl Project {
             merged_utility_styles_snapshot_cache: None,
             parse_epoch: 0,
             importers: FxHashMap::default(),
+            unresolved_importers: FxHashMap::default(),
             affected_files: FxHashSet::default(),
             config_recipes,
             config_slot_recipes,
@@ -339,7 +342,8 @@ impl Project {
         );
         let _guard = span.enter();
         let source_hash = hash_source(source);
-        self.mark_affected(path, Some(source_hash));
+        let is_new_file = !self.files.contains_key(path);
+        self.mark_affected(path, Some(source_hash), is_new_file);
         if self.files.get(path).is_some_and(|entry| {
             entry.cacheable
                 && entry.source_hash == source_hash
@@ -409,6 +413,7 @@ impl Project {
         // Feeds build-info barrel resolution.
         let exports = result.exports;
         let dependencies = result.dependencies;
+        let unresolved_dependencies = result.unresolved_dependencies;
 
         let mut diagnostics = result.diagnostics;
         let line_index = LineIndex::new(source);
@@ -778,8 +783,12 @@ impl Project {
         };
         self.parse_attempt_diagnostics.remove(path);
         match mode {
-            ParseMode::Replace => self.add_file_state(path_key, entry),
-            ParseMode::Additive => self.add_file_state_additive(path_key, entry),
+            ParseMode::Replace => {
+                self.add_file_state(path_key, entry, &unresolved_dependencies);
+            }
+            ParseMode::Additive => {
+                self.add_file_state_additive(path_key, entry, &unresolved_dependencies);
+            }
         }
         report
     }
@@ -820,7 +829,7 @@ impl Project {
     ) -> bool {
         if !self.files.contains_key(path) {
             // Untracked modules (outside `include`) still feed folded values.
-            self.mark_affected(path, Some(hash_source(source)));
+            self.mark_affected(path, Some(hash_source(source)), true);
             return false;
         }
         self.parse_file_inner(
@@ -861,7 +870,7 @@ impl Project {
     }
 
     pub fn remove_file(&mut self, path: &str) -> bool {
-        self.mark_affected(path, None);
+        self.mark_affected(path, None, false);
         let had_file = self.remove_file_entry(path).is_some();
         let had_parse_attempt = self.parse_attempt_diagnostics.remove(path).is_some();
         let recipes_dropped = self.drop_recipes_for(path);
@@ -921,7 +930,11 @@ impl Project {
         self.hydrated_view_transitions.clear();
         self.hydrated_view_transition_order.clear();
         self.importers.clear();
+        self.unresolved_importers.clear();
         self.affected_files.clear();
+        if let Some(resolver) = self.config.extractor_config.cross_file.as_ref() {
+            resolver.clear_resolution_cache();
+        }
     }
 
     /// Forces the next `parse_file` for any path to recompute, even if its
@@ -977,18 +990,34 @@ impl Project {
 
     /// Affected files keep their own source, so `cacheable` is dropped to get
     /// past the unchanged-source short-circuit.
-    fn mark_affected(&mut self, path: &str, source_hash: Option<u64>) {
-        let Some(importers) = self
+    fn mark_affected(&mut self, path: &str, source_hash: Option<u64>, retry_unresolved: bool) {
+        let mut affected = self
             .dependency_key(path)
             .and_then(|key| self.importers.get(&key))
-        else {
-            return;
-        };
-        let affected = importers
-            .iter()
+            .into_iter()
+            .flat_map(|importers| importers.iter())
             .filter(|(importer, seen)| **seen != source_hash && importer.as_ref() != path)
             .map(|(importer, _)| Arc::clone(importer))
-            .collect::<Vec<_>>();
+            .collect::<FxHashSet<_>>();
+
+        if retry_unresolved
+            && !self.unresolved_importers.is_empty()
+            && let Some(resolver) = self.config.extractor_config.cross_file.as_ref()
+        {
+            let newly_resolved = self
+                .unresolved_importers
+                .iter()
+                .filter(|(importer, deps)| {
+                    importer.as_ref() != path && resolver.any_resolvable(deps)
+                })
+                .map(|(importer, _)| Arc::clone(importer))
+                .collect::<Vec<_>>();
+            if !newly_resolved.is_empty() {
+                resolver.clear_resolution_cache();
+                affected.extend(newly_resolved);
+            }
+        }
+
         for importer in affected {
             if let Some(entry) = self.files.get_mut(importer.as_ref()) {
                 entry.cacheable = false;
@@ -1011,6 +1040,7 @@ impl Project {
     }
 
     fn unindex_file_deps(&mut self, path: &str) {
+        self.unresolved_importers.remove(path);
         let Some(deps) = self.files.get(path).map(|entry| entry.dependencies.clone()) else {
             return;
         };
@@ -1038,10 +1068,27 @@ impl Project {
         }
     }
 
-    fn add_file_state(&mut self, path: Arc<str>, entry: FileEntry) {
+    fn index_unresolved_file_deps(
+        &mut self,
+        path: &Arc<str>,
+        dependencies: &[UnresolvedCrossFileDependency],
+    ) {
+        if !dependencies.is_empty() {
+            self.unresolved_importers
+                .insert(Arc::clone(path), dependencies.to_vec());
+        }
+    }
+
+    fn add_file_state(
+        &mut self,
+        path: Arc<str>,
+        entry: FileEntry,
+        unresolved_dependencies: &[UnresolvedCrossFileDependency],
+    ) {
         self.affected_files.remove(path.as_ref());
         self.unindex_file_deps(path.as_ref());
         self.index_file_deps(path.as_ref(), &entry.dependencies);
+        self.index_unresolved_file_deps(&path, unresolved_dependencies);
         self.invalidate_stylesheet_snapshots();
         for atom in &entry.atoms {
             let atoms_cache = &mut self.atoms_cache;
@@ -1059,15 +1106,21 @@ impl Project {
         self.files.insert(path, entry);
     }
 
-    fn add_file_state_additive(&mut self, path: Arc<str>, entry: FileEntry) {
+    fn add_file_state_additive(
+        &mut self,
+        path: Arc<str>,
+        entry: FileEntry,
+        unresolved_dependencies: &[UnresolvedCrossFileDependency],
+    ) {
         if !self.files.contains_key(&path) {
-            self.add_file_state(path, entry);
+            self.add_file_state(path, entry, unresolved_dependencies);
             return;
         }
 
         self.affected_files.remove(path.as_ref());
         self.unindex_file_deps(path.as_ref());
         self.index_file_deps(path.as_ref(), &entry.dependencies);
+        self.index_unresolved_file_deps(&path, unresolved_dependencies);
         self.invalidate_stylesheet_snapshots();
         let mut missing_atoms = Vec::new();
         let mut missing_utility_styles = Vec::new();

--- a/crates/pandacss_project/tests/cross_file_watch.rs
+++ b/crates/pandacss_project/tests/cross_file_watch.rs
@@ -142,6 +142,89 @@ fn editing_a_token_file_that_is_not_a_project_file_still_affects_importers() {
 }
 
 #[test]
+fn creating_a_missing_index_module_affects_its_importer() {
+    let (fs, mut project) = watch_project(&[("App.tsx", app_source())]);
+    project.parse_file("/proj/App.tsx", app_source());
+
+    assert!(project.take_affected_files().is_empty());
+    assert_yaml_snapshot!(sorted_atoms(&project), @"[]");
+
+    write(&fs, "tokens/index.ts", "export const brand = 'red';\n");
+    assert!(!project.refresh_file("/proj/tokens/index.ts", "export const brand = 'red';\n"));
+
+    assert_eq!(refresh_affected(&mut project, &fs), vec!["/proj/App.tsx"]);
+    assert_yaml_snapshot!(sorted_atoms(&project), @r"
+    - prop: color
+      value: red
+      conditions: []
+    ");
+}
+
+#[test]
+fn creating_a_missing_reexported_token_file_affects_the_importer() {
+    let (fs, mut project) = watch_project(&[
+        ("App.tsx", barrel_app_source()),
+        ("barrel.ts", "export { brand } from './tokens';\n"),
+    ]);
+    project.parse_file("/proj/App.tsx", barrel_app_source());
+
+    assert!(project.take_affected_files().is_empty());
+    assert_yaml_snapshot!(sorted_atoms(&project), @"[]");
+
+    write(&fs, "tokens.ts", "export const brand = 'red';\n");
+    assert!(!project.refresh_file("/proj/tokens.ts", "export const brand = 'red';\n"));
+
+    assert_eq!(refresh_affected(&mut project, &fs), vec!["/proj/App.tsx"]);
+    assert_yaml_snapshot!(sorted_atoms(&project), @r"
+    - prop: color
+      value: red
+      conditions: []
+    ");
+}
+
+#[test]
+fn creating_an_unrelated_file_does_not_affect_an_unresolved_importer() {
+    let (fs, mut project) = watch_project(&[("App.tsx", app_source())]);
+    project.parse_file("/proj/App.tsx", app_source());
+
+    write(&fs, "other.ts", "export const value = 'blue';\n");
+    assert!(!project.refresh_file("/proj/other.ts", "export const value = 'blue';\n"));
+
+    assert!(project.take_affected_files().is_empty());
+    assert_yaml_snapshot!(sorted_atoms(&project), @"[]");
+}
+
+#[test]
+fn removing_an_unresolved_importer_drops_its_pending_request() {
+    let (fs, mut project) = watch_project(&[("App.tsx", app_source())]);
+    project.parse_file("/proj/App.tsx", app_source());
+    assert!(project.remove_file("/proj/App.tsx"));
+
+    write(&fs, "tokens.ts", "export const brand = 'red';\n");
+    assert!(!project.refresh_file("/proj/tokens.ts", "export const brand = 'red';\n"));
+
+    assert!(project.take_affected_files().is_empty());
+    assert_yaml_snapshot!(sorted_atoms(&project), @"[]");
+}
+
+#[test]
+fn clear_drops_pending_requests_and_cached_resolution_misses() {
+    let (fs, mut project) = watch_project(&[("App.tsx", app_source())]);
+    project.parse_file("/proj/App.tsx", app_source());
+    project.clear();
+
+    write(&fs, "tokens.ts", "export const brand = 'red';\n");
+    project.parse_file("/proj/App.tsx", app_source());
+
+    assert!(project.take_affected_files().is_empty());
+    assert_yaml_snapshot!(sorted_atoms(&project), @r"
+    - prop: color
+      value: red
+      conditions: []
+    ");
+}
+
+#[test]
 fn removing_a_token_file_drops_the_folded_atom() {
     let (fs, mut project) = watch_project(&[
         ("App.tsx", app_source()),

--- a/design-notes/cross-file-resolution.md
+++ b/design-notes/cross-file-resolution.md
@@ -67,8 +67,10 @@ refresh, so dev CSS keeps the old atom alongside the new one until the next full
 Host paths may not match the resolver's realpath form (`/var` vs `/private/var`). `dependency_key` normalizes through
 the resolver's filesystem. A deleted file canonicalizes its parent so unlink events still match.
 
-Known gap: an import that failed to resolve at extract time records no path, so creating the missing module later does
-not mark the importer. Editing the importer, or a full build, picks it up.
+Failed resolutions are retained as `(from_file, specifier)` requests. When a new file enters the project, `Project`
+probes only those requests with a fresh resolver. If one now resolves, the long-lived resolver cache is cleared and its
+importer is reported through `affectedFiles()`. Nested requests are also stored on cached exports, so creating a module
+behind a re-export invalidates the cached miss.
 
 ## What folds
 

--- a/packages/compiler-wasm/__tests__/browser-driver.test.ts
+++ b/packages/compiler-wasm/__tests__/browser-driver.test.ts
@@ -164,6 +164,38 @@ describe('createBrowserDriver', () => {
     expect(driver.cssgen().css).toContain('blue')
   })
 
+  it('re-extracts an importer when a missing token module is created', async () => {
+    const app = "import { css } from '@panda/css'; import { brand } from './tokens'; css({ color: brand })"
+    const driver = await createBrowserDriver({
+      snapshot,
+      sources: { '/proj/App.tsx': app },
+    })
+    driver.parseFiles()
+    expect(driver.cssgen().css).not.toContain('color: red')
+
+    expect(
+      driver.applyChange({
+        path: '/proj/tokens.ts',
+        kind: 'add',
+        content: "export const brand = 'red'",
+      }),
+    ).toBe(true)
+    expect(driver.compiler.getFile('/proj/tokens.ts')).toBeNull()
+
+    const incrementalCss = driver.cssgen().css
+    expect(incrementalCss).toContain('color: red')
+
+    const cold = await createBrowserDriver({
+      snapshot,
+      sources: {
+        '/proj/App.tsx': app,
+        '/proj/tokens.ts': "export const brand = 'red'",
+      },
+    })
+    cold.parseFiles()
+    expect(incrementalCss).toBe(cold.cssgen().css)
+  })
+
   it('keeps explicitly registered sources refreshable outside the configured source set', async () => {
     const driver = await createBrowserDriver({ snapshot })
     const injected = '/proj/Injected.ts'

--- a/packages/compiler/__tests__/node-driver.test.ts
+++ b/packages/compiler/__tests__/node-driver.test.ts
@@ -202,6 +202,36 @@ describe('createNodeDriver', () => {
     }
   })
 
+  it('re-extracts an importer when a missing token module is created', async () => {
+    const watchDir = mkdtempSync(join(tmpdir(), 'panda-driver-cross-file-create-'))
+    try {
+      writeFileTree(watchDir, {
+        'panda.config.ts': `export default {
+          include: ['**/*.tsx'],
+          importMap: { css: ['@panda/css'] },
+        }`,
+        'App.tsx': "import { brand } from './tokens'; import { css } from '@panda/css'; css({ color: brand })",
+      })
+      const driver = await createNodeDriver({ cwd: watchDir })
+      driver.parseFiles()
+      expect(driver.cssgen().css).not.toContain('color: red')
+
+      const tokens = join(watchDir, 'tokens.ts')
+      writeFileSync(tokens, "export const brand = 'red'")
+      expect(driver.applyChange({ path: tokens, kind: 'add' })).toBe(true)
+      expect(driver.compiler.getFile(tokens)).toBeNull()
+
+      const incrementalCss = driver.cssgen().css
+      expect(incrementalCss).toContain('color: red')
+
+      const cold = await createNodeDriver({ cwd: watchDir })
+      cold.parseFiles()
+      expect(incrementalCss).toBe(cold.cssgen().css)
+    } finally {
+      rmSync(watchDir, { recursive: true, force: true })
+    }
+  })
+
   it('re-extracts importers through the config pattern transform', async () => {
     const watchDir = mkdtempSync(join(tmpdir(), 'panda-driver-cross-file-pattern-'))
     try {


### PR DESCRIPTION
## Description

Retains failed cross-file resolution requests and retries them when a new file is observed. If a request now
resolves, its importer is reported through `affectedFiles()` and refreshed through the existing host path.

Nested requests are retained with cached exports, so creating a missing module behind a re-export also invalidates the cached miss. Retry probes use a fresh resolver; the long-lived resolver cache is cleared only after a request becomes resolvable.

Closes #3782

## Current behavior

Creating a module that was missing during extraction does not refresh its importer. Incremental output remains stale until the importer changes or a full build runs.

## New behavior

Creating the module refreshes direct and re-exporting importers. Resolution continues to use `oxc_resolver`, including extension probing and directory indexes. Unrelated additions do not refresh unresolved importers.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validation:

- Rust 1.93 format and clippy checks
- 2,446 Rust tests
- Native compiler build and 602 tests
- WASM node and web builds and 67 tests
- `wasm32-unknown-unknown` check
- TypeScript typecheck


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR retains unresolved cross-file import requests and retries them when newly observed files make those requests resolvable.

- Propagates direct and nested unresolved dependencies through extractor results.
- Adds project-side pending-request indexing and affected-file invalidation.
- Clears resolver misses when a pending request becomes resolvable.
- Adds Rust, Node driver, and browser driver coverage for newly created modules and lifecycle cleanup.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security defects identified.

The new retry path consistently retains unresolved requests, probes additions with a fresh resolver, invalidates cached misses, refreshes affected importers through the existing host path, and cleans pending state during normal lifecycle operations.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/pandacss_extractor/src/cross_file.rs | Retains nested resolution misses in export-cache entries, probes them with resolver semantics, and invalidates stale cached exports when they become resolvable. |
| crates/pandacss_extractor/src/extract.rs | Adds unresolved cross-file dependencies to internal extraction results without changing serialized output. |
| crates/pandacss_extractor/src/scope.rs | Deduplicates and propagates unresolved requests encountered while resolving direct and nested imported values. |
| crates/pandacss_project/src/lib.rs | Indexes unresolved requests by importer, retries them for newly observed files, and integrates cleanup with reparse, removal, and project clearing. |
| crates/pandacss_project/tests/cross_file_watch.rs | Covers direct and re-exported module creation, unrelated additions, importer removal, and cache clearing. |
| packages/compiler/src/driver.ts | Existing host event routing supports the new project behavior by refreshing untracked additions before registering source files. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Host
    participant Project
    participant Resolver
    participant Importer
    Host->>Project: add newly created module
    Project->>Resolver: probe retained unresolved requests
    Resolver-->>Project: request now resolves
    Project->>Resolver: clear resolution cache
    Project-->>Host: affected importer paths
    Host->>Project: refresh importer
    Project->>Importer: re-extract with resolved module
    Importer-->>Project: updated styles and dependencies
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(project): retry unresolved cross-fil..."](https://github.com/chakra-ui/panda/commit/d8132ae01ccd54f6e4005c0d907a68f95607899a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61075687)</sub>

<!-- /greptile_comment -->