### PR TITLE
perf(extractor): skip template scans for script files

### DIFF
--- a/.changeset/skip-template-scans.md
+++ b/.changeset/skip-template-scans.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Speed up JSX extraction for JavaScript and TypeScript files by skipping template scans reserved for Vue, Svelte, and Astro files.

--- a/bench/src/bin/jsx_heavy_extract.rs
+++ b/bench/src/bin/jsx_heavy_extract.rs
@@ -25,20 +25,24 @@ fn main() {
     let source = generated_source(args.elements);
     let config = config();
 
+    assert_fixture_contract(&config);
+
     for _ in 0..args.warm {
         let _ = extract(&source, "fixture.tsx", &config);
     }
 
     let start = Instant::now();
-    let mut checksum = 0usize;
+    let mut calls = 0usize;
+    let mut jsx = 0usize;
+    let mut diagnostics = 0usize;
     for _ in 0..args.iterations {
         let result = extract(&source, "fixture.tsx", &config);
-        checksum = checksum
-            .wrapping_add(result.calls.len())
-            .wrapping_add(result.jsx.len())
-            .wrapping_add(result.diagnostics.len());
+        calls = calls.wrapping_add(result.calls.len());
+        jsx = jsx.wrapping_add(result.jsx.len());
+        diagnostics = diagnostics.wrapping_add(result.diagnostics.len());
     }
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let checksum = calls.wrapping_add(jsx).wrapping_add(diagnostics);
 
     println!(
         "{}",
@@ -48,43 +52,83 @@ fn main() {
             "elements": args.elements,
             "iterations": args.iterations,
             "elapsedMs": elapsed_ms,
-            "perIterationMs": elapsed_ms / args.iterations.max(1) as f64,
+            "perIterationMs": elapsed_ms / args.iterations as f64,
+            "callsPerIteration": calls / args.iterations,
+            "jsxPerIteration": jsx / args.iterations,
+            "diagnosticsPerIteration": diagnostics / args.iterations,
             "checksum": checksum,
         })
     );
 }
 
+fn assert_fixture_contract(config: &ExtractorConfig) {
+    let preflight = extract(&generated_source(8), "fixture.tsx", config);
+    assert!(
+        preflight.diagnostics.is_empty(),
+        "JSX benchmark fixture produced diagnostics: {:?}",
+        preflight.diagnostics
+    );
+    assert_eq!(preflight.calls.len(), 1, "expected one css() call");
+    let mut jsx_names: Vec<_> = preflight
+        .jsx
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect();
+    jsx_names.sort_unstable();
+    assert_eq!(
+        jsx_names,
+        [
+            "Box",
+            "FieldInput",
+            "Grid",
+            "PrimaryAction",
+            "Stack",
+            "styled.div"
+        ],
+        "expected the configured JSX component and factory cases"
+    );
+}
+
 fn parse_args() -> Args {
-    let mut args = Args {
+    parse_args_from(std::env::args().skip(1))
+}
+
+fn parse_args_from(argv: impl IntoIterator<Item = String>) -> Args {
+    let mut parsed = Args {
         elements: 2_000,
         warm: 10,
         iterations: 50,
     };
-    let mut iter = std::env::args().skip(1);
+    let mut iter = argv.into_iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--elements" => {
-                args.elements = iter
-                    .next()
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or(args.elements);
+                parsed.elements = parse_usize_value(&mut iter, "--elements");
             }
             "--warm" => {
-                args.warm = iter
-                    .next()
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or(args.warm);
+                parsed.warm = parse_usize_value(&mut iter, "--warm");
             }
             "--iterations" => {
-                args.iterations = iter
-                    .next()
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or(args.iterations);
+                parsed.iterations = parse_usize_value(&mut iter, "--iterations");
             }
             _ => {}
         }
     }
-    args
+    assert!(parsed.elements > 0, "--elements must be greater than zero");
+    assert!(
+        parsed.iterations > 0,
+        "--iterations must be greater than zero"
+    );
+    parsed
+}
+
+fn parse_usize_value(iter: &mut impl Iterator<Item = String>, flag: &str) -> usize {
+    let value = iter
+        .next()
+        .unwrap_or_else(|| panic!("missing {flag} value"));
+    value
+        .parse()
+        .unwrap_or_else(|_| panic!("invalid {flag} value: {value}"))
 }
 
 fn config() -> ExtractorConfig {
@@ -126,7 +170,7 @@ fn config() -> ExtractorConfig {
             modules: vec!["@panda/tokens".to_owned()],
             names: NameMatcher::only(["token"]),
         },
-        jsx_factories: None,
+        jsx_factories: Some(vec!["styled".to_owned()]),
         ..Default::default()
     })
     .with_jsx(JsxExtractionConfig {
@@ -145,6 +189,7 @@ fn config() -> ExtractorConfig {
         component_regex_blocklist_set: None,
         valid_style_props,
     })
+    .with_jsx_framework(true)
 }
 
 fn generated_source(elements: usize) -> String {
@@ -170,4 +215,20 @@ fn generated_source(elements: usize) -> String {
     }
     source.push_str("</>;\n}\ncss({ color: 'red' });\n");
     source
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{assert_fixture_contract, config, parse_args_from};
+
+    #[test]
+    fn fixture_exercises_jsx_extraction() {
+        assert_fixture_contract(&config());
+    }
+
+    #[test]
+    #[should_panic(expected = "--iterations must be greater than zero")]
+    fn zero_iterations_are_rejected() {
+        parse_args_from(["--iterations".to_owned(), "0".to_owned()]);
+    }
 }

