### PR TITLE
feat(dev): add defineConditions helper

### DIFF
--- a/.changeset/define-conditions.md
+++ b/.changeset/define-conditions.md
@@ -1,0 +1,13 @@
+---
+'@pandacss/dev': minor
+---
+
+Add a `defineConditions` helper so custom conditions get the same typed authoring experience as tokens, recipes, and the other config blocks.
+
+```ts
+import { defineConditions } from '@pandacss/dev'
+
+export const conditions = defineConditions({
+  hover: '&:is(:hover, [data-hover])',
+})
+```

--- a/packages/dev/src/config.ts
+++ b/packages/dev/src/config.ts
@@ -1,9 +1,9 @@
 import type {
   AnimationStyles,
   CompositionStyles,
-  Conditions,
   Config,
   CssKeyframes,
+  ExtendableConditions,
   GlobalFontface,
   GlobalStyleObject,
   LayerStyles,
@@ -77,7 +77,7 @@ export function defineUtility(utility: PropertyConfig): PropertyConfig {
   return utility
 }
 
-export function defineConditions(definition: Conditions): Conditions {
+export function defineConditions(definition: ExtendableConditions): ExtendableConditions {
   return definition
 }
 

--- a/packages/dev/src/config.ts
+++ b/packages/dev/src/config.ts
@@ -1,6 +1,7 @@
 import type {
   AnimationStyles,
   CompositionStyles,
+  Conditions,
   Config,
   CssKeyframes,
   GlobalFontface,
@@ -74,6 +75,10 @@ export function defineGlobalFontface(definition: GlobalFontface): GlobalFontface
 
 export function defineUtility(utility: PropertyConfig): PropertyConfig {
   return utility
+}
+
+export function defineConditions(definition: Conditions): Conditions {
+  return definition
 }
 
 export function definePlugin(plugin: PandaPlugin): PandaPlugin {

--- a/packages/dev/src/index.ts
+++ b/packages/dev/src/index.ts
@@ -2,6 +2,7 @@ export type { Config, Preset, UserConfig } from '@pandacss/types'
 
 export {
   defineAnimationStyles,
+  defineConditions,
   defineConfig,
   defineGlobalFontface,
   defineGlobalStyles,

--- a/website/content/docs/reference/config-functions.mdx
+++ b/website/content/docs/reference/config-functions.mdx
@@ -230,6 +230,35 @@ export const br = defineUtility({
 })
 ```
 
+### `defineConditions`
+
+For custom [conditions](/docs/theming/conditions) authored outside `defineConfig`.
+
+```ts
+import { defineConditions } from '@pandacss/dev'
+
+export const conditions = defineConditions({
+  groupHover: '.group:hover &',
+  cardHover: '[data-card]:hover &'
+})
+```
+
+### `defineViewTransitions`
+
+For named [view transitions](/docs/styling/view-transition) authored outside `defineConfig`.
+
+```ts
+import { defineViewTransitions } from '@pandacss/dev'
+
+export const viewTransitions = defineViewTransitions({
+  slide: {
+    group: { animationDuration: '0.4s' },
+    old: { opacity: 0 },
+    new: { opacity: 1 }
+  }
+})
+```
+
 ### `defineStyles`
 
 For a chunk of `SystemStyleObject` you want to reuse across variants, spread it into each one instead of repeating


### PR DESCRIPTION
## 📝 Description

Add a `defineConditions` helper to `@pandacss/dev`, so you can author conditions in their own file with full type checking, the same way you already can for tokens, keyframes, recipes, and the rest.

## ⛳️ Current behavior (updates)

Conditions was the only object-shaped config block without a matching `define*` helper. Pull your conditions out of `defineConfig` into their own file and you lose the autocomplete and type-checking that every other block keeps.

## 🚀 New behavior

```ts
import { defineConditions } from '@pandacss/dev'

export const conditions = defineConditions({
  groupHover: '.group:hover &'
})
```

The Config Functions reference page now documents the helper, alongside `defineViewTransitions`, which had shipped but was never listed there.

## 💣 Is this a breaking change (Yes/No):

No. It adds a new export and two doc sections, nothing changes for existing setups.

## 📝 Additional Information

Ships with a `@pandacss/dev` minor changeset.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds and publicly exports a typed `defineConditions` configuration helper, documents it alongside `defineViewTransitions`, and records the package release.

- Adds the `defineConditions` identity helper to `@pandacss/dev`.
- Documents standalone condition and view-transition authoring.
- Adds a minor changeset for the new public API.
</details>


<h3>Confidence Score: 4/5</h3>

The conditions helper should be widened to the same extendable shape accepted by `Config.conditions` before merging.

The exported helper rejects supported extendable condition configurations, so some valid standalone conditions lose the type-checking experience this feature is intended to provide.

**Files Needing Attention:** packages/dev/src/config.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/dev/src/config.ts | Adds the helper, but types it more narrowly than the `Config.conditions` property it is intended to author. |
| packages/dev/src/index.ts | Correctly exposes `defineConditions` from the package entrypoint. |
| website/content/docs/reference/config-functions.mdx | Adds valid examples and links for `defineConditions` and `defineViewTransitions`. |
| .changeset/define-conditions.md | Records the new public helper as a minor `@pandacss/dev` change. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20chakra-ui%2Fpanda%20PR%20%233787%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=chakra-ui%2Fpanda&pr=3787&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fdev%2Fsrc%2Fconfig.ts%3A80-82%0A**Conditions%20helper%20narrows%20valid%20configs**%0A%0AWhen%20a%20consumer%20wraps%20a%20valid%20configuration%20containing%20%60extend%60%20or%20nested%20condition%20groups%20with%20%60defineConditions%60%2C%20the%20narrower%20%60Conditions%60%20parameter%20rejects%20shapes%20accepted%20by%20%60Config.conditions%60%2C%20causing%20supported%20configurations%20to%20fail%20TypeScript%20checking.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fpanda&pr=3787&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/dev/src/config.ts:80-82
**Conditions helper narrows valid configs**

When a consumer wraps a valid configuration containing `extend` or nested condition groups with `defineConditions`, the narrower `Conditions` parameter rejects shapes accepted by `Config.conditions`, causing supported configurations to fail TypeScript checking.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dev): add defineConditions helper"](https://github.com/chakra-ui/panda/commit/e6e9ca7bdadd65e21c9618f6dc4a30eb42422957) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61284161)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->