### PR TITLE
fix(transform): preserve recipe tree shaking

### DIFF
--- a/.changeset/pure-transformed-recipe-factories.md
+++ b/.changeset/pure-transformed-recipe-factories.md
@@ -1,0 +1,7 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/transformer': patch
+---
+
+Mark transformed `cva()`, `sva()`, and `styled()` recipe factories as pure so bundlers can remove unused definitions and
+their runtime helpers.

--- a/crates/pandacss_project/src/transform/plan.rs
+++ b/crates/pandacss_project/src/transform/plan.rs
@@ -300,10 +300,10 @@ pub(crate) fn build_plan(
                 }
             }
             MatchCategory::Jsx if targets.jsx_enabled() => {
-                if let Some(rewrite) =
-                    super::recipe_inline::rewrite_for_styled_call(project, source, call)
+                if let Some(rewrites) =
+                    super::recipe_inline::rewrites_for_styled_call(project, source, call)
                 {
-                    plan.push(rewrite);
+                    plan.extend(rewrites);
                 }
             }
             _ => {}

--- a/crates/pandacss_project/src/transform/recipe_inline.rs
+++ b/crates/pandacss_project/src/transform/recipe_inline.rs
@@ -29,7 +29,7 @@ pub(crate) fn rewrite_for_cva_call(
     Some(Rewrite {
         start: span.start,
         end: span.end,
-        content: format!("{CVA_HELPER_LOCAL}({encoded})"),
+        content: format!("/* @__PURE__ */ {CVA_HELPER_LOCAL}({encoded})"),
         preserved: style
             .map(style_lower::preserved_source_spans)
             .unwrap_or_default(),
@@ -50,7 +50,7 @@ pub(crate) fn rewrite_for_sva_call(
     Some(Rewrite {
         start: span.start,
         end: span.end,
-        content: format!("{SVA_HELPER_LOCAL}({encoded})"),
+        content: format!("/* @__PURE__ */ {SVA_HELPER_LOCAL}({encoded})"),
         preserved: Vec::new(),
         helper: TransformHelperFacts::sva(),
     })
@@ -415,7 +415,7 @@ pub(crate) fn rewrite_styled_config_arg(
     let arg = arg_spans.get(config_arg_index)?;
     let content = {
         let encoded = encode_cva_config(project, source, config, style)?;
-        format!("{CVA_HELPER_LOCAL}({encoded})")
+        format!("/* @__PURE__ */ {CVA_HELPER_LOCAL}({encoded})")
     };
     Some(Rewrite {
         start: arg.start,
@@ -429,11 +429,11 @@ pub(crate) fn rewrite_styled_config_arg(
 }
 
 /// `styled('tag', config)` / `styled.tag(config)` factory call transforms.
-pub(crate) fn rewrite_for_styled_call(
+pub(crate) fn rewrites_for_styled_call(
     project: &Project,
     source: &str,
     call: &pandacss_extractor::ExtractedCall,
-) -> Option<Rewrite> {
+) -> Option<[Rewrite; 2]> {
     if call.category != pandacss_extractor::MatchCategory::Jsx || call.jsx_recipe_ident.is_some() {
         return None;
     }
@@ -446,14 +446,26 @@ pub(crate) fn rewrite_for_styled_call(
         .style_args
         .get(config_index)
         .and_then(|value| value.as_ref());
-    rewrite_styled_config_arg(
+    let config = rewrite_styled_config_arg(
         project,
         source,
         &call.arg_spans,
         config_index,
         config,
         style,
-    )
+    )?;
+    let callee_span = call.facts.callee_span;
+    let callee = super::resolve::span_slice(source, callee_span)?;
+    let outer = Rewrite {
+        start: callee_span.start,
+        end: callee_span.end,
+        content: format!("/* @__PURE__ */ {callee}"),
+        // The replacement re-emits the original callee. Keep its resolved
+        // import reference live during dead-import cleanup.
+        preserved: vec![callee_span],
+        helper: TransformHelperFacts::none(),
+    };
+    Some([outer, config])
 }
 
 fn is_jsx_factory_call(call: &pandacss_extractor::ExtractedCall) -> bool {

--- a/crates/pandacss_project/tests/transform/edges.rs
+++ b/crates/pandacss_project/tests/transform/edges.rs
@@ -787,7 +787,7 @@ fn styled_call_syntax_rewrites_config_to_string_branch_cva() {
     assert_snapshot!(output.code, @r"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    export const Card = styled('div', __pcva({ base: 'color_red' }));
+    export const Card = /* @__PURE__ */ styled('div', /* @__PURE__ */ __pcva({ base: 'color_red' }));
     ");
 }
 
@@ -805,7 +805,7 @@ fn styled_member_call_rewrites_style_object_to_string_branch_cva() {
     assert_snapshot!(output.code, @r"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    export const Card = styled.div(__pcva({ base: 'color_red' }));
+    export const Card = /* @__PURE__ */ styled.div(/* @__PURE__ */ __pcva({ base: 'color_red' }));
     ");
 }
 

--- a/crates/pandacss_project/tests/transform/import_cleanup.rs
+++ b/crates/pandacss_project/tests/transform/import_cleanup.rs
@@ -83,7 +83,7 @@ fn narrows_partial_css_import_when_only_cva_stays_live() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     export const cls = "color_red";
-    export const button = __pcva({ base: 'color_blue' });
+    export const button = /* @__PURE__ */ __pcva({ base: 'color_blue' });
     "#);
 }
 

--- a/crates/pandacss_project/tests/transform/jsx_chain_fold.rs
+++ b/crates/pandacss_project/tests/transform/jsx_chain_fold.rs
@@ -18,7 +18,7 @@ fn element_props_win_over_the_chain_base() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }));
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }));
     export const el = <button type="submit" className="color_blue" />;
     "#);
 }
@@ -38,7 +38,7 @@ fn an_alias_of_a_folded_chain_still_folds() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }));
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }));
     const Alias = Button;
     export const el = <button className="color_red" />;
     "#);