--- a/bench/src/bin/sandbox_vite_ts.rs
+++ b/bench/src/bin/sandbox_vite_ts.rs
@@ -534,7 +534,7 @@ fn extractor_config_matching(_config: &UserConfig) -> ExtractorConfig {
             modules: vec!["../styled-system/tokens".to_owned()],
             names: NameMatcher::only(["token"]),
         },
-        jsx_factories: None,
+        jsx_factories: Some(vec!["panda".to_owned()]),
         ..Default::default()
     })
     .with_jsx(JsxExtractionConfig {
@@ -553,6 +553,7 @@ fn extractor_config_matching(_config: &UserConfig) -> ExtractorConfig {
         component_regex_blocklist_set: None,
         valid_style_props,
     })
+    .with_jsx_framework(true)
 }
 
 /// Hand-rolled JSON config mirroring the *shape* of `sandbox/vite-ts/panda.config.ts`.

--- a/bench/src/bin/sandbox_vite_ts.rs
+++ b/bench/src/bin/sandbox_vite_ts.rs
@@ -566,6 +566,7 @@ const CONFIG_JSON: &str = r##"{
   "outdir": "styled-system",
   "include": ["./src/**/*.{tsx,jsx}"],
   "exclude": [],
+  "jsxFramework": "react",
   "jsxFactory": "panda",
   "importMap": {
     "css":     ["../styled-system/css"],

--- a/bench/src/jsx-heavy-compare.ts
+++ b/bench/src/jsx-heavy-compare.ts
@@ -22,11 +22,13 @@ const rustConfig = {
     tokens: ['@panda/tokens'],
   },
   jsxFactory: 'styled',
+  jsxFramework: 'react',
 }
 const rustSnapshot = createConfigSnapshot(rustConfig)
 
-const componentNames = new Set(['Box', 'Stack', 'Grid', 'styled.div'])
+const componentNames = new Set(['Box', 'Stack', 'Grid', 'styled.div', 'PrimaryAction', 'FieldInput'])
 const functionNames = new Set(['css'])
+const preflightNames = ['Box', 'FieldInput', 'Grid', 'PrimaryAction', 'Stack', 'css', 'styled.div']
 
 function main() {
   const args = parseArgs(process.argv.slice(2))
@@ -50,6 +52,27 @@ function main() {
   } as any)
 
   const rustExtractor = createCompilerFromSnapshot(rustSnapshot)
