### PR TITLE
docs(website): make the v2 post easier to skim

### DIFF
--- a/website/content/blog/panda-css-v2.mdx
+++ b/website/content/blog/panda-css-v2.mdx
@@ -78,6 +78,8 @@ feeds every step — collecting imports, matching them against your config, walk
 identifiers. Imports, `css()` calls, and `<styled.div>` elements all read from the same parse and the same semantic
 pass.
 
+![In v1 the build, playground, and editor each parsed your files separately and drifted apart; in v2 one Oxc parse feeds all three](/blog/panda-v2-one-parse.svg)
+
 That single pass has a fast exit built in. Before doing any real work, the engine collects the file's imports and
 matches them against your Panda entry points. If nothing in the file imports from `styled-system` (or wherever your
 Panda output lives), it stops right there — no identifier resolution, no visitor walks. On a real project most files are
@@ -86,9 +88,14 @@ faster.
 
 ### The engine builds itself once
 
-`createCompiler(config)` returns a long-lived compiler. The expensive setup happens exactly once, at construction:
-turning your config into matchers, utilities, conditions, a token dictionary, and recipes. After that, source files
-stream in through `parseFile`, atoms accumulate in a deduplicated registry, and `compile()` drains that registry to CSS.
+`createCompiler(config)` returns a long-lived compiler. The shape is three calls, and only the first is expensive:
+
+```ts
+const compiler = createCompiler(config) // once: config → matchers, tokens, recipes
+compiler.parseFile(source) // per file: atoms accumulate in a deduplicated registry
+const css = compiler.compile() // drains the registry to CSS
+```
+
 You pay for config compilation once and reuse it across every file and every rebuild, which is what makes `panda dev`
 cheap on the second keystroke.
 
@@ -96,7 +103,7 @@ Watch mode is incremental by contract. Each file's contribution to the global se
 path first drops its previous atoms and then re-encodes it. Removed or renamed styles can't linger as ghosts in the
 output, and a single-file change costs work proportional to that file, not to your whole project.
 
-### Extraction that understands your code
+### Resolving your values
 
 The old engine leaned on a JavaScript interpreter to fold constant expressions. The new one folds them directly in Rust,
 matching JavaScript's coercion rules so the CSS comes out the same. With same-file scope resolution in place, a lot more
@@ -133,7 +140,7 @@ position-preserving JavaScript, so spans stay aligned with your original file an
 line. Oxc then parses the JavaScript it understands. The built-in set covers `.vue`, `.svelte`, and `.astro`; other
 formats can still be handled by a filtered transform on the JS host.
 
-### Matching JSX components with data, not callbacks
+### Matching JSX with data
 
 v1 let you match custom JSX components with a `matchTag` callback — a JavaScript function Panda ran for every element.
 That can't cross into a Rust or WebAssembly engine, so v2 replaces it with `jsxMatchTag`, a declarative rule list