@@ -58,7 +58,7 @@ fn folds_a_styled_definition_to_its_intrinsic_tag() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }));
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }));
     export const el = <button className="color_red">hi</button>;
     "#);
 }
@@ -79,7 +79,7 @@ fn folds_a_multi_level_chain_with_the_outermost_level_winning() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const L0 = styled('button', __pcva({ base: 'color_red margin_0' }));
+    const L0 = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red margin_0' }));
     const L1 = styled(L0, { base: { color: 'blue' } });
     const L2 = styled(L1, { base: { color: 'green' } });
     export const el = <button className="color_green margin_0">hi</button>;
@@ -100,7 +100,7 @@ fn the_as_prop_retargets_a_folded_chain() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }));
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }));
     export const el = <a href="/home" className="color_red" />;
     "#);
 }
@@ -225,7 +225,7 @@ fn style_only_default_props_fold_into_the_class_string() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { margin: '0' },
     });
     export const el = <button className="color_red margin_0">hi</button>;
@@ -248,7 +248,7 @@ fn a_shorthand_default_prop_folds() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { bg: 'blue' },
     });
     export const el = <button className="bg_blue color_red" />;
@@ -271,7 +271,7 @@ fn default_props_win_over_the_chain_base() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { color: 'blue' },
     });
     export const el = <button className="color_blue" />;
@@ -294,7 +294,7 @@ fn element_props_win_over_default_props() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { color: 'blue' },
     });
     export const el = <button className="color_green" />;
@@ -318,7 +318,7 @@ fn an_alias_of_a_chain_with_default_props_still_folds() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { margin: '0' },
     });
     const Alias = Button;
@@ -345,7 +345,7 @@ fn wrapping_a_chain_drops_the_inner_levels_default_props() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Base = styled('button', __pcva({ base: 'color_red' }), {
+    const Base = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { margin: '0' },
     });
     const Button = styled(Base, { base: { padding: '4px' } });
@@ -404,7 +404,7 @@ fn a_statically_resolved_spread_in_default_props_still_folds() {
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
     const shared = { margin: '0' };
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { ...shared, color: 'blue' },
     });
     export const el = <button className="color_blue margin_0" />;
@@ -460,7 +460,7 @@ fn a_conditional_default_prop_folds() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    const Button = styled('button', __pcva({ base: 'color_red' }), {
+    const Button = /* @__PURE__ */ styled('button', /* @__PURE__ */ __pcva({ base: 'color_red' }), {
       defaultProps: { color: { base: 'blue', _hover: 'green' } },
     });
     export const el = <button className="color_blue hover:color_green" />;

--- a/crates/pandacss_project/tests/transform/recipe_inline.rs
+++ b/crates/pandacss_project/tests/transform/recipe_inline.rs
@@ -26,7 +26,7 @@ fn rewrites_inline_cva_to_string_branch_config() {
     assert!(output.helper.needs_cva);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    export const button = __pcva({ base: 'background-color_blue color_red', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } });
+    export const button = /* @__PURE__ */ __pcva({ base: 'background-color_blue color_red', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } });
     "#);
 }
 
