### PR TITLE
fix(bench): restore JSX extraction coverage

### DIFF
--- a/bench/src/bin/jsx_heavy_extract.rs
+++ b/bench/src/bin/jsx_heavy_extract.rs
@@ -25,20 +25,24 @@ fn main() {
     let source = generated_source(args.elements);
     let config = config();
 
+    assert_fixture_contract(&config);
+
     for _ in 0..args.warm {
         let _ = extract(&source, "fixture.tsx", &config);
     }
 
     let start = Instant::now();
-    let mut checksum = 0usize;
+    let mut calls = 0usize;
+    let mut jsx = 0usize;
+    let mut diagnostics = 0usize;
     for _ in 0..args.iterations {
         let result = extract(&source, "fixture.tsx", &config);
-        checksum = checksum
-            .wrapping_add(result.calls.len())
-            .wrapping_add(result.jsx.len())
-            .wrapping_add(result.diagnostics.len());
+        calls = calls.wrapping_add(result.calls.len());
+        jsx = jsx.wrapping_add(result.jsx.len());
+        diagnostics = diagnostics.wrapping_add(result.diagnostics.len());
     }
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let checksum = calls.wrapping_add(jsx).wrapping_add(diagnostics);
 
     println!(
         "{}",
@@ -48,43 +52,83 @@ fn main() {
             "elements": args.elements,
             "iterations": args.iterations,
             "elapsedMs": elapsed_ms,
-            "perIterationMs": elapsed_ms / args.iterations.max(1) as f64,
+            "perIterationMs": elapsed_ms / args.iterations as f64,
+            "callsPerIteration": calls / args.iterations,
+            "jsxPerIteration": jsx / args.iterations,
+            "diagnosticsPerIteration": diagnostics / args.iterations,
             "checksum": checksum,
         })
     );
 }
 
+fn assert_fixture_contract(config: &ExtractorConfig) {
+    let preflight = extract(&generated_source(8), "fixture.tsx", config);
+    assert!(
+        preflight.diagnostics.is_empty(),
+        "JSX benchmark fixture produced diagnostics: {:?}",
+        preflight.diagnostics
+    );
+    assert_eq!(preflight.calls.len(), 1, "expected one css() call");
+    let mut jsx_names: Vec<_> = preflight
+        .jsx
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect();
+    jsx_names.sort_unstable();
+    assert_eq!(
+        jsx_names,
+        [
+            "Box",
+            "FieldInput",
+            "Grid",
+            "PrimaryAction",
+            "Stack",
+            "styled.div"
+        ],
+        "expected the configured JSX component and factory cases"
+    );
+}
+
 fn parse_args() -> Args {
-    let mut args = Args {
+    parse_args_from(std::env::args().skip(1))
+}
+
+fn parse_args_from(argv: impl IntoIterator<Item = String>) -> Args {
+    let mut parsed = Args {
         elements: 2_000,
         warm: 10,
         iterations: 50,
     };
-    let mut iter = std::env::args().skip(1);
+    let mut iter = argv.into_iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--elements" => {
-                args.elements = iter
-                    .next()
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or(args.elements);
+                parsed.elements = parse_usize_value(&mut iter, "--elements");
             }
             "--warm" => {
-                args.warm = iter
-                    .next()
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or(args.warm);
+                parsed.warm = parse_usize_value(&mut iter, "--warm");
             }
             "--iterations" => {
-                args.iterations = iter
-                    .next()
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or(args.iterations);
+                parsed.iterations = parse_usize_value(&mut iter, "--iterations");
             }
             _ => {}
         }
     }
