### PR TITLE
fix(rollup): handle source file lifecycle events

### DIFF
--- a/.changeset/rollup-source-lifecycle.md
+++ b/.changeset/rollup-source-lifecycle.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/rollup': patch
+---
+
+Keep generated CSS in sync when matching source files are created or deleted in Rollup watch mode. Panda now watches
+source directories, config dependencies, and design-system files.

--- a/packages/rollup/__tests__/plugin-watch.test.ts
+++ b/packages/rollup/__tests__/plugin-watch.test.ts
@@ -1,0 +1,161 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { watch, type RollupWatcher, type RollupWatcherEvent } from 'rollup'
+import { afterEach, describe, expect, it } from 'vitest'
+import { pandacss } from '../src'
+
+const CONFIG = `export default {
+  outdir: 'styled-system',
+  include: ['./src/**/*.tsx'],
+  importMap: {
+    css: ['@panda/css'],
+    recipe: ['@panda/recipes'],
+    pattern: ['@panda/patterns'],
+    jsx: ['@panda/jsx'],
+    tokens: ['@panda/tokens'],
+  },
+}
+`
+
+const APP = (color: string) => `import { css } from '@panda/css'
+export const className = css({ color: '${color}' })
+`
+
+function createFixture(color: string) {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'panda-rollup-')))
+  mkdirSync(join(dir, 'src'))
+  writeFileSync(join(dir, 'panda.config.ts'), CONFIG)
+  writeFileSync(join(dir, 'index.js'), 'export const value = 1\n')
+  writeFileSync(join(dir, 'src', 'App.tsx'), APP(color))
+  return dir
+}
+
+function startWatcher(dir: string, watchedFiles: string[]): { watcher: RollupWatcher; ready: Promise<void> } {
+  const watcher = watch({
+    input: join(dir, 'index.js'),
+    output: { dir: join(dir, 'dist'), format: 'es' },
+    plugins: [
+      pandacss({ cwd: dir }),
+      {
+        name: 'capture-watch-files',
+        buildEnd() {
+          watchedFiles.splice(0, watchedFiles.length, ...this.getWatchFiles())
+        },
+      },
+    ],
+  })
+  return { watcher, ready: waitForBuild(watcher) }
+}
+
+function waitForBuild(watcher: RollupWatcher): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    watcher.on('event', (event) => {
+      if (settled) return
+      if (event.code === 'ERROR') {
+        settled = true
+        reject(event.error)
+      } else if (event.code === 'END') {
+        settled = true
+        resolve()
+      }
+    })
+  })
+}
+
+function waitForWatchRegistration(watcher: RollupWatcher, file: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let rebuilding = false
+    const interval = setInterval(() => appendFileSync(file, '\n'), 100)
+    const timeout = setTimeout(() => finish(new Error('timed out waiting for Rollup to register watch files')), 5_000)
+
+    const finish = (error?: Error) => {
+      clearInterval(interval)
+      clearTimeout(timeout)
+      watcher.off('event', onEvent)
+      if (error) reject(error)
+      else resolve()
+    }
+    const onEvent = (event: RollupWatcherEvent) => {
+      if (event.code === 'ERROR') finish(event.error)
+      if (event.code === 'BUNDLE_START') {
+        rebuilding = true
+        clearInterval(interval)
+      } else if (event.code === 'END' && rebuilding) {
+        finish()
+      }
+    }
+
+    watcher.on('event', onEvent)
+    appendFileSync(file, '\n')
+  })
+}
+
+async function waitForCss(dir: string, predicate: (css: string) => boolean): Promise<string> {
+  const file = join(dir, 'dist', 'panda.css')
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (existsSync(file)) {
+      const css = readFileSync(file, 'utf8')
+      if (predicate(css)) return css
+    }
+    await new Promise((done) => setTimeout(done, 100))
+  }
+  throw new Error('timed out waiting for the generated CSS')
+}
+
+describe('@pandacss/rollup watch mode', () => {
+  let dir: string | undefined
+  let watcher: RollupWatcher | undefined
+
+  afterEach(async () => {
+    await watcher?.close()
+    watcher = undefined
+    if (dir) rmSync(dir, { recursive: true, force: true })
+    dir = undefined
+  })
+
+  it('adds CSS when a matching source file is created', async () => {
+    dir = createFixture('red')
+    const watchedFiles: string[] = []
+    const started = startWatcher(dir, watchedFiles)
+    watcher = started.watcher
+    await started.ready
+    await waitForWatchRegistration(watcher, join(dir, 'src', 'App.tsx'))
+    expect(await waitForCss(dir, (css) => css.includes('red'))).not.toContain('rebeccapurple')
+    expect(watchedFiles).toContain(join(dir, 'src', 'App.tsx'))
+    expect(watchedFiles).toContain(join(dir, 'src'))
+
+    const rebuild = waitForBuild(watcher)
+    writeFileSync(join(dir, 'src', 'New.tsx'), APP('rebeccapurple'))
+    await rebuild
+
+    expect(await waitForCss(dir, (css) => css.includes('rebeccapurple'))).toContain('rebeccapurple')
+  })
+
+  it('removes CSS when a source file is deleted', async () => {
+    dir = createFixture('rebeccapurple')
+    const watchedFiles: string[] = []
+    const started = startWatcher(dir, watchedFiles)
+    watcher = started.watcher
+    await started.ready
+    await waitForWatchRegistration(watcher, join(dir, 'src', 'App.tsx'))
+    expect(await waitForCss(dir, (css) => css.includes('rebeccapurple'))).toContain('rebeccapurple')
+    expect(watchedFiles).toContain(join(dir, 'src', 'App.tsx'))
+
+    const rebuild = waitForBuild(watcher)
+    rmSync(join(dir, 'src', 'App.tsx'))
+    await rebuild
+
+    expect(await waitForCss(dir, (css) => !css.includes('rebeccapurple'))).not.toContain('rebeccapurple')
+  })
+})