@@ -57,7 +57,7 @@ fn rewrites_inline_sva_to_string_branch_config() {
     assert!(output.helper.needs_sva);
     assert_snapshot!(output.code, @r#"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const tabs = __psva({ slots: ['root', 'trigger'], base: { root: 'd_flex', trigger: 'cursor_pointer' }, variants: { size: { sm: 'fs_12px' } } });
+    export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], base: { root: 'd_flex', trigger: 'cursor_pointer' }, variants: { size: { sm: 'fs_12px' } } });
     "#);
 }
 
@@ -88,7 +88,7 @@ fn rewrites_cva_with_compound_variants() {
     assert!(output.helper.needs_cva);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    export const button = __pcva({ base: 'color_white', variants: { size: { sm: 'fs_12px' }, intent: { danger: 'background-color_red' } }, defaultVariants: { size: 'sm', intent: 'danger' }, compoundVariants: [{ size: 'sm', intent: 'danger', css: 'color_black' }] });
+    export const button = /* @__PURE__ */ __pcva({ base: 'color_white', variants: { size: { sm: 'fs_12px' }, intent: { danger: 'background-color_red' } }, defaultVariants: { size: 'sm', intent: 'danger' }, compoundVariants: [{ size: 'sm', intent: 'danger', css: 'color_black' }] });
     "#);
 }
 
@@ -129,7 +129,7 @@ fn rewrites_sva_variants_per_slot_when_slots_differ() {
     assert!(output.helper.needs_sva);
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const card = __psva({ slots: ['root', 'header', 'body'], base: { root: 'd_grid' }, variants: { size: { sm: { root: 'padding_4px', header: 'fs_12px' }, lg: { root: 'padding_16px', header: 'fs_20px', body: 'gap_8px' } } }, defaultVariants: { size: 'lg' }, compoundVariants: [{ size: 'sm', css: { body: 'd_none' } }] });
+    export const card = /* @__PURE__ */ __psva({ slots: ['root', 'header', 'body'], base: { root: 'd_grid' }, variants: { size: { sm: { root: 'padding_4px', header: 'fs_12px' }, lg: { root: 'padding_16px', header: 'fs_20px', body: 'gap_8px' } } }, defaultVariants: { size: 'lg' }, compoundVariants: [{ size: 'sm', css: { body: 'd_none' } }] });
     ");
 }
 
@@ -147,7 +147,7 @@ fn keeps_an_sva_variant_off_the_slots_it_does_not_style() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const tabs = __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'fs_12px' } } } });
+    export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'fs_12px' } } } });
     ");
 }
 
@@ -171,7 +171,7 @@ fn rewrites_sva_boolean_variant_that_styles_one_slot() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const tabs = __psva({ slots: ['root', 'trigger'], variants: { fitted: { true: { trigger: 'flex_1' }, false: { trigger: 'flex_none' } } }, defaultVariants: { fitted: true } });
+    export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], variants: { fitted: { true: { trigger: 'flex_1' }, false: { trigger: 'flex_none' } } }, defaultVariants: { fitted: true } });
     ");
 }
 
@@ -189,7 +189,7 @@ fn rewrites_sva_boolean_variant_shared_by_every_slot() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const card = __psva({ slots: ['root', 'title'], variants: { muted: { true: 'opacity_0.5' } } });
+    export const card = /* @__PURE__ */ __psva({ slots: ['root', 'title'], variants: { muted: { true: 'opacity_0.5' } } });
     ");
 }
 
@@ -211,7 +211,7 @@ fn rewrites_sva_boolean_compound_condition_as_a_boolean() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const tabs = __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'gap_4px' } }, fitted: { true: { trigger: 'flex_1' } } }, compoundVariants: [{ size: 'sm', fitted: true, css: { trigger: 'padding_0' } }] });
+    export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'gap_4px' } }, fitted: { true: { trigger: 'flex_1' } } }, compoundVariants: [{ size: 'sm', fitted: true, css: { trigger: 'padding_0' } }] });
     ");
 }
 
