### PR TITLE
feat: add a versioned design-system spec artifact

### DIFF
--- a/.changeset/versioned-design-system-spec.md
+++ b/.changeset/versioned-design-system-spec.md
@@ -1,0 +1,11 @@
+---
+'@pandacss/cli': minor
+'@pandacss/compiler': minor
+'@pandacss/compiler-shared': minor
+'@pandacss/compiler-wasm': minor
+'@pandacss/config': minor
+---
+
+Add a versioned design-system spec with resolved tokens, conditions, recipes, patterns, compositions, and themes. Semantic tokens are identified independently of primitive token aliases.
+
+Generate the artifact with `panda spec`, or publish it with `panda lib` at `panda/spec.json`.

--- a/crates/pandacss_config/src/lib.rs
+++ b/crates/pandacss_config/src/lib.rs
@@ -20,9 +20,12 @@ pub use theme::{
 pub use type_data::{
     ConditionTypeData, PatternPropertyTypeData, PatternPropertyTypeKind, PatternTypeData,
     PatternTypeDefinition, PrimitiveType, RESERVED_VALUE_ALIAS_NAMES, RecipeTypeData,
-    RecipeTypeDefinition, SelectorTypeData, SlotRecipeTypeDefinition, Spec, TokenCategoryTypeData,
-    TokenTypeData, TypeData, TypegenOptions, UtilityPropertyTypeData, UtilityTypeData,
-    ValueAliasTypeData, ValueTypePart, VariantTypeData, token_category_type_name, value_alias_name,
+    RecipeTypeDefinition, SPEC_SCHEMA_VERSION, SelectorTypeData, SlotRecipeTypeDefinition, Spec,
+    SpecCatalog, SpecCompoundVariantDefinition, SpecPatternDefinition,
+    SpecPatternPropertyDefinition, SpecRecipeDefinition, SpecThemeDefinition, SpecTokenDefinition,
+    SpecTokenValue, TokenCategoryTypeData, TokenTypeData, TypeData, TypegenOptions,
+    UtilityPropertyTypeData, UtilityTypeData, ValueAliasTypeData, ValueTypePart, VariantTypeData,
+    token_category_type_name, value_alias_name,
 };
 pub use validate::{validate_config, validate_config_value, validation_mode_from_value};
 

--- a/crates/pandacss_config/src/type_data.rs
+++ b/crates/pandacss_config/src/type_data.rs
@@ -13,20 +13,158 @@ use serde_json::Value;
 use pandacss_shared::pascal_case;
 
 use crate::{
-    Deprecated, ImportMap, JsxStylePropsConfig, PatternConfig, PatternPropertyConfig, RecipeConfig,
-    UserConfig,
+    ConditionQuery, Deprecated, ImportMap, JsxSpecifier, JsxStylePropsConfig, PatternConfig,
+    PatternPropertyConfig, RecipeConfig, UserConfig, VariantSelection,
 };
+
+/// Current wire version for [`Spec`].
+pub const SPEC_SCHEMA_VERSION: u32 = 1;
 
 /// Tooling introspection snapshot: `TypeData` plus the bits it lacks
 /// (canonical property order, jsx factory, import map).
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Spec {
+    pub schema_version: u32,
     #[serde(flatten)]
     pub types: TypeData,
     pub property_order: Vec<String>,
     pub jsx_factory: Option<String>,
     pub import_map: Option<ImportMap>,
+    pub catalog: SpecCatalog,
+}
+
+impl Default for Spec {
+    fn default() -> Self {
+        Self {
+            schema_version: SPEC_SCHEMA_VERSION,
+            types: TypeData::default(),
+            property_order: Vec::new(),
+            jsx_factory: None,
+            import_map: None,
+            catalog: SpecCatalog::default(),
+        }
+    }
+}
+
+/// Resolved design-system definitions for documentation and external tooling.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecCatalog {
+    pub conditions: BTreeMap<String, ConditionQuery>,
+    pub tokens: BTreeMap<String, SpecTokenDefinition>,
+    pub recipes: BTreeMap<String, SpecRecipeDefinition>,
+    pub slot_recipes: BTreeMap<String, SpecRecipeDefinition>,
+    pub patterns: BTreeMap<String, SpecPatternDefinition>,
+    pub keyframes: BTreeMap<String, Value>,
+    pub text_styles: BTreeMap<String, Value>,
+    pub layer_styles: BTreeMap<String, Value>,
+    pub animation_styles: BTreeMap<String, Value>,
+    pub view_transitions: BTreeMap<String, Value>,
+    pub position_try: BTreeMap<String, Value>,
+    pub themes: BTreeMap<String, SpecThemeDefinition>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecTokenDefinition {
+    pub path: String,
+    pub category: String,
+    pub css_var: String,
+    pub semantic: bool,
+    pub values: Vec<SpecTokenValue>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecTokenValue {
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<Deprecated>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecRecipeDefinition {
+    pub name: String,
+    pub class_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub jsx: Vec<JsxSpecifier>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub slots: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<Value>,
+    pub variants: BTreeMap<String, BTreeMap<String, Value>>,
+    pub default_variants: BTreeMap<String, VariantSelection>,
+    pub compound_variants: Vec<SpecCompoundVariantDefinition>,
+    #[serde(skip_serializing_if = "Value::is_null")]
+    pub static_css: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<Deprecated>,
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecPatternDefinition {
+    pub name: String,
+    pub jsx_name: String,
+    pub jsx_element: String,
+    pub jsx: Vec<JsxSpecifier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub properties: BTreeMap<String, SpecPatternPropertyDefinition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_values: Option<Value>,
+    pub has_dynamic_default_values: bool,
+    pub has_transform: bool,
+    pub strict: bool,
+    pub blocklist: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<Deprecated>,
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecCompoundVariantDefinition {
+    pub css: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub class_name: Option<String>,
+    #[serde(flatten)]
+    pub conditions: BTreeMap<String, VariantSelection>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecPatternPropertyDefinition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecThemeDefinition {
+    pub name: String,
+    pub condition: String,
+    pub root_selector: String,
 }
 
 /// The full derived type surface, one field per config section the `.d.ts`

--- a/crates/pandacss_project/src/config.rs
+++ b/crates/pandacss_project/src/config.rs
@@ -228,13 +228,7 @@ fn pattern_definitions_from_config(
     patterns
         .iter()
         .map(|(name, config)| {
-            let mut jsx_names = vec![
-                config
-                    .jsx_name
-                    .clone()
-                    .unwrap_or_else(|| capitalize(name).into_owned()),
-            ];
-            collect_jsx_strings(&config.jsx, &mut jsx_names);
+            let jsx_names = pattern_jsx_names(name, config);
             Ok(PatternDefinition {
                 name: name.clone(),
                 jsx_names,
@@ -735,7 +729,18 @@ fn variant_selection_to_literal(value: &VariantSelection) -> Literal {
     }
 }
 
-fn recipe_jsx_names(name: &str, recipe: &RecipeConfig) -> Vec<String> {
+pub(super) fn pattern_jsx_names(name: &str, pattern: &PatternConfig) -> Vec<String> {
+    let mut names = vec![
+        pattern
+            .jsx_name
+            .clone()
+            .unwrap_or_else(|| capitalize(name).into_owned()),
+    ];
+    collect_jsx_strings(&pattern.jsx, &mut names);
+    names
+}
+
+pub(super) fn recipe_jsx_names(name: &str, recipe: &RecipeConfig) -> Vec<String> {
     let names: Vec<_> = recipe
         .jsx
         .iter()
@@ -749,7 +754,7 @@ fn recipe_jsx_names(name: &str, recipe: &RecipeConfig) -> Vec<String> {
     }
 }
 
-fn slot_recipe_jsx_names(name: &str, recipe: &RecipeConfig) -> Vec<String> {
+pub(super) fn slot_recipe_jsx_names(name: &str, recipe: &RecipeConfig) -> Vec<String> {
     let capitalized = capitalize(name);
     let mut names = recipe_jsx_names(name, recipe);
     for slot in &recipe.slots {

--- a/crates/pandacss_project/src/design_system.rs
+++ b/crates/pandacss_project/src/design_system.rs
@@ -4,12 +4,12 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Bumped when the wire shape changes; a version mismatch surfaces a diagnostic
-/// rather than mis-reading the manifest.
+/// Bumped for incompatible wire changes; additive optional fields remain readable
+/// by older consumers.
 pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
 
-/// The published `panda/lib.json` record. `preset` / `buildInfo` are relative to
-/// the manifest directory; `files` are relative to the lib outdir.
+/// The published `panda/lib.json` record. `preset`, `buildInfo`, and `spec` are
+/// relative to the manifest directory; `files` are relative to the lib outdir.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DesignSystemManifest {
@@ -22,6 +22,9 @@ pub struct DesignSystemManifest {
     pub panda: String,
     pub preset: String,
     pub build_info: String,
+    /// Versioned semantic spec for documentation and external tooling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub import_map: Option<ManifestImportMap>,
     /// Parent design system package name. Omitted at a root.
@@ -62,6 +65,8 @@ pub struct ManifestInput {
     pub preset: String,
     pub build_info: String,
     #[serde(default)]
+    pub spec: Option<String>,
+    #[serde(default)]
     pub import_map: Option<ManifestImportMap>,
     #[serde(default)]
     pub design_system: Option<String>,
@@ -86,6 +91,7 @@ impl super::Project {
             panda: input.panda,
             preset: input.preset,
             build_info: input.build_info,
+            spec: input.spec,
             import_map: input.import_map,
             design_system: input.design_system,
             files: input.files,

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -31,6 +31,7 @@ mod parsed_file;
 mod patterns;
 mod recipes;
 mod runtime_config;
+mod spec;
 mod static_patterns;
 mod system;
 mod transform;

--- a/crates/pandacss_project/src/spec.rs
+++ b/crates/pandacss_project/src/spec.rs
@@ -1,0 +1,274 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use pandacss_config::{
+    ConditionQuery, Deprecated, JsxSpecifier, PatternConfig, RecipeConfig, SPEC_SCHEMA_VERSION,
+    Spec, SpecCatalog, SpecCompoundVariantDefinition, SpecPatternDefinition,
+    SpecPatternPropertyDefinition, SpecRecipeDefinition, SpecThemeDefinition, SpecTokenDefinition,
+    SpecTokenValue, TypeData, UserConfig,
+};
+use pandacss_shared::pascal_case;
+use pandacss_tokens::TokenDictionary;
+
+use crate::{
+    Project,
+    config::{pattern_jsx_names, recipe_jsx_names, slot_recipe_jsx_names},
+};
+
+impl Project {
+    /// Build the versioned design-system snapshot used by tooling and artifact writers.
+    ///
+    /// Property ordering belongs to the stylesheet layer. Accepting it as a closure keeps
+    /// the project crate below the emitter while still constructing the complete spec once.
+    #[must_use]
+    pub fn spec(
+        &self,
+        config: &UserConfig,
+        property_order: impl FnOnce(&TypeData) -> Vec<String>,
+    ) -> Spec {
+        let _span = tracing::trace_span!(target: "codegen", "spec").entered();
+        let types = self.type_data(config);
+        let property_order = property_order(&types);
+        let catalog = {
+            let _span = tracing::trace_span!(target: "codegen", "spec_catalog").entered();
+            build_catalog(config, self.config().token_dictionary().as_deref())
+        };
+
+        Spec {
+            schema_version: SPEC_SCHEMA_VERSION,
+            types,
+            property_order,
+            jsx_factory: Some(config.jsx_factory().to_owned()),
+            import_map: config.import_map.clone(),
+            catalog,
+        }
+    }
+}
+
+fn build_catalog(config: &UserConfig, dictionary: Option<&TokenDictionary>) -> SpecCatalog {
+    SpecCatalog {
+        conditions: condition_definitions(config),
+        tokens: dictionary.map(token_definitions).unwrap_or_default(),
+        recipes: recipe_definitions(&config.theme.recipes, recipe_jsx_names),
+        slot_recipes: recipe_definitions(&config.theme.slot_recipes, slot_recipe_jsx_names),
+        patterns: pattern_definitions(&config.patterns),
+        keyframes: object_entries(&config.theme.keyframes),
+        text_styles: object_entries(&config.theme.text_styles),
+        layer_styles: object_entries(&config.theme.layer_styles),
+        animation_styles: object_entries(&config.theme.animation_styles),
+        view_transitions: config.theme.view_transitions.clone(),
+        position_try: config.theme.position_try.clone(),
+        themes: config
+            .themes
+            .keys()
+            .filter_map(|name| {
+                let condition = pandacss_config::theme_condition_name(name);
+                Some((
+                    name.clone(),
+                    SpecThemeDefinition {
+                        name: name.clone(),
+                        root_selector: config.theme_root_selector(name)?,
+                        condition,
+                    },
+                ))
+            })
+            .collect(),
+    }
+}
+
+fn condition_definitions(config: &UserConfig) -> BTreeMap<String, ConditionQuery> {
+    config
+        .condition_names()
+        .into_iter()
+        .filter(|name| name != "base")
+        .filter_map(|name| {
+            let query = config
+                .breakpoint_condition(&name)
+                .or_else(|| config.container_condition(&name))
+                .or_else(|| config.theme_condition(&name))
+                .map(ConditionQuery::String)
+                .or_else(|| {
+                    name.strip_prefix('_')
+                        .and_then(|key| config.conditions.get(key))
+                        .cloned()
+                })?;
+            Some((name, query))
+        })
+        .collect()
+}
+
+fn token_definitions(dictionary: &TokenDictionary) -> BTreeMap<String, SpecTokenDefinition> {
+    let mut definitions = BTreeMap::<String, SpecTokenDefinition>::new();
+
+    for token in dictionary.iter() {
+        let path = token.path.to_string();
+        let definition = definitions
+            .entry(path)
+            .or_insert_with_key(|path| SpecTokenDefinition {
+                path: path.clone(),
+                category: token.category.as_str().to_owned(),
+                css_var: token.var.to_string(),
+                semantic: false,
+                values: Vec::new(),
+            });
+        definition.semantic |= token.semantic;
+        definition.values.push(SpecTokenValue {
+            value: token.value.to_string(),
+            condition: token.condition.as_deref().map(str::to_owned),
+            original_value: token.original_value.as_deref().map(str::to_owned),
+            description: token.description.as_deref().map(str::to_owned),
+            deprecated: token.deprecated.then(|| {
+                token
+                    .deprecated_reason
+                    .as_deref()
+                    .map_or(Deprecated::Bool(true), |reason| {
+                        Deprecated::Message(reason.to_owned())
+                    })
+            }),
+        });
+    }
+
+    for definition in definitions.values_mut() {
+        definition.values.sort_by(|left, right| {
+            left.condition
+                .is_some()
+                .cmp(&right.condition.is_some())
+                .then_with(|| left.condition.cmp(&right.condition))
+        });
+    }
+
+    definitions
+}
+
+fn recipe_definitions(
+    recipes: &BTreeMap<String, RecipeConfig>,
+    jsx_names: fn(&str, &RecipeConfig) -> Vec<String>,
+) -> BTreeMap<String, SpecRecipeDefinition> {
+    recipes
+        .iter()
+        .map(|(name, recipe)| {
+            let mut metadata = recipe.extra.clone();
+            let description = take_string(&mut metadata, "description");
+            let jsx = effective_jsx(jsx_names(name, recipe), &recipe.jsx);
+            (
+                name.clone(),
+                SpecRecipeDefinition {
+                    name: name.clone(),
+                    class_name: recipe.class_name.clone().unwrap_or_else(|| name.clone()),
+                    description,
+                    jsx,
+                    slots: recipe.slots.clone(),
+                    base: recipe.base.clone(),
+                    variants: recipe.variants.clone(),
+                    default_variants: recipe.default_variants.clone(),
+                    compound_variants: recipe
+                        .compound_variants
+                        .iter()
+                        .map(|compound| SpecCompoundVariantDefinition {
+                            css: compound.css.clone(),
+                            class_name: compound.class_name.clone(),
+                            conditions: compound.conditions.clone(),
+                        })
+                        .collect(),
+                    static_css: recipe.static_css.clone(),
+                    deprecated: Deprecated::normalize(recipe.deprecated.as_ref()),
+                    metadata,
+                },
+            )
+        })
+        .collect()
+}
+
+fn pattern_definitions(
+    patterns: &BTreeMap<String, PatternConfig>,
+) -> BTreeMap<String, SpecPatternDefinition> {
+    patterns
+        .iter()
+        .map(|(name, pattern)| {
+            let mut metadata = pattern.extra.clone();
+            let description = take_string(&mut metadata, "description");
+            let jsx_element = take_string(&mut metadata, "jsxElement")
+                .unwrap_or_else(|| pandacss_config::DEFAULT_PATTERN_JSX_ELEMENT.to_owned());
+            let has_dynamic_default_values =
+                pattern.default_values.as_ref().is_some_and(is_callback_ref);
+            let default_values = pattern
+                .default_values
+                .as_ref()
+                .filter(|value| !is_callback_ref(value))
+                .cloned();
+            let jsx_name = pattern
+                .jsx_name
+                .clone()
+                .unwrap_or_else(|| pascal_case(name));
+            (
+                name.clone(),
+                SpecPatternDefinition {
+                    name: name.clone(),
+                    jsx_name,
+                    jsx_element,
+                    jsx: effective_jsx(pattern_jsx_names(name, pattern), &pattern.jsx),
+                    description,
+                    properties: pattern
+                        .properties
+                        .iter()
+                        .map(|(name, property)| {
+                            (
+                                name.clone(),
+                                SpecPatternPropertyDefinition {
+                                    r#type: property.r#type.clone(),
+                                    value: property.value.clone(),
+                                    property: property.property.clone(),
+                                    description: property.description.clone(),
+                                    metadata: property.extra.clone(),
+                                },
+                            )
+                        })
+                        .collect(),
+                    default_values,
+                    has_dynamic_default_values,
+                    has_transform: pattern.transform.is_some(),
+                    strict: pattern.strict,
+                    blocklist: pattern.blocklist.clone(),
+                    deprecated: Deprecated::normalize(pattern.deprecated.as_ref()),
+                    metadata,
+                },
+            )
+        })
+        .collect()
+}
+
+fn effective_jsx(names: Vec<String>, configured: &[JsxSpecifier]) -> Vec<JsxSpecifier> {
+    names
+        .into_iter()
+        .map(JsxSpecifier::String)
+        .chain(
+            configured
+                .iter()
+                .filter(|specifier| specifier.as_regex().is_some())
+                .cloned(),
+        )
+        .collect()
+}
+
+fn object_entries(value: &Value) -> BTreeMap<String, Value> {
+    value
+        .as_object()
+        .into_iter()
+        .flat_map(|entries| entries.iter())
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect()
+}
+
+fn take_string(metadata: &mut serde_json::Map<String, Value>, name: &str) -> Option<String> {
+    metadata
+        .remove(name)
+        .and_then(|value| value.as_str().map(str::to_owned))
+}
+
+fn is_callback_ref(value: &Value) -> bool {
+    value
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind == "js-callback")
+}

--- a/crates/pandacss_project/tests/design_system.rs
+++ b/crates/pandacss_project/tests/design_system.rs
@@ -13,6 +13,7 @@ fn full_input() -> ManifestInput {
         "panda": "^2.0.0",
         "preset": "./preset.mjs",
         "buildInfo": "./buildinfo.json",
+        "spec": "./spec.json",
         "importMap": { "css": "@acme/ds/css", "recipes": "@acme/ds/recipes" },
         "designSystem": "@acme/foundations",
         "files": ["../src/**/*.{js,mjs}"],
@@ -29,6 +30,7 @@ fn stamps_schema_version_and_carries_input_fields() {
     assert_eq!(manifest.name, "@acme/ds");
     assert_eq!(manifest.version.as_deref(), Some("1.2.3"));
     assert_eq!(manifest.panda, "^2.0.0");
+    assert_eq!(manifest.spec.as_deref(), Some("./spec.json"));
     assert_eq!(manifest.design_system.as_deref(), Some("@acme/foundations"));
     assert_eq!(
         manifest.import_map.as_ref().and_then(|m| m.css.as_deref()),
@@ -56,6 +58,7 @@ fn omits_optional_fields_when_absent() {
     assert!(json.get("version").is_none());
     assert!(json.get("importMap").is_none());
     assert!(json.get("designSystem").is_none());
+    assert!(json.get("spec").is_none());
     assert!(json.get("files").is_none());
 }
 

--- a/crates/pandacss_project/tests/main.rs
+++ b/crates/pandacss_project/tests/main.rs
@@ -14,6 +14,7 @@ mod lifecycle;
 mod parsed_file;
 mod patterns;
 mod scan;
+mod spec;
 mod static_patterns;
 mod svelte;
 mod transform;

--- a/crates/pandacss_project/tests/spec.rs
+++ b/crates/pandacss_project/tests/spec.rs
@@ -1,0 +1,414 @@
+//! `Project::spec` — one versioned, resolved snapshot for tooling and artifact writers.
+
+use insta::assert_yaml_snapshot;
+use pandacss_config::SPEC_SCHEMA_VERSION;
+use pandacss_project::{Project, System};
+use serde_json::json;
+
+use crate::common::create_config;
+
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "single end-to-end spec wire contract fixture"
+)]
+fn spec_exposes_resolved_design_system_definitions() {
+    let config = create_config(json!({
+        "conditions": {
+            "hover": "&:hover"
+        },
+        "patterns": {
+            "stack": {
+                "description": "Arrange children vertically",
+                "jsxName": "VStack",
+                "jsx": [{
+                    "kind": "regex",
+                    "source": "^LegacyStack$",
+                    "flags": ""
+                }],
+                "jsxElement": "section",
+                "properties": {
+                    "gap": {
+                        "type": "token",
+                        "value": "spacing",
+                        "description": "Space between children"
+                    }
+                },
+                "defaultValues": {
+                    "kind": "js-callback",
+                    "id": "patterns.stack.defaultValues"
+                },
+                "transform": {
+                    "kind": "js-callback",
+                    "id": "patterns.stack.transform"
+                },
+                "docs": {
+                    "category": "layout"
+                }
+            }
+        },
+        "theme": {
+            "breakpoints": {
+                "sm": "640px"
+            },
+            "tokens": {
+                "colors": {
+                    "brand": {
+                        "value": "#0055ff",
+                        "description": "Brand blue"
+                    },
+                    "alias": {
+                        "value": "{colors.brand}"
+                    }
+                }
+            },
+            "semanticTokens": {
+                "colors": {
+                    "accent": {
+                        "value": "#ff00aa"
+                    },
+                    "fg": {
+                        "value": {
+                            "base": "{colors.brand}",
+                            "_dark": "#ffffff"
+                        },
+                        "deprecated": "Use colors.text"
+                    }
+                }
+            },
+            "recipes": {
+                "button": {
+                    "description": "A button",
+                    "className": "btn",
+                    "base": {
+                        "display": "inline-flex"
+                    },
+                    "variants": {
+                        "size": {
+                            "sm": {
+                                "height": "8"
+                            }
+                        }
+                    },
+                    "defaultVariants": {
+                        "size": "sm"
+                    },
+                    "compoundVariants": [{
+                        "size": "sm",
+                        "css": {
+                            "fontWeight": "bold"
+                        }
+                    }],
+                    "staticCss": [{ "size": ["sm"] }],
+                    "docs": {
+                        "status": "stable"
+                    }
+                }
+            },
+            "slotRecipes": {
+                "card": {
+                    "slots": ["root", "title"],
+                    "base": {
+                        "root": {
+                            "display": "grid"
+                        }
+                    }
+                }
+            },
+            "keyframes": {
+                "fade-in": {
+                    "from": {
+                        "opacity": 0
+                    },
+                    "to": {
+                        "opacity": 1
+                    }
+                }
+            },
+            "textStyles": {
+                "heading": {
+                    "value": {
+                        "fontSize": "2xl"
+                    }
+                }
+            },
+            "layerStyles": {
+                "raised": {
+                    "value": {
+                        "boxShadow": "md"
+                    }
+                }
+            },
+            "animationStyles": {
+                "entrance": {
+                    "value": {
+                        "animationName": "fade-in"
+                    }
+                }
+            },
+            "viewTransitions": {
+                "slide": {
+                    "old": { "opacity": 0 },
+                    "new": { "opacity": 1 }
+                }
+            },
+            "positionTry": {
+                "below": {
+                    "top": "anchor(bottom)"
+                }
+            }
+        },
+        "themes": {
+            "dark": {
+                "tokens": {
+                    "colors": {
+                        "brand": {
+                            "value": "#88aaff"
+                        }
+                    }
+                }
+            }
+        }
+    }));
+    let project = Project::new(System::new(config.clone()).expect("valid project config"));
+
+    let spec = project.spec(&config, |_| vec!["display".to_owned()]);
+    let value = serde_json::to_value(spec).expect("serialize spec");
+
+    assert_eq!(value["schemaVersion"], SPEC_SCHEMA_VERSION);
+    assert_yaml_snapshot!(json!({
+        "conditions": value["catalog"]["conditions"],
+        "tokens": {
+            "brand": value["catalog"]["tokens"]["colors.brand"],
+            "alias": value["catalog"]["tokens"]["colors.alias"],
+            "accent": value["catalog"]["tokens"]["colors.accent"],
+            "fg": value["catalog"]["tokens"]["colors.fg"]
+        },
+        "recipes": value["catalog"]["recipes"],
+        "slotRecipes": value["catalog"]["slotRecipes"],
+        "patterns": value["catalog"]["patterns"],
+        "keyframes": value["catalog"]["keyframes"],
+        "textStyles": value["catalog"]["textStyles"],
+        "layerStyles": value["catalog"]["layerStyles"],
+        "animationStyles": value["catalog"]["animationStyles"],
+        "viewTransitions": value["catalog"]["viewTransitions"],
+        "positionTry": value["catalog"]["positionTry"],
+        "themes": value["catalog"]["themes"],
+        "propertyOrder": value["propertyOrder"]
+    }), @r##"
+    conditions:
+      _hover: "&:hover"
+      _themeDark: "&:where([data-panda-theme=dark], [data-panda-theme=dark] *)"
+      sm: "@media (width >= 40rem)"
+      smDown: "@media (width < 40rem)"
+      smOnly: "@media (width >= 40rem)"
+    tokens:
+      brand:
+        path: colors.brand
+        category: colors
+        cssVar: var(--colors-brand)
+        semantic: false
+        values:
+          - value: "#0055ff"
+            description: Brand blue
+          - value: "#88aaff"
+            condition: _themeDark
+      alias:
+        path: colors.alias
+        category: colors
+        cssVar: var(--colors-alias)
+        semantic: false
+        values:
+          - value: var(--colors-brand)
+            originalValue: "{colors.brand}"
+      accent:
+        path: colors.accent
+        category: colors
+        cssVar: var(--colors-accent)
+        semantic: true
+        values:
+          - value: "#ff00aa"
+      fg:
+        path: colors.fg
+        category: colors
+        cssVar: var(--colors-fg)
+        semantic: true
+        values:
+          - value: var(--colors-brand)
+            originalValue: "{colors.brand}"
+            deprecated: Use colors.text
+          - value: "#ffffff"
+            condition: _dark
+            deprecated: Use colors.text
+    recipes:
+      button:
+        name: button
+        className: btn
+        description: A button
+        jsx:
+          - Button
+        base:
+          display: inline-flex
+        variants:
+          size:
+            sm:
+              height: "8"
+        defaultVariants:
+          size: sm
+        compoundVariants:
+          - css:
+              fontWeight: bold
+            size: sm
+        staticCss:
+          - size:
+              - sm
+        metadata:
+          docs:
+            status: stable
+    slotRecipes:
+      card:
+        name: card
+        className: card
+        jsx:
+          - Card
+          - Card.Root
+          - CardRoot
+          - Card.Title
+          - CardTitle
+        slots:
+          - root
+          - title
+        base:
+          root:
+            display: grid
+        variants: {}
+        defaultVariants: {}
+        compoundVariants: []
+    patterns:
+      stack:
+        name: stack
+        jsxName: VStack
+        jsxElement: section
+        jsx:
+          - VStack
+          - kind: regex
+            source: ^LegacyStack$
+            flags: ""
+        description: Arrange children vertically
+        properties:
+          gap:
+            type: token
+            value: spacing
+            description: Space between children
+        hasDynamicDefaultValues: true
+        hasTransform: true
+        strict: false
+        blocklist: []
+        metadata:
+          docs:
+            category: layout
+    keyframes:
+      fade-in:
+        from:
+          opacity: 0
+        to:
+          opacity: 1
+    textStyles:
+      heading:
+        value:
+          fontSize: 2xl
+    layerStyles:
+      raised:
+        value:
+          boxShadow: md
+    animationStyles:
+      entrance:
+        value:
+          animationName: fade-in
+    viewTransitions:
+      slide:
+        old:
+          opacity: 0
+        new:
+          opacity: 1
+    positionTry:
+      below:
+        top: anchor(bottom)
+    themes:
+      dark:
+        name: dark
+        condition: _themeDark
+        rootSelector: "[data-panda-theme=dark]"
+    propertyOrder:
+      - display
+    "##);
+}
+
+#[test]
+fn spec_preserves_nested_conditions_and_container_queries() {
+    let config = create_config(json!({
+        "conditions": {
+            "hoverFine": {
+                "@media (hover: hover)": {
+                    "&:hover": "@slot"
+                }
+            }
+        },
+        "theme": {
+            "containers": {
+                "sm": "24rem"
+            },
+            "containerNames": ["sidebar"]
+        }
+    }));
+    let project = Project::new(System::new(config.clone()).expect("valid project config"));
+
+    let value =
+        serde_json::to_value(project.spec(&config, |_| Vec::new())).expect("serialize spec");
+
+    assert_eq!(
+        value["catalog"]["conditions"]["_hoverFine"],
+        json!({
+            "@media (hover: hover)": {
+                "&:hover": "@slot"
+            }
+        })
+    );
+    assert_eq!(
+        value["catalog"]["conditions"]["@sidebar/sm"],
+        "@container sidebar (inline-size >= 24rem)"
+    );
+}
+
+#[test]
+fn spec_is_deterministic_for_equivalent_config_order() {
+    let first = create_config(json!({
+        "conditions": { "focus": "&:focus", "hover": "&:hover" },
+        "theme": {
+            "tokens": {
+                "colors": {
+                    "b": { "value": "blue" },
+                    "a": { "value": "red" }
+                }
+            }
+        }
+    }));
+    let second = create_config(json!({
+        "conditions": { "hover": "&:hover", "focus": "&:focus" },
+        "theme": {
+            "tokens": {
+                "colors": {
+                    "a": { "value": "red" },
+                    "b": { "value": "blue" }
+                }
+            }
+        }
+    }));
+
+    let serialize = |config: pandacss_config::UserConfig| {
+        let project = Project::new(System::new(config.clone()).expect("valid project config"));
+        serde_json::to_string(&project.spec(&config, |_| Vec::new())).expect("serialize spec")
+    };
+
+    assert_eq!(serialize(first), serialize(second));
+}

--- a/crates/pandacss_tokens/src/builder.rs
+++ b/crates/pandacss_tokens/src/builder.rs
@@ -145,7 +145,7 @@ impl TokenDictionaryBuilder {
             if token.deprecated {
                 deprecated_paths_cache.push(Arc::clone(&token.path));
             }
-            if parse_token_ref(token.original_value.as_deref()).is_some() {
+            if token.semantic {
                 semantic_categories.insert(token.category.clone());
             }
         }
@@ -233,7 +233,7 @@ fn build_suggestion_index(
             .or_default()
             .push(TokenSuggestion {
                 token: rel.to_owned(),
-                semantic: parse_token_ref(token.original_value.as_deref()).is_some(),
+                semantic: token.semantic,
                 conditional: by_path_condition.contains_key(&token.path),
             });
     }

--- a/crates/pandacss_tokens/src/from_config.rs
+++ b/crates/pandacss_tokens/src/from_config.rs
@@ -218,7 +218,7 @@ fn collect_token_category<T: TokenValueString>(
 ) {
     walk_token_group(group, &mut vec![category], &mut |path, token| {
         let token_path = TokenPath::from_segments(path);
-        let metadata = token_metadata(token, token_path.is_default);
+        let metadata = token_metadata(token, token_path.is_default, false);
         push_token(
             builder,
             context,
@@ -241,7 +241,7 @@ fn collect_semantic_category<T: TokenValueString>(
 ) {
     walk_token_group(group, &mut vec![category], &mut |path, token| {
         let token_path = TokenPath::from_segments(path);
-        let metadata = token_metadata(token, token_path.is_default);
+        let metadata = token_metadata(token, token_path.is_default, true);
 
         if let Some(condition) = forced_condition {
             visit_semantic_values(&token.value, None, &mut |nested_condition, value| {
@@ -334,9 +334,14 @@ struct TokenMetadata<'a> {
     deprecated: bool,
     deprecated_reason: Option<&'a str>,
     is_default: bool,
+    is_semantic: bool,
 }
 
-fn token_metadata<T>(token: &TokenEntry<T>, is_default: bool) -> TokenMetadata<'_> {
+fn token_metadata<T>(
+    token: &TokenEntry<T>,
+    is_default: bool,
+    is_semantic: bool,
+) -> TokenMetadata<'_> {
     let deprecated = token.deprecated.as_ref().is_some_and(|value| match value {
         Deprecated::Bool(value) => *value,
         Deprecated::Message(value) => !value.is_empty(),
@@ -350,6 +355,7 @@ fn token_metadata<T>(token: &TokenEntry<T>, is_default: bool) -> TokenMetadata<'
         deprecated,
         deprecated_reason,
         is_default,
+        is_semantic,
     }
 }
 
@@ -447,6 +453,9 @@ fn push_token(
         }
         if metadata.is_default {
             token.set_extension("isDefault", "true");
+        }
+        if metadata.is_semantic {
+            token = token.semantic();
         }
     }
 
@@ -580,6 +589,7 @@ fn add_negative_spacing_tokens(builder: &mut TokenDictionaryBuilder) {
 
         let mut negative = Token::new(path, value, "", TokenCategory::Spacing);
         negative.condition.clone_from(&token.condition);
+        negative.semantic = token.semantic;
         negative.original_value = Some(Arc::clone(&token.value));
         negative.description.clone_from(&token.description);
         negative.deprecated = token.deprecated;

--- a/crates/pandacss_tokens/src/lib.rs
+++ b/crates/pandacss_tokens/src/lib.rs
@@ -415,9 +415,7 @@ impl TokenDictionary {
 
     #[must_use]
     pub fn is_semantic_token(&self, path: &str) -> bool {
-        self.token(path)
-            .and_then(|token| parse_token_ref(token.original_value.as_deref()))
-            .is_some()
+        self.token(path).is_some_and(|token| token.semantic)
     }
 
     #[must_use]

--- a/crates/pandacss_tokens/src/token.rs
+++ b/crates/pandacss_tokens/src/token.rs
@@ -27,6 +27,8 @@ pub struct Token {
     pub var: Arc<str>,
     pub category: TokenCategory,
     pub condition: Option<Arc<str>>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub semantic: bool,
     /// Pre-alias-substitution value; `None` once references are expanded.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub original_value: Option<Arc<str>>,
@@ -57,6 +59,8 @@ struct TokenWire {
     category: TokenCategory,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     condition: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    semantic: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     original_value: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -78,6 +82,7 @@ impl From<TokenWire> for Token {
             var: Arc::from(value.var),
             category: value.category,
             condition: value.condition.map(Arc::from),
+            semantic: value.semantic,
             original_value: value.original_value.map(Arc::from),
             description: value.description.map(Arc::from),
             deprecated: value.deprecated,
@@ -96,6 +101,7 @@ impl From<Token> for TokenWire {
             var: value.var.to_string(),
             category: value.category,
             condition: value.condition.map(|value| value.to_string()),
+            semantic: value.semantic,
             original_value: value.original_value.map(|value| value.to_string()),
             description: value.description.map(|value| value.to_string()),
             deprecated: value.deprecated,
@@ -119,6 +125,7 @@ impl Token {
             var: Arc::from(var.as_ref()),
             category,
             condition: None,
+            semantic: false,
             original_value: None,
             description: None,
             deprecated: false,
@@ -130,6 +137,12 @@ impl Token {
     #[must_use]
     pub fn with_condition(mut self, condition: impl AsRef<str>) -> Self {
         self.condition = Some(Arc::from(condition.as_ref()));
+        self
+    }
+
+    #[must_use]
+    pub fn semantic(mut self) -> Self {
+        self.semantic = true;
         self
     }
 
@@ -173,4 +186,13 @@ impl Token {
             .into_iter()
             .flat_map(|m| m.iter().map(|(k, v)| (k.as_str(), v.as_str())))
     }
+}
+
+#[cfg(feature = "serde")]
+#[allow(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde `skip_serializing_if` requires `fn(&T) -> bool`"
+)]
+fn is_false(value: &bool) -> bool {
+    !value
 }

--- a/crates/pandacss_tokens/tests/from_config.rs
+++ b/crates/pandacss_tokens/tests/from_config.rs
@@ -6,7 +6,7 @@
 use crate::common::{snapshot_token_values, snapshot_tokens};
 use insta::assert_yaml_snapshot;
 use pandacss_config::UserConfig;
-use pandacss_tokens::TokenDictionary;
+use pandacss_tokens::{TokenCategory, TokenDictionary};
 use serde_json::json;
 
 #[test]
@@ -136,6 +136,48 @@ fn from_config_collects_theme_tokens_semantic_tokens_and_breakpoints() {
     redDeprecated: true
     darkFg: "#fff"
     "##);
+}
+
+#[test]
+fn literal_semantic_tokens_remain_identifiable_after_resolution() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "semanticTokens": {
+                "colors": {
+                    "accent": { "value": "#ff00aa" }
+                }
+            }
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert!(dict.is_semantic_token("colors.accent"));
+}
+
+#[test]
+fn primitive_token_aliases_are_not_classified_as_semantic_tokens() {
+    let config: UserConfig = serde_json::from_value(json!({
+        "theme": {
+            "tokens": {
+                "colors": {
+                    "brand": { "value": "#0055ff" },
+                    "alias": { "value": "{colors.brand}" }
+                }
+            }
+        }
+    }))
+    .expect("config");
+
+    let dict = TokenDictionary::from_config(&config)
+        .expect("token dictionary")
+        .expect("non-empty dictionary");
+
+    assert!(!dict.is_semantic_token("colors.alias"));
+    assert!(!dict.has_semantic_tokens(&TokenCategory::Colors));
 }
 
 #[test]

--- a/crates/pandacss_tokens/tests/queries.rs
+++ b/crates/pandacss_tokens/tests/queries.rs
@@ -511,6 +511,27 @@ fn serde_roundtrip_rebuilds_indexes() {
 }
 
 #[test]
+fn serde_roundtrip_preserves_literal_semantic_identity() {
+    let original = TokenDictionary::builder()
+        .insert(
+            t(
+                "colors.accent",
+                "#ff00aa",
+                "var(--colors-accent)",
+                TokenCategory::Colors,
+            )
+            .semantic(),
+        )
+        .build();
+
+    let wire = serde_json::to_string(&original).expect("serialize");
+    let restored: TokenDictionary = serde_json::from_str(&wire).expect("deserialize");
+
+    assert!(restored.is_semantic_token("colors.accent"));
+    assert!(restored.has_semantic_tokens(&TokenCategory::Colors));
+}
+
+#[test]
 fn builder_push_supports_imperative_construction() {
     // Mirror what a JS bridge or a loop-built dictionary looks like:
     // hold a `&mut builder` and `push` tokens without taking ownership

--- a/design-notes/README.md
+++ b/design-notes/README.md
@@ -15,6 +15,8 @@ Some topics span several notes. Keep the detailed contract in one place and link
   diagnostics, and current built/deferred status.
 - `build-info.md` owns the portable build-info payload, token identity, hydration, module/export tree-shaking, and
   stacked hydrate semantics.
+- `design-system-spec.md` owns the versioned `compiler.spec()` and `spec.json` contract, catalog contents, and adapter
+  boundary.
 - `virtual-styled-system.md` owns the canonical DS `styled-system` package surface, dual importMap behavior, and overlay
   codegen plan.
 - `chakra-ui-design-system-migration.md` applies those contracts to Chakra. It should not redefine the generic
@@ -67,6 +69,8 @@ Some topics span several notes. Keep the detailed contract in one place and link
 - [Build info](./build-info.md) — `panda.buildinfo.json`: the portable encoder state a design system ships, its
   condensed format, per-module tree-shaking + import resolution, stacked DS-on-DS consume sketch, the version guard, and
   the engine/JS/CLI layering.
+- [Design-system spec artifact](./design-system-spec.md) — the versioned `compiler.spec()` snapshot and `spec.json`
+  artifact: resolved catalog definitions, deterministic serialization, dynamic-config boundary, and external adapters.
 - [Design-system manifest](./design-system-manifest.md) — `designSystem: '@acme/ds'`: the `panda/lib.json` manifest,
   gen + load as fs-free compiler methods (`compiler.designSystem.*`), the parent-chain walk for nested design systems,
   module/type resolution, setup diagnostics, and the incremental PR breakdown.

--- a/design-notes/design-system-manifest.md
+++ b/design-notes/design-system-manifest.md
@@ -31,7 +31,8 @@ export default {
 ```
 
 The library publishes one manifest, `panda/lib.json`. The manifest points to the library preset, portable build info,
-import roots, fallback files, and optional parent design system. The author creates all of it with:
+versioned design-system spec, import roots, fallback files, and optional parent design system. The author creates all of
+it with:
 
 ```sh
 panda lib
@@ -109,8 +110,8 @@ hash-space questions. We should not add that surface without clear demand.
 ## The manifest is the package contract
 
 The library publishes machine artifacts under a private `panda/` folder. Consumers resolve
-`@acme/ds/panda/lib.json`. `preset` and `buildInfo` are relative to the manifest file; `files` are relative to the
-lib outdir (parent of `panda/`). The same layout works from `node_modules`, a workspace symlink, or a Docker layer.
+`@acme/ds/panda/lib.json`. `preset`, `buildInfo`, and `spec` are relative to the manifest file; `files` are relative to
+the lib outdir (parent of `panda/`). The same layout works from `node_modules`, a workspace symlink, or a Docker layer.
 
 ```jsonc
 {
@@ -120,6 +121,7 @@ lib outdir (parent of `panda/`). The same layout works from `node_modules`, a wo
   "panda": "^2.0.0", // peer range the consumer must satisfy
   "preset": "./preset.mjs", // compiled preset module
   "buildInfo": "./buildinfo.json",
+  "spec": "./spec.json", // resolved, versioned design-system catalog
   "importMap": {
     "css": "@acme/ds/css",
     "recipes": "@acme/ds/recipes",
@@ -136,6 +138,8 @@ Field meanings:
 
 - `preset`: compiled `.mjs` config. It carries token definitions, recipes, utilities, conditions, and font-face config.
 - `buildInfo`: portable extraction cache. It carries token usage and encoded atoms/recipes.
+- `spec`: resolved design-system definitions for documentation and external tooling. Panda consumers do not need it to
+  compile CSS.
 - `importMap`: package roots used by the library's compiled JSX.
 - `designSystem`: this library's parent design system, if any.
 - `panda` and `schemaVersion`: compatibility guards.
@@ -172,6 +176,7 @@ It writes:
 dist/panda/lib.json
 dist/panda/buildinfo.json
 dist/panda/preset.mjs
+dist/panda/spec.json
 ```
 
 `preset.mjs` is bundled from the author config, but app-only fields are stripped:
@@ -269,7 +274,7 @@ Turbo-style setup:
   "tasks": {
     "lib": {
       "dependsOn": ["^lib"],
-      "outputs": ["dist/panda/lib.json", "dist/panda/buildinfo.json", "dist/panda/preset.mjs"],
+      "outputs": ["dist/panda/lib.json", "dist/panda/buildinfo.json", "dist/panda/preset.mjs", "dist/panda/spec.json"],
     },
     "dev": {
       "cache": false,
@@ -294,6 +299,7 @@ Nx-style setup:
         "{projectRoot}/dist/panda/lib.json",
         "{projectRoot}/dist/panda/buildinfo.json",
         "{projectRoot}/dist/panda/preset.mjs",
+        "{projectRoot}/dist/panda/spec.json",
       ],
       "cache": true,
     },

--- a/design-notes/design-system-spec.md
+++ b/design-notes/design-system-spec.md
@@ -1,0 +1,124 @@
+---
+title: Design-system spec artifact
+status: current
+scope:
+  - crates/pandacss_config
+  - crates/pandacss_project
+  - packages/compiler-shared
+  - packages/compiler
+  - packages/compiler-wasm
+  - packages/cli
+related:
+  - design-system-manifest.md
+  - output-and-host-layer.md
+---
+
+# Design-system spec artifact
+
+## Summary
+
+`compiler.spec()` is the canonical, versioned description of a resolved Panda design system. `panda spec` writes that
+value to `spec.json`, and `panda lib` publishes the same value at `panda/spec.json` for tools that consume a design
+system from another package.
+
+The spec serves two jobs:
+
+1. The existing type-data fields support Panda's editor, lint, and codegen queries.
+2. `catalog` preserves the resolved definitions needed by documentation, design-system catalogs, and external adapters.
+
+Both views come from one compiler-owned model. Hosts write the serialized value but do not reconstruct it.
+
+## The wire contract
+
+Every spec includes `schemaVersion`. Version 1 keeps the existing type-data fields and adds a definition catalog:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "options": { "strictTokens": false, "strictPropertyValues": false, "jsxStyleProps": "all" },
+  "conditions": { "keys": [], "breakpoints": [], "containers": [] },
+  "selectors": { "selectors": [], "arbitrary": [] },
+  "tokens": { "categories": {}, "colorPalettes": [], "values": {}, "deprecated": {} },
+  "utilities": { "properties": {}, "shorthands": {}, "deprecated": {}, "aliases": {}, "classNames": {} },
+  "recipes": {},
+  "slotRecipes": {},
+  "patterns": {},
+  "propertyOrder": [],
+  "catalog": {
+    "conditions": {},
+    "tokens": {},
+    "recipes": {},
+    "slotRecipes": {},
+    "patterns": {},
+    "keyframes": {},
+    "textStyles": {},
+    "layerStyles": {},
+    "animationStyles": {},
+    "viewTransitions": {},
+    "positionTry": {},
+    "themes": {},
+  },
+}
+```
+
+The type-data fields are compact indexes. The catalog is the richer JSON-safe definition layer:
+
+- Conditions keep their resolved query, including nested condition objects.
+- Tokens are grouped by path. Each entry records its category, CSS variable, semantic-token identity, and ordered
+  conditional values. Resolved values and authored references are both available.
+- Recipes and slot recipes include styles, variants, defaults, compounds, static CSS selections, JSX names,
+  deprecations, and JSON-safe metadata.
+- Patterns include their public property definitions, static defaults, JSX settings, and flags for dynamic defaults and
+  transforms.
+- Keyframes, composition styles, view transitions, position try definitions, and named themes retain their resolved
+  values.
+
+Named catalog entries use sorted keys. Token values put the base value first, followed by conditions in lexical order.
+Nested style objects preserve their resolved config order because declaration order can affect CSS semantics. The same
+resolved config therefore serializes to identical JSON.
+
+## Dynamic config stays out of the artifact
+
+Config bundling replaces JavaScript callbacks with callback references for the Rust boundary. The public spec does not
+publish callback identifiers or function bodies. A pattern reports `hasDynamicDefaultValues` and `hasTransform` so a
+consumer knows that static JSON is incomplete without depending on host code.
+
+This rule keeps `spec.json` portable and avoids treating executable config as data. A future feature that needs callback
+results must define a separate evaluated-data contract.
+
+## Ownership and output
+
+The layers follow the existing compiler boundary:
+
+| Layer                    | Responsibility                                                                         |
+| ------------------------ | -------------------------------------------------------------------------------------- |
+| `pandacss_config`        | Serializable spec types and `SPEC_SCHEMA_VERSION`                                      |
+| `pandacss_project`       | Build the complete spec from the resolved config and token dictionary                  |
+| stylesheet               | Supply canonical property ordering without creating a project-to-stylesheet dependency |
+| native and wasm bindings | Serialize the same Rust value                                                          |
+| TypeScript host          | Write `spec.json` and expose public TypeScript types                                   |
+| CLI                      | Choose the output path and render command diagnostics                                  |
+
+`panda spec` writes `<configured outdir>/specs/spec.json` by default. `--outdir` selects another directory and
+`--minify` removes formatting. `panda lib` writes `dist/panda/spec.json` and links it from `panda/lib.json` as `spec`.
+
+The library artifact contains the fully resolved design system, including inherited presets and parent design systems.
+This makes the published spec self-contained for registries and documentation tools. It does not change build-info
+hydration or the config chain used by Panda consumers.
+
+## Versioning and adapters
+
+Consumers must inspect `schemaVersion` before reading the artifact. Additive fields can remain within version 1. A
+removed field, renamed field, or changed field meaning requires a new schema version.
+
+Adapters belong outside the compiler. They can map this stable model to DESIGN.md, uSpec, an MCP resource, or another
+catalog format without adding those formats or vendors to Panda. Recipe and pattern metadata give design-system authors
+a small JSON-safe extension point; Panda does not interpret adapter-specific keys.
+
+## Non-goals
+
+- Preserve the v1 spec byte-for-byte.
+- Publish source files or executable config callbacks.
+- Infer application-level component compositions from source usage.
+- Add Figma, MCP, DESIGN.md, or another external format to the compiler.
+- Make `spec.json` part of CSS generation or runtime behavior.

--- a/design-notes/output-and-host-layer.md
+++ b/design-notes/output-and-host-layer.md
@@ -91,13 +91,15 @@ Three principles fall out of this:
 
 ## Introspection (`spec` + `introspect`)
 
-The engine exposes one **`compiler.spec()`** snapshot — `TypeData` (conditions, tokens incl. `deprecated`, utilities
-incl. `shorthands`/`deprecated`, patterns, recipes) plus `propertyOrder`, `jsxFactory`, `importMap`. It crosses the
-boundary once. **`introspect(spec)`** (in `@pandacss/compiler-shared`) indexes it into O(1) queries — `isValidProperty`,
-`resolveShorthand`, `getPropCategory`, `isColorProperty`, `isValidToken`/`isDeprecatedToken`/ `isColorToken`,
-`conditions`, `patterns`/`recipes`, `jsxFactory`, and `sortProps`/`compareProps` (canonical property order). The Driver
-caches it as `driver.introspect` (rebuilt on `reload`). This is the shared surface a linter, formatter, or reporter
-builds on — never a per-item engine call in a hot loop.
+The engine exposes one versioned **`compiler.spec()`** snapshot. It contains `TypeData` (conditions, tokens incl.
+`deprecated`, utilities incl. `shorthands`/`deprecated`, patterns, recipes), `propertyOrder`, `jsxFactory`, `importMap`,
+and a resolved definition `catalog`. It crosses the boundary once. [`design-system-spec.md`](./design-system-spec.md)
+owns the wire contract. **`introspect(spec)`** (in `@pandacss/compiler-shared`) indexes the compact fields into O(1)
+queries — `isValidProperty`, `resolveShorthand`, `getPropCategory`, `isColorProperty`,
+`isValidToken`/`isDeprecatedToken`/ `isColorToken`, `conditions`, `patterns`/`recipes`, `jsxFactory`, and
+`sortProps`/`compareProps` (canonical property order). The Driver caches it as `driver.introspect` (rebuilt on
+`reload`). This is the shared surface a linter, formatter, or reporter builds on — never a per-item engine call in a hot
+loop.
 
 ## The Driver interface (sketch)
 

--- a/packages/cli/__tests__/cli-smoke.test.ts
+++ b/packages/cli/__tests__/cli-smoke.test.ts
@@ -40,7 +40,7 @@ describe('cli smoke', () => {
     expect(normalizeCliOutput(result.stdout)).toMatchInlineSnapshot(`
       "Generate the panda system and CSS. Run with no subcommand for the full build. (panda v<version>)
 
-      USAGE panda [OPTIONS] init|dev|build|check|doctor|debug|buildinfo|lib|analyze|codegen|cssgen
+      USAGE panda [OPTIONS] init|dev|build|check|doctor|debug|buildinfo|lib|spec|analyze|codegen|cssgen
 
       OPTIONS
 
@@ -77,6 +77,7 @@ describe('cli smoke', () => {
       debug Dump resolved config and per-file extraction for bug reports
       buildinfo Build a portable panda.buildinfo.json for a design-system library
       lib Publish a design system: write machine artifacts under panda/, and sync package.json exports
+      spec Generate a versioned design-system spec
       analyze Inspect Panda usage across project sources
       codegen Generate the panda system
       cssgen Generate CSS from project files
@@ -85,14 +86,14 @@ describe('cli smoke', () => {
 
       "
     `)
-    expect(result.stdout).toContain('init|dev|build|check|doctor|debug|buildinfo|lib|analyze|codegen|cssgen')
+    expect(result.stdout).toContain('init|dev|build|check|doctor|debug|buildinfo|lib|spec|analyze|codegen|cssgen')
     expect(result.stdout).toContain(`panda v${version}`)
     expect(result.stdout).not.toContain('inspect')
     expect(result.stdout).not.toContain('validate')
     expect(result.stdout).not.toContain('`info`')
   })
 
-  it.each(['build', 'dev', 'check', 'doctor', 'analyze', 'cssgen'])('prints help for panda %s', (command) => {
+  it.each(['build', 'dev', 'check', 'doctor', 'spec', 'analyze', 'cssgen'])('prints help for panda %s', (command) => {
     const result = runCli([command, '--help'])
 
     expect(result.exitCode).toBe(0)

--- a/packages/cli/__tests__/lib.test.ts
+++ b/packages/cli/__tests__/lib.test.ts
@@ -54,6 +54,7 @@ describe('lib command', () => {
         "panda": "^2.0.0",
         "preset": "./preset.mjs",
         "schemaVersion": 1,
+        "spec": "./spec.json",
         "version": "1.2.3",
       }
     `)
@@ -61,6 +62,7 @@ describe('lib command', () => {
     const buildInfo = JSON.parse(readFileSync(join(dir, 'dist', 'panda', 'buildinfo.json'), 'utf8'))
     expect(Object.keys(buildInfo.modules).length).toBeGreaterThan(0)
     expect(readFileSync(join(dir, 'dist', 'panda', 'preset.mjs'), 'utf8')).toMatch(/as default|export default/)
+    expect(JSON.parse(readFileSync(join(dir, 'dist', 'panda', 'spec.json'), 'utf8')).schemaVersion).toBe(1)
 
     const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
     expect(pkg.exports).toMatchInlineSnapshot(`
@@ -198,6 +200,7 @@ describe('lib command', () => {
     expect(existsSync(join(dir, 'dist', 'panda', 'lib.json'))).toBe(false)
     expect(existsSync(join(dir, 'dist', 'panda', 'buildinfo.json'))).toBe(false)
     expect(existsSync(join(dir, 'dist', 'panda', 'preset.mjs'))).toBe(false)
+    expect(existsSync(join(dir, 'dist', 'panda', 'spec.json'))).toBe(false)
 
     const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
     expect(pkg.exports).toBeUndefined()

--- a/packages/cli/__tests__/spec.test.ts
+++ b/packages/cli/__tests__/spec.test.ts
@@ -1,0 +1,81 @@
+import type { Spec } from '@pandacss/compiler-shared'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runSpec } from '../src'
+
+function createSpecFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'panda-cli-spec-'))
+  writeFileSync(
+    join(dir, 'panda.config.ts'),
+    `export default {
+      outdir: 'styled-system',
+      conditions: { hover: '&:hover' },
+      theme: {
+        tokens: { colors: { brand: { value: '#05f', description: 'Brand blue' } } },
+        semanticTokens: { colors: { fg: { value: '{colors.brand}' } } },
+        recipes: {
+          button: {
+            description: 'A button',
+            variants: { size: { sm: { height: '8' } } },
+            defaultVariants: { size: 'sm' },
+          },
+        },
+      },
+    }`,
+  )
+  return dir
+}
+
+function readSpec(dir: string, path = 'styled-system/specs/spec.json'): Spec {
+  return JSON.parse(readFileSync(join(dir, path), 'utf8'))
+}
+
+describe('spec command', () => {
+  let dir: string | undefined
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+    dir = undefined
+  })
+
+  it('writes one versioned spec under the configured outdir', async () => {
+    dir = createSpecFixture()
+
+    const result = await runSpec({ cwd: dir, logLevel: 'silent' })
+
+    expect(result.ok).toBe(true)
+    expect(result.outfile).toBe(join(dir, 'styled-system', 'specs', 'spec.json'))
+    expect(result.bytes).toBeGreaterThan(0)
+
+    const spec = readSpec(dir)
+    expect(spec.schemaVersion).toBe(1)
+    expect(spec.catalog.conditions._hover).toBe('&:hover')
+    expect(spec.catalog.tokens['colors.brand']).toMatchObject({
+      path: 'colors.brand',
+      semantic: false,
+      values: [{ value: '#05f', description: 'Brand blue' }],
+    })
+    expect(spec.catalog.tokens['colors.fg']).toMatchObject({
+      semantic: true,
+      values: [{ value: 'var(--colors-brand)', originalValue: '{colors.brand}' }],
+    })
+    expect(spec.catalog.recipes.button).toMatchObject({
+      name: 'button',
+      description: 'A button',
+      defaultVariants: { size: 'sm' },
+    })
+  })
+
+  it('supports a custom output directory and minified JSON', async () => {
+    dir = createSpecFixture()
+
+    const result = await runSpec({ cwd: dir, outdir: 'artifacts', minify: true, logLevel: 'silent' })
+
+    expect(result.ok).toBe(true)
+    expect(existsSync(join(dir, 'artifacts', 'spec.json'))).toBe(true)
+    expect(readFileSync(join(dir, 'artifacts', 'spec.json'), 'utf8')).not.toContain('\n  ')
+    expect(readSpec(dir, 'artifacts/spec.json').schemaVersion).toBe(1)
+  })
+})

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -32,6 +32,7 @@ export async function main(argv = process.argv): Promise<void> {
         debug: () => import('./commands/debug').then((m) => m.debugCommand),
         buildinfo: () => import('./commands/buildinfo').then((m) => m.buildinfoCommand),
         lib: () => import('./commands/lib').then((m) => m.libCommand),
+        spec: () => import('./commands/spec').then((m) => m.specCommand),
         analyze: () => import('./commands/analyze').then((m) => m.analyzeCommand),
         codegen: () => import('./commands/codegen').then((m) => m.codegenCommand),
         cssgen: () => import('./commands/cssgen').then((m) => m.cssgenCommand),

--- a/packages/cli/src/commands/lib.ts
+++ b/packages/cli/src/commands/lib.ts
@@ -34,7 +34,7 @@ export const libCommand = defineCommand({
       description:
         'Re-extract fallback globs for consumers, relative to the output dir (comma-separated, or repeat the flag)',
     },
-    minify: { type: 'boolean', description: 'Minify the generated build info JSON', alias: 'm' },
+    minify: { type: 'boolean', description: 'Minify the generated build info and spec JSON', alias: 'm' },
     ...outputArgs(),
     ...traceArgs(),
   }),
@@ -73,6 +73,7 @@ export async function runLib(flags: LibFlags = {}, output: OutputSink = consoleO
           manifestPath: generated.manifestPath,
           buildInfoPath: generated.buildInfoPath,
           presetPath: generated.presetPath,
+          specPath: generated.specPath,
           exportsChanged: generated.exportsChanged,
         },
         diagnostics: generated.diagnostics,
@@ -106,6 +107,7 @@ export async function runLib(flags: LibFlags = {}, output: OutputSink = consoleO
         manifestPath: generated.manifestPath,
         buildInfoPath: generated.buildInfoPath,
         presetPath: generated.presetPath,
+        specPath: generated.specPath,
         exportsChanged: generated.exportsChanged,
         diagnostics: generated.diagnostics,
       })

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -1,0 +1,73 @@
+import { defineCommand } from 'citty'
+import { baseArgs, outputArgs, parseCliFlags, traceArgs } from '../args'
+import { consoleOutput, renderCommandDiagnostics, shouldPrintHumanSummary, type OutputSink } from '../output'
+import { setExitCode } from '../result'
+import { runCommand } from '../run-command'
+import { specFlagsSchema, type SpecFlags, type SpecResult } from '../schema'
+import { time } from '../timing'
+
+export const specCommand = defineCommand({
+  meta: {
+    name: 'spec',
+    description: 'Generate a versioned design-system spec',
+  },
+  args: () => ({
+    ...baseArgs(),
+    outdir: {
+      type: 'string',
+      description: "Output directory (default '<styled-system>/specs')",
+      alias: 'o',
+    },
+    minify: { type: 'boolean', description: 'Minify the generated JSON', alias: 'm' },
+    ...outputArgs(),
+    ...traceArgs(),
+  }),
+  run: async ({ args }) => setExitCode(await runSpec(parseCliFlags(specFlagsSchema, args))),
+})
+
+export async function runSpec(flags: SpecFlags = {}, output: OutputSink = consoleOutput): Promise<SpecResult> {
+  return runCommand({
+    command: 'spec',
+    flags,
+    output,
+    failData: () => ({ outfile: undefined, bytes: 0 }),
+    async execute({ driver, cwd, timings }) {
+      const outdir = flags.outdir
+        ? driver.resolvePath(flags.outdir)
+        : driver.compiler.path.join([driver.paths().root, 'specs'])
+      const serialized = time({
+        timings,
+        phase: 'spec',
+        run: () => `${JSON.stringify(driver.compiler.spec(), null, flags.minify ? 0 : 2)}\n`,
+      })
+      const [outfile] = time({
+        timings,
+        phase: 'write',
+        run: () =>
+          driver.compiler.writeArtifacts({
+            outdir,
+            cwd,
+            artifacts: [
+              {
+                id: 'spec',
+                files: [{ path: 'spec.json', code: serialized, dependencies: [] }],
+              },
+            ],
+          }),
+      })
+
+      return {
+        data: {
+          outfile,
+          bytes: Buffer.byteLength(serialized),
+        },
+      }
+    },
+    renderHuman(ctx, result) {
+      renderCommandDiagnostics(result.diagnostics, ctx.output, flags, ctx.cwd)
+      if (result.ok && shouldPrintHumanSummary(flags)) {
+        ctx.output.log(`spec: ${result.bytes} bytes → ${result.outfile}`)
+      }
+    },
+  }) as Promise<SpecResult>
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ export { runDebug } from './commands/debug'
 export { runDoctor } from './commands/doctor'
 export { runBuildinfo } from './commands/buildinfo'
 export { runLib } from './commands/lib'
+export { runSpec } from './commands/spec'
 export { runAnalyze } from './commands/analyze'
 export { projectSummary, type ProjectSummary } from './project-summary'
 export { runInit, setupGitIgnore } from './commands/init'
@@ -29,5 +30,7 @@ export type {
   InitResult,
   LibFlags,
   LibResult,
+  SpecFlags,
+  SpecResult,
   LogLevel,
 } from './schema'

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -115,6 +115,11 @@ export const infoFlagsSchema = commonFlagsSchema.pick({
   traceFile: true,
 })
 
+export const specFlagsSchema = infoFlagsSchema.omit({ include: true }).extend({
+  outdir: stringFlag,
+  minify: booleanFlag,
+})
+
 // `doctor` reports config-resolved watch targets and never takes a one-off
 // `--include` override (that belongs on scan commands).
 export const doctorFlagsSchema = infoFlagsSchema.omit({ include: true })
@@ -141,6 +146,7 @@ export type BuildFlags = FlagsInfer<typeof buildFlagsSchema>
 export type InitFlags = FlagsInfer<typeof initFlagsSchema>
 export type BuildinfoFlags = FlagsInfer<typeof buildinfoFlagsSchema>
 export type LibFlags = FlagsInfer<typeof libFlagsSchema>
+export type SpecFlags = FlagsInfer<typeof specFlagsSchema>
 export type DoctorFlags = FlagsInfer<typeof doctorFlagsSchema>
 export type DebugFlags = FlagsInfer<typeof debugFlagsSchema>
 type AnalyzeScopeRaw = FlagsInfer<typeof analyzeFlagsSchema>['scope']
@@ -160,7 +166,13 @@ export interface LibResult extends CommandResult<NodeDriver> {
   manifestPath?: string
   buildInfoPath?: string
   presetPath?: string
+  specPath?: string
   exportsChanged: boolean
+}
+
+export interface SpecResult extends CommandResult<NodeDriver> {
+  outfile?: string
+  bytes: number
 }
 
 export interface CommandResult<TDriver extends Driver = Driver> extends CliResult {

--- a/packages/compiler-shared/__tests__/inspection.test.ts
+++ b/packages/compiler-shared/__tests__/inspection.test.ts
@@ -475,7 +475,24 @@ const rawRange: SourceRange = {
   end: { line: 2, column: 10 },
 }
 const spec: Spec = {
+  schemaVersion: 1,
+  options: { strictTokens: false, strictPropertyValues: false, jsxStyleProps: 'all' },
+  catalog: {
+    conditions: {},
+    tokens: {},
+    recipes: {},
+    slotRecipes: {},
+    patterns: {},
+    keyframes: {},
+    textStyles: {},
+    layerStyles: {},
+    animationStyles: {},
+    viewTransitions: {},
+    positionTry: {},
+    themes: {},
+  },
   conditions: { keys: [], breakpoints: [], containers: [] },
+  selectors: { selectors: [], arbitrary: [] },
   tokens: {
     categories: {
       colors: { name: 'colors', typeName: 'ColorsToken', values: ['red.500', 'blue.500'] },
@@ -486,10 +503,20 @@ const spec: Spec = {
   },
   utilities: {
     properties: {
-      color: { name: 'color', tokenCategory: 'colors', literals: [], alias: 'ColorsValue' },
+      color: {
+        name: 'color',
+        cssProperty: null,
+        mappedCssProperty: null,
+        tokenCategory: 'colors',
+        literals: [],
+        primitive: null,
+        alias: 'ColorsValue',
+      },
     },
     shorthands: {},
     deprecated: {},
+    aliases: {},
+    classNames: {},
   },
   keyframes: { keys: ['spin'] },
   patterns: {},
@@ -505,6 +532,8 @@ const spec: Spec = {
   },
   slotRecipes: {},
   propertyOrder: [],
+  jsxFactory: null,
+  importMap: null,
 }
 function file(input: Partial<FileInspectionResult> = {}): FileInspectionResult {
   return {

--- a/packages/compiler-shared/__tests__/introspect.test.ts
+++ b/packages/compiler-shared/__tests__/introspect.test.ts
@@ -2,7 +2,24 @@ import { describe, expect, it } from 'vitest'
 import { type Spec, introspect } from '../src'
 
 const spec: Spec = {
+  schemaVersion: 1,
+  options: { strictTokens: false, strictPropertyValues: false, jsxStyleProps: 'all' },
+  catalog: {
+    conditions: {},
+    tokens: {},
+    recipes: {},
+    slotRecipes: {},
+    patterns: {},
+    keyframes: {},
+    textStyles: {},
+    layerStyles: {},
+    animationStyles: {},
+    viewTransitions: {},
+    positionTry: {},
+    themes: {},
+  },
   conditions: { keys: ['base', '_hover', 'md'], breakpoints: ['md'], containers: [] },
+  selectors: { selectors: [], arbitrary: [] },
   tokens: {
     categories: { colors: { name: 'colors', typeName: 'ColorToken', values: ['red.500'] } },
     colorPalettes: ['red'],
@@ -11,11 +28,29 @@ const spec: Spec = {
   },
   utilities: {
     properties: {
-      color: { name: 'color', cssProperty: 'color', tokenCategory: 'colors', literals: [], alias: 'color' },
-      padding: { name: 'padding', cssProperty: 'padding', tokenCategory: 'spacing', literals: [], alias: 'padding' },
+      color: {
+        name: 'color',
+        cssProperty: 'color',
+        mappedCssProperty: null,
+        tokenCategory: 'colors',
+        literals: [],
+        primitive: null,
+        alias: 'color',
+      },
+      padding: {
+        name: 'padding',
+        cssProperty: 'padding',
+        mappedCssProperty: null,
+        tokenCategory: 'spacing',
+        literals: [],
+        primitive: null,
+        alias: 'padding',
+      },
     },
     shorthands: { p: 'padding' },
     deprecated: {},
+    aliases: {},
+    classNames: {},
   },
   keyframes: { keys: [] },
   patterns: {
@@ -26,6 +61,7 @@ const spec: Spec = {
   slotRecipes: { menu: { name: 'menu', typeName: 'Menu', slots: [], variants: {} } },
   propertyOrder: ['padding', 'color'],
   jsxFactory: 'styled',
+  importMap: null,
 }
 
 describe('introspect', () => {

--- a/packages/compiler-shared/src/introspect.ts
+++ b/packages/compiler-shared/src/introspect.ts
@@ -48,7 +48,8 @@ export function introspect(spec: Spec): Introspection {
   const propRank = new Map(spec.propertyOrder.map((prop, index) => [prop, index]))
 
   const resolveShorthand = (prop: string) => shorthands[prop] ?? prop
-  const getPropCategory = (prop: string) => spec.utilities.properties[resolveShorthand(prop)]?.tokenCategory
+  const getPropCategory = (prop: string) =>
+    spec.utilities.properties[resolveShorthand(prop)]?.tokenCategory ?? undefined
   const category = (path: string) => path.slice(0, path.indexOf('.'))
 
   // Properties rank in emit order; unknown props sort after known ones; condition
@@ -74,7 +75,7 @@ export function introspect(spec: Spec): Introspection {
     isCondition: (key) => conditionRank.has(key),
     patterns: () => Object.keys(spec.patterns),
     recipes: () => [...Object.keys(spec.recipes), ...Object.keys(spec.slotRecipes)],
-    jsxFactory: () => spec.jsxFactory,
+    jsxFactory: () => spec.jsxFactory ?? undefined,
     compareProps: (a, b) => rankOf(a) - rankOf(b) || (a < b ? -1 : a > b ? 1 : 0),
     sortProps: (keys) => [...keys].sort((a, b) => rankOf(a) - rankOf(b) || (a < b ? -1 : a > b ? 1 : 0)),
   }

--- a/packages/compiler-shared/src/types/compiler.ts
+++ b/packages/compiler-shared/src/types/compiler.ts
@@ -174,6 +174,10 @@ export interface DesignSystemManifestInput {
   panda: string
   preset: string
   buildInfo: string
+  /**
+   * Versioned semantic spec for documentation and external tooling.
+   */
+  spec?: string
   importMap?: DesignSystemManifestImportMap
   /**
    * Parent design-system link. Absent at a root.

--- a/packages/compiler-shared/src/types/output.ts
+++ b/packages/compiler-shared/src/types/output.ts
@@ -201,10 +201,28 @@ export interface LayerNames {
 
 export interface SpecUtilityProperty {
   name: string
-  cssProperty?: string
-  tokenCategory?: string
+  cssProperty: string | null
+  mappedCssProperty: string | null
+  tokenCategory: string | null
   literals: string[]
+  primitive: SpecPrimitiveType | null
   alias: string
+}
+
+export type SpecPrimitiveType = 'string' | 'number' | 'boolean'
+
+export type SpecValueTypePart =
+  | { kind: 'tokenCategory'; value: string }
+  | { kind: 'cssProperty'; value: string }
+  | { kind: 'literal'; value: string }
+  | { kind: 'primitive'; value: SpecPrimitiveType }
+  | { kind: 'cssVars' }
+  | { kind: 'anyString' }
+  | { kind: 'anyNumber' }
+
+export interface SpecValueAlias {
+  name: string
+  parts: SpecValueTypePart[]
 }
 
 export interface SpecTokenCategory {
@@ -240,8 +258,103 @@ export interface SpecPattern {
   deprecated?: Deprecation
 }
 
+export type SpecConditionDefinition = string | { [key: string]: SpecConditionDefinition }
+
+export type SpecJsxSpecifier = string | { kind: 'regex'; source: string; flags: string }
+
+export interface SpecTokenValue {
+  value: string
+  condition?: string
+  originalValue?: string
+  description?: string
+  deprecated?: Deprecation
+}
+
+export interface SpecTokenDefinition {
+  path: string
+  category: string
+  cssVar: string
+  semantic: boolean
+  values: SpecTokenValue[]
+}
+
+export type SpecVariantSelection = string | number | boolean | SpecVariantSelection[]
+
+export interface SpecCompoundVariantDefinition {
+  css: unknown
+  className?: string
+  [variant: string]: unknown
+}
+
+export interface SpecRecipeDefinition {
+  name: string
+  className: string
+  description?: string
+  jsx: SpecJsxSpecifier[]
+  slots?: string[]
+  base?: unknown
+  variants: Record<string, Record<string, unknown>>
+  defaultVariants: Record<string, SpecVariantSelection>
+  compoundVariants: SpecCompoundVariantDefinition[]
+  staticCss?: unknown
+  deprecated?: Deprecation
+  metadata?: Record<string, unknown>
+}
+
+export interface SpecPatternPropertyDefinition {
+  type?: string
+  value?: unknown
+  property?: string
+  description?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface SpecPatternDefinition {
+  name: string
+  jsxName: string
+  jsxElement: string
+  jsx: SpecJsxSpecifier[]
+  description?: string
+  properties: Record<string, SpecPatternPropertyDefinition>
+  defaultValues?: unknown
+  hasDynamicDefaultValues: boolean
+  hasTransform: boolean
+  strict: boolean
+  blocklist: string[]
+  deprecated?: Deprecation
+  metadata?: Record<string, unknown>
+}
+
+export interface SpecThemeDefinition {
+  name: string
+  condition: string
+  rootSelector: string
+}
+
+export interface SpecCatalog {
+  conditions: Record<string, SpecConditionDefinition>
+  tokens: Record<string, SpecTokenDefinition>
+  recipes: Record<string, SpecRecipeDefinition>
+  slotRecipes: Record<string, SpecRecipeDefinition>
+  patterns: Record<string, SpecPatternDefinition>
+  keyframes: Record<string, unknown>
+  textStyles: Record<string, unknown>
+  layerStyles: Record<string, unknown>
+  animationStyles: Record<string, unknown>
+  viewTransitions: Record<string, unknown>
+  positionTry: Record<string, unknown>
+  themes: Record<string, SpecThemeDefinition>
+}
+
 export interface Spec {
+  schemaVersion: number
+  options: {
+    strictTokens: boolean
+    strictPropertyValues: boolean
+    jsxStyleProps: 'all' | 'minimal' | 'none'
+  }
   conditions: { keys: string[]; breakpoints: string[]; containers: string[] }
+  selectors: { selectors: string[]; arbitrary: string[] }
   tokens: {
     categories: Record<string, SpecTokenCategory>
     colorPalettes: string[]
@@ -252,12 +365,15 @@ export interface Spec {
     properties: Record<string, SpecUtilityProperty>
     shorthands: Record<string, string>
     deprecated: Record<string, Deprecation>
+    aliases: Record<string, SpecValueAlias>
+    classNames: Record<string, string>
   }
   keyframes: { keys: string[] }
   patterns: Record<string, SpecPattern>
   recipes: Record<string, SpecRecipe>
   slotRecipes: Record<string, SpecSlotRecipe>
   propertyOrder: string[]
-  jsxFactory?: string
-  importMap?: ImportMapOutput
+  jsxFactory: string | null
+  importMap: ImportMapOutput | null
+  catalog: SpecCatalog
 }

--- a/packages/compiler-wasm/__tests__/design-system.test.ts
+++ b/packages/compiler-wasm/__tests__/design-system.test.ts
@@ -10,6 +10,7 @@ const fullInput: DesignSystemManifestInput = {
   panda: '^2.0.0',
   preset: './preset.mjs',
   buildInfo: './buildinfo.json',
+  spec: './spec.json',
   importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes' },
   designSystem: '@acme/foundations',
   files: ['./dist/**/*.mjs'],
@@ -27,6 +28,7 @@ describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
       panda: '^2.0.0',
       preset: './preset.mjs',
       buildInfo: './buildinfo.json',
+      spec: './spec.json',
       importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes' },
       designSystem: '@acme/foundations',
       files: ['./dist/**/*.mjs'],
@@ -55,6 +57,7 @@ describeIfBuilt('@pandacss/compiler-wasm designSystem', () => {
     expect(manifest.version).toBeUndefined()
     expect(manifest.importMap).toBeUndefined()
     expect(manifest.designSystem).toBeUndefined()
+    expect(manifest.spec).toBeUndefined()
     expect('files' in manifest).toBe(false)
   })
 

--- a/packages/compiler-wasm/crate/src/project/config.rs
+++ b/packages/compiler-wasm/crate/src/project/config.rs
@@ -26,16 +26,11 @@ impl WasmCompiler {
     /// # Errors
     /// Returns a JS error if the snapshot fails to serialize.
     pub fn spec(&self) -> Result<JsValue, JsValue> {
-        let types = self.inner.type_data(&self.user_config);
-        let property_order = pandacss_stylesheet::order_properties(
-            types.utilities.properties.keys().map(String::as_str),
-        );
-        let spec = pandacss_config::Spec {
-            types,
-            property_order,
-            jsx_factory: Some(self.user_config.jsx_factory().to_owned()),
-            import_map: self.user_config.import_map.clone(),
-        };
+        let spec = self.inner.spec(&self.user_config, |types| {
+            pandacss_stylesheet::order_properties(
+                types.utilities.properties.keys().map(String::as_str),
+            )
+        });
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         spec.serialize(&serializer)
             .map_err(|err| JsValue::from_str(&err.to_string()))

--- a/packages/compiler/__tests__/design-system/manifest.test.ts
+++ b/packages/compiler/__tests__/design-system/manifest.test.ts
@@ -10,6 +10,7 @@ const fullInput: DesignSystemManifestInput = {
   panda: '^2.0.0',
   preset: './preset.mjs',
   buildInfo: './buildinfo.json',
+  spec: './spec.json',
   importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes' },
   designSystem: '@acme/foundations',
   files: ['./dist/**/*.mjs'],
@@ -27,6 +28,7 @@ describe('compiler.designSystem', () => {
       panda: '^2.0.0',
       preset: './preset.mjs',
       buildInfo: './buildinfo.json',
+      spec: './spec.json',
       importMap: { css: '@acme/ds/css', recipes: '@acme/ds/recipes' },
       designSystem: '@acme/foundations',
       files: ['./dist/**/*.mjs'],
@@ -44,6 +46,7 @@ describe('compiler.designSystem', () => {
     expect(manifest.version).toBeUndefined()
     expect(manifest.importMap).toBeUndefined()
     expect(manifest.designSystem).toBeUndefined()
+    expect(manifest.spec).toBeUndefined()
     expect('files' in manifest).toBe(false)
   })
 

--- a/packages/compiler/__tests__/node-driver.test.ts
+++ b/packages/compiler/__tests__/node-driver.test.ts
@@ -733,6 +733,7 @@ describe('NodeDriver writeDesignSystemLib', () => {
       manifestPath: join(dir, 'dist', 'panda', 'lib.json'),
       buildInfoPath: join(dir, 'dist', 'panda', 'buildinfo.json'),
       presetPath: join(dir, 'dist', 'panda', 'preset.mjs'),
+      specPath: join(dir, 'dist', 'panda', 'spec.json'),
       exportsChanged: true,
       parsedFileCount: 1,
       diagnostics: [],
@@ -747,6 +748,7 @@ describe('NodeDriver writeDesignSystemLib', () => {
         "panda": "^2.0.0",
         "preset": "./preset.mjs",
         "buildInfo": "./buildinfo.json",
+        "spec": "./spec.json",
         "importMap": {
           "css": "@acme/ds/css",
           "recipes": "@acme/ds/recipes",
@@ -759,6 +761,8 @@ describe('NodeDriver writeDesignSystemLib', () => {
         ],
       }
     `)
+
+    expect(JSON.parse(readFileSync(join(dir, 'dist', 'panda', 'spec.json'), 'utf8')).schemaVersion).toBe(1)
 
     const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
     expect(pkg.exports).toMatchInlineSnapshot(`
@@ -852,8 +856,9 @@ describe('NodeDriver writeDesignSystemLib', () => {
     expect(result.diagnostics.filter((d) => d.code === 'design_system_files_not_publishable')).toEqual([])
   })
 
-  it('does not publish hydrated parent build info as fallback files', async () => {
-    dir = createLibProject("  designSystem: '@acme/foundations',")
+  it('writes a resolved child spec without publishing parent build info as fallback files', async () => {
+    dir = createLibProject(`  designSystem: '@acme/foundations',
+  theme: { tokens: { colors: { child: { value: '#222' } } } },`)
 
     const parent = createProject()
     parent.parseFileSource('surface.tsx', "import { css } from '@panda/css'; css({ color: 'teal' })")
@@ -872,7 +877,8 @@ describe('NodeDriver writeDesignSystemLib', () => {
         buildInfo: './buildinfo.json',
         importMap: { css: '@acme/foundations/css' },
       }),
-      'node_modules/@acme/foundations/panda/preset.mjs': 'export default { name: "@acme/foundations" }',
+      'node_modules/@acme/foundations/panda/preset.mjs':
+        'export default { name: "@acme/foundations", theme: { tokens: { colors: { parent: { value: "#111" } } } } }',
       'node_modules/@acme/foundations/panda/buildinfo.json': JSON.stringify(
         parent.buildInfo.create({ panda: '^2.0.0' }),
       ),
@@ -890,6 +896,7 @@ describe('NodeDriver writeDesignSystemLib', () => {
         "panda": "^2.0.0",
         "preset": "./preset.mjs",
         "buildInfo": "./buildinfo.json",
+        "spec": "./spec.json",
         "importMap": {
           "css": "@acme/ds/css",
           "recipes": "@acme/ds/recipes",
@@ -903,6 +910,9 @@ describe('NodeDriver writeDesignSystemLib', () => {
         ],
       }
     `)
+
+    const spec = JSON.parse(readFileSync(join(dir, 'dist', 'panda', 'spec.json'), 'utf8'))
+    expect(Object.keys(spec.catalog.tokens)).toEqual(expect.arrayContaining(['colors.parent', 'colors.child']))
   })
 
   it('does not write artifacts when diagnostics fail the warning budget', async () => {

--- a/packages/compiler/__tests__/spec.test.ts
+++ b/packages/compiler/__tests__/spec.test.ts
@@ -17,6 +17,9 @@ describe('compiler.spec()', () => {
       color: spec.utilities.properties.color,
       conditions: spec.conditions.keys,
       tokenValues: spec.tokens.values,
+      schemaVersion: spec.schemaVersion,
+      catalogCondition: spec.catalog.conditions._hover,
+      catalogToken: spec.catalog.tokens['colors.red'],
       hasPropertyOrder: spec.propertyOrder.length > 0,
     }).toMatchInlineSnapshot(`
       {
@@ -36,6 +39,19 @@ describe('compiler.spec()', () => {
         "tokenValues": {
           "colors.colorPalette": "",
           "colors.red": "#f00",
+        },
+        "schemaVersion": 1,
+        "catalogCondition": "&:hover",
+        "catalogToken": {
+          "path": "colors.red",
+          "category": "colors",
+          "cssVar": "var(--colors-red)",
+          "semantic": false,
+          "values": [
+            {
+              "value": "#f00",
+            },
+          ],
         },
         "hasPropertyOrder": true,
       }

--- a/packages/compiler/crate/src/project/config.rs
+++ b/packages/compiler/crate/src/project/config.rs
@@ -61,16 +61,11 @@ impl Compiler {
     /// Returns an error if the snapshot fails to serialize.
     #[napi]
     pub fn spec(&self) -> napi::Result<serde_json::Value> {
-        let types = self.inner.type_data(&self.user_config);
-        let property_order = pandacss_stylesheet::order_properties(
-            types.utilities.properties.keys().map(String::as_str),
-        );
-        let spec = pandacss_config::Spec {
-            types,
-            property_order,
-            jsx_factory: Some(self.user_config.jsx_factory().to_owned()),
-            import_map: self.user_config.import_map.clone(),
-        };
+        let spec = self.inner.spec(&self.user_config, |types| {
+            pandacss_stylesheet::order_properties(
+                types.utilities.properties.keys().map(String::as_str),
+            )
+        });
         serde_json::to_value(&spec).map_err(|err| napi::Error::from_reason(err.to_string()))
     }
 

--- a/packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts
+++ b/packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts
@@ -34,7 +34,10 @@ export declare class Compiler {
   writeArtifacts(options: WriteArtifactsOptions): Array<string>
   generateArtifacts(options?: GenerateArtifactOptions | undefined | null): Array<CodegenArtifact>
   generateArtifact(id: string, options?: GenerateArtifactOptions | undefined | null): CodegenArtifact | null
-  generateAffectedArtifacts(dependencies: Array<string>, options?: GenerateArtifactOptions | undefined | null): Array<CodegenArtifact>
+  generateAffectedArtifacts(
+    dependencies: Array<string>,
+    options?: GenerateArtifactOptions | undefined | null,
+  ): Array<CodegenArtifact>
   /**
    * Return the serialized config snapshot this project was constructed
    * with.
@@ -238,7 +241,11 @@ export declare class Compiler {
   /** Register a JS-backed `parser:before` source transform. */
   registerSourceTransform(id: string, filter: any | undefined | null, callback: SourceTransformRef): void
   /** Construct a compiler from the resolved, JSON-safe Panda config snapshot. */
-  static fromConfig(config: any, options?: ProjectOptions | undefined | null, utilityValuesCallbacks?: UtilityValueCallbacks | undefined | null): Compiler
+  static fromConfig(
+    config: any,
+    options?: ProjectOptions | undefined | null,
+    utilityValuesCallbacks?: UtilityValueCallbacks | undefined | null,
+  ): Compiler
 }
 
 /**
@@ -393,12 +400,17 @@ export interface DiagnosticLabel {
 export declare const enum DiagnosticSeverity {
   Info = 'info',
   Warning = 'warning',
-  Error = 'error'
+  Error = 'error',
 }
 
 export declare function extract(path: string, source: string, matchers: Matchers): ExtractResult
 
-export declare function extractCalls(path: string, source: string, matched: Array<MatchedImport>, matchers: Matchers): ExtractedCallsResult
+export declare function extractCalls(
+  path: string,
+  source: string,
+  matched: Array<MatchedImport>,
+  matchers: Matchers,
+): ExtractedCallsResult
 
 export declare function extractDebug(path: string, source: string, matchers: Matchers): ExtractDebugResult
 
@@ -427,7 +439,7 @@ export interface ExtractedArg {
  */
 export declare const enum ExtractedArgKind {
   Value = 'value',
-  Missing = 'missing'
+  Missing = 'missing',
 }
 
 export interface ExtractedCall {
@@ -462,7 +474,12 @@ export interface ExtractedJsxResult {
   diagnostics: Array<Diagnostic>
 }
 
-export declare function extractJsx(path: string, source: string, matched: Array<MatchedImport>, matchers: Matchers): ExtractedJsxResult
+export declare function extractJsx(
+  path: string,
+  source: string,
+  matched: Array<MatchedImport>,
+  matchers: Matchers,
+): ExtractedJsxResult
 
 /**
  * Lean result for the production hot path — `imports` and `matched` are
@@ -483,7 +500,7 @@ export interface GenerateArtifactOptions {
 
 export declare const enum ImportKind {
   SideEffect = 'sideEffect',
-  Value = 'value'
+  Value = 'value',
 }
 
 export interface ImportRecord {
@@ -510,7 +527,7 @@ export interface ImportSpecifier {
 export declare const enum ImportSpecifierKind {
   Named = 'named',
   Default = 'default',
-  Namespace = 'namespace'
+  Namespace = 'namespace',
 }
 
 export interface InputFile {
@@ -522,7 +539,7 @@ export declare const enum JsxKind {
   Factory = 'factory',
   Pattern = 'pattern',
   Recipe = 'recipe',
-  Component = 'component'
+  Component = 'component',
 }
 
 export interface LayerCssOptions {
@@ -546,7 +563,7 @@ export declare const enum MatchCategory {
   Recipe = 'recipe',
   Pattern = 'pattern',
   Jsx = 'jsx',
-  Tokens = 'tokens'
+  Tokens = 'tokens',
 }
 
 export interface MatchedImport {

--- a/packages/compiler/src/driver.ts
+++ b/packages/compiler/src/driver.ts
@@ -67,6 +67,7 @@ export interface WriteDesignSystemLibResult {
   manifestPath: string
   buildInfoPath: string
   presetPath: string
+  specPath: string
   exportsChanged: boolean
   parsedFileCount: number
   diagnostics: Diagnostic[]
@@ -496,6 +497,7 @@ export class NodeDriver extends BaseDriver {
     const manifestPath = this.compiler.path.join([pandaDir, 'lib.json'])
     const buildInfoPath = this.compiler.path.join([pandaDir, 'buildinfo.json'])
     const presetPath = this.compiler.path.join([pandaDir, 'preset.mjs'])
+    const specPath = this.compiler.path.join([pandaDir, 'spec.json'])
 
     const info = this.compiler.buildInfo.create({ panda: pandaRange })
     const buildInfo = this.compiler.buildInfo.normalize(info, {
@@ -519,6 +521,7 @@ export class NodeDriver extends BaseDriver {
       panda: pandaRange,
       preset: './preset.mjs',
       buildInfo: './buildinfo.json',
+      spec: './spec.json',
       importMap: defaultImportMap(identity.name),
       designSystem: typeof this.config.designSystem === 'string' ? this.config.designSystem : undefined,
       files: libFiles,
@@ -546,6 +549,11 @@ export class NodeDriver extends BaseDriver {
               code: preset.code,
               dependencies: [],
             },
+            {
+              path: 'panda/spec.json',
+              code: `${JSON.stringify(this.compiler.spec(), null, options.minify ? 0 : 2)}\n`,
+              dependencies: [],
+            },
           ],
         },
       ],
@@ -560,6 +568,7 @@ export class NodeDriver extends BaseDriver {
       manifestPath,
       buildInfoPath,
       presetPath,
+      specPath,
       exportsChanged,
       parsedFileCount: parsed.parsedFileCount,
       diagnostics: [...parsed.diagnostics, ...filesDiagnostics, ...exportConflictDiagnostics(identity.name, conflicts)],
@@ -650,6 +659,7 @@ function skippedDesignSystemLib(parsed: ParsedDesignSystemLib): WriteDesignSyste
     manifestPath: '',
     buildInfoPath: '',
     presetPath: '',
+    specPath: '',
     exportsChanged: false,
     parsedFileCount: parsed.parsedFileCount,
     diagnostics: parsed.diagnostics,

--- a/packages/compiler/src/fallback.ts
+++ b/packages/compiler/src/fallback.ts
@@ -9,6 +9,7 @@ import type {
   FileInspectionResult,
   LayerCssOptions,
   SourceFileInput,
+  Spec,
   SplitCssOptions,
   WriteArtifactsOptions,
   WriteCssOptions,
@@ -167,16 +168,35 @@ class FallbackCompiler implements Compiler {
   stripLayerOrderStatements(css: string) {
     return css
   }
-  spec() {
+  spec(): Spec {
     return {
+      schemaVersion: -1,
+      options: { strictTokens: false, strictPropertyValues: false, jsxStyleProps: 'all' },
       conditions: { keys: [], breakpoints: [], containers: [] },
+      selectors: { selectors: [], arbitrary: [] },
       tokens: { categories: {}, colorPalettes: [], values: {}, deprecated: {} },
-      utilities: { properties: {}, shorthands: {}, deprecated: {} },
+      utilities: { properties: {}, shorthands: {}, deprecated: {}, aliases: {}, classNames: {} },
       keyframes: { keys: [] },
       patterns: {},
       recipes: {},
       slotRecipes: {},
       propertyOrder: [],
+      jsxFactory: null,
+      importMap: null,
+      catalog: {
+        conditions: {},
+        tokens: {},
+        recipes: {},
+        slotRecipes: {},
+        patterns: {},
+        keyframes: {},
+        textStyles: {},
+        layerStyles: {},
+        animationStyles: {},
+        viewTransitions: {},
+        positionTry: {},
+        themes: {},
+      },
     }
   }
   sources() {

--- a/packages/config/__tests__/design-system/chain.test.ts
+++ b/packages/config/__tests__/design-system/chain.test.ts
@@ -280,6 +280,7 @@ describe('resolveAuthoredPresets / designSystem', () => {
     ['schemaVersion', { schemaVersion: 0 }, 'positive integer "schemaVersion"'],
     ['name', { name: '  ' }, 'missing a "name" entry'],
     ['panda', { panda: '' }, 'missing a "panda" entry'],
+    ['spec', { spec: [] }, '"spec" entry'],
     ['files', { files: './button.js' }, '"files" entry'],
     ['importMap', { importMap: { css: ['@acme/ds/css'] } }, '"importMap.css" entry'],
   ])('validates the complete manifest shape before loading its preset (%s)', async (field, manifest, message) => {

--- a/packages/config/src/design-system/chain.ts
+++ b/packages/config/src/design-system/chain.ts
@@ -380,6 +380,10 @@ function validateManifest(spec: string, manifestPath: string, value: unknown): D
     issues.push('has a "designSystem" entry that must be a non-empty string')
   }
 
+  if (value.spec !== undefined && !isNonEmptyString(value.spec)) {
+    issues.push('has a "spec" entry that must be a non-empty string')
+  }
+
   if (
     value.files !== undefined &&
     (!Array.isArray(value.files) || !value.files.every((file) => isNonEmptyString(file)))

--- a/website/content/docs/design-systems/publishing.mdx
+++ b/website/content/docs/design-systems/publishing.mdx
@@ -29,8 +29,8 @@ pnpm --filter @acme/ds publish
 }
 ```
 
-`dist/panda/` has to ship. That is `lib.json`, `preset.mjs`, and `buildinfo.json`. `styled-system` has to ship if
-your `exports` point at it (the default after `panda lib`).
+`dist/panda/` has to ship. That is `lib.json`, `preset.mjs`, `buildinfo.json`, and `spec.json`. `styled-system` also has
+to ship if your `exports` point at it (the default after `panda lib`).
 
 `"files": ["dist"]` alone is not enough when codegen writes `styled-system/` at the package root. Either add
 `styled-system` to `files`, or set `outdir` under `dist`.
@@ -99,6 +99,7 @@ Confirm you see:
 dist/panda/lib.json
 dist/panda/preset.mjs
 dist/panda/buildinfo.json
+dist/panda/spec.json
 ```
 
 and the `styled-system` files your `exports` point at. Confirm you do not see `.env` or a stray `src/` you meant

--- a/website/content/docs/reference/cli.mdx
+++ b/website/content/docs/reference/cli.mdx
@@ -21,6 +21,7 @@ The commands are:
 | `panda doctor`    | Validate your setup and print a project summary                        |
 | `panda debug`     | Dump resolved config and per-file extraction for bug reports           |
 | `panda lib`       | Publish a design system other apps can consume                        |
+| `panda spec`      | Write a versioned design-system catalog                               |
 | `panda buildinfo` | Write a portable `panda.buildinfo.json` only                          |
 
 ## Shared flags
@@ -385,9 +386,40 @@ pnpm panda lib --panda '^2.0.0'
 | `--outdir, -o <dir>` | Output directory for the artifacts (default `dist`)                                        | -       |
 | `--panda <range>` | Peer Panda version range to stamp (defaults to your `@pandacss/dev` peer, or the running major) | -       |
 | `--files <globs>` | Re-extract fallback globs for consumers, relative to the output dir (repeat or comma-separate) | -       |
-| `--minify, -m`    | Minify the generated build-info JSON                                                           | -       |
+| `--minify, -m`    | Minify the generated build-info and spec JSON                                                  | -       |
+
+`panda lib` also writes `panda/spec.json`, a versioned catalog of the resolved design system. The package manifest links
+to it through its `spec` field.
 
 `panda lib` also accepts the [shared flags](#shared-flags), `--include`, and `--watch` / `--watch-debounce`.
+
+---
+
+## spec
+
+Write a versioned JSON description of the resolved design system. The output includes tokens and their conditional
+values, conditions, recipes, slot recipes, patterns, keyframes, composition styles, and themes. Use it as the stable
+input for documentation or other design-system tooling.
+
+```bash
+pnpm panda spec
+
+# Write dist/catalog/spec.json
+pnpm panda spec --outdir ./dist/catalog
+
+# Remove JSON formatting
+pnpm panda spec --minify
+```
+
+| Flag                 | Description                                            | Related |
+| -------------------- | ------------------------------------------------------ | ------- |
+| `--outdir, -o <dir>` | Output directory (default `<configured outdir>/specs`) | -       |
+| `--minify, -m`       | Minify the generated JSON                              | -       |
+
+Read `schemaVersion` before consuming the file. External adapters can map the catalog to another format without changing
+Panda's config or compiler.
+
+`panda spec` also accepts the [shared flags](#shared-flags).
 
 ---
 


### PR DESCRIPTION
Related discussion: https://github.com/chakra-ui/panda/discussions/3795

## Description

Add a versioned, compiler-owned design-system spec for external tooling and cross-repository design-system packages.

## Current behavior

`compiler.spec()` exposes compact typegen indexes, but v2 has no standalone or published artifact containing the resolved design-system definitions.

## New behavior

- `compiler.spec()` includes `schemaVersion` and a resolved definition catalog.
- `panda spec` writes `<configured outdir>/specs/spec.json`.
- `panda lib` publishes `panda/spec.json` and links it from `panda/lib.json`.
- Published child design systems include definitions inherited from their parent.
- Native and WASM use the same Rust implementation.
- Public TypeScript types describe the complete emitted wire format.

The catalog includes conditions, tokens and conditional values, recipes, slot recipes, patterns, keyframes, composition styles, view transitions, position-try definitions, themes, JSX matchers, deprecations, and JSON-safe metadata.

## Is this a breaking change (Yes/No):

No runtime or CSS behavior changes. The v2 `Spec` interface now accurately describes fields and nullability already emitted by Rust, so custom hand-written `Spec` mocks may need to add those fields.

## Additional Information

Dynamic pattern callbacks are represented by capability flags. Function bodies and internal callback identifiers are not serialized.

External format adapters remain outside the compiler.

This branch also applies Prettier to `packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts`. The exact `v2` base commit fails the repository-wide Prettier check on that tracked generated declaration.

Validation:

- `cargo nextest run --workspace --locked`
- `cargo test --workspace --doc --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `tsc --noEmit`
- Native compiler, WASM, CLI, compiler-shared, config, and codegen sandbox tests
