### PR TITLE
fix(rollup): refresh codegen for design-system artifacts

### DIFF
--- a/.changeset/refresh-rollup-design-system-codegen.md
+++ b/.changeset/refresh-rollup-design-system-codegen.md
@@ -1,0 +1,5 @@
+---
+'@pandacss/rollup': patch
+---
+
+Regenerate styled-system output when an imported design-system artifact changes during Rollup watch mode.

--- a/.changeset/refresh-rollup-design-system-codegen.md
+++ b/.changeset/refresh-rollup-design-system-codegen.md
@@ -1,5 +1,6 @@
 ---
 '@pandacss/rollup': patch
+'@pandacss/vite': patch
 ---
 
-Regenerate styled-system output when an imported design-system artifact changes during Rollup watch mode.
+Regenerate styled-system output when an imported design-system artifact changes in watch mode.

--- a/packages/rollup/__tests__/plugin.test.ts
+++ b/packages/rollup/__tests__/plugin.test.ts
@@ -125,6 +125,29 @@ describe('@pandacss/rollup', () => {
 
     expect(driver.applyChange).toHaveBeenCalledWith({ path: '/project/src/app.tsx', kind })
   })
+
+  it('regenerates codegen when a design-system artifact changes', async () => {
+    const driver = createDriver([])
+    driver.isDesignSystemFile.mockReturnValue('artifact')
+    driver.syncDesignSystemFileChange.mockResolvedValue(true)
+    mocks.createNodeDriver.mockResolvedValue(driver)
+    const plugin = pandacss({ cwd: '/project', outdir: 'styled-system' })[0] as unknown as TestPlugin
+
+    await plugin.buildStart.call(createContext())
+    driver.codegen.mockClear()
+    await plugin.watchChange('/project/node_modules/@acme/ds/panda/lib.json', { event: 'update' })
+
+    expect(driver.syncDesignSystemFileChange).toHaveBeenCalledWith({
+      path: '/project/node_modules/@acme/ds/panda/lib.json',
+      kind: 'change',
+    })
+    expect(driver.codegen).toHaveBeenCalledWith({ cwd: '/project', outdir: 'styled-system' })
+
+    driver.codegen.mockClear()
+    driver.syncDesignSystemFileChange.mockResolvedValue(false)
+    await plugin.watchChange('/project/node_modules/@acme/ds/panda/lib.json', { event: 'update' })
+    expect(driver.codegen).not.toHaveBeenCalled()
+  })
 })
 
 function createDriver(diagnostics: Array<{ severity: 'error' | 'info' | 'warning'; code: string; message: string }>) {
@@ -146,11 +169,11 @@ function createDriver(diagnostics: Array<{ severity: 'error' | 'info' | 'warning
       },
     ]),
     isConfigFile: vi.fn(() => false),
-    isDesignSystemFile: vi.fn(() => false),
+    isDesignSystemFile: vi.fn((): 'artifact' | 'source' | false => false),
     isSourceFile: vi.fn(() => false),
     reload: vi.fn(),
     resolvePath: vi.fn((path: string) => path),
-    syncDesignSystemFileChange: vi.fn(),
+    syncDesignSystemFileChange: vi.fn(async (): Promise<boolean> => false),
     watchTargets: vi.fn(() => ({ dirs: ['/project/src'], config: ['/project/panda.shared.ts'], sources: [] })),
   }
 }

--- a/packages/rollup/__tests__/plugin.test.ts
+++ b/packages/rollup/__tests__/plugin.test.ts
@@ -142,10 +142,37 @@ describe('@pandacss/rollup', () => {
       kind: 'change',
     })
     expect(driver.codegen).toHaveBeenCalledWith({ cwd: '/project', outdir: 'styled-system' })
+  })
 