@@ -232,7 +232,7 @@ fn rewrites_cva_boolean_compound_condition_as_a_boolean() {
 
     assert_snapshot!(output.code, @"
     import { cva as __pcva } from '@pandacss-internal/css';
-    export const button = __pcva({ variants: { size: { sm: 'fs_12px' }, block: { true: 'd_flex' } }, compoundVariants: [{ size: 'sm', block: true, css: 'padding_0' }] });
+    export const button = /* @__PURE__ */ __pcva({ variants: { size: { sm: 'fs_12px' }, block: { true: 'd_flex' } }, compoundVariants: [{ size: 'sm', block: true, css: 'padding_0' }] });
     ");
 }
 
@@ -250,7 +250,7 @@ fn rewrites_sva_responsive_slot_styles_to_conditional_classes() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const tabs = __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'fs_12px md:fs_14px' } } } });
+    export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'fs_12px md:fs_14px' } } } });
     ");
 }
 
@@ -271,7 +271,7 @@ fn derives_sva_slots_from_base_when_slots_is_omitted() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const card = __psva({ slots: ['root', 'title'], base: { root: 'd_grid', title: 'font-weight_700' }, variants: { muted: { true: 'opacity_0.5' }, size: { sm: { title: 'fs_12px' } } } });
+    export const card = /* @__PURE__ */ __psva({ slots: ['root', 'title'], base: { root: 'd_grid', title: 'font-weight_700' }, variants: { muted: { true: 'opacity_0.5' }, size: { sm: { title: 'fs_12px' } } } });
     ");
 }
 
@@ -289,7 +289,7 @@ fn encodes_an_sva_option_with_no_styles_as_an_empty_map() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const tabs = __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'gap_4px' }, md: {} } } });
+    export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], variants: { size: { sm: { root: 'gap_4px' }, md: {} } } });
     ");
 }
 
@@ -308,7 +308,7 @@ fn quotes_sva_slot_names_that_are_not_identifiers() {
 
     assert_snapshot!(output.code, @"
     import { sva as __psva } from '@pandacss-internal/css';
-    export const field = __psva({ slots: ['root', 'helper-text'], base: { 'helper-text': 'fs_12px' }, variants: { invalid: { true: { 'helper-text': 'color_red' } } } });
+    export const field = /* @__PURE__ */ __psva({ slots: ['root', 'helper-text'], base: { 'helper-text': 'fs_12px' }, variants: { invalid: { true: { 'helper-text': 'color_red' } } } });
     ");
 }
 
@@ -335,7 +335,7 @@ fn rewrites_styled_with_full_recipe_config() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled } from '@panda/jsx';
-    export const Card = styled('div', __pcva({ base: 'color_red padding_8px', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } }));
+    export const Card = /* @__PURE__ */ styled('div', /* @__PURE__ */ __pcva({ base: 'color_red padding_8px', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } }));
     "#);
 }
 
@@ -352,7 +352,7 @@ fn rewrites_an_aliased_styled_factory_from_its_callee_shape() {
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { styled as s } from '@panda/jsx';
-    export const Card = s('div', __pcva({ base: 'color_red' }));
+    export const Card = /* @__PURE__ */ s('div', /* @__PURE__ */ __pcva({ base: 'color_red' }));
     "#);
 }
 
@@ -393,7 +393,7 @@ fn rewrites_cva_base_with_property_conditional() {
     assert!(output.helper.needs_cva);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    export const button = __pcva({ base: cond ? "color_red" : "color_blue" });
+    export const button = /* @__PURE__ */ __pcva({ base: cond ? "color_red" : "color_blue" });
     "#);
 }
 
@@ -445,7 +445,7 @@ fn keeps_boolean_cva_call_sites_on_memoized_runtime() {
     assert!(!output.helper.needs_cx);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const recipe = __pcva({ base: 'd_inline-flex', variants: { r0: { true: 'opacity_0.5' }, r1: { true: 'fs_12px' } }, defaultVariants: { r0: true } });
+    const recipe = /* @__PURE__ */ __pcva({ base: 'd_inline-flex', variants: { r0: { true: 'opacity_0.5' }, r1: { true: 'fs_12px' } }, defaultVariants: { r0: true } });
     export const cls = recipe({
       r0: !active,
       r1: variant === 'secondary' || variant === 'outline',
@@ -493,7 +493,7 @@ fn folds_cva_raw_with_base_only() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red' });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red' });
     export const out = {"color":"red"};
     "#);
 }