@@ -148,7 +155,7 @@ export default defineConfig({
 Rules are evaluated last-match-wins over Panda's own detection, and because it's data rather than code, it works
 identically in the CLI and in the browser.
 
-### Emitting CSS, in Rust
+### Emitting CSS in Rust
 
 The old pipeline handed generation to PostCSS. v2 emits CSS natively in a dedicated crate. It does the CSS-aware work
 that matters for output quality:
@@ -164,18 +171,47 @@ that matters for output quality:
 - **Deterministic cascade order.** Output is sorted into Panda's layers (`reset, base, tokens, recipes, utilities`),
   with a stable ordering within each so shorthands rank below longhands and the cascade is predictable across builds.
 
+Grouping and modern breakpoints together turn this:
+
+```css
+@media (min-width: 48rem) {
+  .fs_lg {
+    font-size: 1.125rem;
+  }
+}
+@media (min-width: 48rem) {
+  .fw_bold {
+    font-weight: 700;
+  }
+}
+```
+
+into this:
+
+```css
+@media (width >= 48rem) {
+  .fs_lg {
+    font-size: 1.125rem;
+  }
+  .fw_bold {
+    font-weight: 700;
+  }
+}
+```
+
 One honest note: this crate emits and formats CSS, but it is not yet a full CSS optimizer. Value-level minification at
 the quality of a tool like Lightning CSS is the one part of the old pipeline we haven't fully matched, and it's the top
 item on the roadmap. Everything else about the output is at parity, minus the deliberate improvements above.
 
-### The same engine, native and in the browser
+### One engine everywhere
 
 Because the engine is plain Rust over Oxc, it compiles two ways. A native binding (`@pandacss/compiler`) powers the CLI,
-Vite, and PostCSS. A WebAssembly binding (`@pandacss/compiler-wasm`) runs the identical code in the browser — that's
-what the playground uses. The Wasm bundle is about 490 KB gzipped, and cross-file resolution works there too: editing a
-file in the playground pushes it into an in-memory filesystem the resolver reads immediately. For the first time, the
-playground and your build run the same extractor and produce the same CSS, because they are literally the same code. If
-you want the mental model, see [Why Panda → How it works](/docs/get-started/getting-started#how-it-works).
+Vite, and PostCSS. A WebAssembly binding (`@pandacss/compiler-wasm`) runs the identical code in the browser, which is
+what the playground uses. The Wasm bundle is about 490 KB gzipped, and cross-file resolution works there too: edit a file
+in the playground and it lands in an in-memory filesystem the resolver reads at once.
+
+So for the first time the playground and your build run the same extractor and produce the same CSS, because they are the
+same code. For the mental model, see [Why Panda → How it works](/docs/get-started/getting-started#how-it-works).
 
 ## Faster
 
@@ -186,7 +222,7 @@ Rust 1.93), not a clean-room CI box, so treat the absolute times as indicative a
 benchmark reads the same source bytes through both engines with file I/O excluded, so what's being compared is the work
 itself.
 
-### Extraction is 15–37× faster
+### 15–37× faster extraction
 
 Extraction is the core of what the rewrite replaced: parsing your files and pulling out the styles. Across fixtures from
 a handful of real files up to a synthetic thousand-file project, the Oxc engine runs a cold extraction 15 to 37 times
@@ -203,14 +239,14 @@ around 37 MB/s — about a 30× gap that holds steady as projects grow.
 
 ![Cold parse of 100 files dropped from 187ms to 7.5ms; watch-mode re-parse per file from 652µs to 1.8µs](/blog/chart-extraction.svg)
 
-### Watch-mode re-parsing is hundreds of times faster
+### Watch-mode re-parsing
 
 The number you feel every day is the one for saving a file. When a single file changes, the old engine re-parsed it
 through the TypeScript compiler; the new engine re-parses it through Oxc. On a steady-state watch, that step went from
 around 650 microseconds per file to under 2 — roughly 360–390× faster. Real sandboxes bear it out end to end: a Next.js
 pages project's parse step dropped from 762 ms to 31 ms.
 
-### staticCss builds are ~85× faster
+### staticCss builds, ~85× faster
 
 `staticCss` pre-generates a matrix of utilities and recipes, often across breakpoints and containers. It was one of the
 slowest things you could ask v1 to do, and two long-standing community reports centered on it. On the larger of the two
@@ -230,7 +266,7 @@ back.
 
 ![staticCss build time by container count on a log scale: the before line climbs from 399ms to 52.6s while Panda 2.0 stays flat near 25ms](/blog/chart-staticcss.svg)
 
-### Your generated types cost your editor far less
+### Lighter generated types
 
 The static-extraction win has a quieter cousin: the TypeScript types Panda generates for your `styled-system`. v2 emits
 a leaner type graph built around a single shared conditional-value type instead of thousands of individually
@@ -244,7 +280,7 @@ instantiated ones. Type-checking the same usage file against the generated types
 
 That's a faster editor when you hover a prop, and less work for `tsc` in CI.
 
-### The runtime got faster too
+### A faster runtime
 
 Not all of Panda runs at build time. The `css()` function and recipe runtimes ship to the browser for the dynamic cases
 static extraction can't cover, and v2 layers memoization over them. Repeated inline styles on a dense server-rendered
@@ -254,7 +290,7 @@ you'll see.
 
 ![Runtime css() on dense SSR pages as a share of the unmemoized path: repeated inline 3x faster, a 3-level wrapper chain 4x, a 6-level chain 3x, repeated flat objects 30 to 40 percent faster](/blog/chart-runtime.svg)
 
-### What isn't faster yet, and where output differs
+### What isn't faster yet
 
 Two honest caveats, because a release post that only lists wins isn't much use:
 
@@ -271,7 +307,7 @@ Two honest caveats, because a release post that only lists wins isn't much use:
 A faster engine is the headline, but the rewrite also cleared the way for capabilities the old architecture couldn't
 reach. Here's what shipped alongside it.
 
-### Design systems you can publish
+### Publishable design systems
 
 This is the big one. A Panda design system is now an npm package that ships components and the Panda config they were
 built against, and consuming it takes one line.
@@ -301,13 +337,16 @@ extracts itself once, at publish time, and every app that installs it reuses tha
 
 ![Design-system flow: the author runs panda lib to ship a manifest, preset, and build info; the consumer sets designSystem and reuses the pre-extracted styles](/blog/panda-v2-design-system.svg)
 
-A few things make this pleasant in practice. Your `theme.extend` layers on top and the app wins on any conflicting
-token, surfaced as a diagnostic rather than a silent override, so you customize without forking. Resolution works
-through workspaces, symlinks, and Docker layers because the manifest is resolved as a package export, not by reaching
-into source paths. Design systems can extend other design systems, and Panda walks the parent chain for you. When
-something is misconfigured, you get an actionable diagnostic (a stale build info, a missing export, an unsatisfied peer
-range) instead of mysterious missing styles. There's a dedicated `optimize.treeshakeDesignSystem` that hydrates only the
-modules your app actually imports.
+A few things make this pleasant in practice:
+
+- **You customize without forking.** Your `theme.extend` layers on top and the app wins on any conflicting token,
+  surfaced as a diagnostic rather than a silent override.
+- **Resolution survives your setup.** The manifest resolves as a package export, not a source path, so workspaces,
+  symlinks, and Docker layers all work.
+- **Design systems compose.** One can extend another, and Panda walks the parent chain for you.
+- **Misconfiguration tells you what's wrong.** A stale build info, a missing export, or an unsatisfied peer range comes
+  back as an actionable diagnostic, not mysterious missing styles.
+- **You ship only what you use.** `optimize.treeshakeDesignSystem` hydrates just the modules your app imports.
 
 ### View transitions
 
@@ -327,7 +366,7 @@ const slide = viewTransition({
 You can also name reusable transitions in your theme so a preset can share them, and `viewTransition('slide')` inlines
 the shared class. Unused named transitions stay out of your CSS.
 
-### New utilities in the base preset
+### New base-preset utilities
 
 The base preset picked up a batch of utilities for things that used to mean hand-writing raw CSS.
 
@@ -354,7 +393,7 @@ post-interaction validity (`_userValid`, `_userInvalid`), the `_inert` state, ev
 **Fixed transform axes** — `rotateX`, `rotateY`, and `rotateZ` now do what they say, `rotate: 'auto'` composes them onto
 `transform`, and non-uniform `scale` applies rotation after scaling.
 
-### Variables register with @property instead of resetting everything
+### Variables via @property
 
 v1 seeded 34 CSS variables on `*, ::before, ::after, ::backdrop` so that things like transforms and filters had
 defaults. That's a lot of declarations on every element whether you used them or not. v2 registers those variables with
@@ -383,7 +422,7 @@ The command set got a cleanup and some genuinely new tools. Bare `panda` runs co
 Logging moved to a single `--log-level silent|error|warn|info|debug`, and startup got lighter — flag parsing no longer
 loads a schema library on every invocation.
 
-### Linting, on the real engine
+### A first-party ESLint plugin
 
 There's a first-party ESLint plugin with a recommended flat config, and because extraction lives in a shared engine now,
 the linter reads the same extraction your build does rather than approximating it. The rules cover the mistakes Panda
@@ -417,7 +456,7 @@ export default defineConfig({
 This post is rendered by it. The [Typography guide](/docs/theming/typography) has the options, and the
 [launch post](/blog/typography-preset) has the reasoning.
 
-### Extraction that folds more of your code away
+### Folding dynamic code away
 
 Beyond the correctness of extraction, v2 does more to turn dynamic-looking code into static classes:
 
@@ -431,7 +470,7 @@ Beyond the correctness of extraction, v2 does more to turn dynamic-looking code 
 - **Shared classes hoist.** A class present in every branch of a conditional is emitted once instead of being repeated
   across branches.
 
-### Codegen and type fixes worth knowing
+### Codegen and type fixes
 
 A handful of type-level changes remove long-standing papercuts. Keyframe names are inlined into the generated types, so
 `css({ animationName: 'spin' })` type-checks under `strictTokens` without the escape-hatch brackets. Empty token
@@ -441,7 +480,7 @@ native CSS keywords like `cursor: 'pointer'` are accepted without brackets even 
 One rename to be aware of: the built-in CSS value types now carry a `Css` prefix (`CssPosition`, `CssLength`,
 `CssGlobals`) so your own `{Property}Value` aliases can't shadow them. It's in the upgrade checklist below.
 
-### MCP and framework plugins moved out
+### MCP and plugins moved out
 
 The MCP server is now its own package — run `npx -y @pandacss/mcp` instead of the old `panda mcp` subcommand. Vue,
 Svelte, and Lightning CSS support are available as standalone opt-in plugins (`@pandacss/plugin-vue`,
@@ -493,7 +532,7 @@ export default defineConfig({
 `cssgen:done` is observe-only now — you can read the generated CSS but not rewrite the string. The engine-internal hooks
 (`context:created`, `parser:after`, `tokens:created`, `utility:created`, and the rest) are gone.
 
-### `createStyleContext` split into two helpers
+### `createStyleContext` split
 
 ```ts
 // Before
@@ -506,7 +545,7 @@ const ctx = createRecipeContext(recipe)
 
 There's a new `withRootProvider` for a slot root that renders no slot of its own.
 
-### Config options that were removed
+### Removed config options
 
 Ten options are gone: `studio`, `eject`, `emitTokensOnly`, `gitignore`, `clean`, `watch`, `poll`, `lightningcss`, and
 `browserslist`. `forceConsistentTypeExtension` became `forceImportExtension` (different semantics, not a rename), and
@@ -521,7 +560,7 @@ became `--profile` (which now covers Rust engine time too). Shared flags are keb
 `panda ship` is gone, replaced by the design-system flow — `panda lib` to author, `designSystem` to consume. More on
 that below.
 
-### Internal packages folded into the compiler
+### Internal packages folded in
 
 If you imported `@pandacss/core`, `/extractor`, `/generator`, `/node`, `/parser`, `/token-dictionary`, `/is-valid-prop`,
 `/logger`, or `/reporter` directly, drop those imports — they're internal to the compiler now. If you only use
@@ -541,7 +580,7 @@ These are intentional and worth knowing about before you diff your output:
 - **`scrollbarWidth` takes keywords now** (`auto | thin | none`), not a token. A single `scrollbarColor` value moves to
   `scrollbarThumb`.
 
-### Migrating a large codebase gradually
+### Migrating gradually
 
 The one surprise nobody expects is layering. Panda ships its CSS inside `@layer`, and per the CSS spec, any unlayered
 rule beats every layered rule, so your legacy, unlayered styles win over converted Panda components by default. If

--- a/website/public/blog/panda-v2-one-parse.svg
+++ b/website/public/blog/panda-v2-one-parse.svg
@@ -1,0 +1,82 @@
+<svg width="1200" height="470" viewBox="0 0 1200 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="In v1 the build, playground, and editor each parsed your files separately and drifted apart; in v2 one Oxc parse feeds all three.">
+  <style>
+    .surface { fill: #FBF9F3; }
+    .ink { fill: #1A1A17; }
+    .muted { fill: #5E584C; }
+    .card { fill: #FFFFFF; stroke: #1A1A17; stroke-width: 2; }
+    .yl { fill: #F6E458; }
+    .yltile { fill: #F6E458; stroke: #1A1A17; stroke-width: 2; }
+    .ony { fill: #1A1A17; }
+    .rail { fill: #F3EFE3; stroke: #E4DECF; stroke-width: 1.5; }
+    .chip { fill: #FFFFFF; stroke: #CFC8B8; stroke-width: 1.5; }
+    .flow { stroke: #1A1A17; stroke-width: 3; fill: none; }
+    .ghost { stroke: #B7AE99; stroke-width: 2; fill: none; stroke-dasharray: 5 5; }
+    .sans { font-family: 'Onest','Segoe UI',system-ui,sans-serif; }
+    .mono { font-family: 'Source Code Pro',ui-monospace,monospace; }
+    @media (prefers-color-scheme: dark) {
+      .surface { fill: #17171B; } .ink { fill: #F5F2E9; } .muted { fill: #B7B1A3; }
+      .card { fill: #23232B; stroke: #3A3A42; } .rail { fill: #1E1E25; stroke: #34343A; }
+      .chip { fill: #23232B; stroke: #3A3A42; } .flow { stroke: #E7E2D6; }
+      .ghost { stroke: #55503F; }
+    }
+  </style>
+  <rect width="1200" height="470" class="surface"/>
+
+  <rect x="60" y="40" width="52" height="7" rx="3.5" class="yl"/>
+  <text x="60" y="84" class="sans ink" font-size="29" font-weight="800" letter-spacing="-0.4">One parse, shared by everything.</text>
+  <text x="60" y="114" class="sans muted" font-size="16.5">v1 parsed your files three times over. v2 parses once and hands the result around.</text>
+
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto">
+      <path d="M0 1 L9 5 L0 9" fill="none" stroke="currentColor" class="ink" stroke-width="2.2"/>
+    </marker>
+    <marker id="g" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0 1 L9 5 L0 9" fill="none" stroke="currentColor" class="ghost" stroke-width="2.2"/>
+    </marker>
+  </defs>
+
+  <g class="sans">
+    <!-- v1 panel -->
+    <rect x="60" y="150" width="515" height="280" rx="18" class="rail"/>
+    <rect x="88" y="176" width="40" height="26" rx="8" class="chip"/><text x="108" y="194" text-anchor="middle" class="muted mono" font-size="13" font-weight="700">v1</text>
+    <text x="140" y="194" class="muted" font-size="14" font-weight="800" letter-spacing="2">THREE PARSERS</text>
+
+    <!-- three consumers, each with its own parse -->
+    <g transform="translate(88 224)"><rect width="176" height="44" rx="11" class="chip"/><text x="18" y="28" class="ink" font-size="15">build (ts-morph)</text></g>
+    <g transform="translate(88 285)"><rect width="176" height="44" rx="11" class="chip"/><text x="18" y="28" class="ink" font-size="15">playground</text></g>
+    <g transform="translate(88 346)"><rect width="176" height="44" rx="11" class="chip"/><text x="18" y="28" class="ink" font-size="15">editor ext</text></g>
+
+    <g class="ghost">
+      <line x1="268" y1="246" x2="316" y2="246" marker-end="url(#g)"/>
+      <line x1="268" y1="307" x2="316" y2="307" marker-end="url(#g)"/>
+      <line x1="268" y1="368" x2="316" y2="368" marker-end="url(#g)"/>
+    </g>
+
+    <g transform="translate(320 224)"><rect width="120" height="44" rx="11" class="card"/><text x="60" y="28" text-anchor="middle" class="ink mono" font-size="14">parse</text></g>
+    <g transform="translate(320 285)"><rect width="120" height="44" rx="11" class="card"/><text x="60" y="28" text-anchor="middle" class="ink mono" font-size="14">parse</text></g>
+    <g transform="translate(320 346)"><rect width="120" height="44" rx="11" class="card"/><text x="60" y="28" text-anchor="middle" class="ink mono" font-size="14">parse</text></g>
+
+    <text x="88" y="416" class="muted" font-size="13.5">each reimplements extraction, so they drift apart.</text>
+
+    <!-- v2 panel -->
+    <rect x="625" y="150" width="515" height="280" rx="18" class="card"/>
+    <rect x="653" y="176" width="40" height="26" rx="8" class="yltile"/><text x="673" y="194" text-anchor="middle" class="ony mono" font-size="13" font-weight="700">v2</text>
+    <text x="705" y="194" class="ink" font-size="14" font-weight="800" letter-spacing="2">ONE PARSE</text>
+
+    <!-- single Oxc parse -->
+    <g transform="translate(653 250)"><rect width="150" height="120" rx="16" class="yltile"/><text x="75" y="55" text-anchor="middle" class="ony" font-size="20" font-weight="700">Oxc</text><text x="75" y="82" text-anchor="middle" class="ony mono" font-size="15">parse</text></g>
+
+    <!-- fan-out to the three consumers -->
+    <g class="flow">
+      <path d="M803 296 C 860 296, 880 246, 936 246" marker-end="url(#a)"/>
+      <path d="M803 310 L 936 310" marker-end="url(#a)"/>
+      <path d="M803 324 C 860 324, 880 374, 936 374" marker-end="url(#a)"/>
+    </g>
+
+    <g transform="translate(940 224)"><rect width="176" height="44" rx="11" class="chip"/><text x="18" y="28" class="ink" font-size="15">build</text></g>
+    <g transform="translate(940 288)"><rect width="176" height="44" rx="11" class="chip"/><text x="18" y="28" class="ink" font-size="15">playground</text></g>
+    <g transform="translate(940 352)"><rect width="176" height="44" rx="11" class="chip"/><text x="18" y="28" class="ink" font-size="15">editor ext</text></g>
+
+    <text x="653" y="416" class="muted" font-size="13.5">one extractor, so the CSS is identical everywhere.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## 📝 Description

Make the v2 announcement post easier to skim. It reads long and tiring in a few places; this pass changes how it's laid out, not what it says. Only the blog post and one new image are touched.

## ⛳️ Current behavior (updates)

- Twenty-one sub-headings are long enough to wrap onto two lines in the right-hand table of contents, so the outline is hard to scan.
- The design-system section packs five separate capabilities into one paragraph, and the "one engine" section is a single run-on sentence.
- The post says v1 parsed your files several times over while v2 parses once, but never shows it.

## 🚀 New behavior

- Every sub-heading now fits one line in the rail, and the three "extraction" sections read as distinct.
- The design-system block becomes five scannable bullets; the "one engine" paragraph is split in two.
- A new diagram shows v1's build, playground, and editor each parsing and drifting apart, against v2's single parse feeding all three. It matches the other diagrams in the post and works in light and dark.
- Two short code snippets replace prose that was easier to show than describe: the three-call compiler lifecycle, and a before/after of grouped media queries.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

No copy claims changed. Nothing outside the blog post is affected.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the readability of the Panda CSS 2.0 announcement without changing its substantive claims.
- Shortens section headings and restructures dense prose for easier scanning.
- Adds compiler-lifecycle and grouped-media-query examples.
- Adds a light- and dark-mode SVG illustrating the shared v2 parsing pipeline.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable build, rendering, accessibility, or content defect identified.

The changes are confined to documentation structure, standard MDX constructs, and a referenced static SVG asset that is present in the public directory.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| website/content/blog/panda-css-v2.mdx | Reworks headings and prose, adds supported fenced examples, and references an existing new illustration asset; no actionable defect found. |
| website/public/blog/panda-v2-one-parse.svg | Adds an accessible responsive-color-scheme pipeline illustration consistent with the post’s existing diagrams; no concrete rendering failure found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(website): trim the v2 post headings..."](https://github.com/chakra-ui/panda/commit/4cbf11a5fc46d7366f6c7c725197eb717bb88596) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61286353)</sub>

<!-- /greptile_comment -->