+  const preflightSource = generatedSource(8)
+  const jsPreflight = inspectJs(project, preflightSource, path)
+  const rustPreflight = rustExtractor.extractFileSource(path, preflightSource)
+  const rustPreflightNames = [...rustPreflight.calls, ...rustPreflight.jsx].map((item) => item.name).sort()
+
+  if (rustPreflight.diagnostics.length !== 0) {
+    throw new Error(`Rust extraction produced ${rustPreflight.diagnostics.length} diagnostics`)
+  }
+  if (!sameNames(jsPreflight.names, preflightNames)) {
+    throw new Error(
+      `Expected JS preflight names ${preflightNames.join(', ')}, received ${jsPreflight.names.join(', ')}`,
+    )
+  }
+  if (!sameNames(rustPreflightNames, preflightNames)) {
+    throw new Error(
+      `Expected Rust preflight names ${preflightNames.join(', ')}, received ${rustPreflightNames.join(', ')}`,
+    )
+  }
+  if (jsPreflight.count !== rustPreflightNames.length) {
+    throw new Error(`Extraction checksum mismatch: JS ${jsPreflight.count}, Rust ${rustPreflightNames.length}`)
+  }
 
   for (let i = 0; i < args.warm; i++) {
     runJs(project, source, path)
@@ -65,11 +88,20 @@ function main() {
 
   const rustStart = performance.now()
   let rustChecksum = 0
+  let rustDiagnostics = 0
   for (let i = 0; i < args.iterations; i++) {
     const result = rustExtractor.extractFileSource(path, source)
-    rustChecksum += result.calls.length + result.jsx.length + result.diagnostics.length
+    rustChecksum += result.calls.length + result.jsx.length
+    rustDiagnostics += result.diagnostics.length
   }
   const rustMs = performance.now() - rustStart
+
+  if (rustDiagnostics !== 0) {
+    throw new Error(`Rust extraction produced ${rustDiagnostics} diagnostics during measurement`)
+  }
+  if (jsChecksum !== rustChecksum) {
+    throw new Error(`Extraction checksum mismatch: JS ${jsChecksum}, Rust ${rustChecksum}`)
+  }
 
   console.log(
     JSON.stringify(
@@ -97,11 +129,18 @@ function main() {
 }
 
 function runJs(project: Project, source: string, path: string): number {
+  const result = extractJs(project, source, path)
+  let count = 0
+  for (const item of result.values()) count += item.queryList.length
+  return count
+}
+
+function extractJs(project: Project, source: string, path: string) {
   const sourceFile = project.createSourceFile(path, source, {
     overwrite: true,
     scriptKind: ts.ScriptKind.TSX,
   })
-  const result = jsExtract({
+  return jsExtract({
     ast: sourceFile,
     components: {
       matchTag: ({ tagName }) => componentNames.has(tagName),
@@ -114,9 +153,22 @@ function runJs(project: Project, source: string, path: string): number {
     },
     flags: { skipTraverseFiles: true },
   })
+}
+
+function inspectJs(project: Project, source: string, path: string): { count: number; names: string[] } {
+  const result = extractJs(project, source, path)
   let count = 0
-  for (const item of result.values()) count += item.queryList.length
-  return count
+  const names: string[] = []
+  for (const item of result.values()) {
+    count += item.queryList.length
+    names.push(...item.queryList.map((query) => query.name))
+  }
+  names.sort()
+  return { count, names }
+}
+
+function sameNames(actual: string[], expected: string[]): boolean {
+  return actual.length === expected.length && actual.every((name, index) => name === expected[index])
 }
 
 function parseArgs(argv: string[]): Args {
@@ -165,7 +217,7 @@ return <>
         source += `<PrimaryAction color='purple' />\n`
         break
       case 5:
-        source += `<FieldInput bg='gray.100' />\n`
+        source += `<FieldInput color='gray' />\n`
         break
       case 6:
         source += `<button.Root size='md' />\n`

--- a/crates/pandacss_extractor/src/template_styles.rs
+++ b/crates/pandacss_extractor/src/template_styles.rs
@@ -50,7 +50,8 @@ pub(crate) fn collect_template_styles(
     resolver: &crate::Resolver<'_, '_>,
     retain_transform_facts: bool,
 ) -> Vec<ExtractedJsx> {
-    if !config.has_jsx_framework {
+    // PERF(port): template extraction scans the full source and AST; only SFC formats need it.
+    if !config.has_jsx_framework || !has_template_extension(path) {
         return Vec::new();
     }
 
@@ -80,6 +81,12 @@ pub(crate) fn collect_template_styles(
         return collect_astro_template_styles(source, matched, config, &context);
     }
     Vec::new()
+}
+
+fn has_template_extension(path: &str) -> bool {
+    ["vue", "svelte", "astro"]
+        .into_iter()
+        .any(|extension| has_extension(path, extension))
 }
 
 /// Astro markup uses the same JSX attribute syntax as Svelte (`attr="x"`,
@@ -849,4 +856,22 @@ fn find_markup_tag_end(source: &str, from: usize, limit: usize) -> Option<usize>
         index += 1;
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_template_extension;
+
+    #[test]
+    fn template_extensions_are_explicit() {
+        for path in ["Card.vue", "Card.SVELTE", "Card.astro"] {
+            assert!(has_template_extension(path), "expected {path} to match");
+        }
+        for path in ["Card.ts", "Card.tsx", "Card.jsx", "Card.vue.ts"] {
+            assert!(
+                !has_template_extension(path),
+                "expected {path} to be skipped"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Depends on #3798.

## Description

Vue, Svelte, and Astro template extraction scans both source text and the parsed AST. The same path currently runs for every JSX-enabled JavaScript and TypeScript file even though those files cannot contain an SFC template.

This change gates template extraction by supported extension before either scan begins.

## Current behavior

Every `.js`, `.jsx`, `.ts`, and `.tsx` file enters the framework-template path when `jsxFramework` is configured. The path walks the AST and scans the full source before returning no template styles.

## New behavior

Script files skip template-only work. Vue, Svelte, and Astro extraction is unchanged.

## Breaking changes

None.

## Performance

Median of five alternating release-mode runs against the preceding commit, using 1,100 unique TS/TSX files totaling 2.17 MB:

| Scenario | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Cold Panda build | 53.06 ms | 40.10 ms | 24.4% |
| Single-file reparse | 0.125 ms | 0.099 ms | 20.5% |
| Complete watch update | 0.411 ms | 0.384 ms | 6.7% |
| Extraction only | 34.66 ms | 22.97 ms | 33.7% |

Every run produced the same extraction counts, atom count, and CSS byte count.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo nextest run -p pandacss_extractor --locked` (513 tests)



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61797692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/panda/3799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness or security issues identified.

<details><summary><h3>Summary</h3></summary>

- Adds an explicit `.vue`, `.svelte`, and `.astro` extension gate before template source and AST scanning.
- Updates JSX-heavy benchmarks to exercise framework-enabled extraction and validate equivalent extraction results.
- Adds a patch changeset for the compiler packages.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[collect_template_styles] --> B{JSX framework configured?}
    B -- No --> E[Return no template styles]
    B -- Yes --> C{Extension is vue, svelte, or astro?}
    C -- No --> E
    C -- Yes --> D[Run framework template source and AST scans]
    D --> F[Return extracted template styles]
```
</details>

<!-- /greptile_comment -->