@@ -515,7 +515,7 @@ fn folds_cva_raw_applying_default_variants() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px', lg: 'padding_8px' } }, defaultVariants: { size: 'sm' } });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px', lg: 'padding_8px' } }, defaultVariants: { size: 'sm' } });
     export const out = {"color":"red","padding":"4px"};
     "#);
 }
@@ -537,7 +537,7 @@ fn folds_cva_raw_with_an_explicit_variant_overriding_the_default() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px', lg: 'padding_8px' } }, defaultVariants: { size: 'sm' } });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px', lg: 'padding_8px' } }, defaultVariants: { size: 'sm' } });
     export const out = {"color":"red","padding":"8px"};
     "#);
 }
@@ -558,7 +558,7 @@ fn folds_cva_raw_ignoring_an_unknown_variant_value() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' } } });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' } } });
     export const out = {"color":"red"};
     "#);
 }
@@ -582,7 +582,7 @@ fn folds_cva_raw_with_a_matching_compound_variant() {
         output.code,
         @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' }, tone: { a: 'color_blue' } }, compoundVariants: [{ size: 'sm', tone: 'a', css: 'margin_2px' }] });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' }, tone: { a: 'color_blue' } }, compoundVariants: [{ size: 'sm', tone: 'a', css: 'margin_2px' }] });
     export const out = {"color":"blue","padding":"4px","margin":"2px"};
     "#
     );
@@ -605,7 +605,7 @@ fn folds_cva_raw_skipping_an_unmatched_compound_variant() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' }, tone: { a: 'color_blue' } }, compoundVariants: [{ size: 'sm', tone: 'a', css: 'margin_2px' }] });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' }, tone: { a: 'color_blue' } }, compoundVariants: [{ size: 'sm', tone: 'a', css: 'margin_2px' }] });
     export const out = {"color":"red","padding":"4px"};
     "#);
 }
@@ -626,7 +626,7 @@ fn folds_cva_raw_with_a_boolean_variant() {
     assert!(output.changed);
     assert_snapshot!(output.code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { on: { true: 'opacity_0.5' } } });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { on: { true: 'opacity_0.5' } } });
     export const out = {"color":"red","opacity":"0.5"};
     "#);
 }
@@ -651,7 +651,7 @@ fn folds_sva_raw_to_one_object_per_slot() {
         output.code,
         @r#"
     import { sva as __psva } from '@pandacss-internal/css';
-    const styles = __psva({ slots: ['root', 'icon'], base: { root: 'color_red', icon: 'padding_1px' }, variants: { size: { sm: { root: 'padding_4px' } } }, defaultVariants: { size: 'sm' } });
+    const styles = /* @__PURE__ */ __psva({ slots: ['root', 'icon'], base: { root: 'color_red', icon: 'padding_1px' }, variants: { size: { sm: { root: 'padding_4px' } } }, defaultVariants: { size: 'sm' } });
     export const out = {"root":{"color":"red","padding":"4px"},"icon":{"padding":"1px"}};
     "#
     );