--- a/packages/rollup/__tests__/plugin.test.ts
+++ b/packages/rollup/__tests__/plugin.test.ts
@@ -14,6 +14,7 @@ import { pandacss } from '../src'
 
 interface TestPlugin {
   buildStart(this: TestContext): Promise<void>
+  watchChange(id: string, change: { event: 'create' | 'delete' | 'update' }): Promise<void>
   generateBundle(this: TestContext, output: { dir?: string; file?: string }): Promise<void>
 }
 
@@ -85,16 +86,72 @@ describe('@pandacss/rollup', () => {
       }
     `)
   })
+
+  it('watches source directories, config dependencies, and design-system files', async () => {
+    const driver = createDriver([])
+    driver.scan.mockReturnValue(['/project/src/app.tsx'])
+    mocks.createNodeDriver.mockResolvedValue(driver)
+    const plugin = pandacss()[0] as unknown as TestPlugin
+    const context = createContext()
+
+    await plugin.buildStart.call(context)
+
+    expect(context.addWatchFile.mock.calls.map(([file]) => file)).toMatchInlineSnapshot(`
+      [
+        "/project/src",
+        "/project/panda.shared.ts",
+        "/project/panda.config.ts",
+        "/project/src/app.tsx",
+        "/project/node_modules/@acme/ds/panda/lib.json",
+        "/project/node_modules/@acme/ds/panda/buildinfo.json",
+        "/project/node_modules/@acme/ds/panda/preset.mjs",
+        "/project/node_modules/@acme/ds/src/button.tsx",
+      ]
+    `)
+  })
+
+  it.each([
+    ['create', 'add'],
+    ['update', 'change'],
+    ['delete', 'unlink'],
+  ] as const)('maps Rollup %s events to Panda %s changes', async (event, kind) => {
+    const driver = createDriver([])
+    driver.isSourceFile.mockReturnValue(true)
+    mocks.createNodeDriver.mockResolvedValue(driver)
+    const plugin = pandacss()[0] as unknown as TestPlugin
+
+    await plugin.buildStart.call(createContext())
+    await plugin.watchChange('/project/src/app.tsx', { event })
+
+    expect(driver.applyChange).toHaveBeenCalledWith({ path: '/project/src/app.tsx', kind })
+  })
 })
 
 function createDriver(diagnostics: Array<{ severity: 'error' | 'info' | 'warning'; code: string; message: string }>) {
   return {
     compiler: {},
-    configPath: undefined,
+    configPath: '/project/panda.config.ts',
+    applyChange: vi.fn(),
     codegen: vi.fn(),
     parseFiles: vi.fn(),
-    scan: vi.fn(() => []),
+    scan: vi.fn((): string[] => []),
     cssgen: vi.fn(() => ({ css: '.generated { color: red }', diagnostics })),
+    designSystemDiagnostics: [],
+    designSystemWatchTargets: vi.fn(() => [
+      {
+        manifestPath: '/project/node_modules/@acme/ds/panda/lib.json',
+        buildInfoPath: '/project/node_modules/@acme/ds/panda/buildinfo.json',
+        presetPath: '/project/node_modules/@acme/ds/panda/preset.mjs',
+        sourceFiles: ['/project/node_modules/@acme/ds/src/button.tsx'],
+      },
+    ]),
+    isConfigFile: vi.fn(() => false),
+    isDesignSystemFile: vi.fn(() => false),
+    isSourceFile: vi.fn(() => false),
+    reload: vi.fn(),
+    resolvePath: vi.fn((path: string) => path),
+    syncDesignSystemFileChange: vi.fn(),
+    watchTargets: vi.fn(() => ({ dirs: ['/project/src'], config: ['/project/panda.shared.ts'], sources: [] })),
   }
 }
 

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -1,5 +1,5 @@
 import { createNodeDriver, type NodeDriver } from '@pandacss/compiler'
-import { formatDiagnostic, type Diagnostic } from '@pandacss/compiler-shared'
+import { formatDiagnostic, type Diagnostic, type SourceChange } from '@pandacss/compiler-shared'
 import { pandaTransformer } from '@pandacss/transformer'
 import { dirname } from 'node:path'
 import type { Plugin, PluginContext } from 'rollup'
@@ -63,21 +63,33 @@ export function pandacss(options: PandaRollupOptions = {}): Plugin[] {
 
     async buildStart() {
       await build()
-      // Watch the config and every scanned source so a change rebuilds.
+      const watchTargets = driver!.watchTargets()
+      for (const dir of watchTargets.dirs) this.addWatchFile(driver!.resolvePath(dir))
+      for (const config of watchTargets.config) this.addWatchFile(driver!.resolvePath(config))
       if (driver!.configPath) this.addWatchFile(driver!.configPath)
       for (const file of driver!.scan()) this.addWatchFile(file)
+      for (const target of driver!.designSystemWatchTargets()) {
+        this.addWatchFile(target.manifestPath)
+        this.addWatchFile(target.buildInfoPath)
+        this.addWatchFile(target.presetPath)
+        for (const file of target.sourceFiles) this.addWatchFile(file)
+      }
     },
 
-    async watchChange(id) {
+    async watchChange(id, change) {
       if (!driver) return
-      if (driver.isConfigFile(id)) {
+      const sourceChange = sourceChangeFromRollup(id, change.event)
+      const designSystemFile = driver.isDesignSystemFile(id)
+      if (designSystemFile) {
+        await driver.syncDesignSystemFileChange(sourceChange)
+      } else if (driver.isConfigFile(id)) {
         const diff = await driver.reload()
         if (diff.hasChanged) {
           driver.codegen({ cwd, outdir })
           driver.parseFiles()
         }
       } else if (driver.isSourceFile(id)) {
-        driver.applyChange({ path: id, kind: 'change' })
+        driver.applyChange(sourceChange)
       }
     },
 
@@ -104,6 +116,11 @@ export function pandacss(options: PandaRollupOptions = {}): Plugin[] {
   })
 
   return [orchestrator, ...(Array.isArray(transform) ? transform : [transform])]
+}
+
+function sourceChangeFromRollup(path: string, event: 'create' | 'delete' | 'update'): SourceChange {
+  const kind = event === 'create' ? 'add' : event === 'delete' ? 'unlink' : 'change'
+  return { path, kind }
 }
 
 function reportDiagnostics(context: PluginContext, diagnostics: readonly Diagnostic[]) {


### PR DESCRIPTION
## Description

Updates @pandacss/rollup to watch source directories, config dependencies, and design-system files. Rollup create, update, and delete events now map to Panda add, change, and unlink events.

## Current behavior

Rollup watches only files found during the initial scan and treats every event as a change. CSS from new matching files is missing, and CSS from deleted files remains until the watcher restarts.

## New behavior

New matching files trigger a rebuild, and deleted files are removed from generated CSS. Config dependencies and design-system inputs also participate in watch mode.

## Is this a breaking change (Yes/No):

No.

## Additional Information

Validation:

- 8 Rollup package tests, including real watch mode
- Rollup package build with declarations
- Rollup sandbox build
- Rolldown 1.2.7 sandbox build
- TypeScript typecheck
- ESLint and Prettier

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the Rollup plugin’s watch integration to track source directories, config dependencies, and design-system inputs while translating Rollup lifecycle events into Panda source changes.
- Registers source directories, config dependencies, scanned sources, and design-system artifacts with Rollup
- Maps create, update, and delete events to Panda add, change, and unlink operations
- Adds unit and real-watch coverage for source creation and deletion
</details>


<h3>Confidence Score: 4/5</h3>

The design-system watch path should be fixed before merging because it can rebuild CSS while leaving associated styled-system codegen stale.

Newly watched design-system artifacts are routed through synchronization that reloads and reparses the compiler but omits the codegen call used for config changes, allowing generated artifacts and CSS to diverge.

**Files Needing Attention:** packages/rollup/src/index.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/rollup/src/index.ts | Adds comprehensive watch-target registration and lifecycle mapping, but design-system artifact events bypass codegen regeneration. |
| packages/rollup/__tests__/plugin-watch.test.ts | Adds real Rollup watch tests covering CSS updates for source-file creation and deletion. |
| packages/rollup/__tests__/plugin.test.ts | Adds unit coverage for watch registration and event mapping, but not synchronization of generated artifacts after design-system changes. |
| .changeset/rollup-source-lifecycle.md | Accurately describes the expanded Rollup watch behavior at a high level. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FS as Watched filesystem
    participant Rollup
    participant Plugin as Panda Rollup plugin
    participant Driver as NodeDriver
    FS->>Rollup: design-system artifact changes
    Rollup->>Plugin: watchChange(id, event)
    Plugin->>Driver: syncDesignSystemFileChange(change)
    Driver->>Driver: reload() and parseFiles()
    Note over Driver: codegen() is not invoked
    Rollup->>Plugin: generateBundle()
    Plugin->>Driver: cssgen()
    Driver-->>Plugin: Updated CSS
    Note over Plugin,Driver: Styled-system codegen remains stale
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20chakra-ui%2Fpanda%20PR%20%233785%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=chakra-ui%2Fpanda&pr=3785&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Frollup%2Fsrc%2Findex.ts%3A82-84%0A**Design-system%20codegen%20remains%20stale**%0A%0AWhen%20a%20watched%20design-system%20manifest%2C%20build-info%20file%2C%20or%20preset%20changes%2C%20this%20branch%20calls%20%60syncDesignSystemFileChange%60%2C%20which%20reloads%20and%20parses%20without%20running%20%60codegen%60%3B%20because%20these%20artifacts%20also%20classify%20as%20config%20files%2C%20the%20subsequent%20config%20branch%20never%20runs%2C%20causing%20CSS%20to%20update%20while%20generated%20styled-system%20artifacts%20such%20as%20token%20typings%20remain%20stale.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fpanda&pr=3785&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/rollup/src/index.ts:82-84
**Design-system codegen remains stale**

When a watched design-system manifest, build-info file, or preset changes, this branch calls `syncDesignSystemFileChange`, which reloads and parses without running `codegen`; because these artifacts also classify as config files, the subsequent config branch never runs, causing CSS to update while generated styled-system artifacts such as token typings remain stale.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rollup): handle source file lifecycl..."](https://github.com/chakra-ui/panda/commit/09a46c9e41c55ce9d523b0abc36284a8c27dd641) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61085107)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->