### PR TITLE
perf(extractor): reuse cross-file analysis across batches

### DIFF
--- a/.changeset/reuse-cross-file-analysis.md
+++ b/.changeset/reuse-cross-file-analysis.md
@@ -1,0 +1,6 @@
+---
+'@pandacss/compiler': patch
+'@pandacss/compiler-wasm': patch
+---
+
+Reuse cross-file analysis across `parseFiles()` batches so shared imported values are read and folded once per batch.

--- a/crates/pandacss_extractor/src/calls.rs
+++ b/crates/pandacss_extractor/src/calls.rs
@@ -115,16 +115,20 @@ pub fn extract_calls(
         .with_options(crate::adapter::parse_options_for(format))
         .parse();
 
+    let cross_file = config
+        .cross_file
+        .as_ref()
+        .map(crate::CrossFileResolver::session);
+    let cross_file_context = cross_file
+        .as_ref()
+        .map(crate::cross_file::CrossFileContext::new);
     let resolver = crate::Resolver::build(crate::scope::ResolverBuildInput {
         program: &parser_return.program,
         matched,
         matchers: Some(&config.matchers),
         tokens: config.token_dictionary.as_deref(),
         prefix: config.class_name_prefix.as_str(),
-        cross_file: config
-            .cross_file
-            .as_ref()
-            .map(crate::CrossFileResolver::as_lookup),
+        cross_file: cross_file_context.as_ref(),
         source_path: Some(std::path::PathBuf::from(path)),
         line_index: None,
         pattern_raw_transform: None,

--- a/crates/pandacss_extractor/src/cross_file.rs
+++ b/crates/pandacss_extractor/src/cross_file.rs
@@ -12,8 +12,9 @@
 //! Folds top-level `export const X = <foldable>` and simple pure function
 //! exports into an owned descriptor.
 
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -85,13 +86,49 @@ fn default_resolve_options() -> ResolveOptions {
 
 /// Type-erased over `F: FileSystem` so `ExtractorConfig` stays non-generic.
 pub struct CrossFileResolver {
-    inner: Box<dyn CrossFileLookup>,
+    inner: Arc<dyn CrossFileLookup>,
+}
+
+/// One consistent view of imported modules across a batch of extractions.
+///
+/// The first lookup validates a module against the filesystem. Later lookups
+/// reuse that immutable analyzed export set, including when another resolver
+/// session refreshes the shared cache concurrently.
+pub struct CrossFileSession {
+    inner: Arc<dyn CrossFileLookup>,
+    files: RefCell<FxHashMap<PathBuf, Arc<CachedFileExports>>>,
+    unreadable: RefCell<FxHashSet<PathBuf>>,
+    unresolved: RefCell<FxHashMap<PathBuf, FxHashSet<String>>>,
+}
+
+/// Per-extraction recursion state over a shared analyzed-module session.
+pub(crate) struct CrossFileContext<'a> {
+    session: &'a CrossFileSession,
+    in_flight: RefCell<FxHashSet<(PathBuf, String)>>,
 }
 
 impl std::fmt::Debug for CrossFileResolver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CrossFileResolver")
             .field("cached_files", &self.inner.cache_len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for CrossFileSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CrossFileSession")
+            .field("analyzed_files", &self.files.borrow().len())
+            .field("unreadable_files", &self.unreadable.borrow().len())
+            .field(
+                "unresolved_imports",
+                &self
+                    .unresolved
+                    .borrow()
+                    .values()
+                    .map(FxHashSet::len)
+                    .sum::<usize>(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -120,12 +157,19 @@ impl CrossFileResolver {
         options: ResolveOptions,
     ) -> Self {
         Self {
-            inner: Box::new(ResolverImpl::new(fs, options)),
+            inner: Arc::new(ResolverImpl::new(fs, options)),
         }
     }
 
-    pub(crate) fn as_lookup(&self) -> &dyn CrossFileLookup {
-        self.inner.as_ref()
+    /// Start a consistent cross-file analysis batch.
+    #[must_use]
+    pub fn session(&self) -> CrossFileSession {
+        CrossFileSession {
+            inner: Arc::clone(&self.inner),
+            files: RefCell::default(),
+            unreadable: RefCell::default(),
+            unresolved: RefCell::default(),
+        }
     }
 
     #[must_use]
@@ -149,6 +193,94 @@ impl CrossFileResolver {
     pub fn clear_resolution_cache(&self) {
         self.inner.clear_resolution_cache();
     }
+}
+
+impl CrossFileSession {
+    fn cached_resolution(&self, path: &Path, name: &str) -> Option<CrossFileResolution> {
+        let files = self.files.borrow();
+        let cached = files.get(path)?;
+        Some(CrossFileResolution::from_cached(
+            path.to_path_buf(),
+            cached,
+            name,
+        ))
+    }
+
+    fn insert(&self, path: PathBuf, cached: Arc<CachedFileExports>) {
+        self.files.borrow_mut().insert(path, cached);
+    }
+
+    fn extend(&self, entries: impl IntoIterator<Item = (PathBuf, Arc<CachedFileExports>)>) {
+        self.files.borrow_mut().extend(entries);
+    }
+
+    fn is_unreadable(&self, path: &Path) -> bool {
+        self.unreadable.borrow().contains(path)
+    }
+
+    fn record_unreadable(&self, path: PathBuf) {
+        self.unreadable.borrow_mut().insert(path);
+    }
+
+    fn is_unresolved(&self, directory: &Path, specifier: &str) -> bool {
+        self.unresolved
+            .borrow()
+            .get(directory)
+            .is_some_and(|specifiers| specifiers.contains(specifier))
+    }
+
+    fn record_unresolved(&self, directory: &Path, specifier: &str) {
+        self.unresolved
+            .borrow_mut()
+            .entry(directory.to_path_buf())
+            .or_default()
+            .insert(specifier.to_owned());
+    }
+
+    #[must_use]
+    pub(crate) fn resolve_path(&self, from_file: &Path, specifier: &str) -> Option<PathBuf> {
+        self.inner.resolve_path(from_file, specifier)
+    }
+}
+
+impl<'a> CrossFileContext<'a> {
+    pub(crate) fn new(session: &'a CrossFileSession) -> Self {
+        Self {
+            session,
+            in_flight: RefCell::default(),
+        }
+    }
+
+    pub(crate) fn resolve_named_export(
+        &self,
+        from_file: &Path,
+        specifier: &str,
+        name: &str,
+        matchers: Option<&Matchers>,
+        tokens: Option<&TokenDictionary>,
+        prefix: &str,
+    ) -> CrossFileResolution {
+        self.session.inner.resolve_named_export(
+            self,
+            CrossFileRequest {
+                from_file,
+                specifier,
+                name,
+                matchers,
+                tokens,
+                prefix,
+            },
+        )
+    }
+}
+
+pub(crate) struct CrossFileRequest<'a> {
+    from_file: &'a Path,
+    specifier: &'a str,
+    name: &'a str,
+    matchers: Option<&'a Matchers>,
+    tokens: Option<&'a TokenDictionary>,
+    prefix: &'a str,
 }
 
 /// Folded export plus resolved path. `path` is a build dep even when the export does not fold.
@@ -200,17 +332,23 @@ impl CrossFileResolution {
         self.unresolved = unresolved;
         self
     }
+
+    fn from_cached(path: PathBuf, cached: &CachedFileExports, name: &str) -> Self {
+        Self::at_path(
+            path,
+            Some(cached.source_hash),
+            cached.exports.get(name).cloned(),
+            cached.deps.clone(),
+        )
+        .with_unresolved(cached.unresolved.clone())
+    }
 }
 
 pub(crate) trait CrossFileLookup: Send + Sync {
     fn resolve_named_export(
         &self,
-        from_file: &Path,
-        specifier: &str,
-        name: &str,
-        matchers: Option<&Matchers>,
-        tokens: Option<&TokenDictionary>,
-        prefix: &str,
+        context: &CrossFileContext<'_>,
+        request: CrossFileRequest<'_>,
     ) -> CrossFileResolution;
 
     fn resolve_path(&self, from_file: &Path, specifier: &str) -> Option<PathBuf>;
@@ -227,8 +365,7 @@ pub(crate) trait CrossFileLookup: Send + Sync {
 struct ResolverImpl<F: FileSystem + Clone> {
     inner: ResolverGeneric<F>,
     fs: F,
-    cache: Mutex<FxHashMap<PathBuf, CachedFileExports>>,
-    in_flight: Mutex<FxHashSet<(PathBuf, String)>>,
+    cache: Mutex<FxHashMap<PathBuf, Arc<CachedFileExports>>>,
 }
 
 impl<F: FileSystem + Clone> ResolverImpl<F> {
@@ -238,12 +375,11 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
             inner,
             fs,
             cache: Mutex::default(),
-            in_flight: Mutex::default(),
         }
     }
 
     fn extract_exports(
-        &self,
+        context: &CrossFileContext<'_>,
         path: &Path,
         source: &str,
         matchers: Option<&Matchers>,
@@ -263,7 +399,7 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
             matchers,
             tokens,
             prefix,
-            cross_file: Some(self),
+            cross_file: Some(context),
             source_path: Some(path.to_path_buf()),
             line_index: None,
             pattern_raw_transform: None,
@@ -271,7 +407,7 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
         });
 
         // Oxc recovers a partial AST on parse errors. Walk what we get.
-        let exports = collect_exports(&parser_return.program, path, self, &resolver, &matched);
+        let exports = collect_exports(&parser_return.program, path, context, &resolver, &matched);
         let deps = resolver
             .take_cross_file_deps()
             .into_iter()
@@ -293,6 +429,19 @@ impl<F: FileSystem + Clone> ResolverImpl<F> {
                 .map(|source| pandacss_shared::fx_hash(&source))
                 == *expected
         })
+    }
+
+    fn seed_session_dependencies(
+        &self,
+        session: &CrossFileSession,
+        deps: &[(PathBuf, Option<u64>)],
+    ) {
+        let cache = self.cache.lock().expect("cross-file cache poisoned");
+        let entries = deps.iter().filter_map(|(path, expected)| {
+            let cached = cache.get(path)?;
+            (Some(cached.source_hash) == *expected).then(|| (path.clone(), Arc::clone(cached)))
+        });
+        session.extend(entries);
     }
 
     fn unresolved_still_missing(&self, deps: &UnresolvedDependencies) -> bool {
@@ -351,20 +500,36 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
 
     fn resolve_named_export(
         &self,
-        from_file: &Path,
-        specifier: &str,
-        name: &str,
-        matchers: Option<&Matchers>,
-        tokens: Option<&TokenDictionary>,
-        prefix: &str,
+        context: &CrossFileContext<'_>,
+        request: CrossFileRequest<'_>,
     ) -> CrossFileResolution {
+        let CrossFileRequest {
+            from_file,
+            specifier,
+            name,
+            matchers,
+            tokens,
+            prefix,
+        } = request;
+        let session = context.session;
         let Some(directory) = from_file.parent() else {
             return CrossFileResolution::none();
         };
+        if session.is_unresolved(directory, specifier) {
+            return CrossFileResolution::unresolved(from_file, specifier);
+        }
         let Ok(resolution) = self.inner.resolve(directory, specifier) else {
+            session.record_unresolved(directory, specifier);
             return CrossFileResolution::unresolved(from_file, specifier);
         };
         let path = to_forward_slash(&resolution.full_path());
+
+        if let Some(resolution) = session.cached_resolution(&path, name) {
+            return resolution;
+        }
+        if session.is_unreadable(&path) {
+            return CrossFileResolution::at_path(path, None, None, Vec::new());
+        }
 
         // Read-fail drops the entry so a deleted file never serves stale exports.
         let Ok(source) = <F as oxc_resolver::FileSystem>::read_to_string(&self.fs, &path) else {
@@ -372,6 +537,7 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
                 .lock()
                 .expect("cross-file cache poisoned")
                 .remove(&path);
+            session.record_unreadable(path.clone());
             return CrossFileResolution::at_path(path, None, None, Vec::new());
         };
         let source_hash = pandacss_shared::fx_hash(&source);
@@ -379,56 +545,47 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
         // Record `path` on every remaining exit. Resolved modules are deps even when they don't fold.
         let cached = {
             let guard = self.cache.lock().expect("cross-file cache poisoned");
-            guard.get(&path).and_then(|cached| {
-                if cached.source_hash != source_hash {
-                    return None;
-                }
-                Some((
-                    cached.exports.get(name).cloned(),
-                    cached.deps.clone(),
-                    cached.unresolved.clone(),
-                ))
-            })
+            guard
+                .get(&path)
+                .filter(|cached| cached.source_hash == source_hash)
+                .map(Arc::clone)
         };
-        if let Some((entry, deps, unresolved)) = cached
-            && self.provenance_fresh(&deps)
-            && self.unresolved_still_missing(&unresolved)
+        if let Some(cached) = cached
+            && self.provenance_fresh(&cached.deps)
+            && self.unresolved_still_missing(&cached.unresolved)
         {
-            return CrossFileResolution::at_path(path, Some(source_hash), entry, deps)
-                .with_unresolved(unresolved);
+            self.seed_session_dependencies(session, &cached.deps);
+            let result = CrossFileResolution::from_cached(path.clone(), &cached, name);
+            session.insert(path, cached);
+            return result;
         }
 
         // Cycle guard: `a.ts ↔ b.ts` would otherwise overflow the stack.
         let guard_key = (path.clone(), name.to_owned());
         {
-            let mut in_flight = self.in_flight.lock().expect("cross-file guard poisoned");
+            let mut in_flight = context.in_flight.borrow_mut();
             if !in_flight.insert(guard_key.clone()) {
                 return CrossFileResolution::at_path(path, Some(source_hash), None, Vec::new());
             }
         }
 
         let (exports, deps, unresolved) =
-            self.extract_exports(&path, &source, matchers, tokens, prefix);
-        self.in_flight
-            .lock()
-            .expect("cross-file guard poisoned")
-            .remove(&guard_key);
+            Self::extract_exports(context, &path, &source, matchers, tokens, prefix);
+        context.in_flight.borrow_mut().remove(&guard_key);
 
-        let entry = exports.get(name).cloned();
+        let cached = Arc::new(CachedFileExports {
+            source_hash,
+            exports,
+            deps,
+            unresolved,
+        });
+        let result = CrossFileResolution::from_cached(path.clone(), &cached, name);
         self.cache
             .lock()
             .expect("cross-file cache poisoned")
-            .insert(
-                path.clone(),
-                CachedFileExports {
-                    source_hash,
-                    exports,
-                    deps: deps.clone(),
-                    unresolved: unresolved.clone(),
-                },
-            );
-        CrossFileResolution::at_path(path, Some(source_hash), entry, deps)
-            .with_unresolved(unresolved)
+            .insert(path.clone(), Arc::clone(&cached));
+        session.insert(path, cached);
+        result
     }
 
     fn cache_len(&self) -> usize {
@@ -439,7 +596,7 @@ impl<F: FileSystem + Clone> CrossFileLookup for ResolverImpl<F> {
 fn collect_exports(
     program: &Program<'_>,
     path: &Path,
-    lookup: &dyn CrossFileLookup,
+    context: &CrossFileContext<'_>,
     resolver: &Resolver<'_, '_>,
     matched: &[MatchedImport],
 ) -> FileExports {
@@ -449,7 +606,7 @@ fn collect_exports(
         let Statement::ExportNamedDeclaration(decl) = stmt else {
             continue;
         };
-        collect_from_named(decl, path, lookup, resolver, matched, &mut exports);
+        collect_from_named(decl, path, context, resolver, matched, &mut exports);
     }
 
     exports
@@ -487,7 +644,7 @@ fn exported_recipe(
 fn collect_from_named(
     decl: &ExportNamedDeclaration<'_>,
     path: &Path,
-    lookup: &dyn CrossFileLookup,
+    context: &CrossFileContext<'_>,
     resolver: &Resolver<'_, '_>,
     matched: &[MatchedImport],
     out: &mut FileExports,
@@ -510,7 +667,7 @@ fn collect_from_named(
         let exported = module_export_name(&specifier.exported);
         let local = module_export_name(&specifier.local);
         let entry = if let Some(source) = &decl.source {
-            let resolution = lookup.resolve_named_export(
+            let resolution = context.resolve_named_export(
                 path,
                 source.value.as_str(),
                 &local,

--- a/crates/pandacss_extractor/src/extract.rs
+++ b/crates/pandacss_extractor/src/extract.rs
@@ -13,8 +13,8 @@ use crate::scope::{
 };
 use crate::source_refs::StyleSourceRef;
 use crate::{
-    Diagnostic, ExportInfo, ExtractedCall, ExtractedJsx, ExtractorConfig, ImportRecord, Literal,
-    MatchCategory, MatchedImport, Span, VisitorContext, collect_imports,
+    CrossFileSession, Diagnostic, ExportInfo, ExtractedCall, ExtractedJsx, ExtractorConfig,
+    ImportRecord, Literal, MatchCategory, MatchedImport, Span, VisitorContext, collect_imports,
     collect_parser_diagnostics, match_import_records_resolved,
 };
 use oxc_allocator::Allocator;
@@ -173,7 +173,39 @@ pub fn extract(source: &str, path: &str, config: &ExtractorConfig) -> ExtractUsa
     let _span =
         tracing::trace_span!(target: "extract", "extract", path = path, source_len = source.len())
             .entered();
-    let outcome = run_extract(source, path, config, None, None, false, false);
+    let session = cross_file_session(config);
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        RunExtractOptions {
+            cross_file: session.as_ref(),
+            ..RunExtractOptions::default()
+        },
+    );
+    extract_usage(outcome)
+}
+
+/// Extract within an existing cross-file analysis session.
+///
+/// Reusing a session across project files validates each imported module once
+/// and gives every file a consistent view of its analyzed exports.
+#[must_use]
+pub fn extract_in_session(
+    source: &str,
+    path: &str,
+    config: &ExtractorConfig,
+    session: &CrossFileSession,
+) -> ExtractUsage {
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        RunExtractOptions {
+            cross_file: Some(session),
+            ..RunExtractOptions::default()
+        },
+    );
     extract_usage(outcome)
 }
 
@@ -187,7 +219,17 @@ pub fn extract_for_transform(source: &str, path: &str, config: &ExtractorConfig)
         source_len = source.len()
     )
     .entered();
-    let outcome = run_extract(source, path, config, None, None, false, true);
+    let session = cross_file_session(config);
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        RunExtractOptions {
+            cross_file: session.as_ref(),
+            retain_transform_facts: true,
+            ..RunExtractOptions::default()
+        },
+    );
     extract_usage(outcome)
 }
 
@@ -211,7 +253,18 @@ where
     .entered();
     let erased: &mut RecipeRawResolveFn<'_> = recipe_resolve;
     let cell: RecipeRawResolveCell<'_> = RefCell::new(erased);
-    let outcome = run_extract(source, path, config, None, Some(&cell), false, true);
+    let session = cross_file_session(config);
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        RunExtractOptions {
+            cross_file: session.as_ref(),
+            recipe_raw_resolve: Some(&cell),
+            retain_transform_facts: true,
+            ..RunExtractOptions::default()
+        },
+    );
     extract_usage(outcome)
 }
 
@@ -243,6 +296,30 @@ where
     P: FnMut(&str, &Literal) -> Result<Option<Literal>, Diagnostic>,
     R: FnMut(&str, &Literal, &Literal) -> Option<Literal>,
 {
+    let session = cross_file_session(config);
+    extract_with_raw_resolvers_in_session(
+        source,
+        path,
+        config,
+        session.as_ref(),
+        pattern_transform,
+        recipe_resolve,
+    )
+}
+
+/// [`extract_with_raw_resolvers`] within a shared cross-file analysis session.
+pub fn extract_with_raw_resolvers_in_session<P, R>(
+    source: &str,
+    path: &str,
+    config: &ExtractorConfig,
+    session: Option<&CrossFileSession>,
+    pattern_transform: Option<&mut P>,
+    recipe_resolve: &mut R,
+) -> ExtractUsage
+where
+    P: FnMut(&str, &Literal) -> Result<Option<Literal>, Diagnostic>,
+    R: FnMut(&str, &Literal, &Literal) -> Option<Literal>,
+{
     let has_pattern_transform = pattern_transform.is_some();
     let _span = tracing::trace_span!(
         target: "extract",
@@ -262,10 +339,12 @@ where
         source,
         path,
         config,
-        pattern_cell.as_ref(),
-        Some(&recipe_cell),
-        false,
-        false,
+        RunExtractOptions {
+            cross_file: session,
+            pattern_raw_transform: pattern_cell.as_ref(),
+            recipe_raw_resolve: Some(&recipe_cell),
+            ..RunExtractOptions::default()
+        },
     );
     extract_usage(outcome)
 }
@@ -274,7 +353,17 @@ where
 pub fn extract_debug(source: &str, path: &str, config: &ExtractorConfig) -> ExtractDebugResult {
     let _span = tracing::trace_span!(target: "extract", "extract_debug", path = path, source_len = source.len())
         .entered();
-    let outcome = run_extract(source, path, config, None, None, false, true);
+    let session = cross_file_session(config);
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        RunExtractOptions {
+            cross_file: session.as_ref(),
+            retain_transform_facts: true,
+            ..RunExtractOptions::default()
+        },
+    );
     ExtractDebugResult {
         imports: outcome.module.imports,
         matched: outcome.matched,
@@ -293,7 +382,17 @@ pub fn extract_verbose(source: &str, path: &str, config: &ExtractorConfig) -> Ex
         source_len = source.len()
     )
     .entered();
-    let outcome = run_extract(source, path, config, None, None, true, false);
+    let session = cross_file_session(config);
+    let outcome = run_extract(
+        source,
+        path,
+        config,
+        RunExtractOptions {
+            cross_file: session.as_ref(),
+            verbose: true,
+            ..RunExtractOptions::default()
+        },
+    );
     ExtractVerboseResult {
         calls: outcome.calls,
         jsx: outcome.jsx,
@@ -324,30 +423,55 @@ fn match_file_imports(
     config: &ExtractorConfig,
     path: &str,
     imports: &[ImportRecord],
+    session: Option<&CrossFileSession>,
 ) -> Vec<MatchedImport> {
     let file_path = std::path::Path::new(path);
     match_import_records_resolved(imports, &config.matchers, |specifier| {
-        config
-            .cross_file
-            .as_ref()
-            .and_then(|resolver| resolver.resolve_path(file_path, specifier))
+        session
+            .and_then(|session| session.resolve_path(file_path, specifier))
+            .or_else(|| {
+                config
+                    .cross_file
+                    .as_ref()
+                    .and_then(|resolver| resolver.resolve_path(file_path, specifier))
+            })
             .map(|resolved| resolved.to_string_lossy().into_owned())
     })
+}
+
+fn cross_file_session(config: &ExtractorConfig) -> Option<CrossFileSession> {
+    config
+        .cross_file
+        .as_ref()
+        .map(crate::CrossFileResolver::session)
+}
+
+#[derive(Clone, Copy, Default)]
+struct RunExtractOptions<'session, 'callback> {
+    cross_file: Option<&'session CrossFileSession>,
+    pattern_raw_transform: Option<&'callback PatternRawTransformCell<'callback>>,
+    recipe_raw_resolve: Option<&'callback RecipeRawResolveCell<'callback>>,
+    verbose: bool,
+    retain_transform_facts: bool,
 }
 
 #[allow(
     clippy::too_many_lines,
     reason = "single-parse pipeline stays readable as one ordered function; splitting would scatter the per-stage span+record pairs across helpers"
 )]
-fn run_extract<'cb>(
+fn run_extract(
     source: &str,
     path: &str,
     config: &ExtractorConfig,
-    pattern_raw_transform: Option<&'cb PatternRawTransformCell<'cb>>,
-    recipe_raw_resolve: Option<&'cb RecipeRawResolveCell<'cb>>,
-    verbose: bool,
-    retain_transform_facts: bool,
+    options: RunExtractOptions<'_, '_>,
 ) -> ExtractResult {
+    let RunExtractOptions {
+        cross_file,
+        pattern_raw_transform,
+        recipe_raw_resolve,
+        verbose,
+        retain_transform_facts,
+    } = options;
     let allocator = Allocator::default();
     let raw_source = source;
     let format = crate::adapter::SfcFormat::from_path(path);
@@ -372,7 +496,7 @@ fn run_extract<'cb>(
     let matched = {
         let span = tracing::trace_span!(target: "extract", "match_imports", matched_count = tracing::field::Empty);
         let _entered = span.enter();
-        let matched = match_file_imports(config, path, &imports);
+        let matched = match_file_imports(config, path, &imports, cross_file);
         span.record("matched_count", matched.len());
         matched
     };
@@ -426,6 +550,7 @@ fn run_extract<'cb>(
     }
 
     let line_index = crate::LineIndex::new(source);
+    let cross_file_context = cross_file.map(crate::cross_file::CrossFileContext::new);
     let resolver = {
         let _span = tracing::trace_span!(target: "parse", "resolve_scopes", path = path).entered();
         Resolver::build(crate::scope::ResolverBuildInput {
@@ -434,10 +559,7 @@ fn run_extract<'cb>(
             matchers: Some(&config.matchers),
             tokens: config.token_dictionary.as_deref(),
             prefix: config.class_name_prefix.as_str(),
-            cross_file: config
-                .cross_file
-                .as_ref()
-                .map(crate::CrossFileResolver::as_lookup),
+            cross_file: cross_file_context.as_ref(),
             source_path: Some(std::path::PathBuf::from(path)),
             line_index: Some(&line_index),
             pattern_raw_transform,

--- a/crates/pandacss_extractor/src/jsx.rs
+++ b/crates/pandacss_extractor/src/jsx.rs
@@ -153,16 +153,20 @@ pub fn extract_jsx(
         .with_options(crate::adapter::parse_options_for(format))
         .parse();
 
+    let cross_file = config
+        .cross_file
+        .as_ref()
+        .map(crate::CrossFileResolver::session);
+    let cross_file_context = cross_file
+        .as_ref()
+        .map(crate::cross_file::CrossFileContext::new);
     let resolver = crate::Resolver::build(crate::scope::ResolverBuildInput {
         program: &parser_return.program,
         matched,
         matchers: Some(&config.matchers),
         tokens: config.token_dictionary.as_deref(),
         prefix: config.class_name_prefix.as_str(),
-        cross_file: config
-            .cross_file
-            .as_ref()
-            .map(crate::CrossFileResolver::as_lookup),
+        cross_file: cross_file_context.as_ref(),
         source_path: Some(std::path::PathBuf::from(path)),
         line_index: None,
         pattern_raw_transform: None,

--- a/crates/pandacss_extractor/src/lib.rs
+++ b/crates/pandacss_extractor/src/lib.rs
@@ -43,7 +43,8 @@ pub use extract::{
     CrossFileDependency, ExtractDebugResult, ExtractUsage, ExtractVerboseResult,
     ImportBindingFacts, ImportedRecipeRawCall, ModuleFacts, TokenRef,
     UnresolvedCrossFileDependency, analyze_module, extract, extract_debug, extract_for_transform,
-    extract_for_transform_with_recipe_resolver, extract_verbose, extract_with_raw_resolvers,
+    extract_for_transform_with_recipe_resolver, extract_in_session, extract_verbose,
+    extract_with_raw_resolvers, extract_with_raw_resolvers_in_session,
 };
 pub use imports::{
     ImportKind, ImportRecord, ImportScanResult, ImportSpecifier, ImportSpecifierKind,
@@ -52,7 +53,7 @@ pub use imports::{
 pub use local_bindings::{LocalBindingCall, LocalCallBinding, LocalDeclarationKind};
 // Internal helpers that take Oxc-shaped inputs — kept out of the public
 // surface so consumers don't accidentally couple to oxc_ast / oxc_diagnostics.
-pub use cross_file::CrossFileResolver;
+pub use cross_file::{CrossFileResolver, CrossFileSession};
 pub(crate) use export_names::collect_export_info;
 pub use export_names::{ExportInfo, ReExport};
 pub use fragment::{

--- a/crates/pandacss_extractor/src/scope.rs
+++ b/crates/pandacss_extractor/src/scope.rs
@@ -23,7 +23,7 @@ use pandacss_tokens::{TokenCategory, TokenDictionary};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
-use crate::cross_file::{CrossFileLookup, ExportEntry};
+use crate::cross_file::{CrossFileContext, ExportEntry};
 use crate::extract::{CrossFileDependency, UnresolvedCrossFileDependency};
 use crate::literal::expression_to_literal;
 use crate::matcher::{MatchCategory, MatchedImport, Matchers};
@@ -67,7 +67,7 @@ pub(crate) struct Resolver<'a, 'cb> {
     /// Config class-name prefix used to build `positionTry(...)` dashed-idents
     /// byte-identically to the emitter/transform. Empty for no prefix.
     prefix: &'a str,
-    cross_file: Option<&'a dyn CrossFileLookup>,
+    cross_file: Option<&'a CrossFileContext<'a>>,
     source_path: Option<PathBuf>,
     line_index: Option<&'a crate::LineIndex<'a>>,
     diagnostics: RefCell<Vec<crate::Diagnostic>>,
@@ -121,7 +121,7 @@ pub(crate) struct ResolverBuildInput<'a, 'cb> {
     pub matchers: Option<&'a Matchers>,
     pub tokens: Option<&'a TokenDictionary>,
     pub prefix: &'a str,
-    pub cross_file: Option<&'a dyn CrossFileLookup>,
+    pub cross_file: Option<&'a CrossFileContext<'a>>,
     pub source_path: Option<PathBuf>,
     pub line_index: Option<&'a crate::LineIndex<'a>>,
     pub pattern_raw_transform: Option<&'cb PatternRawTransformCell<'cb>>,
@@ -177,6 +177,10 @@ impl<'a, 'cb> Resolver<'a, 'cb> {
 
     pub(crate) fn take_diagnostics(&self) -> Vec<crate::Diagnostic> {
         std::mem::take(&mut self.diagnostics.borrow_mut())
+    }
+
+    pub(crate) fn cross_file_context(&self) -> Option<&CrossFileContext<'a>> {
+        self.cross_file
     }
 
     /// Token paths resolved from `token()` / `token.var()` calls, with spans.

--- a/crates/pandacss_extractor/src/template_styles.rs
+++ b/crates/pandacss_extractor/src/template_styles.rs
@@ -71,6 +71,7 @@ pub(crate) fn collect_template_styles(
         path,
         matched,
         config,
+        cross_file: resolver.cross_file_context(),
         literals: literal_index.literals,
         retain_transform_facts,
     };
@@ -144,6 +145,7 @@ struct TemplateContext<'a> {
     path: &'a str,
     matched: &'a [MatchedImport],
     config: &'a ExtractorConfig,
+    cross_file: Option<&'a crate::cross_file::CrossFileContext<'a>>,
     literals: FxHashMap<(u32, u32), Literal>,
     retain_transform_facts: bool,
 }
@@ -622,11 +624,7 @@ fn parse_expression_literal(
             matchers: Some(&context.config.matchers),
             tokens: context.config.token_dictionary.as_deref(),
             prefix: context.config.class_name_prefix.as_str(),
-            cross_file: context
-                .config
-                .cross_file
-                .as_ref()
-                .map(crate::CrossFileResolver::as_lookup),
+            cross_file: context.cross_file,
             source_path: Some(std::path::PathBuf::from(context.path)),
             line_index: None,
             pattern_raw_transform: None,

--- a/crates/pandacss_extractor/tests/cross_file.rs
+++ b/crates/pandacss_extractor/tests/cross_file.rs
@@ -4,12 +4,119 @@
 //! Fixtures use [`pandacss_fs::MemoryFileSystem`] so the resolver and our
 //! extractor share an in-memory tree — no tempdir, no disk I/O.
 
+use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::common::{matcher, panda_config};
 use insta::assert_yaml_snapshot;
-use pandacss_extractor::{CrossFileResolver, ExtractUsage, ExtractorConfig, Matchers, extract};
-use pandacss_fs::MemoryFileSystem;
+use oxc_resolver::{FileMetadata, FileSystem as OxcFileSystem, ResolveError};
+use pandacss_extractor::{
+    CrossFileResolver, ExtractUsage, ExtractorConfig, Matchers, extract, extract_in_session,
+};
+use pandacss_fs::{FileSystem, MemoryFileSystem};
+
+#[derive(Clone)]
+struct CountingFileSystem {
+    inner: MemoryFileSystem,
+    reads: Arc<AtomicUsize>,
+    fail_source_reads: Arc<AtomicBool>,
+}
+
+impl CountingFileSystem {
+    fn new(inner: MemoryFileSystem) -> Self {
+        Self {
+            inner,
+            reads: Arc::default(),
+            fail_source_reads: Arc::default(),
+        }
+    }
+
+    fn reads(&self) -> usize {
+        self.reads.load(Ordering::Relaxed)
+    }
+
+    fn set_fail_source_reads(&self, fail: bool) {
+        self.fail_source_reads.store(fail, Ordering::Relaxed);
+    }
+
+    fn source_read_error(&self, path: &Path) -> Option<io::Error> {
+        (self.fail_source_reads.load(Ordering::Relaxed)
+            && path.extension().is_some_and(|extension| extension == "ts"))
+        .then(|| io::Error::new(io::ErrorKind::PermissionDenied, "fixture read failure"))
+    }
+}
+
+impl FileSystem for CountingFileSystem {
+    fn write(&self, path: &Path, content: &[u8]) -> io::Result<()> {
+        self.inner.write(path, content)
+    }
+
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir_all(path)
+    }
+
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_dir_all(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.inner.exists(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+        self.inner.read_dir(path)
+    }
+}
+
+impl OxcFileSystem for CountingFileSystem {
+    fn new() -> Self {
+        Self::new(MemoryFileSystem::new())
+    }
+
+    fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+        if let Some(err) = self.source_read_error(path) {
+            return Err(err);
+        }
+        let result = OxcFileSystem::read(&self.inner, path);
+        if result.is_ok() {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+        }
+        result
+    }
+
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        if let Some(err) = self.source_read_error(path) {
+            return Err(err);
+        }
+        let result = OxcFileSystem::read_to_string(&self.inner, path);
+        if result.is_ok() {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+        }
+        result
+    }
+
+    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.metadata(path)
+    }
+
+    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.symlink_metadata(path)
+    }
+
+    fn read_link(&self, path: &Path) -> Result<PathBuf, ResolveError> {
+        self.inner.read_link(path)
+    }
+
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        self.inner.canonicalize(path)
+    }
+}
 
 /// Build an in-memory project at `/proj` with `main.tsx` plus N sibling
 /// files. Returns the populated FS + the absolute main.tsx path.
@@ -459,6 +566,34 @@ fn cyclic_imports_drop_safely_without_panic() {
 }
 
 #[test]
+fn cycle_guard_is_reset_between_extractions_in_one_session() {
+    let source = indoc::indoc! {r"
+        import { brand } from './a';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(
+        source,
+        &[
+            ("a.ts", "import { brand } from './b';\nexport { brand };\n"),
+            ("b.ts", "import { brand } from './a';\nexport { brand };\n"),
+        ],
+    );
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs));
+    let session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+
+    let first = extract_in_session(source, main.to_str().unwrap(), &config, &session);
+    let second = extract_in_session(source, main.to_str().unwrap(), &config, &session);
+
+    assert_yaml_snapshot!(shape(&first), @"calls: []");
+    assert_yaml_snapshot!(shape(&second), @"calls: []");
+}
+
+#[test]
 fn cache_reuses_across_multiple_extracts() {
     // Build one cross-file resolver, run extract() twice — the second run
     // should hit the cached tokens file. The contract is "two runs
@@ -659,6 +794,201 @@ fn cache_reloads_exports_through_a_re_export() {
           data:
             - color: blue
     ");
+}
+
+#[test]
+fn session_keeps_one_module_revision_while_other_sessions_refresh() {
+    let source = indoc::indoc! {r"
+        import { brand } from './barrel';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(
+        source,
+        &[
+            ("barrel.ts", "export { brand } from './tokens';\n"),
+            ("tokens.ts", "export const brand = 'red';\n"),
+        ],
+    );
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+    let session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+
+    let first = extract_in_session(source, main.to_str().unwrap(), &config, &session);
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const brand = 'blue';\n".to_vec(),
+    );
+    let refreshed = extract(source, main.to_str().unwrap(), &config);
+    let same_session = extract_in_session(source, main.to_str().unwrap(), &config, &session);
+    let next_session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+    let next = extract_in_session(source, main.to_str().unwrap(), &config, &next_session);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "first": shape(&first),
+        "refreshed": shape(&refreshed),
+        "sameSession": shape(&same_session),
+        "nextSession": shape(&next),
+    }), @r"
+    first:
+      calls:
+        - name: css
+          data:
+            - color: red
+    refreshed:
+      calls:
+        - name: css
+          data:
+            - color: blue
+    sameSession:
+      calls:
+        - name: css
+          data:
+            - color: red
+    nextSession:
+      calls:
+        - name: css
+          data:
+            - color: blue
+    ");
+}
+
+#[test]
+fn session_keeps_an_unresolved_import_missing() {
+    let source = indoc::indoc! {r"
+        import { brand } from './tokens';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let (fs, main) = project(source, &[]);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+    let session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+
+    let missing = extract_in_session(source, main.to_str().unwrap(), &config, &session);
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const brand = 'blue';\n".to_vec(),
+    );
+    config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .clear_resolution_cache();
+    let same_session = extract_in_session(source, main.to_str().unwrap(), &config, &session);
+    let next_session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+    let next = extract_in_session(source, main.to_str().unwrap(), &config, &next_session);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "missing": shape(&missing),
+        "sameSession": shape(&same_session),
+        "nextSession": shape(&next),
+    }), @r"
+    missing:
+      calls: []
+    sameSession:
+      calls: []
+    nextSession:
+      calls:
+        - name: css
+          data:
+            - color: blue
+    ");
+}
+
+#[test]
+fn session_keeps_an_unreadable_module_unavailable() {
+    let source = indoc::indoc! {r"
+        import { brand } from './tokens';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+    let fs = MemoryFileSystem::new();
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const brand = 'blue';\n".to_vec(),
+    );
+    let fs = CountingFileSystem::new(fs);
+    fs.set_fail_source_reads(true);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+    let session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+
+    let unreadable = extract_in_session(source, "/proj/A.tsx", &config, &session);
+    fs.set_fail_source_reads(false);
+    let same_session = extract_in_session(source, "/proj/B.tsx", &config, &session);
+    let next_session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+    let next = extract_in_session(source, "/proj/C.tsx", &config, &next_session);
+
+    assert_yaml_snapshot!(serde_json::json!({
+        "unreadable": shape(&unreadable),
+        "sameSession": shape(&same_session),
+        "nextSession": shape(&next),
+    }), @r"
+    unreadable:
+      calls: []
+    sameSession:
+      calls: []
+    nextSession:
+      calls:
+        - name: css
+          data:
+            - color: blue
+    ");
+}
+
+#[test]
+fn session_reads_a_shared_re_export_chain_once() {
+    let fs = MemoryFileSystem::new();
+    fs.add_file(
+        PathBuf::from("/proj/barrel.ts"),
+        b"export { brand } from './tokens';\n".to_vec(),
+    );
+    fs.add_file(
+        PathBuf::from("/proj/tokens.ts"),
+        b"export const brand = 'red';\n".to_vec(),
+    );
+    let fs = CountingFileSystem::new(fs);
+    let config = panda_config().with_cross_file(CrossFileResolver::with_fs(fs.clone()));
+    let session = config
+        .cross_file
+        .as_ref()
+        .expect("cross-file resolver")
+        .session();
+    let source = indoc::indoc! {r"
+        import { brand } from './barrel';
+        import { css } from '@panda/css';
+        css({ color: brand });
+    "};
+
+    for index in 0..20 {
+        let path = format!("/proj/consumer-{index}.tsx");
+        let result = extract_in_session(source, &path, &config, &session);
+        assert_eq!(result.calls.len(), 1);
+    }
+
+    assert_eq!(fs.reads(), 2, "each imported module should be read once");
 }
 
 #[test]

--- a/crates/pandacss_project/src/lib.rs
+++ b/crates/pandacss_project/src/lib.rs
@@ -48,8 +48,9 @@ use smallvec::SmallVec;
 use pandacss_config::UserConfig;
 use pandacss_encoder::{Atom, Encoder, compare_atoms_by_emit_order};
 use pandacss_extractor::{
-    CrossFileDependency, CrossFileResolver, ExportInfo, ExtractedCall, ExtractedJsx, JsxKind,
-    LineIndex, Literal, MatchCategory, UnresolvedCrossFileDependency, extract,
+    CrossFileDependency, CrossFileResolver, CrossFileSession, ExportInfo, ExtractedCall,
+    ExtractedJsx, JsxKind, LineIndex, Literal, MatchCategory, UnresolvedCrossFileDependency,
+    extract,
 };
 use pandacss_recipes::{Recipe, SlotRecipe};
 use pandacss_shared::css_properties::is_css_property;
@@ -193,6 +194,11 @@ pub struct Project {
     hydrated_keyframes_order: Vec<Arc<str>>,
 }
 
+/// One consistent view of imported modules across ordered file parses.
+pub struct ParseSession {
+    cross_file: Option<CrossFileSession>,
+}
+
 pub struct ProjectStylesheetSnapshots<'a> {
     pub atoms: &'a [Atom],
     pub encoded_recipes: &'a EncodedRecipesSnapshot,
@@ -317,7 +323,37 @@ impl Project {
     /// Re-parsing a path *replaces* its previous bucket, so full rebuilds
     /// clear stale styles.
     pub fn parse_file(&mut self, path: &str, source: &str) -> ParseFileReport {
-        self.parse_file_inner(path, source, None, None, None, ParseMode::Replace)
+        let session = self.parse_session();
+        self.parse_file_in_session(path, source, &session)
+    }
+
+    /// Start an ordered parse session with one consistent cross-file view.
+    #[must_use]
+    pub fn parse_session(&self) -> ParseSession {
+        ParseSession {
+            cross_file: self
+                .config
+                .extractor_config
+                .cross_file
+                .as_ref()
+                .map(CrossFileResolver::session),
+        }
+    }
+
+    /// [`Self::parse_file`] within an existing [`ParseSession`].
+    pub fn parse_file_in_session(
+        &mut self,
+        path: &str,
+        source: &str,
+        session: &ParseSession,
+    ) -> ParseFileReport {
+        self.parse_file_inner(
+            path,
+            source,
+            session.cross_file.as_ref(),
+            ParseTransforms::default(),
+            ParseMode::Replace,
+        )
     }
 
     /// [`Self::parse_file`] with transform callbacks, rebuilt fresh per call
@@ -328,12 +364,23 @@ impl Project {
         source: &str,
         transforms: ParseTransforms<'_>,
     ) -> ParseFileReport {
+        let session = self.parse_session();
+        self.parse_file_with_in_session(path, source, &session, transforms)
+    }
+
+    /// [`Self::parse_file_with`] within an existing [`ParseSession`].
+    pub fn parse_file_with_in_session(
+        &mut self,
+        path: &str,
+        source: &str,
+        session: &ParseSession,
+        transforms: ParseTransforms<'_>,
+    ) -> ParseFileReport {
         self.parse_file_inner(
             path,
             source,
-            transforms.source,
-            transforms.pattern,
-            transforms.utility,
+            session.cross_file.as_ref(),
+            transforms,
             ParseMode::Replace,
         )
     }
@@ -354,11 +401,15 @@ impl Project {
         &mut self,
         path: &str,
         source: &str,
-        source_transform: Option<&mut SourceTransformFn<'_>>,
-        mut pattern_transform: Option<&mut PatternTransformFn<'_>>,
-        utility_transform: Option<&mut UtilityTransformFn<'_>>,
+        cross_file: Option<&CrossFileSession>,
+        transforms: ParseTransforms<'_>,
         mode: ParseMode,
     ) -> ParseFileReport {
+        let ParseTransforms {
+            source: source_transform,
+            pattern: mut pattern_transform,
+            utility: utility_transform,
+        } = transforms;
         let span = tracing::trace_span!(
             "file_parse",
             path = path,
@@ -421,10 +472,11 @@ impl Project {
                 let props = transform::recipe_inline::literal_variant_props(props)?;
                 transform::recipe_inline::resolve_inline_recipe_raw(self, factory, config, &props)
             };
-            pandacss_extractor::extract_with_raw_resolvers(
+            pandacss_extractor::extract_with_raw_resolvers_in_session(
                 source,
                 path,
                 &self.config.extractor_config,
+                cross_file,
                 has_pattern_transform.then_some(&mut raw_transform),
                 &mut resolve_recipe_raw,
             )
@@ -913,12 +965,12 @@ impl Project {
             self.mark_affected(path, Some(hash_source(source)), true);
             return false;
         }
+        let session = self.parse_session();
         self.parse_file_inner(
             path,
             source,
-            transforms.source,
-            transforms.pattern,
-            transforms.utility,
+            session.cross_file.as_ref(),
+            transforms,
             ParseMode::Additive,
         );
         true

--- a/crates/pandacss_project/tests/cross_file_watch.rs
+++ b/crates/pandacss_project/tests/cross_file_watch.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::common::{create_project, sorted_atoms};
 use indoc::indoc;
 use insta::assert_yaml_snapshot;
+use pandacss_encoder::AtomValue;
 use pandacss_extractor::CrossFileResolver;
 use pandacss_fs::{FileSystem as _, MemoryFileSystem};
 use pandacss_project::Project;
@@ -80,6 +81,29 @@ fn cold_build_affects_nothing() {
         vec!["/proj/App.tsx"]
     );
     assert!(project.take_affected_files().is_empty());
+}
+
+#[test]
+fn parse_session_keeps_one_cross_file_revision() {
+    let (fs, mut project) = watch_project(&[("tokens.ts", "export const brand = 'red';\n")]);
+
+    let session = project.parse_session();
+    project.parse_file_in_session("/proj/A.tsx", app_source(), &session);
+    write(&fs, "tokens.ts", "export const brand = 'blue';\n");
+    project.parse_file_in_session("/proj/B.tsx", app_source(), &session);
+    drop(session);
+    project.parse_file("/proj/C.tsx", app_source());
+
+    let values = ["A", "B", "C"].map(|name| {
+        let path = format!("/proj/{name}.tsx");
+        let file = project.get_file(&path).expect("parsed file");
+        let atom = file.atoms().iter().next().expect("color atom");
+        let AtomValue::String(value) = atom.value() else {
+            panic!("expected string atom")
+        };
+        value.to_string()
+    });
+    assert_eq!(values, ["red", "red", "blue"]);
 }
 
 #[test]

--- a/design-notes/compiler-lifecycle.md
+++ b/design-notes/compiler-lifecycle.md
@@ -103,9 +103,9 @@ work; `cacheDir` is only a reserved API shape today.
 - **`compile()` must drain instance state.** `compiler.compile()` emits from exactly the `atoms()`/`recipes()` the
   instance accumulated; otherwise "compile" and "parseFile + atoms" drift into two different notions of project state.
   Keep that invariant.
-- **Batch ingestion + parallelism.** Phase 1 is single-file. A `parseFiles(iter)` seam (with `rayon`) is the natural
-  place for per-file parallelism without disturbing the single-file API (noted in
-  [project-lifecycle](./project-lifecycle.md)).
+- **Batch ingestion.** `parseFiles()` remains ordered so callbacks and per-file replacement keep their existing
+  semantics, but shares one cross-file analysis session across the batch. Parallelism requires a separate pure-analysis
+  phase and is not implied by the batch API.
 - **Static CSS ownership.** `pandacss_stylesheet` owns CSS emission and supported static CSS expansion. Per-theme JSON
   artifacts (`styled-system/themes/*`) are codegen'd in Rust for runtime `getTheme` / `injectTheme`.
 - **Incremental CSS emission.** `Project` updates its atom registry incrementally, but `compile()` still sorts and emits

--- a/design-notes/cross-file-resolution.md
+++ b/design-notes/cross-file-resolution.md
@@ -4,13 +4,14 @@
 
 `CrossFileResolver` lets the same-file `Resolver` follow `import { x } from './tokens'` references and fold the imported
 value. Module resolution itself is delegated to `oxc_resolver` (relative paths, extension probing, tsconfig paths,
-package.json `exports`). The resolver caches per-session. Unchanged imported files are parsed and folded once across the
-batch; changed files replace their cached exports on the next lookup.
+package.json `exports`). The resolver keeps a validated cache across the compiler lifetime and pins analyzed exports in
+a short-lived `CrossFileSession`. `parseFiles()` shares one session, so each imported revision is read and validated
+once across the ordered batch. A later batch observes changed files on its first lookup.
 
 ## Cache shape
 
 ```rust
-Mutex<FxHashMap<PathBuf, CachedFileExports>>
+Mutex<FxHashMap<PathBuf, Arc<CachedFileExports>>>
 
 struct CachedFileExports {
     source_hash: u64,
@@ -34,8 +35,9 @@ stored as `deps` with the hash seen, `None` when the module could not be read. A
 Pure function exports are lowered to a closed owned IR **while the AST is live**, then the AST is dropped. The cache
 keeps descriptors, not `Program`s, so the resolver doesn't pin every imported file's allocator.
 
-The cache is behind a `Mutex`, not `RefCell`, so the resolver can be shared by `ExtractorConfig` in future
-parallel/bulk-file paths. The public type is `Send + Sync`.
+The long-lived cache is behind a `Mutex`, so `CrossFileResolver` remains `Send + Sync`. A `CrossFileSession` uses a
+`RefCell` because `parseFiles()` is ordered and synchronous. It pins `Arc<CachedFileExports>` entries without cloning
+their maps or adding a lock to repeated lookups.
 
 ## Watch invalidation
 
@@ -117,34 +119,38 @@ AST memory alive.
 ## Cycle guard
 
 ```rust
-in_flight: Mutex<FxHashSet<(PathBuf, String)>>
+CrossFileContext {
+    in_flight: RefCell<FxHashSet<(PathBuf, String)>>,
+}
 ```
 
 `a.ts` re-exports from `b.ts` which re-exports from `a.ts` would otherwise overflow the stack. The guard is best-effort:
-when the same `(path, export_name)` is already being resolved, return `None`. The guard is removed after the file's
-exports are collected.
+when the same `(path, export_name)` is already being resolved, return `None`. The guard belongs to one extraction
+traversal rather than the shared resolver, so independent consumers cannot be mistaken for a cycle.
 
 ## Lifecycle and sharing
 
-`CrossFileResolver` is **not** `Clone`. Wrap in `Arc` for shared ownership across sessions. The expected pattern: one
-resolver per build / dev-server session, threaded through `ExtractorConfig` for every `extract()` call in the batch.
+`CrossFileResolver` is **not** `Clone`. The expected pattern is one resolver per build or dev-server session, threaded
+through `ExtractorConfig`. Standalone `extract()` calls create a fresh short-lived session; callers processing a batch
+can reuse one explicitly.
 
 ```rust
 let cross_file = CrossFileResolver::new();
 let config = ExtractorConfig::new(matchers).with_cross_file(cross_file);
+let session = config.cross_file.as_ref().unwrap().session();
 for file in files {
-    let result = extract(file.source, file.path, &config);
+    let result = extract_in_session(file.source, file.path, &config, &session);
 }
 ```
 
-The `Project` façade does this automatically — `with_cross_file` on the project plumbs the resolver into the shared
-config.
+The `Project` façade does this automatically. `parse_file()` creates one session for the file; `parseFiles()` keeps one
+session for the complete ordered batch, including files processed through host callbacks.
 
 ## I/O failures
 
-A read failure removes the previous cache entry and returns no export, so a deleted or unreadable file never serves
-stale data. Parse failures use Oxc's partial AST and cache any exports that still fold, matching the JS extractor's
-best-effort recovery behavior. Recreating a previously resolved file refreshes its exports on the next lookup.
+A read failure on the first lookup removes the previous cache entry and returns no export, so a new session never serves
+stale data. A session that already observed the module keeps that revision for internal consistency. Parse failures use
+Oxc's partial AST and cache any exports that still fold, matching the JS extractor's best-effort recovery behavior.
 
 ## StyleTree hand-off
 

--- a/design-notes/project-lifecycle.md
+++ b/design-notes/project-lifecycle.md
@@ -139,9 +139,9 @@ can keep using `Project::from_config(config)` as the single entrypoint.
 
 ## Reflection: per-file parallelism
 
-Not yet done. Per-file parallelism is worth doing eventually via `rayon`, but it's tied to a deferred bulk-file API. A
-`parse_files(iter)` shape is the natural seam — once batch input lands, the parallelism can opt in there without
-disturbing the single-file API surface.
+Not yet done. The binding's `parseFiles()` loop is ordered and synchronous because source, pattern, and utility callbacks
+can call the JS host. It shares one `ParseSession` without changing callback or commit order. Future parallelism needs a
+separate pure-analysis phase; it should not turn `ParseSession` into a synchronized mutation API.
 
 ## Related
 

--- a/packages/compiler-wasm/crate/src/project/files.rs
+++ b/packages/compiler-wasm/crate/src/project/files.rs
@@ -35,7 +35,8 @@ impl WasmCompiler {
     /// Returns a JS error if serializing the per-call report fails.
     #[wasm_bindgen(js_name = parseFileSource)]
     pub fn parse_file_source(&mut self, path: &str, source: &str) -> Result<JsValue, JsValue> {
-        let report = self.parse_inner(path, source);
+        let session = self.inner.parse_session();
+        let report = self.parse_inner(path, source, &session);
         let _span = tracing::trace_span!("boundary_encode", method = "parse_file_report").entered();
         let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
         parse_file_report(path, report)
@@ -156,10 +157,11 @@ impl WasmCompiler {
     pub fn parse_files(&mut self, paths: JsValue) -> Result<JsValue, JsValue> {
         let paths: Vec<String> = serde_wasm_bindgen::from_value(paths)
             .map_err(|err| JsValue::from_str(&format!("invalid source paths: {err}")))?;
+        let session = self.inner.parse_session();
         let mut reports = Vec::with_capacity(paths.len());
         for path in paths {
             let report = match self.fs.read_to_string(Path::new(&path)) {
-                Ok(source) => self.parse_inner(&path, &source),
+                Ok(source) => self.parse_inner(&path, &source, &session),
                 Err(err) => self.inner.record_read_failure(&path, &err),
             };
             reports.push(parse_file_report(&path, report));
@@ -197,12 +199,17 @@ impl WasmCompiler {
 
     /// Shared parse path used by `parse_file` and `parseFiles` — wires the
     /// registered transform callbacks (if any) and returns the core report.
-    fn parse_inner(&mut self, path: &str, source: &str) -> pandacss_project::ParseFileReport {
+    fn parse_inner(
+        &mut self,
+        path: &str,
+        source: &str,
+        session: &pandacss_project::ParseSession,
+    ) -> pandacss_project::ParseFileReport {
         let has_source_transforms = self.callbacks.has_source_transforms();
         let has_pattern_transforms = self.callbacks.has_pattern_transforms();
         let has_utility_transforms = self.callbacks.has_utility_transforms();
         if !has_source_transforms && !has_pattern_transforms && !has_utility_transforms {
-            return self.inner.parse_file(path, source);
+            return self.inner.parse_file_in_session(path, source, session);
         }
         let WasmCompiler {
             inner, callbacks, ..
@@ -231,9 +238,10 @@ impl WasmCompiler {
         let mut source_transform = |path: &str, source: &str| {
             apply_source_transforms(path, source, &callbacks.source_transforms)
         };
-        inner.parse_file_with(
+        inner.parse_file_with_in_session(
             path,
             source,
+            session,
             pandacss_project::ParseTransforms {
                 source: has_source_transforms.then_some(
                     &mut source_transform as &mut pandacss_project::SourceTransformFn<'_>,

--- a/packages/compiler/crate/src/project/files.rs
+++ b/packages/compiler/crate/src/project/files.rs
@@ -45,7 +45,8 @@ impl Compiler {
     )]
     pub fn parse_file_source(&mut self, env: Env, path: String, source: String) -> ParseFileReport {
         crate::init_tracing();
-        let report = self.parse_inner(&env, &path, &source);
+        let session = self.inner.parse_session();
+        let report = self.parse_inner(&env, &path, &source, &session);
         let _span =
             tracing::trace_span!(target: "css", "snapshot_parse_report", path = path.as_str())
                 .entered();
@@ -62,12 +63,13 @@ impl Compiler {
         env: &Env,
         path: &str,
         source: &str,
+        session: &pandacss_project::ParseSession,
     ) -> pandacss_project::ParseFileReport {
         let has_source_transforms = self.callbacks.has_source_transforms();
         let has_pattern_transforms = self.callbacks.has_pattern_transforms();
         let has_utility_transforms = self.callbacks.has_utility_transforms();
         if !has_source_transforms && !has_pattern_transforms && !has_utility_transforms {
-            return self.inner.parse_file(path, source);
+            return self.inner.parse_file_in_session(path, source, session);
         }
         let Compiler {
             inner, callbacks, ..
@@ -98,9 +100,10 @@ impl Compiler {
         let mut source_transform = |path: &str, source: &str| {
             apply_source_transforms(path, source, &callbacks.source_transforms, env)
         };
-        inner.parse_file_with(
+        inner.parse_file_with_in_session(
             path,
             source,
+            session,
             pandacss_project::ParseTransforms {
                 source: has_source_transforms.then_some(
                     &mut source_transform as &mut pandacss_project::SourceTransformFn<'_>,
@@ -258,10 +261,11 @@ impl Compiler {
         paths: Vec<String>,
     ) -> napi::Result<Vec<ParseFileReport>> {
         crate::init_tracing();
+        let session = self.inner.parse_session();
         let mut reports = Vec::with_capacity(paths.len());
         for path in paths {
             let report = match self.fs.read_to_string(std::path::Path::new(&path)) {
-                Ok(source) => self.parse_inner(&env, &path, &source),
+                Ok(source) => self.parse_inner(&env, &path, &source, &session),
                 Err(err) => self.inner.record_read_failure(&path, &err),
             };
             reports.push(convert_report(path, report));


### PR DESCRIPTION
## Summary

`parseFiles()` currently reads and folds the same imported values again for every consumer file.

This change reuses one cross-file analysis session for each batch. Shared modules, re-export chains, and missing-file observations are resolved once while standalone extraction and later batches still receive a fresh view of the filesystem.

## Performance

Release benchmark with 100 consumer files, 8 imported exports, a 4-level re-export chain, and 30 measured iterations:

| Path | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Direct extractor | 7.365 ms | 1.416 ms | 80.8% |
| Project parsing | 9.330 ms | 3.209 ms | 65.6% |

Successful source reads fell from 500 to 5 in the direct extractor benchmark and from 516 to 21 through the project API.

These results isolate a cross-file-heavy parsing workload; they are not an estimate of complete Panda build time.

## Behavior

- Each batch sees one consistent view of imported modules, including unresolved and unreadable files.
- A new batch observes files created, repaired, or changed after the previous batch.
- Parse order, callbacks, diagnostics, CSS output, and the public API are unchanged.
- Cached analysis is released when the batch ends.

## Breaking changes

None.

## Verification

- `cargo nextest run -p pandacss_extractor --locked` (522 tests)
- `cargo nextest run -p pandacss_project --locked` (927 tests)
- `cargo nextest run -p pandacss_stylesheet --locked` (555 tests)
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm test:compiler` (623 tests)
- `pnpm --filter @pandacss/compiler-wasm test` (67 passed, 2 skipped)
- `pnpm prettier`

No CSS snapshots changed.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces batch-scoped cross-file analysis sessions so consumers can reuse imported-module analysis without carrying stale observations into later batches.
- Adds session-local caches for analyzed, unreadable, and unresolved modules.
- Threads sessions through extractor, project, native compiler, and WASM compiler parsing paths.
- Adds lifecycle and filesystem-revision tests plus design documentation.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete behavioral, build, or security regression remains.

Batch sessions consistently pin cross-file observations only for their intended lifetime, while standalone calls and later batches retain fresh filesystem views and existing extraction behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/pandacss_extractor/src/cross_file.rs | Introduces batch-scoped module observations and per-extraction recursion state while retaining the shared validated export cache. |
| crates/pandacss_extractor/src/extract.rs | Adds session-aware extraction entrypoints and preserves fresh sessions for standalone extraction. |
| crates/pandacss_project/src/lib.rs | Adds project parse sessions and threads them through file parsing without extending their lifetime beyond a batch. |
| packages/compiler/crate/src/project/files.rs | Reuses one project parse session across each native `parseFiles()` batch. |
| packages/compiler-wasm/crate/src/project/files.rs | Applies the same batch-session lifecycle to the WASM compiler path. |
| crates/pandacss_extractor/tests/cross_file.rs | Covers shared reads, consistent revisions, cycles, and unresolved or unreadable observations across session boundaries. |
| crates/pandacss_project/tests/cross_file_watch.rs | Verifies later project batches observe repaired or changed cross-file dependencies. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as parseFiles caller
    participant P as Project
    participant S as CrossFileSession
    participant E as Extractor
    participant R as CrossFileResolver
    C->>P: parseFiles(files)
    P->>S: create one batch session
    loop each consumer file
        P->>E: parse file in session
        E->>S: resolve imported export
        alt module already analyzed in batch
            S-->>E: reuse pinned exports
        else first lookup in batch
            S->>R: resolve/read/analyze module
            R-->>S: cached exports and provenance
            S-->>E: folded export
        end
    end
    P-->>C: batch results
    P--xS: release session
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(extractor): reuse cross-file analys..."](https://github.com/chakra-ui/panda/commit/1f7ed807f3ca4a1d1b7e8a8a59264deb1841d436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62365494)</sub>

<!-- /greptile_comment -->