@@ -703,7 +703,7 @@ fn cva_raw_and_plain_calls_coexist_when_raw_folds() {
         output.code,
         @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
-    const styles = __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' } } });
+    const styles = /* @__PURE__ */ __pcva({ base: 'color_red', variants: { size: { sm: 'padding_4px' } } });
     export const out = {"color":"red","padding":"4px"};
     export const cls = styles({ size: props.size });
     "#
@@ -1182,7 +1182,7 @@ fn folds_a_raw_call_with_no_arguments() {
     assert_snapshot!(transform("src/styles.tsx", source).code, @r#"
     import { cva as __pcva } from '@pandacss-internal/css';
     import { css } from '@panda/css';
-    const button = __pcva({ base: 'color_red' });
+    const button = /* @__PURE__ */ __pcva({ base: 'color_red' });
     export const cls = css({"color":"red"}, { color: 'blue' });
     "#);
 }

--- a/design-notes/transformer/README.md
+++ b/design-notes/transformer/README.md
@@ -848,8 +848,10 @@ an element's own `css` prop replaces the default wholesale rather than merging p
 `BaseComponent.__base__`, so `Base`'s own `forwardRef` — and its defaults — never run at runtime;
 inheriting only `base` matches that.
 
-The `styled()` definition itself still desugars to `__pcva(…)` as before. After the fold it is
-unreferenced, so bundlers drop it.
+The `styled()` definition itself still desugars to `__pcva(…)` as before. The transform marks both
+the outer `styled()` call and the nested `__pcva()` call as pure. This lets bundlers drop the entire
+definition after the fold, including evaluation of the now-unused recipe config. Transformed
+standalone `cva()` and `sva()` factories carry the same annotation.
 
 ### JSX pattern props
 

--- a/design-notes/transformer/test-matrix.md
+++ b/design-notes/transformer/test-matrix.md
@@ -17,12 +17,13 @@ tests should inherit that corpus instead of replacing it.
 
 ## Current coverage (v2 branch)
 
-| Layer                           | Location                             | Status            |
-| ------------------------------- | ------------------------------------ | ----------------- |
-| Rust transformer snapshots      | `crates/pandacss_project/tests/transform/` | via `cargo nextest run -p pandacss_project transform` |
-| JS facade + runtime             | `packages/transformer/__tests__/`    | 14 tests passing  |
-| Vite plugin                     | `packages/vite/__tests__/`           | 8 tests passing   |
-| Host e2e / bundle-size fixtures | sandbox                              | not started       |
+| Layer                           | Location                                              | Status                                                |
+| ------------------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
+| Rust transformer snapshots      | `crates/pandacss_project/tests/transform/`            | via `cargo nextest run -p pandacss_project transform` |
+| JS facade + runtime             | `packages/transformer/__tests__/`                     | covered                                               |
+| Rolldown tree-shaking           | `packages/transformer/__tests__/tree-shaking.test.ts` | covered                                               |
+| Vite plugin                     | `packages/vite/__tests__/`                            | covered                                               |
+| Bundle-size budgets             | sandbox                                                | not started                                           |
 
 ## Test layers
 

--- a/packages/compiler/__tests__/transform-source/recipes.test.ts
+++ b/packages/compiler/__tests__/transform-source/recipes.test.ts
@@ -408,7 +408,7 @@ describe('compiler.transformSource: inline cva / sva / styled', () => {
     const result = recipeCompiler.transformSource({ path: 'src/recipes.ts', source })
     expect(result.code).toMatchInlineSnapshot(`
       "import { cva as __pcva } from '@pandacss-internal/css';
-      export const button = __pcva({ base: 'background-color_blue color_red', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } })"
+      export const button = /* @__PURE__ */ __pcva({ base: 'background-color_blue color_red', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } })"
     `)
   })
 
@@ -418,7 +418,7 @@ describe('compiler.transformSource: inline cva / sva / styled', () => {
     const result = recipeCompiler.transformSource({ path: 'src/recipes.ts', source })
     expect(result.code).toMatchInlineSnapshot(`
       "import { cva as __pcva } from '@pandacss-internal/css';
-      export const button = __pcva({ base: 'color_red' })"
+      export const button = /* @__PURE__ */ __pcva({ base: 'color_red' })"
     `)
   })
 
@@ -439,7 +439,7 @@ describe('compiler.transformSource: inline cva / sva / styled', () => {
     const result = recipeCompiler.transformSource({ path: 'src/recipes.ts', source })
     expect(result.code).toMatchInlineSnapshot(`
       "import { cva as __pcva } from '@pandacss-internal/css';
-      export const button = __pcva({ base: 'color_white', variants: { size: { sm: 'fs_12px' }, intent: { danger: 'background-color_red' } }, defaultVariants: { size: 'sm', intent: 'danger' }, compoundVariants: [{ size: 'sm', intent: 'danger', css: 'color_black' }] })"
+      export const button = /* @__PURE__ */ __pcva({ base: 'color_white', variants: { size: { sm: 'fs_12px' }, intent: { danger: 'background-color_red' } }, defaultVariants: { size: 'sm', intent: 'danger' }, compoundVariants: [{ size: 'sm', intent: 'danger', css: 'color_black' }] })"
     `)
   })
 
@@ -458,7 +458,7 @@ describe('compiler.transformSource: inline cva / sva / styled', () => {
     const result = recipeCompiler.transformSource({ path: 'src/recipes.ts', source })
     expect(result.code).toMatchInlineSnapshot(`
       "import { sva as __psva } from '@pandacss-internal/css';
-      export const tabs = __psva({ slots: ['root', 'trigger'], base: { root: 'd_flex', trigger: 'cursor_pointer' }, variants: { size: { sm: 'fs_12px' } } })"
+      export const tabs = /* @__PURE__ */ __psva({ slots: ['root', 'trigger'], base: { root: 'd_flex', trigger: 'cursor_pointer' }, variants: { size: { sm: 'fs_12px' } } })"
     `)
   })
 
@@ -478,7 +478,7 @@ describe('compiler.transformSource: inline cva / sva / styled', () => {
     expect(result.code).toMatchInlineSnapshot(`
       "import { cva as __pcva } from '@pandacss-internal/css';
       import { styled } from '@panda/jsx'
-      export const Panel = styled('div', __pcva({ base: 'color_red padding_8px', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } }))"
+      export const Panel = /* @__PURE__ */ styled('div', /* @__PURE__ */ __pcva({ base: 'color_red padding_8px', variants: { size: { sm: 'fs_12px', md: 'fs_16px' } }, defaultVariants: { size: 'md' } }))"
     `)
   })
 
@@ -532,8 +532,8 @@ describe('compiler.transformSource: inline cva / sva / styled', () => {
     const result = recipeCompiler.transformSource({ path: 'src/recipes.ts', source })
     expect(result.code).toMatchInlineSnapshot(`
       "import { cva as __pcva, sva as __psva } from '@pandacss-internal/css';
-      export const button = __pcva({ base: 'color_red' })
-      export const tabs = __psva({ slots: ['root'], base: { root: 'd_flex' } })"
+      export const button = /* @__PURE__ */ __pcva({ base: 'color_red' })
+      export const tabs = /* @__PURE__ */ __psva({ slots: ['root'], base: { root: 'd_flex' } })"
     `)
   })
 })

