### PR TITLE
fix(vite): handle source file lifecycle events

### DIFF
--- a/.changeset/vite-source-lifecycle.md
+++ b/.changeset/vite-source-lifecycle.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/vite': patch
+---
+
+Keep generated CSS in sync when matching source files are created or deleted in Vite. Panda now watches configured
+source directories and handles Vite's create, update, and delete events.

--- a/packages/vite/__tests__/plugin-unit.test.ts
+++ b/packages/vite/__tests__/plugin-unit.test.ts
@@ -11,7 +11,7 @@ interface TestPlugin {
     code: string,
     id: string,
   ) => unknown
-  handleHotUpdate(ctx: unknown): Promise<unknown>
+  hotUpdate: (this: { environment: unknown }, ctx: unknown) => Promise<unknown>
 }
 
 afterEach(() => {
@@ -31,6 +31,7 @@ describe('@pandacss/vite design-system HMR', () => {
     expect(addWatchFile.mock.calls.map(([file]) => file)).toMatchInlineSnapshot(`
       [
         "/project/src/app.tsx",
+        "/project/src",
         "/project/panda.config.ts",
         "/project/node_modules/@acme/ds/panda/lib.json",
         "/project/node_modules/@acme/ds/panda/buildinfo.json",
@@ -68,18 +69,25 @@ describe('@pandacss/vite design-system HMR', () => {
     await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
     plugin.transform.call({ addWatchFile: vi.fn(), warn: vi.fn() }, CSS_ROOT, '/project/src/index.css')
 
-    const modules = await plugin.handleHotUpdate({
-      file: '/project/node_modules/@acme/ds/src/button.css.ts',
-      modules: [componentModule],
-      read: async () => "import { css } from '@acme/ds/css'\nexport const button = css({ fontSize: '20px' })",
-      server: {
-        config: { logger: { warn: vi.fn() } },
-        moduleGraph: {
-          getModuleById: vi.fn((id) => (id === rootModule.id ? rootModule : undefined)),
-          invalidateModule,
+    const environment = {
+      moduleGraph: {
+        getModuleById: vi.fn((id) => (id === rootModule.id ? rootModule : undefined)),
+        invalidateModule,
+      },
+    }
+    const modules = await plugin.hotUpdate.call(
+      { environment },
+      {
+        type: 'update',
+        file: '/project/node_modules/@acme/ds/src/button.css.ts',
+        modules: [componentModule],
+        read: async () => "import { css } from '@acme/ds/css'\nexport const button = css({ fontSize: '20px' })",
+        server: {
+          config: { logger: { warn: vi.fn() } },
+          environments: { client: environment },
         },
       },
-    })
+    )
 
     expect(driver.syncDesignSystemFileChange).toHaveBeenCalledWith({
       path: '/project/node_modules/@acme/ds/src/button.css.ts',
@@ -99,6 +107,66 @@ describe('@pandacss/vite design-system HMR', () => {
         },
       ]
     `)
+  })
+
+  it.each([
+    ['create', 'add', true],
+    ['update', 'change', true],
+    ['delete', 'unlink', false],
+  ] as const)('maps Vite %s events to Panda %s changes', async (type, kind, readsSource) => {
+    const { driver, pandacss } = await setup()
+    const plugin = pandacss() as unknown as TestPlugin
+    const environment = {
+      moduleGraph: {
+        getModuleById: vi.fn(),
+        invalidateModule: vi.fn(),
+      },
+    }
+    const read = vi.fn(async () => "export const cls = css({ color: 'red' })")
+    driver.isSourceFile.mockReturnValue(true)
+
+    await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
+    await plugin.hotUpdate.call(
+      { environment },
+      {
+        type,
+        file: '/project/src/app.tsx',
+        modules: [],
+        read,
+        server: {
+          config: { logger: { warn: vi.fn() } },
+          environments: { client: environment },
+        },
+      },
+    )
+
+    expect(driver.applyChange).toHaveBeenCalledWith({
+      path: '/project/src/app.tsx',
+      kind,
+      ...(readsSource ? { content: "export const cls = css({ color: 'red' })" } : {}),
+    })
+    expect(read).toHaveBeenCalledTimes(readsSource ? 1 : 0)
+  })
+
+  it('updates the shared driver only for the Vite client environment', async () => {
+    const { driver, pandacss } = await setup()
+    const plugin = pandacss() as unknown as TestPlugin
+    const client = { moduleGraph: {} }
+    driver.isSourceFile.mockReturnValue(true)
+
+    await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
+    await plugin.hotUpdate.call(
+      { environment: { moduleGraph: {} } },
+      {
+        type: 'update',
+        file: '/project/src/app.tsx',
+        modules: [],
+        read: vi.fn(),
+        server: { environments: { client } },
+      },
+    )
+
+    expect(driver.applyChange).not.toHaveBeenCalled()
   })
 
   it('skips source rewrite by default', async () => {

--- a/packages/vite/__tests__/plugin.test.ts
+++ b/packages/vite/__tests__/plugin.test.ts
@@ -73,6 +73,15 @@ async function waitForCss(server: ViteDevServer, needle: string): Promise<string
   throw new Error(`timed out waiting for ${JSON.stringify(needle)} in the served CSS`)
 }
 
+async function waitForCssWithout(server: ViteDevServer, needle: string): Promise<string> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const css = await readCss(server)
+    if (!css.includes(needle)) return css
+    await new Promise((done) => setTimeout(done, 100))
+  }
+  throw new Error(`timed out waiting for ${JSON.stringify(needle)} to leave the served CSS`)
+}
+
 async function waitForWarning(warnings: string[], needle: string): Promise<string> {
   for (let attempt = 0; attempt < 50; attempt++) {
     const warning = warnings.find((item) => item.includes(needle))
@@ -126,6 +135,30 @@ describe('@pandacss/vite', () => {
     const updated = await waitForCss(server, '8px')
     // Additive refresh keeps prior styles in dev — no flash of a missing rule.
     expect(updated).toContain('4px')
+  })
+
+  it('adds CSS when a matching source file is created', async () => {
+    dir = createFixture(`{ color: 'red' }`)
+    server = await startServer(dir)
+    expect(await waitForCss(server, 'red')).not.toContain('rebeccapurple')
+
+    const newFile = join(dir, 'New.tsx')
+    writeFileSync(newFile, APP(`{ color: 'rebeccapurple' }`))
+    server.watcher.emit('add', newFile)
+
+    expect(await waitForCss(server, 'rebeccapurple')).toContain('rebeccapurple')
+  })
+
+  it('removes CSS when a source file is deleted', async () => {
+    dir = createFixture(`{ color: 'rebeccapurple' }`)
+    server = await startServer(dir)
+    expect(await waitForCss(server, 'rebeccapurple')).toContain('rebeccapurple')
+
+    const appFile = join(dir, 'App.tsx')
+    rmSync(appFile)
+    server.watcher.emit('unlink', appFile)
+
+    expect(await waitForCssWithout(server, 'rebeccapurple')).not.toContain('rebeccapurple')
   })
 
   it('keeps previous CSS and reports diagnostics when source syntax breaks', async () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,5 +1,5 @@
 import { createNodeDriver, type Diagnostic, type Driver } from '@pandacss/compiler'
-import { formatDiagnostic, withDiagnosticFile } from '@pandacss/compiler-shared'
+import { formatDiagnostic, withDiagnosticFile, type SourceChange } from '@pandacss/compiler-shared'
 import {
   createPandaSourcePluginHooks,
   createSourceTransformer,
@@ -7,7 +7,7 @@ import {
   type SourceTransformer,
 } from '@pandacss/transformer'
 import { extname } from 'node:path'
-import type { HmrContext, ModuleNode, Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import type { DevEnvironment, EnvironmentModuleNode, HotUpdateOptions, Plugin, ResolvedConfig } from 'vite'
 
 export interface PandaPluginOptions {
   /** Project root. Defaults to Vite's resolved `root`. */
@@ -86,7 +86,11 @@ export function pandacss(options: PandaPluginOptions = {}): Plugin {
     for (const file of driver.scan()) {
       if (file !== inputFile) watch(file)
     }
-    for (const dep of driver.watchTargets().config) {
+    const watchTargets = driver.watchTargets()
+    for (const dir of watchTargets.dirs) {
+      watch(driver.resolvePath(dir))
+    }
+    for (const dep of watchTargets.config) {
       watch(driver.resolvePath(dep))
     }
     if (driver.configPath) {
@@ -110,20 +114,20 @@ export function pandacss(options: PandaPluginOptions = {}): Plugin {
     warnDiagnostics(warn, diagnostics, 'while loading the design system')
   }
 
-  const invalidateRoots = (server: ViteDevServer): ModuleNode[] => {
-    const mods: ModuleNode[] = []
+  const invalidateRoots = (environment: DevEnvironment): EnvironmentModuleNode[] => {
+    const mods: EnvironmentModuleNode[] = []
     for (const id of rootIds) {
-      const mod = server.moduleGraph.getModuleById(id)
+      const mod = environment.moduleGraph.getModuleById(id)
       if (mod) {
-        server.moduleGraph.invalidateModule(mod)
+        environment.moduleGraph.invalidateModule(mod)
         mods.push(mod)
       }
     }
     return mods
   }
 
-  const withInvalidatedRoots = (server: ViteDevServer, modules: ModuleNode[]) => {
-    return [...new Set([...invalidateRoots(server), ...modules])]
+  const withInvalidatedRoots = (environment: DevEnvironment, modules: EnvironmentModuleNode[]) => {
+    return [...new Set([...invalidateRoots(environment), ...modules])]
   }
 
   return {
@@ -189,21 +193,20 @@ export function pandacss(options: PandaPluginOptions = {}): Plugin {
       return { code: `${entry}\n${output.css}`, map: null }
     },
 
-    async handleHotUpdate(ctx: HmrContext) {
+    async hotUpdate(ctx: HotUpdateOptions) {
       if (!driver) return
+      // Vite invokes this hook once per environment; the driver is shared.
+      if (this.environment !== ctx.server.environments.client) return ctx.modules
 
       const designSystemFile = driver.isDesignSystemFile?.(ctx.file) ?? false
       if (designSystemFile) {
-        const changed = await driver.syncDesignSystemFileChange({
-          path: ctx.file,
-          kind: 'change',
-          ...(designSystemFile === 'source' ? { content: await ctx.read() } : {}),
-        })
+        const change = await sourceChangeFromHotUpdate(ctx, designSystemFile === 'source')
+        const changed = await driver.syncDesignSystemFileChange(change)
         if (changed) {
           if (designSystemFile === 'artifact') watchedFiles.clear()
           warnDesignSystemDiagnostics((message) => ctx.server.config.logger.warn(message))
         }
-        return withInvalidatedRoots(ctx.server, ctx.modules)
+        return withInvalidatedRoots(this.environment, ctx.modules)
       }
 
       if (driver.isConfigFile(ctx.file)) {
@@ -214,24 +217,33 @@ export function pandacss(options: PandaPluginOptions = {}): Plugin {
         codegen()
         driver.parseFiles()
         warnDesignSystemDiagnostics((message) => ctx.server.config.logger.warn(message))
-        invalidateRoots(ctx.server)
+        invalidateRoots(this.environment)
         ctx.server.ws.send({ type: 'full-reload' })
         return []
       }
 
       if (driver.isSourceFile(ctx.file)) {
-        driver.applyChange({ path: ctx.file, kind: 'change', content: await ctx.read() })
+        driver.applyChange(await sourceChangeFromHotUpdate(ctx, true))
         warnDiagnostics(
           (message) => ctx.server.config.logger.warn(message),
           driver.compiler.getFile(ctx.file)?.diagnostics,
           `while parsing ${ctx.file}`,
           ctx.file,
         )
-        return withInvalidatedRoots(ctx.server, ctx.modules)
+        return withInvalidatedRoots(this.environment, ctx.modules)
       }
 
       return ctx.modules
     },
+  }
+}
+
+async function sourceChangeFromHotUpdate(ctx: HotUpdateOptions, read: boolean): Promise<SourceChange> {
+  const kind = ctx.type === 'create' ? 'add' : ctx.type === 'delete' ? 'unlink' : 'change'
+  return {
+    path: ctx.file,
+    kind,
+    ...(read && kind !== 'unlink' ? { content: await ctx.read() } : {}),
   }
 }
 


### PR DESCRIPTION
## Description

Updates @pandacss/vite to handle Vite create, update, and delete events. It also watches configured source directories so newly matching files reach the plugin.

## Current behavior

Vite only forwards source updates to Panda. CSS from new matching files is missing, and CSS from deleted files remains until the server restarts.

## New behavior

Vite create, update, and delete events map to Panda add, change, and unlink events. The generated CSS root is invalidated after each change.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validation:

- 18 Vite package tests
- Vite package build with declarations
- TypeScript typecheck
- ESLint and Prettier

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the Panda Vite plugin to process source-file create, update, and delete events and invalidate generated CSS modules.
- Registers configured source directories as Vite watch targets.
- Maps Vite lifecycle events to Panda add, change, and unlink operations.
- Moves HMR processing to Vite’s environment-aware `hotUpdate` hook.
- Adds unit and integration coverage for source creation and deletion.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking test gap because the new-file integration case does not exercise actual directory-watch detection.

The lifecycle mapping and invalidation paths are covered, but manually emitting the add event means the test cannot detect a failure in the newly added directory-watch registration.

**Files Needing Attention:** packages/vite/__tests__/plugin.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/vite/src/index.ts | Adds source-directory watches and environment-aware lifecycle-event processing with root invalidation. |
| packages/vite/__tests__/plugin-unit.test.ts | Covers lifecycle-event mapping, content reads, invalidation, and client-environment gating. |
| packages/vite/__tests__/plugin.test.ts | Adds create/delete CSS integration cases, but the create case bypasses actual watcher detection by emitting the event manually. |
| .changeset/vite-source-lifecycle.md | Accurately records the Vite lifecycle synchronization fix as a patch release. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FS as Source filesystem
    participant Vite as Vite watcher
    participant Plugin as Panda Vite plugin
    participant Driver as Panda driver
    participant CSS as Generated CSS root
    FS->>Vite: create / update / delete
    Vite->>Plugin: hotUpdate(type, file)
    Plugin->>Plugin: require client environment
    Plugin->>Driver: add / change / unlink
    Driver-->>Plugin: updated compiler state
    Plugin->>CSS: invalidate module
    CSS-->>Vite: regenerated CSS
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20chakra-ui%2Fpanda%20PR%20%233784%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=chakra-ui%2Fpanda&pr=3784&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fvite%2F__tests__%2Fplugin.test.ts%3A147%0A**Creation%20test%20bypasses%20watcher**%0A%0AThe%20test%20manually%20emits%20the%20%60add%60%20event%20after%20writing%20%60New.tsx%60%2C%20so%20it%20bypasses%20the%20directory-watch%20behavior%20added%20by%20this%20PR%20and%20will%20still%20pass%20when%20that%20registration%20fails%20to%20detect%20newly%20created%20files.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fpanda&pr=3784&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/vite/__tests__/plugin.test.ts:147
**Creation test bypasses watcher**

The test manually emits the `add` event after writing `New.tsx`, so it bypasses the directory-watch behavior added by this PR and will still pass when that registration fails to detect newly created files.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(vite): handle source file lifecycle ..."](https://github.com/chakra-ui/panda/commit/e14462986771946a2a9cecb299c37f93e7b5ed4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61083066)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->