-    driver.codegen.mockClear()
+  it('skips codegen when a design-system artifact is unchanged', async () => {
+    const driver = createDriver([])
+    driver.isDesignSystemFile.mockReturnValue('artifact')
     driver.syncDesignSystemFileChange.mockResolvedValue(false)
+    mocks.createNodeDriver.mockResolvedValue(driver)
+    const plugin = pandacss({ cwd: '/project', outdir: 'styled-system' })[0] as unknown as TestPlugin
+
+    await plugin.buildStart.call(createContext())
+    driver.codegen.mockClear()
     await plugin.watchChange('/project/node_modules/@acme/ds/panda/lib.json', { event: 'update' })
+
+    expect(driver.codegen).not.toHaveBeenCalled()
+  })
+
+  it('skips codegen when a design-system source file changes', async () => {
+    const driver = createDriver([])
+    driver.isDesignSystemFile.mockReturnValue('source')
+    driver.syncDesignSystemFileChange.mockResolvedValue(true)
+    mocks.createNodeDriver.mockResolvedValue(driver)
+    const plugin = pandacss({ cwd: '/project', outdir: 'styled-system' })[0] as unknown as TestPlugin
+
+    await plugin.buildStart.call(createContext())
+    driver.codegen.mockClear()
+    await plugin.watchChange('/project/node_modules/@acme/ds/src/button.tsx', { event: 'update' })
+
+    expect(driver.syncDesignSystemFileChange).toHaveBeenCalledWith({
+      path: '/project/node_modules/@acme/ds/src/button.tsx',
+      kind: 'change',
+    })
     expect(driver.codegen).not.toHaveBeenCalled()
   })
 })

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -81,7 +81,8 @@ export function pandacss(options: PandaRollupOptions = {}): Plugin[] {
       const sourceChange = sourceChangeFromRollup(id, change.event)
       const designSystemFile = driver.isDesignSystemFile(id)
       if (designSystemFile) {
-        await driver.syncDesignSystemFileChange(sourceChange)
+        const changed = await driver.syncDesignSystemFileChange(sourceChange)
+        if (changed && designSystemFile === 'artifact') driver.codegen({ cwd, outdir })
       } else if (driver.isConfigFile(id)) {
         const diff = await driver.reload()
         if (diff.hasChanged) {

--- a/packages/vite/__tests__/plugin-unit.test.ts
+++ b/packages/vite/__tests__/plugin-unit.test.ts
@@ -109,6 +109,68 @@ describe('@pandacss/vite design-system HMR', () => {
     `)
   })
 
+  it('regenerates codegen when a design-system artifact changes', async () => {
+    const { driver, pandacss } = await setup()
+    const plugin = pandacss({ outdir: 'styled-system' }) as unknown as TestPlugin
+    const environment = createEnvironment()
+    driver.isDesignSystemFile.mockReturnValue('artifact')
+    driver.syncDesignSystemFileChange.mockResolvedValue(true)
+
+    await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
+    driver.codegen.mockClear()
+    await plugin.hotUpdate.call(
+      { environment },
+      artifactHotUpdate('/project/node_modules/@acme/ds/panda/lib.json', environment),
+    )
+
+    expect(driver.syncDesignSystemFileChange).toHaveBeenCalledWith({
+      path: '/project/node_modules/@acme/ds/panda/lib.json',
+      kind: 'change',
+    })
+    expect(driver.codegen).toHaveBeenCalledWith({ cwd: '/project', outdir: 'styled-system' })
+  })
+
+  it('skips codegen when a design-system artifact is unchanged', async () => {
+    const { driver, pandacss } = await setup()
+    const plugin = pandacss() as unknown as TestPlugin
+    const environment = createEnvironment()
+    driver.isDesignSystemFile.mockReturnValue('artifact')
+    driver.syncDesignSystemFileChange.mockResolvedValue(false)
+
+    await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
+    driver.codegen.mockClear()
+    await plugin.hotUpdate.call(
+      { environment },
+      artifactHotUpdate('/project/node_modules/@acme/ds/panda/lib.json', environment),
+    )
+
+    expect(driver.codegen).not.toHaveBeenCalled()
+  })
+
+  it('skips codegen when a design-system source file changes', async () => {
+    const { driver, pandacss } = await setup()
+    const plugin = pandacss() as unknown as TestPlugin
+    const environment = createEnvironment()
+    driver.syncDesignSystemFileChange.mockResolvedValue(true)
+
+    await plugin.configResolved({ root: '/project', logger: { warn: vi.fn() } })
+    driver.codegen.mockClear()
+    await plugin.hotUpdate.call(
+      { environment },
+      {
+        ...artifactHotUpdate('/project/node_modules/@acme/ds/src/button.css.ts', environment),
+        read: async () => "export const button = css({ fontSize: '20px' })",
+      },
+    )
+
+    expect(driver.syncDesignSystemFileChange).toHaveBeenCalledWith({
+      path: '/project/node_modules/@acme/ds/src/button.css.ts',
+      kind: 'change',
+      content: "export const button = css({ fontSize: '20px' })",
+    })
+    expect(driver.codegen).not.toHaveBeenCalled()
+  })
+
   it.each([
     ['create', 'add', true],
     ['update', 'change', true],
@@ -301,6 +363,28 @@ async function setup() {
   return { createNodeDriver, createSourceTransformer, driver, pandacss }
 }
 
+function createEnvironment() {
+  return {
+    moduleGraph: {
+      getModuleById: vi.fn(),
+      invalidateModule: vi.fn(),
+    },
+  }
+}
+
+function artifactHotUpdate(file: string, environment: ReturnType<typeof createEnvironment>) {
+  return {
+    type: 'update',
+    file,
+    modules: [],
+    read: vi.fn(),
+    server: {
+      config: { logger: { warn: vi.fn() } },
+      environments: { client: environment },
+    },
+  }
+}
+
 function createMockDriver() {
   const sourceTransformer = {
     transformSource: vi.fn(
@@ -340,7 +424,7 @@ function createMockDriver() {
       },
     ]),
     isConfigFile: vi.fn(() => false),
-    isDesignSystemFile: vi.fn((file: string) =>
+    isDesignSystemFile: vi.fn((file: string): 'artifact' | 'source' | false =>
       file === '/project/node_modules/@acme/ds/src/button.css.ts' ? 'source' : false,
     ),
     isSourceFile: vi.fn((_file: string) => false),

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -206,7 +206,10 @@ export function pandacss(options: PandaPluginOptions = {}): Plugin {
         const change = await sourceChangeFromHotUpdate(ctx, designSystemFile === 'source')
         const changed = await driver.syncDesignSystemFileChange(change)
         if (changed) {
-          if (designSystemFile === 'artifact') watchedFiles.clear()
+          if (designSystemFile === 'artifact') {
+            watchedFiles.clear()
+            codegen()
+          }
           warnDesignSystemDiagnostics((message) => ctx.server.config.logger.warn(message))
         }
         return withInvalidatedRoots(this.environment, ctx.modules)


### PR DESCRIPTION
Follow-up to #3785.

## Description

**Symptom:** In Rollup watch mode, an imported design-system artifact can update emitted CSS while generated styled-system files remain stale.

**Cause:** Artifact synchronization reports whether the compiler changed, but the Rollup plugin ignored that result and only ran codegen for ordinary config changes.

**Fix:** Run codegen when synchronization reports a changed design-system artifact. Source changes and unchanged artifact events continue without extra codegen writes.

**Confidence:** The hook-level regression test covers changed and unchanged artifacts. The full Rollup suite, package build with declarations, Prettier, and ESLint pass.

## Breaking changes

None.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61816003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/panda/3800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness or security issues identified.

<details><summary><h3>Summary</h3></summary>

- Uses the synchronization result to avoid unnecessary codegen writes for unchanged artifacts and source events.
- Adds regression coverage for both changed and unchanged artifact events.
- Adds a patch changeset for `@pandacss/rollup`.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Rollup watchChange] --> B{Design-system file?}
  B -- No --> C[Existing config or source handling]
  B -- Yes --> D[Sync design-system change]
  D --> E{Artifact changed?}
  E -- Yes --> F[Regenerate styled-system codegen]
  E -- No --> G[Skip codegen]
```
</details>

<!-- /greptile_comment -->