--- a/packages/transformer/__tests__/tree-shaking.test.ts
+++ b/packages/transformer/__tests__/tree-shaking.test.ts
@@ -1,0 +1,90 @@
+import { posix } from 'node:path'
+import { createCompiler } from '@pandacss/compiler'
+import { rolldown } from 'rolldown'
+import { describe, expect, it } from 'vitest'
+import {
+  createSourceTransformer,
+  getInternalCssRuntimeSource,
+  INTERNAL_CSS_IMPORT,
+  INTERNAL_CSS_RESOLVED_ID,
+} from '../src'
+
+describe('transformed source tree shaking', () => {
+  it('drops unused transformed recipe factories and their runtime', async () => {
+    const compiler = createCompiler({
+      cwd: '/virtual',
+      outdir: 'styled-system',
+      outExtension: 'mjs',
+      jsxFramework: 'react',
+      jsxFactory: 'styled',
+      importMap: {
+        css: ['@panda/css'],
+        recipe: ['@panda/recipes'],
+        pattern: ['@panda/patterns'],
+        jsx: ['@panda/jsx'],
+        tokens: ['@panda/tokens'],
+      },
+      utilities: {
+        backgroundColor: { className: 'bg', shorthand: 'bg' },
+        borderRadius: { className: 'bdr' },
+      },
+    })
+    const transformed = createSourceTransformer(compiler).transformSource({
+      path: 'src/app.tsx',
+      source: [
+        "import { styled } from '@panda/jsx'",
+        "import { cva, sva } from '@panda/css'",
+        "const Card = styled('article', { base: { bg: 'red', borderRadius: 'xl' } })",
+        "const button = cva({ base: { bg: 'red' } })",
+        "const slots = sva({ slots: ['root'], base: { root: { bg: 'red' } } })",
+        'export function App() { return <Card /> }',
+      ].join('\n'),
+    })
+
+    const modules = new Map<string, string>([['/entry.tsx', transformed.code]])
+    for (const artifact of compiler.generateArtifacts()) {
+      for (const file of artifact.files) {
+        if (file.path.endsWith('.mjs')) modules.set(posix.join('/styled-system', file.path), file.code)
+      }
+    }
+    modules.set(INTERNAL_CSS_RESOLVED_ID, getInternalCssRuntimeSource())
+
+    const build = await rolldown({
+      input: '/entry.tsx',
+      external: ['react', 'react/jsx-runtime'],
+      plugins: [
+        {
+          name: 'panda-tree-shaking-fixture',
+          resolveId(source, importer) {
+            if (modules.has(source)) return source
+            if (source === '@panda/jsx') return '/styled-system/jsx/index.mjs'
+            if (source === INTERNAL_CSS_IMPORT) return INTERNAL_CSS_RESOLVED_ID
+            if (!importer || !source.startsWith('.')) return null
+
+            const resolved = posix.normalize(posix.join(posix.dirname(importer), source))
+            for (const candidate of [resolved, `${resolved}.mjs`]) {
+              if (modules.has(candidate)) return candidate
+            }
+            return null
+          },
+          load(id) {
+            return modules.get(id) ?? null
+          },
+        },
+      ],
+    })
+
+    try {
+      const { output } = await build.generate({ format: 'esm', codeSplitting: false })
+      const chunk = output.find((item) => item.type === 'chunk')
+      expect(chunk?.type).toBe('chunk')
+      if (!chunk || chunk.type !== 'chunk') return
+
+      expect(chunk.code).toContain('function App()')
+      expect(chunk.code).not.toContain('__cva__')
+      expect(chunk.code).not.toContain('splitVariantProps')
+    } finally {
+      await build.close()
+    }
+  })
+})

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -44,6 +44,9 @@
     "@pandacss/compiler-shared": "workspace:*",
     "unplugin": "^2.3.11"
   },
