### PR TITLE
perf(bundlers): reuse parsed files for watch registration

### DIFF
--- a/.changeset/reuse-scanned-watch-files.md
+++ b/.changeset/reuse-scanned-watch-files.md
@@ -1,0 +1,10 @@
+---
+'@pandacss/compiler-shared': patch
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+'@pandacss/rollup': patch
+'@pandacss/vite': patch
+---
+
+Reuse parsed source paths when registering bundler watch files, avoiding a second full project scan during startup. Keep
+tracked paths in sync when explicitly parsed files are deleted.

--- a/design-notes/output-and-host-layer.md
+++ b/design-notes/output-and-host-layer.md
@@ -116,9 +116,13 @@ interface Driver {
   artifacts(filter?: ArtifactFilter): CodegenArtifact[] // {path,code}[] for custom sinks
   writeArtifacts(outdir: string, cwd?: string): string[] // engine-fs sink (disk/memory)
   compile(): CompileOutput // CSS string + manifest; caller routes css
-  watchTargets(): { sources: string[]; dirs: string[]; config: string[] } // patterns, base dirs, config deps
+  watchTargets(): { files?: string[]; sources: string[]; dirs: string[]; config: string[] }
 }
 ```
+
+`files` contains the source paths already discovered by `parseFiles()` and updated by watcher events. Bundler adapters
+reuse them for watch registration instead of scanning the project again. The field is optional so custom Driver
+implementations can fall back to `scan()`.
 
 Note what is **absent** vs v1's `Builder`: no `fileModifiedMap`, no `checkFilesChanged`, no `affecteds` bookkeeping, and
 no JS glob. The Rust `Project` (`refreshFile` / `removeFile` / `generateAffectedArtifacts`) owns incremental + affected

--- a/packages/compiler-shared/src/driver.ts
+++ b/packages/compiler-shared/src/driver.ts
@@ -133,8 +133,8 @@ export interface Driver {
   writeLayerCss(options: WriteLayerCssOptions): WriteCssResult
   /** Generate + write split stylesheet files under the configured `outdir`. */
   writeSplitCss(options?: WriteSplitCssOptions): WriteSplitCssResult
-  /** Watch targets for the host watcher: matched files, their base dirs, config deps. */
-  watchTargets(): { sources: string[]; dirs: string[]; config: string[] }
+  /** Watch targets for the host watcher: parsed files, source patterns, their base dirs, and config deps. */
+  watchTargets(): { files?: string[]; sources: string[]; dirs: string[]; config: string[] }
   /** Watch targets for hydrated design-system artifacts and source fallback files. */
   designSystemWatchTargets(): DesignSystemWatchTarget[]
   /** Classify a watched design-system file as an artifact or source fallback. */
@@ -245,10 +245,9 @@ export abstract class BaseDriver implements Driver {
 
   /** Record source ownership after a host watcher change. */
   protected trackSourceChange(change: SourceChange, applied: boolean): boolean {
+    if (change.kind === 'unlink') this.#scanOwnedFiles.delete(change.path)
     if (!this.#compiler.isSourceFile(change.path)) return applied
-    if (change.kind === 'unlink') {
-      this.#scanOwnedFiles.delete(change.path)
-    } else if (applied) {
+    if (applied) {
       this.#scanOwnedFiles.add(change.path)
     }
     return applied
@@ -342,9 +341,10 @@ export abstract class BaseDriver implements Driver {
     })
   }
 
-  watchTargets(): { sources: string[]; dirs: string[]; config: string[] } {
+  watchTargets(): { files: string[]; sources: string[]; dirs: string[]; config: string[] } {
     const sources = this.#compiler.sources()
     return {
+      files: [...this.#scanOwnedFiles],
       sources: sources.map((source) => source.pattern),
       dirs: [...new Set(sources.map((source) => source.base))],
       config: this.configDependencies,

--- a/packages/compiler/__tests__/node-driver.test.ts
+++ b/packages/compiler/__tests__/node-driver.test.ts
@@ -281,6 +281,7 @@ describe('createNodeDriver', () => {
       driver.compiler.parseFileSource(explicit, explicitSource)
 
       expect(driver.parseFiles()).toHaveLength(2)
+      expect(driver.watchTargets().files).toEqual([join(rescanDir, 'a.tsx'), join(rescanDir, 'b.tsx')])
       expect(driver.compiler.getFile(explicit)).not.toBeNull()
       expect(driver.cssgen().css).toContain('red')
       expect(driver.cssgen().css).toContain('blue')
@@ -290,9 +291,18 @@ describe('createNodeDriver', () => {
       expect(driver.compiler.getFile(join(rescanDir, 'b.tsx'))).not.toBeNull()
       expect(driver.cssgen().css).toContain('blue')
 
+      const targeted = join(rescanDir, 'outside.ts')
+      writeFileSync(targeted, "import { css } from '@panda/css'; css({ color: 'orange' })")
+      expect(driver.parseFiles({ include: ['outside.ts'] })).toHaveLength(1)
+      expect(driver.watchTargets().files).toContain(targeted)
+      unlinkSync(targeted)
+      expect(driver.applyChange({ path: targeted, kind: 'unlink' })).toBe(true)
+      expect(driver.watchTargets().files).not.toContain(targeted)
+
       const added = join(rescanDir, 'added.tsx')
       writeFileSync(added, "import { css } from '@panda/css'; css({ color: 'purple' })")
       expect(driver.applyChange({ path: added, kind: 'add' })).toBe(true)
+      expect(driver.watchTargets().files).toContain(added)
       expect(driver.cssgen().css).toContain('purple')
 
       const removed = join(rescanDir, 'b.tsx')
@@ -300,6 +310,7 @@ describe('createNodeDriver', () => {
       unlinkSync(added)
 
       expect(driver.parseFiles()).toHaveLength(1)
+      expect(driver.watchTargets().files).toEqual([join(rescanDir, 'a.tsx')])
       expect(driver.compiler.getFile(removed)).toBeNull()
       expect(driver.compiler.getFile(added)).toBeNull()
       const incrementalCss = driver.cssgen().css
@@ -556,10 +567,12 @@ describe('createNodeDriver', () => {
     })
   })
 
-  it('lists watch targets (source patterns, base dirs, config deps)', async () => {
+  it('lists watch targets (parsed files, source patterns, base dirs, config deps)', async () => {
     const driver = await createNodeDriver({ cwd: dir })
+    driver.parseFiles()
     const targets = driver.watchTargets()
 
+    expect(targets.files).toEqual([join(dir, 'App.tsx')])
     expect(targets.sources).toMatchInlineSnapshot(`
       [
         "**/*.tsx",

--- a/packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts
+++ b/packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts
@@ -34,10 +34,7 @@ export declare class Compiler {
   writeArtifacts(options: WriteArtifactsOptions): Array<string>
   generateArtifacts(options?: GenerateArtifactOptions | undefined | null): Array<CodegenArtifact>
   generateArtifact(id: string, options?: GenerateArtifactOptions | undefined | null): CodegenArtifact | null
-  generateAffectedArtifacts(
-    dependencies: Array<string>,
-    options?: GenerateArtifactOptions | undefined | null,
-  ): Array<CodegenArtifact>
+  generateAffectedArtifacts(dependencies: Array<string>, options?: GenerateArtifactOptions | undefined | null): Array<CodegenArtifact>
   /**
    * Return the serialized config snapshot this project was constructed
    * with.
@@ -241,11 +238,7 @@ export declare class Compiler {
   /** Register a JS-backed `parser:before` source transform. */
   registerSourceTransform(id: string, filter: any | undefined | null, callback: SourceTransformRef): void
   /** Construct a compiler from the resolved, JSON-safe Panda config snapshot. */
-  static fromConfig(
-    config: any,
-    options?: ProjectOptions | undefined | null,
-    utilityValuesCallbacks?: UtilityValueCallbacks | undefined | null,
-  ): Compiler
+  static fromConfig(config: any, options?: ProjectOptions | undefined | null, utilityValuesCallbacks?: UtilityValueCallbacks | undefined | null): Compiler
 }
 
 /**
@@ -400,17 +393,12 @@ export interface DiagnosticLabel {
 export declare const enum DiagnosticSeverity {
   Info = 'info',
   Warning = 'warning',
-  Error = 'error',
+  Error = 'error'
 }
 
 export declare function extract(path: string, source: string, matchers: Matchers): ExtractResult
 
-export declare function extractCalls(
-  path: string,
-  source: string,
-  matched: Array<MatchedImport>,
-  matchers: Matchers,
-): ExtractedCallsResult
+export declare function extractCalls(path: string, source: string, matched: Array<MatchedImport>, matchers: Matchers): ExtractedCallsResult
 
 export declare function extractDebug(path: string, source: string, matchers: Matchers): ExtractDebugResult
 
@@ -439,7 +427,7 @@ export interface ExtractedArg {
  */
 export declare const enum ExtractedArgKind {
   Value = 'value',
-  Missing = 'missing',
+  Missing = 'missing'
 }
 
 export interface ExtractedCall {
@@ -474,12 +462,7 @@ export interface ExtractedJsxResult {
   diagnostics: Array<Diagnostic>
 }
 
-export declare function extractJsx(
-  path: string,
-  source: string,
-  matched: Array<MatchedImport>,
-  matchers: Matchers,
-): ExtractedJsxResult
+export declare function extractJsx(path: string, source: string, matched: Array<MatchedImport>, matchers: Matchers): ExtractedJsxResult
 
 /**
  * Lean result for the production hot path — `imports` and `matched` are
@@ -500,7 +483,7 @@ export interface GenerateArtifactOptions {
 
 export declare const enum ImportKind {
   SideEffect = 'sideEffect',
-  Value = 'value',
+  Value = 'value'
 }
 
 export interface ImportRecord {
@@ -527,7 +510,7 @@ export interface ImportSpecifier {
 export declare const enum ImportSpecifierKind {
   Named = 'named',
   Default = 'default',
-  Namespace = 'namespace',
+  Namespace = 'namespace'
 }
 
 export interface InputFile {
@@ -539,7 +522,7 @@ export declare const enum JsxKind {
   Factory = 'factory',
   Pattern = 'pattern',
   Recipe = 'recipe',
-  Component = 'component',
+  Component = 'component'
 }
 
 export interface LayerCssOptions {
@@ -563,7 +546,7 @@ export declare const enum MatchCategory {
   Recipe = 'recipe',
   Pattern = 'pattern',
   Jsx = 'jsx',
-  Tokens = 'tokens',
+  Tokens = 'tokens'
 }
 
 export interface MatchedImport {

--- a/packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts
+++ b/packages/compiler/npm/wasm32-wasi/compiler.wasi.d.cts
@@ -34,7 +34,10 @@ export declare class Compiler {
   writeArtifacts(options: WriteArtifactsOptions): Array<string>
   generateArtifacts(options?: GenerateArtifactOptions | undefined | null): Array<CodegenArtifact>
   generateArtifact(id: string, options?: GenerateArtifactOptions | undefined | null): CodegenArtifact | null
-  generateAffectedArtifacts(dependencies: Array<string>, options?: GenerateArtifactOptions | undefined | null): Array<CodegenArtifact>
+  generateAffectedArtifacts(
+    dependencies: Array<string>,
+    options?: GenerateArtifactOptions | undefined | null,
+  ): Array<CodegenArtifact>
   /**
    * Return the serialized config snapshot this project was constructed
    * with.
@@ -238,7 +241,11 @@ export declare class Compiler {
   /** Register a JS-backed `parser:before` source transform. */
   registerSourceTransform(id: string, filter: any | undefined | null, callback: SourceTransformRef): void
   /** Construct a compiler from the resolved, JSON-safe Panda config snapshot. */
-  static fromConfig(config: any, options?: ProjectOptions | undefined | null, utilityValuesCallbacks?: UtilityValueCallbacks | undefined | null): Compiler
+  static fromConfig(
+    config: any,
+    options?: ProjectOptions | undefined | null,
+    utilityValuesCallbacks?: UtilityValueCallbacks | undefined | null,
+  ): Compiler
 }
 
 /**
@@ -393,12 +400,17 @@ export interface DiagnosticLabel {
 export declare const enum DiagnosticSeverity {
   Info = 'info',
   Warning = 'warning',
-  Error = 'error'
+  Error = 'error',
 }
 
 export declare function extract(path: string, source: string, matchers: Matchers): ExtractResult
 
-export declare function extractCalls(path: string, source: string, matched: Array<MatchedImport>, matchers: Matchers): ExtractedCallsResult
+export declare function extractCalls(
+  path: string,
+  source: string,
+  matched: Array<MatchedImport>,
+  matchers: Matchers,
+): ExtractedCallsResult
 
 export declare function extractDebug(path: string, source: string, matchers: Matchers): ExtractDebugResult
 
@@ -427,7 +439,7 @@ export interface ExtractedArg {
  */
 export declare const enum ExtractedArgKind {
   Value = 'value',
-  Missing = 'missing'
+  Missing = 'missing',
 }
 
 export interface ExtractedCall {
@@ -462,7 +474,12 @@ export interface ExtractedJsxResult {
   diagnostics: Array<Diagnostic>
 }
 
-export declare function extractJsx(path: string, source: string, matched: Array<MatchedImport>, matchers: Matchers): ExtractedJsxResult
+export declare function extractJsx(
+  path: string,
+  source: string,
+  matched: Array<MatchedImport>,
+  matchers: Matchers,
+): ExtractedJsxResult
 
 /**
  * Lean result for the production hot path — `imports` and `matched` are
@@ -483,7 +500,7 @@ export interface GenerateArtifactOptions {
 
 export declare const enum ImportKind {
   SideEffect = 'sideEffect',
-  Value = 'value'
+  Value = 'value',
 }
 
 export interface ImportRecord {
@@ -510,7 +527,7 @@ export interface ImportSpecifier {
 export declare const enum ImportSpecifierKind {
   Named = 'named',
   Default = 'default',
-  Namespace = 'namespace'
+  Namespace = 'namespace',
 }
 
 export interface InputFile {
@@ -522,7 +539,7 @@ export declare const enum JsxKind {
   Factory = 'factory',
   Pattern = 'pattern',
   Recipe = 'recipe',
-  Component = 'component'
+  Component = 'component',
 }
 
 export interface LayerCssOptions {
@@ -546,7 +563,7 @@ export declare const enum MatchCategory {
   Recipe = 'recipe',
   Pattern = 'pattern',
   Jsx = 'jsx',
-  Tokens = 'tokens'
+  Tokens = 'tokens',
 }
 
 export interface MatchedImport {

--- a/packages/rollup/__tests__/plugin.test.ts
+++ b/packages/rollup/__tests__/plugin.test.ts
@@ -89,13 +89,13 @@ describe('@pandacss/rollup', () => {
 
   it('watches source directories, config dependencies, and design-system files', async () => {
     const driver = createDriver([])
-    driver.scan.mockReturnValue(['/project/src/app.tsx'])
     mocks.createNodeDriver.mockResolvedValue(driver)
     const plugin = pandacss()[0] as unknown as TestPlugin
     const context = createContext()
 
     await plugin.buildStart.call(context)
 
+    expect(driver.scan).not.toHaveBeenCalled()
     expect(context.addWatchFile.mock.calls.map(([file]) => file)).toMatchInlineSnapshot(`
       [
         "/project/src",
@@ -108,6 +108,21 @@ describe('@pandacss/rollup', () => {
         "/project/node_modules/@acme/ds/src/button.tsx",
       ]
     `)
+  })
+
+  it('scans for watch files when a custom driver does not expose parsed files', async () => {
+    const driver = createDriver([])
+    driver.watchTargets.mockReturnValue({
+      files: undefined,
+      dirs: ['/project/src'],
+      config: ['/project/panda.shared.ts'],
+      sources: [],
+    })
+    mocks.createNodeDriver.mockResolvedValue(driver)
+
+    await (pandacss()[0] as unknown as TestPlugin).buildStart.call(createContext())
+
+    expect(driver.scan).toHaveBeenCalledOnce()
   })
 
   it.each([
@@ -134,7 +149,7 @@ function createDriver(diagnostics: Array<{ severity: 'error' | 'info' | 'warning
     applyChange: vi.fn(),
     codegen: vi.fn(),
     parseFiles: vi.fn(),
-    scan: vi.fn((): string[] => []),
+    scan: vi.fn(() => ['/project/src/app.tsx']),
     cssgen: vi.fn(() => ({ css: '.generated { color: red }', diagnostics })),
     designSystemDiagnostics: [],
     designSystemWatchTargets: vi.fn(() => [
@@ -151,7 +166,12 @@ function createDriver(diagnostics: Array<{ severity: 'error' | 'info' | 'warning
     reload: vi.fn(),
     resolvePath: vi.fn((path: string) => path),
     syncDesignSystemFileChange: vi.fn(),
-    watchTargets: vi.fn(() => ({ dirs: ['/project/src'], config: ['/project/panda.shared.ts'], sources: [] })),
+    watchTargets: vi.fn(() => ({
+      files: ['/project/src/app.tsx'] as string[] | undefined,
+      dirs: ['/project/src'],
+      config: ['/project/panda.shared.ts'],
+      sources: [],
+    })),
   }
 }
 

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -67,7 +67,7 @@ export function pandacss(options: PandaRollupOptions = {}): Plugin[] {
       for (const dir of watchTargets.dirs) this.addWatchFile(driver!.resolvePath(dir))
       for (const config of watchTargets.config) this.addWatchFile(driver!.resolvePath(config))
       if (driver!.configPath) this.addWatchFile(driver!.configPath)
-      for (const file of driver!.scan()) this.addWatchFile(file)
+      for (const file of watchTargets.files ?? driver!.scan()) this.addWatchFile(file)
       for (const target of driver!.designSystemWatchTargets()) {
         this.addWatchFile(target.manifestPath)
         this.addWatchFile(target.buildInfoPath)

--- a/packages/vite/__tests__/plugin-unit.test.ts
+++ b/packages/vite/__tests__/plugin-unit.test.ts
@@ -28,6 +28,7 @@ describe('@pandacss/vite design-system HMR', () => {
     await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
     plugin.transform.call({ addWatchFile, warn: vi.fn() }, CSS_ROOT, '/project/src/index.css')
 
+    expect(driver.scan).not.toHaveBeenCalled()
     expect(addWatchFile.mock.calls.map(([file]) => file)).toMatchInlineSnapshot(`
       [
         "/project/src/app.tsx",
@@ -42,7 +43,23 @@ describe('@pandacss/vite design-system HMR', () => {
     expect(driver.cssgen).toHaveBeenCalledWith({ emitLayerDeclaration: false, polyfill: false })
   })
 
-  it('registers new scan() matches on later CSS transforms without re-adding known files', async () => {
+  it('scans for watch files when a custom driver does not expose parsed files', async () => {
+    const { driver, pandacss } = await setup()
+    driver.watchTargets.mockReturnValue({
+      files: undefined,
+      sources: ['src/**/*.tsx'],
+      dirs: ['/project/src'],
+      config: ['panda.config.ts'],
+    })
+    const plugin = pandacss() as unknown as TestPlugin
+
+    await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
+    plugin.transform.call({ addWatchFile: vi.fn(), warn: vi.fn() }, CSS_ROOT, '/project/src/index.css')
+
+    expect(driver.scan).toHaveBeenCalledOnce()
+  })
+
+  it('registers newly parsed files on later CSS transforms without re-adding known files', async () => {
     const { driver, pandacss } = await setup()
     const plugin = pandacss() as unknown as TestPlugin
     const addWatchFile = vi.fn()
@@ -53,7 +70,12 @@ describe('@pandacss/vite design-system HMR', () => {
     expect(addWatchFile).toHaveBeenCalledWith('/project/src/app.tsx')
 
     addWatchFile.mockClear()
-    driver.scan.mockReturnValueOnce(['/project/src/app.tsx', '/project/src/new.tsx'])
+    driver.watchTargets.mockReturnValueOnce({
+      files: ['/project/src/app.tsx', '/project/src/new.tsx'],
+      sources: ['src/**/*.tsx'],
+      dirs: ['/project/src'],
+      config: ['panda.config.ts'],
+    })
     plugin.transform.call(ctx, CSS_ROOT, '/project/src/index.css')
 
     expect(addWatchFile.mock.calls.map(([file]) => file)).toEqual(['/project/src/new.tsx'])
@@ -345,9 +367,14 @@ function createMockDriver() {
     ),
     isSourceFile: vi.fn((_file: string) => false),
     parseFiles: vi.fn(),
-    reload: vi.fn(async () => ({ hasChanged: true, dependencies: [], recipes: [], patterns: [], changes: [] })),
     scan: vi.fn(() => ['/project/src/app.tsx']),
-    watchTargets: vi.fn(() => ({ sources: ['src/**/*.tsx'], dirs: ['/project/src'], config: ['panda.config.ts'] })),
+    reload: vi.fn(async () => ({ hasChanged: true, dependencies: [], recipes: [], patterns: [], changes: [] })),
+    watchTargets: vi.fn(() => ({
+      files: ['/project/src/app.tsx'] as string[] | undefined,
+      sources: ['src/**/*.tsx'],
+      dirs: ['/project/src'],
+      config: ['panda.config.ts'],
+    })),
     resolvePath: vi.fn((file: string) => (file.startsWith('/') ? file : `/project/${file}`)),
     syncDesignSystemFileChange: vi.fn(async () => true),
   }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -83,10 +83,10 @@ export function pandacss(options: PandaPluginOptions = {}): Plugin {
       addWatchFile(file)
     }
     const inputFile = inputId.split('?')[0] ?? inputId
-    for (const file of driver.scan()) {
+    const watchTargets = driver.watchTargets()
+    for (const file of watchTargets.files ?? driver.scan()) {
       if (file !== inputFile) watch(file)
     }
-    const watchTargets = driver.watchTargets()
     for (const dir of watchTargets.dirs) {
       watch(driver.resolvePath(dir))
     }


### PR DESCRIPTION
## Summary

Vite and Rollup discover every configured source through `driver.parseFiles()` during startup. Watch registration then scanned the project again.

This exposes the driver's tracked source paths through `watchTargets()` and reuses them in both integrations. Custom Driver implementations without `files` still fall back to `scan()`.

## Benefit

This removes one full project scan from bundler startup and Rollup rebuilds.

| Source files | Avoided scan | Panda discovery and parse improvement |
| ---: | ---: | ---: |
| 100 | 0.16 ms | 3% |
| 1,000 | 1.67 ms | 6.6% |
| 5,000 | 8.34 ms | 6.5% |

These are warm-filesystem measurements. I am not reporting an overall build-time percentage because bundler variance exceeded the savings in the 100-file fixture.

## Risk

Low. CSS generation and extraction are unchanged. Source directories remain watched, tracked files follow add and unlink events, and config reloads repopulate the tracked set. The existing scan path remains available as a compatibility fallback.

## Verification

- `pnpm test packages/vite packages/rollup` — 32 tests passed
- `pnpm --filter @pandacss/compiler exec vitest run __tests__/node-driver.test.ts` — 41 tests passed
- `pnpm typecheck`
- Production builds for `@pandacss/compiler-shared`, `@pandacss/vite`, and `@pandacss/rollup`
- Prettier and `git diff --check`


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61752980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/panda/3797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge after addressing the non-blocking stale tracking of deleted source files.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcompiler-shared%2Fsrc%2Fdriver.ts%3A247-254%0AWhen%20a%20parsed%20source%20matching%20the%20configured%20patterns%20is%20unlinked%20and%20successfully%20removed%2C%20this%20branch%20adds%20its%20path%20back%20to%20%60%23scanOwnedFiles%60.%20Later%20Vite%20transforms%20and%20Rollup%20builds%20therefore%20register%20the%20nonexistent%20source%20as%20a%20watch%20file%20until%20a%20full%20parse%20replaces%20the%20tracked%20set.%0A%0A%60%60%60suggestion%0A%20%20protected%20trackSourceChange%28change%3A%20SourceChange%2C%20applied%3A%20boolean%29%3A%20boolean%20%7B%0A%20%20%20%20if%20%28change.kind%20%3D%3D%3D%20'unlink'%29%20this.%23scanOwnedFiles.delete%28change.path%29%0A%20%20%20%20if%20%28!this.%23compiler.isSourceFile%28change.path%29%29%20return%20applied%0A%20%20%20%20if%20%28change.kind%20!%3D%3D%20'unlink'%20%26%26%20applied%29%20%7B%0A%20%20%20%20%20%20this.%23scanOwnedFiles.add%28change.path%29%0A%20%20%20%20%7D%0A%20%20%20%20return%20applied%0A%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fpanda&pr=3797&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Unlinked sources are re\-tracked** <a href="https://github.com/chakra-ui/panda/pull/3797/files#diff-2ba290de9bf21f10626417f3970dd1a3d83dc159a0902a3900647720cde18f07R254">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds parsed-file tracking to the shared driver watch-target contract.
- Uses tracked files for Vite and Rollup watch registration, with a scan fallback for custom drivers.
- Adds tests and documentation for tracked-file registration and compatibility behavior.
</details>

<!-- /greptile_comment -->