### PR TITLE
perf(extractor): reuse style tree values during projection

### DIFF
--- a/.changeset/reuse-style-tree-values.md
+++ b/.changeset/reuse-style-tree-values.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Reduce allocations during CSS call and JSX extraction by reusing owned style keys and values.

--- a/crates/pandacss_extractor/src/calls.rs
+++ b/crates/pandacss_extractor/src/calls.rs
@@ -11,7 +11,7 @@ use crate::{
         StyleSourceOwner, StyleSourceOwnerKind, StyleSourceRef, collect_object_source_refs,
     },
     span_from_oxc,
-    style_tree::{expression_to_style_tree, project_literal},
+    style_tree::{ProjectionRetention, expression_to_style_tree, project_style_args},
 };
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Argument, CallExpression, Expression, IdentifierReference};
@@ -408,11 +408,14 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                 .iter()
                 .map(|arg| argument_to_style_tree(arg, resolver))
                 .collect();
-            let data: Vec<Option<Literal>> = style_args
-                .iter()
-                .map(|tree| tree.as_ref().and_then(project_literal))
-                .collect();
-            let arg_spans = if self.retain_transform_facts {
+            let retain = self.retain_transform_facts;
+            let retention = if retain {
+                ProjectionRetention::Retain
+            } else {
+                ProjectionRetention::Discard
+            };
+            let (data, style_args) = project_style_args(style_args, retention);
+            let arg_spans = if retain {
                 call.arguments
                     .iter()
                     .map(|arg| span_from_oxc(arg.span()))
@@ -443,12 +446,8 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                     jsx_recipe_ident,
                     span: span_from_oxc(call.span),
                     arg_spans,
-                    style_args: if self.retain_transform_facts {
-                        style_args
-                    } else {
-                        Vec::new()
-                    },
-                    facts: if self.retain_transform_facts {
+                    style_args,
+                    facts: if retain {
                         call_facts(call, raw)
                     } else {
                         CallFacts::default()

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -11,7 +11,7 @@ use crate::{
         StyleSourceOwner, StyleSourceOwnerKind, StyleSourceRef, collect_jsx_attribute_source_refs,
     },
     span_from_oxc,
-    style_tree::{jsx_attributes_to_style_tree, project_literal},
+    style_tree::{ProjectionRetention, jsx_attributes_to_style_tree, project_style},
     styled_bindings::{StyledBinding, StyledBindings, collect_styled_bindings},
 };
 use oxc_allocator::Allocator;
@@ -585,10 +585,14 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                 (Some(base), style) => prepend_styled_base(base, style),
                 (None, style) => style,
             };
-            let data = style
-                .as_ref()
-                .and_then(project_literal)
-                .unwrap_or_else(|| Literal::Object(vec![]));
+            let retain = self.retain_transform_facts;
+            let retention = if retain {
+                ProjectionRetention::Retain
+            } else {
+                ProjectionRetention::Discard
+            };
+            let (data, style) = project_style(style, retention);
+            let data = data.unwrap_or_else(|| Literal::Object(vec![]));
             let data_empty = matches!(&data, Literal::Object(entries) if entries.is_empty());
             if data_empty && !emit_empty {
                 walk::walk_jsx_element(self, jsx_el);
@@ -612,7 +616,6 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                 );
             }
 
-            let retain = self.retain_transform_facts;
             self.out.push(ExtractedJsx {
                 category,
                 kind,
@@ -634,7 +637,7 @@ impl<'a> Visit<'a> for Extractor<'_, '_, '_> {
                     Vec::new()
                 },
                 panda_owned,
-                style: if retain { style } else { None },
+                style,
                 source: if retain {
                     JsxSourceFacts {
                         kind: JsxSourceKind::Element,

--- a/crates/pandacss_extractor/src/jsx_react_runtime.rs
+++ b/crates/pandacss_extractor/src/jsx_react_runtime.rs
@@ -7,7 +7,7 @@ use crate::{
     ImportSpecifier, ImportSpecifierKind, Literal, VisitorContext,
     jsx::{ExtractedJsx, Extractor},
     span_from_oxc,
-    style_tree::project_literal,
+    style_tree::{ProjectionRetention, project_style},
 };
 
 #[derive(Default)]
@@ -145,17 +145,20 @@ pub(crate) fn extract_call(
         &ctx.config.jsx,
         tag_name,
     );
-    let data = style
-        .as_ref()
-        .and_then(project_literal)
-        .unwrap_or_else(|| Literal::Object(vec![]));
+    let retain = extractor.retain_transform_facts;
+    let retention = if retain {
+        ProjectionRetention::Retain
+    } else {
+        ProjectionRetention::Discard
+    };
+    let (data, style) = project_style(style, retention);
+    let data = data.unwrap_or_else(|| Literal::Object(vec![]));
     let data_empty = matches!(&data, Literal::Object(entries) if entries.is_empty());
     if data_empty && !resolved.emit_empty {
         return None;
     }
 
     let kind = crate::jsx::jsx_kind(&ctx.config.matchers, &resolved.name, &resolved.alias);
-    let retain = extractor.retain_transform_facts;
     Some(ExtractedJsx {
         category: resolved.category,
         kind,
@@ -166,7 +169,7 @@ pub(crate) fn extract_call(
         closing_span: None,
         attributes: Vec::new(),
         panda_owned: resolved.panda_owned,
-        style: if retain { style } else { None },
+        style,
         source: if retain {
             crate::JsxSourceFacts {
                 kind: crate::JsxSourceKind::RuntimeCall,

--- a/crates/pandacss_extractor/src/style_tree.rs
+++ b/crates/pandacss_extractor/src/style_tree.rs
@@ -95,6 +95,49 @@ impl StyleSpread {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum ProjectionRetention {
+    Retain,
+    Discard,
+}
+
+/// Project one optional style tree and retain it only when transform needs it.
+#[must_use]
+pub(crate) fn project_style(
+    tree: Option<StyleTree>,
+    retention: ProjectionRetention,
+) -> (Option<Literal>, Option<StyleTree>) {
+    match retention {
+        ProjectionRetention::Retain => (tree.as_ref().and_then(project_literal), tree),
+        // PERF(port): normal extraction can move owned strings into `Literal`.
+        ProjectionRetention::Discard => (tree.and_then(into_project_literal), None),
+    }
+}
+
+/// Project positional style arguments and retain their trees only for transform.
+#[must_use]
+pub(crate) fn project_style_args(
+    trees: Vec<Option<StyleTree>>,
+    retention: ProjectionRetention,
+) -> (Vec<Option<Literal>>, Vec<Option<StyleTree>>) {
+    match retention {
+        ProjectionRetention::Retain => (
+            trees
+                .iter()
+                .map(|tree| tree.as_ref().and_then(project_literal))
+                .collect(),
+            trees,
+        ),
+        ProjectionRetention::Discard => (
+            trees
+                .into_iter()
+                .map(|tree| tree.and_then(into_project_literal))
+                .collect(),
+            Vec::new(),
+        ),
+    }
+}
+
 /// Project a `StyleTree` to a [`Literal`] with today's encode semantics.
 #[must_use]
 pub fn project_literal(tree: &StyleTree) -> Option<Literal> {
@@ -121,29 +164,83 @@ pub fn project_literal(tree: &StyleTree) -> Option<Literal> {
             consequent,
             alternate,
             ..
-        } => project_ternary_arms(consequent, alternate),
-        StyleTree::Branches(items) => project_branches(items),
-        StyleTree::Object(obj) => project_object(obj),
+        } => finish_ternary(project_literal(consequent), project_literal(alternate)),
+        StyleTree::Branches(items) => {
+            finish_branches(items.len(), items.iter().map(project_literal))
+        }
+        StyleTree::Object(obj) => finish_object(
+            obj.entries.len(),
+            ObjectInput::from_lengths(obj.entries.len(), obj.spreads.len()),
+            obj.entries
+                .iter()
+                .map(|(key, value)| (key.clone(), project_literal(value))),
+            obj.spreads.iter().map(project_spread),
+        ),
     }
 }
 
-fn project_branches(items: &[StyleTree]) -> Option<Literal> {
-    let mut out = Vec::with_capacity(items.len());
-    for item in items {
-        if let Some(lit) = project_literal(item) {
-            out.push(lit);
+/// Project a `StyleTree` that is no longer needed, reusing its owned strings.
+#[must_use]
+pub(crate) fn into_project_literal(tree: StyleTree) -> Option<Literal> {
+    match tree {
+        StyleTree::String(s) => Some(Literal::String(s)),
+        StyleTree::Number(n) => Some(Literal::Number(n)),
+        StyleTree::Bool(b) => Some(Literal::Bool(b)),
+        StyleTree::Null => Some(Literal::Null),
+        StyleTree::Token { path, value } => Some(Literal::Token { path, value }),
+        StyleTree::Array(items) => Some(Literal::Array(
+            items
+                .into_iter()
+                .map(|item| into_project_literal(item).unwrap_or(Literal::Null))
+                .collect(),
+        )),
+        StyleTree::Open => None,
+        StyleTree::OpenWithFallback(inner) | StyleTree::And { value: inner, .. } => {
+            into_project_literal(*inner)
+        }
+        StyleTree::Ternary {
+            consequent,
+            alternate,
+            ..
+        } => finish_ternary(
+            into_project_literal(*consequent),
+            into_project_literal(*alternate),
+        ),
+        StyleTree::Branches(items) => {
+            let capacity = items.len();
+            finish_branches(capacity, items.into_iter().map(into_project_literal))
+        }
+        StyleTree::Object(obj) => {
+            let StyleObject { entries, spreads } = obj;
+            let input = ObjectInput::from_lengths(entries.len(), spreads.len());
+            finish_object(
+                entries.len(),
+                input,
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, into_project_literal(value))),
+                spreads.into_iter().map(into_project_spread),
+            )
         }
     }
-    match out.as_slice() {
-        [] => None,
-        [only] => Some(only.clone()),
-        [first, rest @ ..] if rest.iter().all(|item| item == first) => Some(first.clone()),
+}
+
+fn finish_branches(
+    capacity: usize,
+    projected: impl IntoIterator<Item = Option<Literal>>,
+) -> Option<Literal> {
+    let mut out = Vec::with_capacity(capacity);
+    out.extend(projected.into_iter().flatten());
+    match out.len() {
+        0 => None,
+        1 => out.pop(),
+        _ if out[1..].iter().all(|item| item == &out[0]) => Some(out.swap_remove(0)),
         _ => Some(Literal::Conditional(out)),
     }
 }
 
-fn project_ternary_arms(consequent: &StyleTree, alternate: &StyleTree) -> Option<Literal> {
-    match (project_literal(consequent), project_literal(alternate)) {
+fn finish_ternary(consequent: Option<Literal>, alternate: Option<Literal>) -> Option<Literal> {
+    match (consequent, alternate) {
         (Some(left), Some(right)) if left == right => Some(left),
         (Some(left), Some(right)) => Some(Literal::Conditional(vec![left, right])),
         (Some(only), None) | (None, Some(only)) => Some(only),
@@ -151,70 +248,111 @@ fn project_ternary_arms(consequent: &StyleTree, alternate: &StyleTree) -> Option
     }
 }
 
-fn project_object(obj: &StyleObject) -> Option<Literal> {
-    let mut entries: Vec<(String, Literal)> = Vec::with_capacity(obj.entries.len());
-    for (key, value) in &obj.entries {
-        if let Some(lit) = project_literal(value) {
-            Literal::upsert_object_entry(&mut entries, key.clone(), lit);
+enum ProjectedSpread {
+    Conditional(Option<Literal>, Option<Literal>),
+    Upsert(Option<Literal>),
+    Open,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ObjectInput {
+    Empty,
+    NonEmpty,
+}
+
+impl ObjectInput {
+    const fn from_lengths(entries: usize, spreads: usize) -> Self {
+        if entries == 0 && spreads == 0 {
+            Self::Empty
+        } else {
+            Self::NonEmpty
+        }
+    }
+}
+
+fn project_spread(spread: &StyleSpread) -> ProjectedSpread {
+    match spread {
+        StyleSpread::Ternary {
+            consequent,
+            alternate,
+            ..
+        } => ProjectedSpread::Conditional(project_literal(consequent), project_literal(alternate)),
+        StyleSpread::And { value, .. } | StyleSpread::OpenWithFallback { fallback: value } => {
+            ProjectedSpread::Upsert(project_literal(value))
+        }
+        StyleSpread::Open { .. } => ProjectedSpread::Open,
+    }
+}
+
+fn into_project_spread(spread: StyleSpread) -> ProjectedSpread {
+    match spread {
+        StyleSpread::Ternary {
+            consequent,
+            alternate,
+            ..
+        } => ProjectedSpread::Conditional(
+            into_project_literal(consequent),
+            into_project_literal(alternate),
+        ),
+        StyleSpread::And { value, .. } | StyleSpread::OpenWithFallback { fallback: value } => {
+            ProjectedSpread::Upsert(into_project_literal(value))
+        }
+        StyleSpread::Open { .. } => ProjectedSpread::Open,
+    }
+}
+
+fn finish_object(
+    entry_capacity: usize,
+    input: ObjectInput,
+    source_entries: impl IntoIterator<Item = (String, Option<Literal>)>,
+    spreads: impl IntoIterator<Item = ProjectedSpread>,
+) -> Option<Literal> {
+    let mut projected_any = false;
+    let mut entries = Vec::with_capacity(entry_capacity);
+
+    for (key, projected) in source_entries {
+        if let Some(lit) = projected {
+            projected_any = true;
+            Literal::upsert_object_entry(&mut entries, key, lit);
         }
     }
 
-    let mut spread_conditions: Vec<(String, Literal)> = Vec::new();
-    for spread in &obj.spreads {
+    let mut spread_conditions = Vec::new();
+    for spread in spreads {
         match spread {
-            StyleSpread::Ternary {
-                consequent,
-                alternate,
-                ..
-            } => {
-                for arm in [consequent, alternate] {
-                    if let Some(Literal::Object(inner)) = project_literal(arm) {
-                        for (k, v) in inner {
-                            Literal::combine_object_entry(&mut spread_conditions, k, v);
+            ProjectedSpread::Conditional(consequent, alternate) => {
+                for lit in [consequent, alternate].into_iter().flatten() {
+                    projected_any = true;
+                    if let Literal::Object(inner) = lit {
+                        for (key, value) in inner {
+                            Literal::combine_object_entry(&mut spread_conditions, key, value);
                         }
                     }
                 }
             }
-            StyleSpread::And { value, .. } | StyleSpread::OpenWithFallback { fallback: value } => {
-                // Encode peels `cond && obj` / `unk || obj` to the object and last-wins merges.
-                if let Some(Literal::Object(inner)) = project_literal(value) {
-                    for (k, v) in inner {
-                        Literal::upsert_object_entry(&mut entries, k, v);
+            ProjectedSpread::Upsert(projected) => {
+                if let Some(lit) = projected {
+                    projected_any = true;
+                    if let Literal::Object(inner) = lit {
+                        for (key, value) in inner {
+                            Literal::upsert_object_entry(&mut entries, key, value);
+                        }
                     }
                 }
             }
-            StyleSpread::Open { .. } => {}
+            ProjectedSpread::Open => {}
         }
     }
 
-    for (k, v) in spread_conditions {
-        Literal::combine_object_entry(&mut entries, k, v);
+    for (key, value) in spread_conditions {
+        Literal::combine_object_entry(&mut entries, key, value);
     }
 
-    if entries.is_empty() && (!obj.entries.is_empty() || !obj.spreads.is_empty()) {
-        // Mirror object_to_literal: all-unresolvable non-empty object → drop.
-        if obj
-            .entries
-            .iter()
-            .all(|(_, v)| project_literal(v).is_none())
-            && obj.spreads.iter().all(|s| match s {
-                StyleSpread::Open { .. } => true,
-                StyleSpread::Ternary {
-                    consequent,
-                    alternate,
-                    ..
-                } => project_literal(consequent).is_none() && project_literal(alternate).is_none(),
-                StyleSpread::And { value, .. }
-                | StyleSpread::OpenWithFallback { fallback: value } => {
-                    project_literal(value).is_none()
-                }
-            })
-        {
-            return None;
-        }
+    if entries.is_empty() && input == ObjectInput::NonEmpty && !projected_any {
+        None
+    } else {
+        Some(Literal::Object(entries))
     }
-
-    Some(Literal::Object(entries))
 }
 
 /// Build a `StyleTree` from an Oxc expression (sole folder for style objects).
@@ -813,6 +951,80 @@ mod tests {
             return None;
         };
         expression_to_style_tree(&expr_stmt.expression, None)
+    }
+
+    fn assert_projection_equivalent(tree: StyleTree) {
+        let borrowed = project_literal(&tree);
+        assert_eq!(into_project_literal(tree), borrowed);
+    }
+
+    #[test]
+    fn consuming_projection_matches_borrowed_projection() {
+        for source in [
+            "{ color: 'red', nested: { px: 4 }, values: ['a', unknown, 2] }",
+            "{ color: cond ? 'red' : 'blue' }",
+            "{ ...(cond ? { color: 'red' } : { color: 'blue' }), color: 'green' }",
+            "{ ...(cond && { color: 'red' }), ...unknown, padding: maybe || '4' }",
+            "{ ...(maybe || { margin: '2' }) }",
+        ] {
+            assert_projection_equivalent(fold_style(source).expect("tree"));
+        }
+
+        for tree in [
+            StyleTree::Token {
+                path: "colors.red".into(),
+                value: "#f00".into(),
+            },
+            StyleTree::Branches(vec![
+                StyleTree::String("red".into()),
+                StyleTree::String("blue".into()),
+            ]),
+            StyleTree::Branches(vec![
+                StyleTree::String("red".into()),
+                StyleTree::String("red".into()),
+                StyleTree::Open,
+            ]),
+            StyleTree::Object(StyleObject {
+                entries: Vec::new(),
+                spreads: vec![StyleSpread::And {
+                    test: Span { start: 0, end: 1 },
+                    value: StyleTree::String("red".into()),
+                    overridden: Vec::new(),
+                }],
+            }),
+            StyleTree::Object(StyleObject {
+                entries: Vec::new(),
+                spreads: vec![StyleSpread::Ternary {
+                    test: Span { start: 0, end: 1 },
+                    consequent: StyleTree::String("red".into()),
+                    alternate: StyleTree::Open,
+                    overridden: Vec::new(),
+                }],
+            }),
+            StyleTree::Object(StyleObject {
+                entries: Vec::new(),
+                spreads: vec![StyleSpread::OpenWithFallback {
+                    fallback: StyleTree::String("red".into()),
+                }],
+            }),
+            StyleTree::Object(StyleObject {
+                entries: vec![("color".into(), StyleTree::Open)],
+                spreads: vec![StyleSpread::Open {
+                    span: Span { start: 0, end: 1 },
+                }],
+            }),
+        ] {
+            assert_projection_equivalent(tree);
+        }
+    }
+
+    #[test]
+    fn equal_branches_keep_the_first_representation() {
+        let tree = StyleTree::Branches(vec![StyleTree::Number(-0.0), StyleTree::Number(0.0)]);
+        let Some(Literal::Number(value)) = into_project_literal(tree) else {
+            panic!("expected number");
+        };
+        assert!(value.is_sign_negative());
     }
 
     #[test]

--- a/crates/pandacss_extractor/tests/extract.rs
+++ b/crates/pandacss_extractor/tests/extract.rs
@@ -389,6 +389,47 @@ fn extract_for_transform_resolves_symbols_for_normal_css_files() {
     assert_eq!(result.calls.len(), 1);
 }
 
+#[test]
+fn normal_and_transform_extraction_project_the_same_data() {
+    let source = indoc! {r#"
+        import { css } from "@panda/css"
+        import { Box } from "@panda/jsx"
+
+        const className = css({
+          color: dark ? "white" : "black",
+          values: ["a", unknown, 2],
+          ...(active && { opacity: 1 }),
+        })
+        const element = (
+          <Box
+            {...(dark ? { color: "white" } : { color: "black" })}
+            padding={size || "4"}
+          />
+        )
+    "#};
+    let config = panda_jsx_config();
+    let normal = extract(source, "fixture.tsx", &config);
+    let transform = extract_for_transform(source, "fixture.tsx", &config);
+
+    assert_eq!(normal.diagnostics, transform.diagnostics);
+    assert_eq!(normal.calls.len(), transform.calls.len());
+    assert_eq!(normal.jsx.len(), transform.jsx.len());
+    assert!(
+        normal
+            .calls
+            .iter()
+            .zip(&transform.calls)
+            .all(|(left, right)| left.data == right.data)
+    );
+    assert!(
+        normal
+            .jsx
+            .iter()
+            .zip(&transform.jsx)
+            .all(|(left, right)| left.data == right.data)
+    );
+}
+
 fn factory_options_json(source: &str) -> serde_json::Value {
     let result = extract(source, "factory.tsx", &panda_jsx_config());
     result

--- a/design-notes/style-tree.md
+++ b/design-notes/style-tree.md
@@ -7,8 +7,9 @@ The extractor attaches one `StyleTree` to each style object (`css()`, JSX, or a 
 `StyleTree` and `style_lower` are the only path for conditional rewrites. The legacy `css_conditional` and
 `jsx_conditional` source collectors are gone.
 
-Encoding and NAPI `Literal` `data` both come from [`project_literal`](../crates/pandacss_extractor/src/style_tree.rs).
-The extractor does not run a separate `expression_to_literal` walk over the same AST.
+Encoding and NAPI `Literal` `data` both use the same projection rules. Transform extraction borrows the tree through
+[`project_literal`](../crates/pandacss_extractor/src/style_tree.rs); normal extraction consumes the tree and moves its
+owned strings into `Literal`. The extractor does not run a separate `expression_to_literal` walk over the same AST.
 
 ## Shape
 
@@ -58,6 +59,10 @@ independent atomic classes cannot represent object last-write-wins behavior.
 
 ## `project_literal`
 
+Borrowed and consuming projection use separate ownership-specific walkers over shared reducers for branch collapsing,
+spread merging, and object precedence. This keeps one semantic contract without cloning the transform tree or the normal
+extraction path's owned keys and values.
+
 Maps `StyleTree` to `Option<Literal>` for encoding:
 
 | StyleTree                       | Literal                                         |
@@ -104,19 +109,20 @@ spread-merged keys fall back to `Literal`.
 
 ## Attach points
 
-| Surface                   | StyleTree                        | `data`            |
-| ------------------------- | -------------------------------- | ----------------- |
-| `css()` / pattern args    | `style_args`                     | `project_literal` |
-| JSX style props           | `style`                          | `project_literal` |
-| Vue/Svelte template attrs | `literal_to_style_tree` (static) | object entries    |
+| Surface                   | StyleTree                        | `data`               |
+| ------------------------- | -------------------------------- | -------------------- |
+| `css()` / pattern args    | `style_args`                     | StyleTree projection |
+| JSX style props           | `style`                          | StyleTree projection |
+| Vue/Svelte template attrs | `literal_to_style_tree` (static) | object entries       |
 
 A missing StyleTree on a dynamic conditional is an extraction bug. Do not restore the source collectors.
 
 ## Transform contract (sole path)
 
 1. Extraction builds a `StyleTree` for the style object (`style_args` or `style`).
-2. Extraction sets `data = project_literal(&tree)` from that tree. It does not run a parallel `Literal` fold when
-   attaching a call or JSX node. Leaf folding inside the `StyleTree` folder may still use `expression_to_literal`.
+2. Extraction projects `data` from that tree. Normal extraction consumes the tree; transform extraction borrows it. It
+   does not run a parallel `Literal` fold when attaching a call or JSX node. Leaf folding inside the `StyleTree` folder
+   may still use `expression_to_literal`.
 3. Transform:
    - A tree with rewrite sites uses `lower_style_tree`. `Static` and `Expr` rewrite the site. `Bail` keeps the original
      site instead of rewriting only its static parts.
@@ -130,20 +136,19 @@ while encode uses the right side for `data`. If the right side does not fold, th
 ## Resolved questions
 
 - **Q1 (flipped):** `StyleTree` is the only IR for conditional transforms. The source-parsing collectors are removed.
-- **Q2 (resolved):** Extraction builds one `StyleTree` for each style object, and encoding sets `data` with
-  `project_literal(StyleTree)`. `OpenWithFallback` lets encoding use the right operand of `||` or `??` while transform
-  still bails.
+- **Q2 (resolved):** Extraction builds one `StyleTree` for each style object and projects `data` from it.
+  `OpenWithFallback` lets encoding use the right operand of `||` or `??` while transform still bails.
 - **Q3 (resolved):** Same-file bindings use a StyleTree cache. Array slots and nested bases are first-class in
   `style_lower`.
 - **Q4 (resolved):** Cross-file conditionals use `Branches`: encode every arm and do not rewrite foreign conditions.
-  Call `data` comes only from `project_literal(style_args)`, with no `Literal` fallback at attachment.
+  Call `data` comes only from StyleTree projection, with no `Literal` fallback at attachment.
 
 ## Extending StyleTree
 
 1. Attach `StyleTree` during extraction. Do not parse the source again during transform.
 2. Handle identifiers, `.raw`, and members in the folder and resolver, not in a project-specific path.
 3. When adding a path or site kind, update `PathSeg`, `Site`, `collect_*`, and `apply_branch` together.
-4. Keep encoding in `project_literal`.
+4. Keep encoding in the shared StyleTree projection reducers.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Normal extraction currently builds a `StyleTree`, clones its keys and values into `Literal`, then discards the tree.

This change consumes the tree when transform facts are not needed, allowing owned strings to move into `Literal`. Transform extraction keeps the existing borrowed projection because it retains the tree for source rewriting.

Both paths use the same reducers for branch collapsing, spread merging, and object precedence.

## Performance

Release benchmark with 2,000 generated JSX elements, alternating 10 runs with 1,000 measured iterations per run:

- Median: 1.029 ms → 0.970 ms
- Improvement: 5.7%

Applied locally on top of #3799:

- Median: 0.835 ms → 0.774 ms
- Improvement: 7.2%

The extracted checksum and diagnostics were unchanged.

## Scope

This does not change the public API or CSS output. A projection-aware compiler IR that avoids constructing `StyleTree` during normal extraction is intentionally left for separate design work.

## Verification

- `cargo nextest run -p pandacss_extractor --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- Native compiler release build
- Compiler Vitest: 616 tests passed
- Borrowed and consuming projection parity across every `StyleTree` variant
- Public normal and transform extraction parity


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61845937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/panda/3801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete behavioral, security, or repository-rule failures identified.

<details><summary><h3>Summary</h3></summary>

- Adds retention-aware projection helpers for individual trees and positional style arguments.
- Routes CSS calls, classic JSX, and React runtime JSX through consuming or borrowed projection according to extraction mode.
- Shares reducers for branch collapsing, spread merging, and object precedence across both projection walkers.
- Adds projection parity tests, extraction parity coverage, a changeset, and updated design documentation.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build StyleTree] --> B{Transform facts needed?}
    B -->|Yes| C[Borrow with project_literal]
    C --> D[Literal data]
    C --> E[Retained StyleTree for rewriting]
    B -->|No| F[Consume with into_project_literal]
    F --> G[Literal data reusing owned strings]
    C --> H[Shared projection reducers]
    F --> H
    H --> I[Branch collapse, spread merge, object precedence]
```
</details>

<!-- /greptile_comment -->