+  "devDependencies": {
+    "rolldown": "1.2.7"
+  },
   "peerDependencies": {
     "vite": ">=6.0.0",
     "webpack": ">=5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,10 @@ importers:
       webpack:
         specifier: '>=5.0.0'
         version: 5.102.1(@swc/core@1.16.1(@swc/helpers@0.5.23))(esbuild@0.28.2)
+    devDependencies:
+      rolldown:
+        specifier: 1.2.7
+        version: 1.2.7
 
   packages/types:
     devDependencies:


### PR DESCRIPTION
## Description

Mark transformed `cva()`, `sva()`, and `styled()` factory calls as pure so bundlers can remove unused definitions and the internal recipe runtime.

## Current behavior

When a same-file `styled()` definition folds to an intrinsic JSX element, the original definition becomes unused but remains in the bundle. Rolldown retains the `styled` and CVA runtime because the transformed calls are not marked pure. Unused standalone `cva()` and `sva()` definitions have the same issue.

This addresses the remaining tree-shaking case reported in https://github.com/chakra-ui/panda/discussions/3599#discussioncomment-18304651.

## New behavior

- annotate transformed recipe factories with `/* @__PURE__ */`
- annotate both the outer `styled()` call and nested `__pcva()` call
- cover the final output with a real Rolldown tree-shaking test

In the reported `styled()` reproduction, the non-minified bundle drops from 53.3 kB to 4.9 kB and no longer includes the CVA runtime.

## Breaking change

No.

## Tests

- `cargo nextest run -p pandacss_project transform`
- `pnpm --dir packages/transformer test`
- compiler transform recipe tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm prettier`


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR marks transformed `cva()`, `sva()`, and `styled()` factory calls as pure so bundlers can remove unused recipe definitions and runtime helpers.
- Emits purity annotations for standalone recipe helpers and both layers of transformed styled factories.
- Extends styled transforms from one rewrite to disjoint callee and configuration rewrites.
- Adds Rolldown tree-shaking coverage and updates compiler snapshots, design notes, package metadata, and the lockfile.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new annotations target factory-call effects while bundlers continue to preserve independently side-effecting argument evaluation, and the two styled rewrites use disjoint spans with correct helper and import-preservation handling.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/pandacss_project/src/transform/recipe_inline.rs | Adds pure annotations to transformed recipe helpers and emits a separate, preserved callee rewrite for eligible styled calls. |
| crates/pandacss_project/src/transform/plan.rs | Extends the transform plan with both disjoint rewrites returned for styled factory calls. |
| packages/transformer/__tests__/tree-shaking.test.ts | Adds an integration test confirming Rolldown removes unused recipe factories and the internal CVA runtime. |
| packages/transformer/package.json | Adds Rolldown as a pinned development dependency for the new integration test. |
| pnpm-lock.yaml | Records the transformer package's new Rolldown development dependency. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Source cva, sva, or styled call] --> B[Recipe transform]
  B --> C[Emit pure-annotated helper call]
  C --> D{Factory result used?}
  D -- Yes --> E[Retain recipe and runtime]
  D -- No --> F[Bundler removes factory]
  F --> G[Unused runtime becomes tree-shakeable]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(transform): preserve recipe tree sha..."](https://github.com/chakra-ui/panda/commit/ee1010f30978e1e5500e66a7e01047190a9cbbc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61099401)</sub>

<!-- /greptile_comment -->