-    args
+    assert!(parsed.elements > 0, "--elements must be greater than zero");
+    assert!(
+        parsed.iterations > 0,
+        "--iterations must be greater than zero"
+    );
+    parsed
+}
+
+fn parse_usize_value(iter: &mut impl Iterator<Item = String>, flag: &str) -> usize {
+    let value = iter
+        .next()
+        .unwrap_or_else(|| panic!("missing {flag} value"));
+    value
+        .parse()
+        .unwrap_or_else(|_| panic!("invalid {flag} value: {value}"))
 }
 
 fn config() -> ExtractorConfig {
@@ -126,7 +170,7 @@ fn config() -> ExtractorConfig {
             modules: vec!["@panda/tokens".to_owned()],
             names: NameMatcher::only(["token"]),
         },
-        jsx_factories: None,
+        jsx_factories: Some(vec!["styled".to_owned()]),
         ..Default::default()
     })
     .with_jsx(JsxExtractionConfig {
@@ -145,6 +189,7 @@ fn config() -> ExtractorConfig {
         component_regex_blocklist_set: None,
         valid_style_props,
     })
+    .with_jsx_framework(true)
 }
 
 fn generated_source(elements: usize) -> String {
@@ -170,4 +215,20 @@ fn generated_source(elements: usize) -> String {
     }
     source.push_str("</>;\n}\ncss({ color: 'red' });\n");
     source
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{assert_fixture_contract, config, parse_args_from};
+
+    #[test]
+    fn fixture_exercises_jsx_extraction() {
+        assert_fixture_contract(&config());
+    }
+
+    #[test]
+    #[should_panic(expected = "--iterations must be greater than zero")]
+    fn zero_iterations_are_rejected() {
+        parse_args_from(["--iterations".to_owned(), "0".to_owned()]);
+    }
 }

--- a/bench/src/bin/sandbox_vite_ts.rs
+++ b/bench/src/bin/sandbox_vite_ts.rs
@@ -534,7 +534,7 @@ fn extractor_config_matching(_config: &UserConfig) -> ExtractorConfig {
             modules: vec!["../styled-system/tokens".to_owned()],
             names: NameMatcher::only(["token"]),
         },
-        jsx_factories: None,
+        jsx_factories: Some(vec!["panda".to_owned()]),
         ..Default::default()
     })
     .with_jsx(JsxExtractionConfig {
@@ -553,6 +553,7 @@ fn extractor_config_matching(_config: &UserConfig) -> ExtractorConfig {
         component_regex_blocklist_set: None,
         valid_style_props,
     })
+    .with_jsx_framework(true)
 }
 
 /// Hand-rolled JSON config mirroring the *shape* of `sandbox/vite-ts/panda.config.ts`.

--- a/bench/src/bin/sandbox_vite_ts.rs
+++ b/bench/src/bin/sandbox_vite_ts.rs
@@ -566,6 +566,7 @@ const CONFIG_JSON: &str = r##"{
   "outdir": "styled-system",
   "include": ["./src/**/*.{tsx,jsx}"],
   "exclude": [],
+  "jsxFramework": "react",
   "jsxFactory": "panda",
   "importMap": {
     "css":     ["../styled-system/css"],

--- a/bench/src/jsx-heavy-compare.ts
+++ b/bench/src/jsx-heavy-compare.ts
@@ -22,11 +22,13 @@ const rustConfig = {
     tokens: ['@panda/tokens'],
   },
   jsxFactory: 'styled',
+  jsxFramework: 'react',
 }
 const rustSnapshot = createConfigSnapshot(rustConfig)
 
-const componentNames = new Set(['Box', 'Stack', 'Grid', 'styled.div'])
+const componentNames = new Set(['Box', 'Stack', 'Grid', 'styled.div', 'PrimaryAction', 'FieldInput'])
 const functionNames = new Set(['css'])
+const preflightNames = ['Box', 'FieldInput', 'Grid', 'PrimaryAction', 'Stack', 'css', 'styled.div']
 
 function main() {
   const args = parseArgs(process.argv.slice(2))
@@ -50,6 +52,27 @@ function main() {
   } as any)
 
   const rustExtractor = createCompilerFromSnapshot(rustSnapshot)
+  const preflightSource = generatedSource(8)
+  const jsPreflight = inspectJs(project, preflightSource, path)
+  const rustPreflight = rustExtractor.extractFileSource(path, preflightSource)
+  const rustPreflightNames = [...rustPreflight.calls, ...rustPreflight.jsx].map((item) => item.name).sort()
+
+  if (rustPreflight.diagnostics.length !== 0) {
+    throw new Error(`Rust extraction produced ${rustPreflight.diagnostics.length} diagnostics`)
+  }
+  if (!sameNames(jsPreflight.names, preflightNames)) {
+    throw new Error(
+      `Expected JS preflight names ${preflightNames.join(', ')}, received ${jsPreflight.names.join(', ')}`,
+    )
+  }
+  if (!sameNames(rustPreflightNames, preflightNames)) {
+    throw new Error(
+      `Expected Rust preflight names ${preflightNames.join(', ')}, received ${rustPreflightNames.join(', ')}`,
+    )
+  }
+  if (jsPreflight.count !== rustPreflightNames.length) {
+    throw new Error(`Extraction checksum mismatch: JS ${jsPreflight.count}, Rust ${rustPreflightNames.length}`)
+  }
 
   for (let i = 0; i < args.warm; i++) {
     runJs(project, source, path)
@@ -65,11 +88,20 @@ function main() {
 
   const rustStart = performance.now()
   let rustChecksum = 0
+  let rustDiagnostics = 0
   for (let i = 0; i < args.iterations; i++) {
     const result = rustExtractor.extractFileSource(path, source)
-    rustChecksum += result.calls.length + result.jsx.length + result.diagnostics.length
+    rustChecksum += result.calls.length + result.jsx.length
+    rustDiagnostics += result.diagnostics.length
   }
   const rustMs = performance.now() - rustStart
+
+  if (rustDiagnostics !== 0) {
+    throw new Error(`Rust extraction produced ${rustDiagnostics} diagnostics during measurement`)
+  }
+  if (jsChecksum !== rustChecksum) {
+    throw new Error(`Extraction checksum mismatch: JS ${jsChecksum}, Rust ${rustChecksum}`)
+  }
 
   console.log(
     JSON.stringify(
@@ -97,11 +129,18 @@ function main() {
 }
 
 function runJs(project: Project, source: string, path: string): number {
+  const result = extractJs(project, source, path)
+  let count = 0
+  for (const item of result.values()) count += item.queryList.length
+  return count
+}
+
+function extractJs(project: Project, source: string, path: string) {
   const sourceFile = project.createSourceFile(path, source, {
     overwrite: true,
     scriptKind: ts.ScriptKind.TSX,
   })
-  const result = jsExtract({
+  return jsExtract({
     ast: sourceFile,
     components: {
       matchTag: ({ tagName }) => componentNames.has(tagName),
@@ -114,9 +153,22 @@ function runJs(project: Project, source: string, path: string): number {
     },
     flags: { skipTraverseFiles: true },
   })
+}
+
+function inspectJs(project: Project, source: string, path: string): { count: number; names: string[] } {
+  const result = extractJs(project, source, path)
   let count = 0
-  for (const item of result.values()) count += item.queryList.length
-  return count
+  const names: string[] = []
+  for (const item of result.values()) {
+    count += item.queryList.length
+    names.push(...item.queryList.map((query) => query.name))
+  }
+  names.sort()
+  return { count, names }
+}
+
+function sameNames(actual: string[], expected: string[]): boolean {
+  return actual.length === expected.length && actual.every((name, index) => name === expected[index])
 }
 
 function parseArgs(argv: string[]): Args {
@@ -165,7 +217,7 @@ return <>
         source += `<PrimaryAction color='purple' />\n`
         break
       case 5:
-        source += `<FieldInput bg='gray.100' />\n`
+        source += `<FieldInput color='gray' />\n`
         break
       case 6:
         source += `<button.Root size='md' />\n`


### PR DESCRIPTION
## Summary

The JSX benchmarks stopped enabling JSX extraction after `jsxFramework` became explicit. The standalone Rust benchmark reported `jsx=0`, while the v1/v2 comparison processed different component sets.

This enables framework and factory matching in the manual benchmark configs, aligns the paired workload, and fails before timing when extracted names or diagnostics drift.

## Validation

- `cargo test -p pandacss_bench --bin jsx_heavy_extract --locked`
- `cargo check -p pandacss_bench --bins --locked`
- `cargo clippy -p pandacss_bench --bin jsx_heavy_extract --no-deps --locked -- -D warnings`
- Paired preflight extracts the same seven names on v1 and v2
- Standalone benchmark extracts 1 call and 1,500 JSX entries at 2,000 elements with zero diagnostics
- `sandbox-vite-ts` extracts 93 calls and 15 JSX entries with zero diagnostics

## Risk

Benchmark-only. No compiler, generated CSS, or public package behavior changes. No changeset.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61775769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/panda/3798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The benchmark-only changes appear safe to merge.

<details><summary><h3>Summary</h3></summary>

- Enables explicit JSX framework and factory matching in Rust benchmark configurations.
- Adds extraction-name, diagnostic, and checksum validation before or around timing.
- Separates standalone benchmark extraction metrics and strengthens argument validation.
</details>

<!-- /greptile_comment -->