### PR TITLE
 docs(blog): rework Panda 2.0 launch post for tone and clarity

### DIFF
--- a/website/content/blog/panda-css-v2.mdx
+++ b/website/content/blog/panda-css-v2.mdx
@@ -10,19 +10,22 @@ type: release
 featured: true
 ---
 
-Today we are releasing Panda CSS 2.0.
+Today we're releasing Panda CSS 2.0.
 
-You write the same Panda you already know. The same `css()`, the same recipes and patterns, the same tokens, conditions,
-and JSX style props. What changed is the machine underneath: we replaced the compiler with a new engine written in Rust,
-and that rewrite opened up capabilities the old engine could not reach.
+It’s the biggest change we’ve made to Panda since we first launched it, but if you’re already using Panda, something
+might surprise you: **the way you write Panda hasn’t really changed.**
+
+You still use the same `css()` function, the same recipes and patterns. Your tokens, conditions, and JSX style props
+also work the same way.
+
+What changed is the engine doing all the work underneath.
+
+For Panda 2.0, **we've replaced the compiler with a new engine written in Rust,** built on [Oxc](https://oxc.rs).
 
 ![Panda CSS 2.0 — rewritten in Rust](/blog/panda-v2-hero.svg)
 
-This is the largest change to Panda since we first shipped it, and almost none of it touches your code. Here's the short
-version:
+Take a look at the difference:
 
-- **A new compiler engine written in Rust**, on [Oxc](https://oxc.rs). Same `css()`, recipes, tokens, and JSX props;
-  identical CSS out.
 - **15–37× faster extraction**, and watch-mode re-parsing on the order of 360× faster.
 - **staticCss builds about 85× faster**, from 25.7 s to 0.3 s on a 29,000-rule config.
 - **~99% fewer TypeScript type instantiations** on your generated types, for a lighter editor and CI.
@@ -32,83 +35,61 @@ version:
   ESLint plugin, a typography preset, and a rebuilt CLI.
 - **ESM-only**, needs Node 22 or newer. It ships as a beta today.
 
-The rest of this post walks through why we rewrote the engine, what the new pipeline looks like, what it made faster,
-and the features that came out of it, then a full checklist for upgrading.
+Over the rest of this post, we'll walk you through why we decided to rewrite the compiler, what changed in terms of
+performance, how the new engine works and everything you need to know to upgrade.
 
 ## Why we rewrote the engine
 
-Panda's original engine was TypeScript analysis running in Node. Extraction was built on
-[ts-morph](https://ts-morph.com), a wrapper over the full TypeScript compiler, and constant values were folded with a
-JavaScript interpreter. That worked, and it shipped a lot of good software. But it carried costs that grew with your
-project, and it boxed us out of things we wanted to build.
+Panda's original engine was built around TypeScript analysis running in Node. We used [ts-morph](https://ts-morph.com),
+a wrapper around the full TypeScript compiler, for extraction and a JavaScript interpreter to evaluate constant values.
 
-**TypeScript builds a whole-program graph. Panda doesn't need one.** A type in TypeScript can be declared anywhere and
-merged across files, so the compiler has to hold the entire program in memory to answer a question about any part of it.
-ts-morph inherits that. Panda's actual question is much narrower: what value does this one style call receive? The old
-engine paid for the general answer anyway, on every build.
+![Panda v1 ran on Node with a JavaScript runtime, Panda 2.0 runs on Rust and compiles anywhere](/blog/panda-v2-why-rewrite.svg)
 
-**A JavaScript interpreter sat on the hot path.** To resolve something like `fontSize: sizes.lg * 2`, v1 ran the
-expression through a JS evaluator at build time. It was correct, but interpreting JavaScript to compute a CSS value is a
-lot of work to repeat for every style in every file on every change.
+That worked well for v1, but it came with costs that grew alongside your project. As we started thinking about v2, there
+were a few things we wanted to improve:
 
-**The engine was Node-only.** It couldn't run in a browser. The playground, the editor extension, and diagnostics each
-had to reimplement or approximate extraction instead of sharing the one the build uses. That's how the playground and
-the compiler drift apart.
+- Reduce system memory usage
+- Run the same engine everywhere
+- Make the compiler significantly faster, especially on large projects
+- Make it easier to build design systems
+- Make Panda work better in monorepos
 
-**Per-file callbacks were expensive.** Hooks like the old `matchTag` ran a JavaScript function for every element in
-every file. Once the engine moved to Rust and the browser, a per-element JS callback crossing that boundary simply isn't
-an option.
+### From Node to Rust
 
-So we rebuilt the hot path in Rust on top of [Oxc](https://oxc.rs), a fast JavaScript toolchain written in Rust. One
-engine, wrapped by two thin bindings: a native binding for the CLI and bundlers, and a WebAssembly binding for the
-browser. Both run the identical code and produce identical CSS. Your `panda.config.ts`, your `css()` calls, your
-recipes: all the same. The machine that reads them is new.
+We rebuilt Panda's hot path in Rust on top of [Oxc](https://oxc.rs), a fast JavaScript toolchain written in Rust. The
+engine has two thin bindings:
 
-![The v2 compiler pipeline](/blog/panda-v2-engine.svg)
+- a native binding for the CLI and bundlers
+- a WebAssembly binding for the browser
+
+| Binding       | Package                                     | Runs in             |
+| ------------- | ------------------------------------------- | ------------------- |
+| Native (NAPI) | `@pandacss/compiler`                        | CLI, Vite, PostCSS  |
+| WebAssembly   | `@pandacss/compiler-wasm` (~490 KB gzipped) | Browser, playground |
 
 ## Inside the new engine
 
-The v2 engine is a one-way pipeline: `extract → encode → emit`. Source files flow in, atomic style rules accumulate, and
-a stylesheet comes out. Each stage is its own Rust crate that knows nothing about the stages around it. Here's what
-happens to your code on the way through.
+The v2 engine follows a simple one-way pipeline: `extract → encode → emit`. Your source files flow in, Panda collects
+the atomic style rules it needs, and a stylesheet flows out. Each stage is its own Rust crate that knows nothing about
+the stages around it.
+
+Here's what happens to your code on the way through.
 
 ### One parse per file
 
-In v1, several tools each parsed your files to answer their own question. In v2 a single Oxc parse produces one AST that
-feeds every step — collecting imports, matching them against your config, walking call sites, walking JSX, resolving
-identifiers. Imports, `css()` calls, and `<styled.div>` elements all read from the same parse and the same semantic
-pass.
+In v1, several tools parsed the same files separately. In v2, Oxc parses each file once, and that single parse is shared
+across imports, `css()` calls, JSX, and identifier resolution.
+
+The engine also checks imports first. If a file doesn't use Panda, it skips it entirely. This is especially useful for
+`node_modules` files that never touch Panda, and is one of the reasons cold builds are faster.
 
 ![In v1 the build, playground, and editor each parsed your files separately and drifted apart; in v2 one Oxc parse feeds all three](/blog/panda-v2-one-parse.svg)
 
-That single pass has a fast exit built in. Before doing any real work, the engine collects the file's imports and
-matches them against your Panda entry points. If nothing in the file imports from `styled-system` (or wherever your
-Panda output lives), it stops right there — no identifier resolution, no visitor walks. On a real project most files are
-`node_modules` JavaScript that never touch Panda, and skipping them cheaply is a measurable part of why cold builds got
-faster.
+### Improved value resolution
 
-### The engine builds itself once
-
-`createCompiler(config)` returns a long-lived compiler. The shape is three calls, and only the first is expensive:
-
-```ts
-const compiler = createCompiler(config) // once: config → matchers, tokens, recipes
-compiler.parseFile(source) // per file: atoms accumulate in a deduplicated registry
-const css = compiler.compile() // drains the registry to CSS
-```
-
-You pay for config compilation once and reuse it across every file and every rebuild, which is what makes `panda dev`
-cheap on the second keystroke.
-
-Watch mode is incremental by contract. Each file's contribution to the global set of atoms is refcounted, so re-adding a
-path first drops its previous atoms and then re-encodes it. Removed or renamed styles can't linger as ghosts in the
-output, and a single-file change costs work proportional to that file, not to your whole project.
-
-### Resolving your values
-
-The old engine leaned on a JavaScript interpreter to fold constant expressions. The new one folds them directly in Rust,
-matching JavaScript's coercion rules so the CSS comes out the same. With same-file scope resolution in place, a lot more
-of your code now resolves at build time:
+The old engine used a JavaScript interpreter to resolve constant expressions. In v2, Panda does this directly in Rust,
+resolving more values at build time, including imports, operators, ternaries, enums, and `token() `references, while
+keeping the same CSS output.
 
 ```ts
 const spacing = { sm: '8px', lg: '24px' }
@@ -121,58 +102,28 @@ css({
 })
 ```
 
-Object member access, template literals, arithmetic and logical operators, ternaries, destructuring with defaults,
-TypeScript enums, and `token()` references all fold. When a value genuinely can't be known at build time, like a real
-ternary on a runtime variable, Panda emits both branches as static classes and lets the runtime pick. Nothing gets
-missed.
+### Cross File Resolution
 
-Resolution follows imports across files, too. If your tokens live in `tokens.ts` and a component imports them, Panda
-parses that file once, folds the exported value, and keeps a small descriptor instead of holding the whole module in
-memory. Simple pure helper functions, local or imported, are lowered to a closed form and applied without running any
-JavaScript.
-
-Shadowing is handled correctly. If you write a local function that happens to be named `css`, Panda checks the symbol
-table, sees it isn't the imported one, and leaves it alone.
-
-### Vue, Svelte, and Astro, natively
-
-Single-file component formats are handled in Rust, before the parse. Adapters mask the template or frontmatter into
-position-preserving JavaScript, so spans stay aligned with your original file and an error still points at the right
-line. Oxc then parses the JavaScript it understands. The built-in set covers `.vue`, `.svelte`, and `.astro`; other
-formats can still be handled by a filtered transform on the JS host.
-
-### Matching JSX with data
-
-v1 let you match custom JSX components with a `matchTag` callback — a JavaScript function Panda ran for every element.
-That can't cross into a Rust or WebAssembly engine, so v2 replaces it with `jsxMatchTag`, a declarative rule list
-matched by component name, a pattern, or the module a component is imported from:
+Panda resolves values across files too. If a value is imported from another file, Panda parses that file once, folds the
+value you're using, and keeps a small descriptor instead of holding the whole file in memory.
 
 ```ts
-export default defineConfig({
-  jsxMatchTag: [{ pattern: '^(Flex|Stack|Box)$' }, { from: '@acme/ui', props: ['padding', 'color'] }]
-})
+// theme.ts
+export const brand = '#4f46e5'
+
+// Card.tsx
+import { brand } from './theme'
+
+css({ borderColor: brand }) // → '#4f46e5'
 ```
 
-Rules are evaluated last-match-wins over Panda's own detection, and because it's data rather than code, it works
-identically in the CLI and in the browser.
-
-### Emitting CSS in Rust
+### Better CSS Output
 
 The old pipeline handed generation to PostCSS. v2 emits CSS natively in a dedicated crate. It does the CSS-aware work
 that matters for output quality:
 
-- **Grouped at-rules.** Rules that share a `@media` or `@supports` wrapper are grouped together under one wrapper
-  instead of repeating it.
-- **Adjacent rule merging.** Consecutive rules with an identical declaration block collapse into one comma-joined
-  selector list, the same optimization PostCSS's merge-rules did. Selectors that can't safely merge (like `:has()` or
-  pseudo-elements) stay isolated.
-- **Modern breakpoints.** Responsive conditions compile to CSS media-range syntax rather than the older
-  `min-width`/`max-width` form. A breakpoint emits `@media (width >= 48rem)`, and a bounded range emits
-  `@media (width >= 40rem) and (width < 64rem)`. Container queries use the same form with `inline-size`.
-- **Deterministic cascade order.** Output is sorted into Panda's layers (`reset, base, tokens, recipes, utilities`),
-  with a stable ordering within each so shorthands rank below longhands and the cascade is predictable across builds.
-
-Grouping and modern breakpoints together turn this:
+**Modern breakpoints** - Responsive conditions now use CSS media-range syntax, like `@media (width >= 48rem)`, instead
+of `min-width/max-width`. Container queries use the same approach with `inline-size`.
 
 ```css
 @media (min-width: 48rem) {
@@ -200,131 +151,140 @@ into this:
 }
 ```
 
-One honest note: this crate emits and formats CSS, but it is not yet a full CSS optimizer. Value-level minification at
-the quality of a tool like Lightning CSS is the one part of the old pipeline we haven't fully matched, and it's the top
-item on the roadmap. Everything else about the output is at parity, minus the deliberate improvements above.
+**Deterministic cascade order** - Output is sorted into Panda's layers (`reset, base, tokens, recipes, utilities`), with
+a stable ordering within each so shorthands rank below longhands and the cascade is predictable across builds.
 
-### One engine everywhere
+```ts
+css({ paddingTop: '4px', padding: '8px' })
+```
 
-Because the engine is plain Rust over Oxc, it compiles two ways. A native binding (`@pandacss/compiler`) powers the CLI,
-Vite, and PostCSS. A WebAssembly binding (`@pandacss/compiler-wasm`) runs the identical code in the browser, which is
-what the playground uses. The Wasm bundle is about 490 KB gzipped, and cross-file resolution works there too: edit a file
-in the playground and it lands in an in-memory filesystem the resolver reads at once.
+```css
+@layer reset, base, tokens, recipes, utilities;
 
-So for the first time the playground and your build run the same extractor and produce the same CSS, because they are the
-same code. For the mental model, see [Why Panda → How it works](/docs/get-started/getting-started#how-it-works).
+@layer utilities {
+  .p_8px {
+    padding: 8px;
+  }
+  .pt_4px {
+    padding-top: 4px;
+  }
+}
+```
 
-## Faster
+<Callout type="info">
+  Even though `paddingTop` comes first in the source, `padding` is emitted first and `paddingTop` after it.
+</Callout>
 
-A rewrite is only worth it if the numbers move. They did.
+**Cleaner global variables** - CSS variables now use the `@property`, so defaults are only generated when the variable
+is actually used.
 
-A note on methodology before the numbers: these were measured on a single developer machine (Apple silicon, Node 22.20,
-Rust 1.93), not a clean-room CI box, so treat the absolute times as indicative and the ratios as the reliable part. Each
-benchmark reads the same source bytes through both engines with file I/O excluded, so what's being compared is the work
-itself.
+```css
+/* v1: seeded on every element, whether it's used or not */
+*,
+::before,
+::after,
+::backdrop {
+  --backdrop-blur: ;
+  /* …and 33 more */
+}
+```
 
-### 15–37× faster extraction
+into this:
+
+```css
+/* v2: registered once, shipped only when something uses it */
+@property --backdrop-blur {
+  syntax: '*';
+  inherits: false;
+}
+```
+
+### One engine for Node and browser
+
+The engine compiles two ways: a native binding (`@pandacss/compiler`) for the CLI and bundlers, and a ~490 KB
+WebAssembly binding (`@pandacss/compiler-wasm`) for the browser. See
+[how it works](/docs/get-started/getting-started#how-it-works).
+
+![One Rust engine compiles two ways: a native binding for the CLI, Vite, and PostCSS, and a WebAssembly binding for the browser, both producing identical CSS](/blog/panda-v2-two-bindings.svg)
+
+## How much faster is Panda 2.0?
+
+One of the biggest reasons for rewriting the engine was performance. So, how much faster is v2?
+
+![How much faster is Panda 2.0: extraction 15 to 37 times faster, watch-mode re-parsing about 360 times faster, staticCss about 85 times faster, 99 percent fewer TypeScript type instantiations, runtime css() up to 4 times faster](/blog/panda-v2-speed-snapshot.svg)
+
+### Extraction is 15–37× faster
 
 Extraction is the core of what the rewrite replaced: parsing your files and pulling out the styles. Across fixtures from
-a handful of real files up to a synthetic thousand-file project, the Oxc engine runs a cold extraction 15 to 37 times
-faster than the ts-morph engine.
-
-| Fixture                  | Files | Cold-build speedup |
-| ------------------------ | ----- | ------------------ |
-| A real Vite + TS sandbox | 5     | 22.6×              |
-| Synthetic project        | 100   | 37.3×              |
-| Synthetic project        | 1000  | 30.3×              |
-
-The underlying reason is parser throughput: the old path sustained roughly 1.2 MB/s of TypeScript source, the new one
-around 37 MB/s — about a 30× gap that holds steady as projects grow.
+a handful of files up to a synthetic thousand-file project, the Oxc engine runs a cold extraction 15 to 37 times faster
+than the ts-morph engine.
 
 ![Cold parse of 100 files dropped from 187ms to 7.5ms; watch-mode re-parse per file from 652µs to 1.8µs](/blog/chart-extraction.svg)
 
-### Watch-mode re-parsing
+### Watch mode is ~360× faster
 
-The number you feel every day is the one for saving a file. When a single file changes, the old engine re-parsed it
-through the TypeScript compiler; the new engine re-parses it through Oxc. On a steady-state watch, that step went from
-around 650 microseconds per file to under 2 — roughly 360–390× faster. Real sandboxes bear it out end to end: a Next.js
-pages project's parse step dropped from 762 ms to 31 ms.
+When you save a file, Panda now re-parses it with Oxc instead of the TypeScript compiler. That dropped re-parsing from
+around **650 microseconds per file to under 2**, roughly 360–390× faster. In a Next.js project, the parse step dropped
+from **762 ms to 31 ms**.
 
-### staticCss builds, ~85× faster
+### staticCss is ~85× faster
 
-`staticCss` pre-generates a matrix of utilities and recipes, often across breakpoints and containers. It was one of the
-slowest things you could ask v1 to do, and two long-standing community reports centered on it. On the larger of the two
-configurations (about 29,000 rules), the numbers now look like this:
+`staticCss` was one of the more expensive things you could ask Panda v1 to do. On a config generating around 29,000
+rules, build time dropped from **25.7 seconds to ~0.3 seconds**. That's roughly 85× faster!
 
-| Engine    | Build time |
-| --------- | ---------- |
-| Panda v1  | 25.7 s     |
-| Panda 2.0 | ~0.3 s     |
+![staticCss build time on a 29,000-rule config: Panda 1 took 25.7 seconds, Panda 2.0 takes about 0.3 seconds, 85 times faster](/blog/chart-staticcss-share.svg)
 
-That's roughly 85× faster, and it holds up as you scale the number of container queries — a 64-container configuration
-that took Panda 52 seconds now finishes in under 40 milliseconds. Part of that is Rust, but part was a genuine
-algorithmic fix: v2 was briefly resolving condition queries once per rule lookup, which made emit cost grow with the
-square of the container count. Resolving them a single time up front is what turns the last few seconds into fractions
-of one, and the CSS it produces is byte-for-byte identical. There's a regression test guarding it so it can't creep
-back.
+### Generated types are lighter
 
-![staticCss build time by container count on a log scale: the before line climbs from 399ms to 52.6s while Panda 2.0 stays flat near 25ms](/blog/chart-staticcss.svg)
+We also changed the type graph Panda generates for styled-system, which means less work for TypeScript and, in turn,
+your editor and CI.
 
-### Lighter generated types
+- ~99% fewer type instantiations
+- ~21–25% less memory in `tsc`
+- 40–60% less type-check time
 
-The static-extraction win has a quieter cousin: the TypeScript types Panda generates for your `styled-system`. v2 emits
-a leaner type graph built around a single shared conditional-value type instead of thousands of individually
-instantiated ones. Type-checking the same usage file against the generated types shows:
+Type-checking the generated `styled-system` types shows the same pattern across all four fixtures:
 
-- **~99% fewer type instantiations** — on the order of 20 instead of 2,600
-- **~21–25% less memory** in `tsc`
-- **40–60% less type-check time**
+| Fixture | Type instantiations (v1 → v2) | `tsc` memory (v1 → v2) | Check time (v1 → v2) |
+| ------- | ----------------------------- | ---------------------- | -------------------- |
+| small   | 2,603 → 20                    | 85 MB → 64 MB          | 50 ms → 30 ms        |
+| medium  | 2,639 → 20                    | 82 MB → 65 MB          | 50 ms → 20 ms        |
+| large   | 2,648 → 20                    | 87 MB → 65 MB          | 50 ms → 20 ms        |
+| strict  | 2,575 → 26                    | 82 MB → 64 MB          | 50 ms → 20 ms        |
 
-![Generated-types cost to tsc, v2 as a share of v1: type instantiations down 99% (20 vs 2,603), peak memory down 24%, check time down 40 to 60%](/blog/chart-types.svg)
+In v2, native CSS properties share one conditional-value type instead of generating their own, which keeps the count
+almost flat even as the fixture grows.
 
-That's a faster editor when you hover a prop, and less work for `tsc` in CI.
+### Runtime is ~4× faster
 
-### A faster runtime
-
-Not all of Panda runs at build time. The `css()` function and recipe runtimes ship to the browser for the dynamic cases
-static extraction can't cover, and v2 layers memoization over them. Repeated inline styles on a dense server-rendered
-page resolve about 3× faster, `css()` calls composed through wrapper chains about 4×, and repeated flat style objects
-hit the cache 30–40% faster. If you render a table of a few hundred styled rows on the server, this is the difference
-you'll see.
+Not all of Panda's work happens at build time. For styles that need to be resolved at runtime, v2 adds memoization to
+`css()` and recipes, so repeated styles don't have to do the same work again.
 
 ![Runtime css() on dense SSR pages as a share of the unmemoized path: repeated inline 3x faster, a 3-level wrapper chain 4x, a 6-level chain 3x, repeated flat objects 30 to 40 percent faster](/blog/chart-runtime.svg)
 
-### What isn't faster yet
+## New Features in v2
 
-Two honest caveats, because a release post that only lists wins isn't much use:
+The new engine is a big part of Panda 2.0, but there's quite a bit more in this release.
 
-- **CSS emit speed and output size aren't a fair comparison yet.** v2 emits CSS without a full value-level minifier, so
-  its raw output is currently a bit larger than v1's fully optimized output — not missing rules, just less densely
-  packed. Minification parity is the top roadmap item, and until it lands we're not publishing an emit-speed or
-  bundle-size claim.
-- **These are single-machine numbers.** We haven't run a clean-room comparison against other CSS tools, and we're not
-  going to imply one exists. The comparisons above are v1 versus v2 on the same hardware, which is the honest question
-  for anyone deciding whether to upgrade.
-
-## What's new
-
-A faster engine is the headline, but the rewrite also cleared the way for capabilities the old architecture couldn't
-reach. Here's what shipped alongside it.
+Let's go through the bigger additions:
 
 ### Publishable design systems
 
-This is the big one. A Panda design system is now an npm package that ships components and the Panda config they were
-built against, and consuming it takes one line.
+In v2, **you can now build a Panda design system, publish it as an npm package**, and use it in another Panda project
+without that project having to extract all of its styles again.
 
-If you've ever tried to share a Panda-based component library, you know the old shape: the consuming app had to wire up
-`presets`, `importMap`, and `include` all pointing at the library, and then re-scan the library's source on every build
-to rediscover styles it had already found once. v2 collapses that.
+Previously, sharing a Panda component library meant configuring `presets`, `importMap`, and `include` in the consuming
+app. The app also had to scan the library's source during its own build.
 
-The library author runs one command:
+Run the command:
 
 ```bash
 panda lib
 ```
 
-That writes a manifest, a preset, and the already-extracted build info into the package, and syncs the package's
-`exports` for you. The consumer sets one field:
+Panda packages the design system's config and syncs the package's `exports` for you.
+
+Then, in the consuming app, set this field:
 
 ```ts
 export default defineConfig({
@@ -332,27 +292,18 @@ export default defineConfig({
 })
 ```
 
-Panda loads the library's theme and recognizes imports from both `@acme/ds` and the app's local `styled-system`. The
-important part: it reuses the styles the library already extracted instead of re-scanning its source. The library
-extracts itself once, at publish time, and every app that installs it reuses that work.
+A few things make this approach an enjoyable user experience:
 
-![Design-system flow: the author runs panda lib to ship a manifest, preset, and build info; the consumer sets designSystem and reuses the pre-extracted styles](/blog/panda-v2-design-system.svg)
-
-A few things make this pleasant in practice:
-
-- **You customize without forking.** Your `theme.extend` layers on top and the app wins on any conflicting token,
-  surfaced as a diagnostic rather than a silent override.
-- **Resolution survives your setup.** The manifest resolves as a package export, not a source path, so workspaces,
-  symlinks, and Docker layers all work.
-- **Design systems compose.** One can extend another, and Panda walks the parent chain for you.
-- **Misconfiguration tells you what's wrong.** A stale build info, a missing export, or an unsatisfied peer range comes
-  back as an actionable diagnostic, not mysterious missing styles.
-- **You ship only what you use.** `optimize.treeshakeDesignSystem` hydrates just the modules your app imports.
+- You customize without forking
+- Works across different setups
+- Design systems can extend each other
+- You get better errors when something goes wrong
+- Ship only what you use symlinks, and Docker layers all work.
 
 ### View transitions
 
-`viewTransition()` is a new styled-system function for the View Transitions API. It returns a stable class and emits the
-matching `::view-transition-*` rules for you:
+We've added a new `viewTransition()` function for working with the View Transitions API. You can define how an element
+transitions between its old and new state directly from your styled system:
 
 ```ts
 import { viewTransition } from 'styled-system/css'
@@ -369,65 +320,54 @@ the shared class. Unused named transitions stay out of your CSS.
 
 ### New base-preset utilities
 
-The base preset picked up a batch of utilities for things that used to mean hand-writing raw CSS.
+The base preset now includes utilities for CSS you previously had to write by hand.
 
-**Masking** — fade an edge or spotlight an image without writing `mask-image` by hand:
+**Masking** lets you create edge fades and radial masks directly from Panda:
 
 ```ts
 css({ maskBottomFrom: '50%' })
 css({ maskRadialFrom: '35%', maskRadialAt: 'center' })
 ```
 
-**Scrollbars** — style each half of the scrollbar as its own property:
+**Scrollbars** can now be styled with separate thumb and track properties:
 
 ```ts
 css({ scrollbarThumb: 'gray.400', scrollbarTrack: 'gray.100' })
 ```
 
-Note that `scrollbarWidth` now takes the CSS keywords `auto | thin | none` rather than a size token, which is one of the
-deliberate breaking changes in the upgrade guide below.
+Note that `scrollbarWidth` now takes the CSS keywords `auto | thin | none` instead of a size token.
 
-**More conditions and keywords** — pointer conditions (`_pointerFine`, `_pointerCoarse`, `_anyPointer*`),
-post-interaction validity (`_userValid`, `_userInvalid`), the `_inert` state, every `text-wrap` keyword including
-`pretty` and `stable`, and two-word alignment values like `safe center` and `first baseline`.
+We've also added new conditions like `_pointerFine`, `_pointerCoarse`, `_anyPointer*`, `_userValid`, `_userInvalid`, and
+`_inert` along with more `text-wrap` values.
 
-**Fixed transform axes** — `rotateX`, `rotateY`, and `rotateZ` now do what they say, `rotate: 'auto'` composes them onto
-`transform`, and non-uniform `scale` applies rotation after scaling.
+`rotateX`, `rotateY`, and `rotateZ` have also been fixed, with better composition between rotation and non-uniform
+scaling.
 
 ### Variables via @property
 
 v1 seeded 34 CSS variables on `*, ::before, ::after, ::backdrop` so that things like transforms and filters had
-defaults. That's a lot of declarations on every element whether you used them or not. v2 registers those variables with
-`@property` instead, so a variable's default ships only when something actually uses it — and it lives right next to the
-utility that writes it. Utilities can even declare their own registered variables now.
+defaults. That's a lot of declarations on every element whether you used them or not.
 
-This needs `@property` support (Chrome 85+, Safari 16.4+, Firefox 128+). For older engines,
-`optimize.propertyFallback: true` also seeds plain-declaration defaults, and there's a native cascade-layer polyfill
-available through config or `--polyfill` for browsers without `@layer` — no PostCSS plugin required.
+v2 registers those variables with `@property`, so defaults are only generated when they're actually needed. Utilities
+can also register their own variables.
 
-### A rebuilt CLI
+### A better CLI
 
-The command set got a cleanup and some genuinely new tools. Bare `panda` runs codegen and CSS generation in one build.
+We've cleaned up the CLI and added a few new tools. Running `panda` now handles both codegen and CSS generation.
 
-- **`panda doctor`** rolls up the old `inspect`, `validate`, and `info` commands into one health check. Pass `--json` to
-  consume it in a script.
-- **`panda analyze`** reports on your token and style usage as JSON, a static HTML report, or a live report UI.
-- **`panda debug`** writes everything a good bug report needs into a folder you can attach to an issue: platform info,
-  resolved config, per-file extraction, and the project stylesheet.
-- **`--profile`** on any command writes a Chrome-tracing / Perfetto profile to `.panda/`, and unlike v1's `--cpu-prof`
-  it captures the Rust engine's time too.
-- **`--include`** overrides your configured source globs for a single run, which is handy for scoping a one-off build.
-- **`panda init -i`** runs an interactive setup wizard with colored output and next-step hints, and it now scaffolds the
-  base presets by default.
+- **`panda doctor`** combines `inspect`, `validate`, and `info` into one project health check.
+- **`panda analyze`** shows how tokens and styles are being used across your project.
+- **`panda debug`** generates the project information and extraction details you need for debugging or reporting an
+  issue.
+- **`--profile`** creates a performance profile that includes time spent inside the Rust engine.
+- **`--include`** lets you override your source globs for a single run.
+- **`panda init -i`** gives you an interactive setup flow and now scaffolds the base presets by default.
 
-Logging moved to a single `--log-level silent|error|warn|info|debug`, and startup got lighter — flag parsing no longer
-loads a schema library on every invocation.
+Logging has also been simplified to a single `--log-level` option.
 
-### A first-party ESLint plugin
+### ESLint plugin
 
-There's a first-party ESLint plugin with a recommended flat config, and because extraction lives in a shared engine now,
-the linter reads the same extraction your build does rather than approximating it. The rules cover the mistakes Panda
-users actually make:
+Panda 2.0 now has an official ESLint plugin that uses the same extraction engine as your build.
 
 ```js
 // eslint.config.js
@@ -443,8 +383,8 @@ entry point.
 
 ### A typography preset
 
-`@pandacss/preset-typography` gives you a `prose` recipe for styling Markdown or CMS-rendered HTML you don't control,
-with size variants and semantic color tokens that already handle dark mode:
+The new `@pandacss/preset-typography` package gives you a `prose` recipe for styling content you don't directly control,
+like Markdown or CMS-rendered HTML.
 
 ```ts
 import typography from '@pandacss/preset-typography'
@@ -454,39 +394,22 @@ export default defineConfig({
 })
 ```
 
-This post is rendered by it. The [Typography guide](/docs/theming/typography) has the options, and the
-[launch post](/blog/typography-preset) has the reasoning.
-
-### Folding dynamic code away
-
-Beyond the correctness of extraction, v2 does more to turn dynamic-looking code into static classes:
-
-- **Compiled JSX** is extracted, not just raw JSX — Panda reads the `jsx()` runtime calls that React, Preact, Vue,
-  Solid, and Qwik compile to, so `css` props survive the framework's own transform.
-- **`styled` chains fold.** A same-file `styled()` chain whose class string is constant collapses to the underlying
-  element, so `<Button>` skips a `forwardRef` layer at runtime. Chains with variants or dynamic bases keep their runtime
-  behavior.
-- **Static styles survive an unknown spread.** A `styled.div` that also spreads unknown props still precomputes
-  everything known at build time into a single class, leaving only the spread for runtime.
-- **Shared classes hoist.** A class present in every branch of a conditional is emitted once instead of being repeated
-  across branches.
+The [Typography guide](/docs/theming/typography) covers more details.
 
 ### Codegen and type fixes
 
-A handful of type-level changes remove long-standing papercuts. Keyframe names are inlined into the generated types, so
-`css({ animationName: 'spin' })` type-checks under `strictTokens` without the escape-hatch brackets. Empty token
-categories no longer collapse to bare `string`, so native-value autocomplete keeps working. And under `strictTokens`,
-native CSS keywords like `cursor: 'pointer'` are accepted without brackets even when the category is empty.
+Keyframe names now work with `strictTokens` without escape-hatch brackets, native CSS values keep their autocomplete
+when a token category is empty, and CSS keywords like `cursor: "pointer"` work as expected under `strictTokens`.
 
-One rename to be aware of: the built-in CSS value types now carry a `Css` prefix (`CssPosition`, `CssLength`,
-`CssGlobals`) so your own `{Property}Value` aliases can't shadow them. It's in the upgrade checklist below.
+### MCP and plugins
 
-### MCP and plugins moved out
+The MCP server is now its own package:
 
-The MCP server is now its own package — run `npx -y @pandacss/mcp` instead of the old `panda mcp` subcommand. Vue,
-Svelte, and Lightning CSS support are available as standalone opt-in plugins (`@pandacss/plugin-vue`,
+run `npx -y @pandacss/mcp`
+
+Vue, Svelte, and Lightning CSS support are available as standalone opt-in plugins (`@pandacss/plugin-vue`,
 `@pandacss/plugin-svelte`, `@pandacss/plugin-lightningcss`), keeping the core install smaller for projects that don't
-need them. Source transforms in the Vite, webpack, and Rollup plugins are now opt-in behind `transform: true`.
+need them.
 
 ## Upgrading from v1
 
@@ -545,6 +468,21 @@ const ctx = createRecipeContext(recipe)
 ```
 
 There's a new `withRootProvider` for a slot root that renders no slot of its own.
+
+### Matching JSX with data
+
+v1 let you match custom JSX components with a `matchTag` callback — a JavaScript function Panda ran for every element.
+That can't cross into a Rust or WebAssembly engine, so v2 replaces it with `jsxMatchTag`, a declarative rule list
+matched by component name, a pattern, or the module a component is imported from:
+
+```ts
+export default defineConfig({
+  jsxMatchTag: [{ pattern: '^(Flex|Stack|Box)$' }, { from: '@acme/ui', props: ['padding', 'color'] }]
+})
+```
+
+Rules are evaluated last-match-wins over Panda's own detection, and because it's data rather than code, it works
+identically in the CLI and in the browser.
 
 ### Removed config options
 

--- a/website/public/blog/chart-staticcss-share.svg
+++ b/website/public/blog/chart-staticcss-share.svg
@@ -1,0 +1,47 @@
+<svg width="1200" height="320" viewBox="0 0 1200 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="staticCss build time on a 29,000-rule config: Panda 1 took 25.7 seconds, Panda 2.0 takes about 0.3 seconds, 85 times faster">
+  <style>
+    .surface { fill: #FBF9F3; }
+    .ink { fill: #1A1A17; }
+    .muted { fill: #5E584C; }
+    .card { fill: #FFFFFF; stroke: #1A1A17; stroke-width: 2; }
+    .win { fill: #F6E458; stroke: #1A1A17; stroke-width: 2; }
+    .ony { fill: #1A1A17; }
+    .flow { stroke: #1A1A17; stroke-width: 5; fill: none; }
+    .sans { font-family: 'Onest','Segoe UI',system-ui,sans-serif; }
+    .mono { font-family: 'Source Code Pro',ui-monospace,monospace; }
+    @media (prefers-color-scheme: dark) {
+      .surface { fill: #17171B; } .ink { fill: #F5F2E9; } .muted { fill: #B7B1A3; }
+      .card { fill: #23232B; stroke: #3A3A42; } .flow { stroke: #E7E2D6; }
+    }
+  </style>
+  <rect width="1200" height="320" class="surface"/>
+
+  <text x="60" y="58" class="sans ink" font-size="28" font-weight="800" letter-spacing="-0.3">staticCss build time, 29,000-rule config</text>
+  <text x="60" y="88" class="sans muted" font-size="16">Same rules, byte-for-byte identical CSS output, just faster to build.</text>
+
+  <defs>
+    <marker id="e3" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="9" markerHeight="9" orient="auto">
+      <path d="M0 0 L10 5 L0 10 Z" class="ink"/>
+    </marker>
+  </defs>
+
+  <g class="sans">
+    <!-- before: Panda v1 -->
+    <g transform="translate(100 130)">
+      <rect width="340" height="140" rx="16" class="card"/>
+      <text x="28" y="34" class="muted" font-size="13" font-weight="800" letter-spacing="1.5">PANDA v1</text>
+      <text x="170" y="102" text-anchor="middle" class="ink mono" font-size="52" font-weight="800">25.7s</text>
+    </g>
+
+    <!-- arrow + multiplier -->
+    <line x1="462" y1="200" x2="738" y2="200" class="flow" marker-end="url(#e3)"/>
+    <text x="600" y="176" text-anchor="middle" class="ink" font-size="22" font-weight="800">85&#215; faster</text>
+
+    <!-- after: Panda 2.0 -->
+    <g transform="translate(760 130)">
+      <rect width="340" height="140" rx="16" class="win"/>
+      <text x="28" y="34" class="ony" font-size="13" font-weight="800" letter-spacing="1.5">PANDA 2.0</text>
+      <text x="170" y="102" text-anchor="middle" class="ony mono" font-size="52" font-weight="800">~0.3s</text>
+    </g>
+  </g>
+</svg>

--- a/website/public/blog/panda-v2-engine.svg
+++ b/website/public/blog/panda-v2-engine.svg
@@ -1,95 +1,53 @@
-<svg width="1200" height="470" viewBox="0 0 1200 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The Panda 2.0 compiler pipeline: parse, extract, encode, emit — one engine, two bindings">
+<svg width="1200" height="260" viewBox="0 0 1200 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Your source files compile through Oxc, written in Rust, into a stylesheet">
   <style>
     .surface { fill: #FBF9F3; }
     .ink { fill: #1A1A17; }
     .muted { fill: #5E584C; }
     .card { fill: #FFFFFF; stroke: #1A1A17; stroke-width: 2; }
-    .yl { fill: #F6E458; }
-    .yltile { fill: #F6E458; stroke: #1A1A17; stroke-width: 2; }
+    .win { fill: #F6E458; stroke: #1A1A17; stroke-width: 2; }
     .ony { fill: #1A1A17; }
-    .rail { fill: #F3EFE3; stroke: #E4DECF; stroke-width: 1.5; }
-    .chip { fill: #FFFFFF; stroke: #CFC8B8; stroke-width: 1.5; }
     .flow { stroke: #1A1A17; stroke-width: 3; fill: none; }
     .sans { font-family: 'Onest','Segoe UI',system-ui,sans-serif; }
     .mono { font-family: 'Source Code Pro',ui-monospace,monospace; }
     @media (prefers-color-scheme: dark) {
       .surface { fill: #17171B; } .ink { fill: #F5F2E9; } .muted { fill: #B7B1A3; }
-      .card { fill: #23232B; stroke: #3A3A42; } .rail { fill: #1E1E25; stroke: #34343A; }
-      .chip { fill: #23232B; stroke: #3A3A42; } .flow { stroke: #E7E2D6; }
+      .card { fill: #23232B; stroke: #3A3A42; } .flow { stroke: #E7E2D6; }
     }
   </style>
-  <rect width="1200" height="470" class="surface"/>
-
-  <rect x="60" y="40" width="52" height="7" rx="3.5" class="yl"/>
-  <text x="60" y="84" class="sans ink" font-size="29" font-weight="800" letter-spacing="-0.4">One parse per file. Zero style runtime.</text>
-  <text x="60" y="114" class="sans muted" font-size="16.5">Your source becomes a static stylesheet in four stages, all in Rust.</text>
+  <rect width="1200" height="260" class="surface"/>
 
   <defs>
-    <marker id="e" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto">
-      <path d="M0 1 L9 5 L0 9" fill="none" stroke="currentColor" class="ink" stroke-width="2.2"/>
+    <marker id="e5" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 L10 5 L0 10 Z" class="ink"/>
     </marker>
   </defs>
 
   <g class="sans">
-    <!-- 01 PARSE -->
-    <g transform="translate(60 168)">
-      <rect width="210" height="140" rx="16" class="card"/>
-      <rect x="22" y="22" width="40" height="26" rx="8" class="yl"/><text x="42" y="40" text-anchor="middle" class="ony mono" font-size="14" font-weight="700">01</text>
-      <text x="72" y="40" class="ink" font-size="14" font-weight="800" letter-spacing="1.3">PARSE</text>
-      <text x="22" y="80" class="ink" font-size="20" font-weight="700">Oxc AST</text>
-      <text x="22" y="106" class="muted mono" font-size="13">.ts .tsx .vue</text>
-      <text x="22" y="126" class="muted mono" font-size="13">.svelte .astro</text>
-    </g>
-    <!-- 02 EXTRACT -->
-    <g transform="translate(306 168)">
-      <rect width="210" height="140" rx="16" class="card"/>
-      <rect x="22" y="22" width="40" height="26" rx="8" class="yl"/><text x="42" y="40" text-anchor="middle" class="ony mono" font-size="14" font-weight="700">02</text>
-      <text x="72" y="40" class="ink" font-size="14" font-weight="800" letter-spacing="1.3">EXTRACT</text>
-      <text x="22" y="80" class="ink" font-size="20" font-weight="700">match &amp; fold</text>
-      <text x="22" y="106" class="muted" font-size="13.5">follow imports,</text>
-      <text x="22" y="126" class="muted" font-size="13.5">resolve scope</text>
-    </g>
-    <!-- 03 ENCODE -->
-    <g transform="translate(552 168)">
-      <rect width="210" height="140" rx="16" class="card"/>
-      <rect x="22" y="22" width="40" height="26" rx="8" class="yl"/><text x="42" y="40" text-anchor="middle" class="ony mono" font-size="14" font-weight="700">03</text>
-      <text x="72" y="40" class="ink" font-size="14" font-weight="800" letter-spacing="1.3">ENCODE</text>
-      <text x="22" y="80" class="ink" font-size="20" font-weight="700">atomic rules</text>
-      <text x="22" y="106" class="muted" font-size="13.5">dedupe, refcount,</text>
-      <text x="22" y="126" class="muted" font-size="13.5">one class each</text>
-    </g>
-    <!-- 04 EMIT -->
-    <g transform="translate(798 168)">
-      <rect width="210" height="140" rx="16" class="card"/>
-      <rect x="22" y="22" width="40" height="26" rx="8" class="yl"/><text x="42" y="40" text-anchor="middle" class="ony mono" font-size="14" font-weight="700">04</text>
-      <text x="72" y="40" class="ink" font-size="14" font-weight="800" letter-spacing="1.3">EMIT</text>
-      <text x="22" y="80" class="ink" font-size="20" font-weight="700">native CSS</text>
-      <text x="22" y="106" class="muted" font-size="13.5">grouped @media,</text>
-      <text x="22" y="126" class="muted" font-size="13.5">sorted layers</text>
-    </g>
-    <!-- output tile -->
-    <g transform="translate(1044 168)">
-      <rect width="96" height="140" rx="16" class="yltile"/>
-      <text x="48" y="70" text-anchor="middle" class="ony mono" font-size="17" font-weight="700">styles</text>
-      <text x="48" y="94" text-anchor="middle" class="ony mono" font-size="17" font-weight="700">.css</text>
+    <!-- source -->
+    <g transform="translate(80 60)">
+      <rect width="280" height="140" rx="18" class="card"/>
+      <text x="24" y="34" class="muted" font-size="13" font-weight="800" letter-spacing="1.5">YOUR SOURCE</text>
+      <text x="24" y="90" class="ink mono" font-size="20" font-weight="700">.ts .tsx</text>
+      <text x="24" y="114" class="ink mono" font-size="20" font-weight="700">.vue .svelte .astro</text>
     </g>
 
-    <g class="flow">
-      <line x1="270" y1="238" x2="304" y2="238" marker-end="url(#e)"/>
-      <line x1="516" y1="238" x2="550" y2="238" marker-end="url(#e)"/>
-      <line x1="762" y1="238" x2="796" y2="238" marker-end="url(#e)"/>
-      <line x1="1008" y1="238" x2="1042" y2="238" marker-end="url(#e)"/>
-    </g>
-  </g>
+    <line x1="372" y1="130" x2="448" y2="130" class="flow" marker-end="url(#e5)"/>
 
-  <!-- bindings rail -->
-  <g class="sans">
-    <rect x="60" y="336" width="1080" height="100" rx="16" class="rail"/>
-    <text x="84" y="372" class="muted" font-size="14" font-weight="800" letter-spacing="2">ONE ENGINE · TWO BINDINGS</text>
-    <g transform="translate(84 386)"><rect width="450" height="40" rx="11" class="chip"/><text x="20" y="26" class="ink mono" font-size="14">NAPI → the CLI, Vite, PostCSS</text></g>
-    <g transform="translate(552 386)"><rect width="410" height="40" rx="11" class="chip"/><text x="20" y="26" class="ink mono" font-size="14">Wasm → the browser playground</text></g>
-    <g transform="translate(1082 356) scale(3.1)">
-      <path d="M10.7608 0.390669C9.38613 -0.0126127 7.98396 -0.067426 6.55506 0.0630881C5.75542 0.147945 4.98667 0.310054 4.24518 0.594509C2.64244 1.20936 1.43903 2.27424 0.72147 3.87754C0.207033 5.02698 0.0211109 6.24802 0.0017347 7.50081C-0.0187424 8.8248 0.143717 10.1305 0.401862 11.4249C0.635852 12.5983 0.947463 13.7487 1.39249 14.8591C1.43477 14.9646 1.48743 15.0002 1.60028 15C3.0078 14.9969 4.41533 14.9969 5.82286 14.9969C6.23955 14.9969 6.65623 14.9969 7.07292 14.9968C7.10483 14.9968 7.13673 14.995 7.17342 14.993C7.19215 14.9919 7.21213 14.9908 7.23399 14.9898C7.22553 14.9693 7.21796 14.9504 7.21087 14.9327C7.19692 14.8979 7.18479 14.8676 7.17125 14.838C7.06947 14.6156 6.96558 14.3942 6.86169 14.1728C6.63635 13.6924 6.41101 13.2121 6.20721 12.7224C5.5891 11.2373 5.11575 9.7082 4.9713 8.08959C4.90756 7.37541 4.91641 6.66531 5.11044 5.96941C5.33222 5.17396 5.80814 4.6124 6.59715 4.37763C7.32168 4.16204 8.05629 4.16346 8.77688 4.40144C9.42 4.61383 9.8393 5.06248 10.0176 5.73423C10.1546 6.25013 10.1546 6.77159 10.051 7.29169C9.97115 7.69214 9.81051 8.05756 9.52137 8.34988C9.00271 8.87423 8.35495 8.9948 7.6599 8.95462C7.53624 8.94747 7.41295 8.93362 7.28592 8.91936C7.22642 8.91267 7.16609 8.9059 7.10452 8.89968C7.10629 8.91977 7.10727 8.93828 7.10819 8.95562C7.10999 8.98973 7.11156 9.01931 7.11843 9.04755C7.14805 9.16913 7.17627 9.29115 7.2045 9.41319C7.27249 9.70715 7.3405 10.0012 7.42793 10.289C7.59961 10.8542 7.79925 11.4058 8.02556 11.9443C9.63883 11.8158 11.1248 11.4062 12.7019 10.4393C12.7256 10.4241 12.7471 10.4103 12.7686 10.3966C13.4461 9.96587 13.9944 9.40712 14.3725 8.68563C14.9848 7.51725 15.1042 6.26777 14.9223 4.97808C14.7345 3.64712 14.1497 2.52993 13.1429 1.6536C12.4446 1.0458 11.6371 0.647746 10.7608 0.390669Z" class="ink"/>
+    <!-- engine -->
+    <g transform="translate(460 60)">
+      <rect width="280" height="140" rx="18" class="win"/>
+      <text x="24" y="34" class="ony" font-size="13" font-weight="800" letter-spacing="1.5">THE NEW ENGINE</text>
+      <text x="24" y="98" class="ony" font-size="34" font-weight="800">Oxc</text>
+      <text x="24" y="122" class="ony" font-size="14.5" opacity="0.75">written in Rust</text>
+    </g>
+
+    <line x1="752" y1="130" x2="828" y2="130" class="flow" marker-end="url(#e5)"/>
+
+    <!-- output -->
+    <g transform="translate(840 60)">
+      <rect width="280" height="140" rx="18" class="card"/>
+      <text x="24" y="34" class="muted" font-size="13" font-weight="800" letter-spacing="1.5">OUTPUT</text>
+      <text x="24" y="98" class="ink mono" font-size="28" font-weight="800">styles.css</text>
     </g>
   </g>
 </svg>

--- a/website/public/blog/panda-v2-speed-snapshot.svg
+++ b/website/public/blog/panda-v2-speed-snapshot.svg
@@ -1,0 +1,74 @@
+<svg width="1200" height="470" viewBox="0 0 1200 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How much faster is Panda 2.0: extraction 15 to 37 times faster, watch-mode re-parsing about 360 times faster, staticCss about 85 times faster, 99 percent fewer TypeScript type instantiations, runtime css() up to 4 times faster">
+  <style>
+    .surface { fill: #FBF9F3; }
+    .ink { fill: #1A1A17; }
+    .muted { fill: #5E584C; }
+    .card { fill: #FFFFFF; stroke: #1A1A17; stroke-width: 2; }
+    .yl { fill: #F6E458; }
+    .sans { font-family: 'Onest','Segoe UI',system-ui,sans-serif; }
+    .mono { font-family: 'Source Code Pro',ui-monospace,monospace; }
+    @media (prefers-color-scheme: dark) {
+      .surface { fill: #17171B; } .ink { fill: #F5F2E9; } .muted { fill: #B7B1A3; }
+      .card { fill: #23232B; stroke: #3A3A42; }
+    }
+  </style>
+  <rect width="1200" height="470" class="surface"/>
+
+  <rect x="60" y="40" width="52" height="7" rx="3.5" class="yl"/>
+  <text x="60" y="84" class="sans ink" font-size="29" font-weight="800" letter-spacing="-0.4">How much faster is Panda 2.0?</text>
+  <text x="60" y="114" class="sans muted" font-size="16.5">Measured against v1 on the same hardware, same source bytes.</text>
+
+  <g class="sans">
+    <!-- 1: Extraction -->
+    <g transform="translate(60 150)">
+      <rect width="200" height="260" rx="16" class="card"/>
+      <rect x="20" y="20" width="32" height="6" rx="3" class="yl"/>
+      <text x="20" y="48" class="muted" font-size="12" font-weight="800" letter-spacing="1">EXTRACTION</text>
+      <text x="100" y="158" text-anchor="middle" class="ink" font-size="34" font-weight="800">15&#8211;37&#215;</text>
+      <text x="100" y="200" text-anchor="middle" class="muted" font-size="11">faster</text>
+      <text x="100" y="220" text-anchor="middle" class="muted" font-size="11">cold build</text>
+    </g>
+
+    <!-- 2: Watch-mode re-parsing -->
+    <g transform="translate(280 150)">
+      <rect width="200" height="260" rx="16" class="card"/>
+      <rect x="20" y="20" width="32" height="6" rx="3" class="yl"/>
+      <text x="20" y="42" class="muted" font-size="12" font-weight="800" letter-spacing="1">WATCH-MODE</text>
+      <text x="20" y="58" class="muted" font-size="12" font-weight="800" letter-spacing="1">RE-PARSING</text>
+      <text x="100" y="158" text-anchor="middle" class="ink" font-size="34" font-weight="800">~360&#215;</text>
+      <text x="100" y="200" text-anchor="middle" class="muted" font-size="11">faster</text>
+      <text x="100" y="220" text-anchor="middle" class="muted" font-size="11">per file, steady state</text>
+    </g>
+
+    <!-- 3: staticCss -->
+    <g transform="translate(500 150)">
+      <rect width="200" height="260" rx="16" class="card"/>
+      <rect x="20" y="20" width="32" height="6" rx="3" class="yl"/>
+      <text x="20" y="48" class="muted mono" font-size="12" font-weight="700" letter-spacing="0.5">staticCss</text>
+      <text x="100" y="158" text-anchor="middle" class="ink" font-size="34" font-weight="800">~85&#215;</text>
+      <text x="100" y="200" text-anchor="middle" class="muted" font-size="11">faster</text>
+      <text x="100" y="220" text-anchor="middle" class="muted" font-size="11">29,000-rule config</text>
+    </g>
+
+    <!-- 4: Type instantiations -->
+    <g transform="translate(720 150)">
+      <rect width="200" height="260" rx="16" class="card"/>
+      <rect x="20" y="20" width="32" height="6" rx="3" class="yl"/>
+      <text x="20" y="42" class="muted" font-size="12" font-weight="800" letter-spacing="1">TYPE</text>
+      <text x="20" y="58" class="muted" font-size="12" font-weight="800" letter-spacing="1">INSTANTIATIONS</text>
+      <text x="100" y="158" text-anchor="middle" class="ink" font-size="34" font-weight="800">~99%</text>
+      <text x="100" y="200" text-anchor="middle" class="muted" font-size="11">fewer</text>
+      <text x="100" y="220" text-anchor="middle" class="muted" font-size="11">generated styled-system</text>
+    </g>
+
+    <!-- 5: Runtime css() -->
+    <g transform="translate(940 150)">
+      <rect width="200" height="260" rx="16" class="card"/>
+      <rect x="20" y="20" width="32" height="6" rx="3" class="yl"/>
+      <text x="20" y="48" class="muted mono" font-size="12" font-weight="700" letter-spacing="0.5">RUNTIME css()</text>
+      <text x="100" y="158" text-anchor="middle" class="ink" font-size="34" font-weight="800">~4&#215;</text>
+      <text x="100" y="200" text-anchor="middle" class="muted" font-size="11">faster, up to</text>
+      <text x="100" y="220" text-anchor="middle" class="muted" font-size="11">wrapper chains</text>
+    </g>
+  </g>
+</svg>

--- a/website/public/blog/panda-v2-two-bindings.svg
+++ b/website/public/blog/panda-v2-two-bindings.svg
@@ -1,0 +1,78 @@
+<svg width="1200" height="470" viewBox="0 0 1200 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="One Rust engine compiles two ways: a native binding for the CLI, Vite, and PostCSS, and a WebAssembly binding for the browser, both producing identical CSS">
+  <style>
+    .surface { fill: #FBF9F3; }
+    .ink { fill: #1A1A17; }
+    .muted { fill: #5E584C; }
+    .card { fill: #FFFFFF; stroke: #1A1A17; stroke-width: 2; }
+    .yl { fill: #F6E458; }
+    .yltile { fill: #F6E458; stroke: #1A1A17; stroke-width: 2; }
+    .ony { fill: #1A1A17; }
+    .flow { stroke: #1A1A17; stroke-width: 3; fill: none; }
+    .sans { font-family: 'Onest','Segoe UI',system-ui,sans-serif; }
+    .mono { font-family: 'Source Code Pro',ui-monospace,monospace; }
+    @media (prefers-color-scheme: dark) {
+      .surface { fill: #17171B; } .ink { fill: #F5F2E9; } .muted { fill: #B7B1A3; }
+      .card { fill: #23232B; stroke: #3A3A42; } .flow { stroke: #E7E2D6; }
+    }
+  </style>
+  <rect width="1200" height="470" class="surface"/>
+
+  <rect x="60" y="40" width="52" height="7" rx="3.5" class="yl"/>
+  <text x="60" y="84" class="sans ink" font-size="29" font-weight="800" letter-spacing="-0.4">Same code, two runtimes</text>
+  <text x="60" y="114" class="sans muted" font-size="16.5">One Rust engine compiles two ways, and both sides produce identical CSS.</text>
+
+  <defs>
+    <marker id="e2" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto">
+      <path d="M0 1 L9 5 L0 9" fill="none" stroke="currentColor" class="ink" stroke-width="2.2"/>
+    </marker>
+  </defs>
+
+  <g class="sans">
+    <!-- shared Rust core -->
+    <g transform="translate(450 124)">
+      <rect width="300" height="70" rx="16" class="card"/>
+      <rect x="20" y="16" width="54" height="26" rx="8" class="yl"/>
+      <text x="47" y="34" text-anchor="middle" class="ony mono" font-size="12" font-weight="700">RUST</text>
+      <text x="88" y="35" class="ink" font-size="16" font-weight="800">Shared Rust engine</text>
+      <text x="20" y="59" class="muted mono" font-size="12">parse → extract → encode → emit</text>
+    </g>
+
+    <!-- branch: core -> two bindings -->
+    <g class="flow">
+      <line x1="600" y1="194" x2="600" y2="214"/>
+      <line x1="310" y1="214" x2="890" y2="214"/>
+      <line x1="310" y1="214" x2="310" y2="242" marker-end="url(#e2)"/>
+      <line x1="890" y1="214" x2="890" y2="242" marker-end="url(#e2)"/>
+    </g>
+
+    <!-- native binding -->
+    <g transform="translate(100 244)">
+      <rect width="420" height="110" rx="16" class="card"/>
+      <text x="22" y="34" class="muted" font-size="13" font-weight="800" letter-spacing="1.5">NATIVE BINDING</text>
+      <text x="22" y="66" class="ink mono" font-size="18" font-weight="700">@pandacss/compiler</text>
+      <text x="22" y="92" class="muted" font-size="13.5">CLI · Vite · PostCSS, via NAPI</text>
+    </g>
+
+    <!-- wasm binding -->
+    <g transform="translate(680 244)">
+      <rect width="420" height="110" rx="16" class="card"/>
+      <text x="22" y="34" class="muted" font-size="13" font-weight="800" letter-spacing="1.5">WEBASSEMBLY BINDING</text>
+      <text x="22" y="66" class="ink mono" font-size="18" font-weight="700">@pandacss/compiler-wasm</text>
+      <text x="22" y="92" class="muted" font-size="13.5">Browser · Playground, ~490 KB gzipped</text>
+    </g>
+
+    <!-- converge: two bindings -> identical CSS -->
+    <g class="flow">
+      <line x1="310" y1="354" x2="310" y2="372"/>
+      <line x1="890" y1="354" x2="890" y2="372"/>
+      <line x1="310" y1="372" x2="890" y2="372"/>
+      <line x1="600" y1="372" x2="600" y2="388" marker-end="url(#e2)"/>
+    </g>
+
+    <!-- output tile -->
+    <g transform="translate(520 390)">
+      <rect width="160" height="40" rx="12" class="yltile"/>
+      <text x="80" y="26" text-anchor="middle" class="ony mono" font-size="15" font-weight="700">identical CSS</text>
+    </g>
+  </g>
+</svg>

--- a/website/public/blog/panda-v2-why-rewrite.svg
+++ b/website/public/blog/panda-v2-why-rewrite.svg
@@ -1,0 +1,45 @@
+<svg width="1200" height="220" viewBox="0 0 1200 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Panda v1 ran on Node with a JavaScript runtime, Panda 2.0 runs on Rust and compiles anywhere">
+  <style>
+    .surface { fill: #FBF9F3; }
+    .ink { fill: #1A1A17; }
+    .muted { fill: #5E584C; }
+    .card { fill: #FFFFFF; stroke: #1A1A17; stroke-width: 2; }
+    .win { fill: #F6E458; stroke: #1A1A17; stroke-width: 2; }
+    .ony { fill: #1A1A17; }
+    .flow { stroke: #1A1A17; stroke-width: 3; fill: none; }
+    .sans { font-family: 'Onest','Segoe UI',system-ui,sans-serif; }
+    .mono { font-family: 'Source Code Pro',ui-monospace,monospace; }
+    @media (prefers-color-scheme: dark) {
+      .surface { fill: #17171B; } .ink { fill: #F5F2E9; } .muted { fill: #B7B1A3; }
+      .card { fill: #23232B; stroke: #3A3A42; } .flow { stroke: #E7E2D6; }
+    }
+  </style>
+  <rect width="1200" height="220" class="surface"/>
+
+  <defs>
+    <marker id="e4" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 L10 5 L0 10 Z" class="ink"/>
+    </marker>
+  </defs>
+
+  <g class="sans">
+    <!-- v1: Node -->
+    <g transform="translate(140 35)">
+      <rect width="380" height="150" rx="18" class="card"/>
+      <text x="26" y="34" class="muted" font-size="13" font-weight="800" letter-spacing="1.5">PANDA v1</text>
+      <text x="26" y="98" class="ink" font-size="42" font-weight="800">Node</text>
+      <text x="26" y="126" class="muted" font-size="14.5">a JavaScript runtime</text>
+    </g>
+
+    <!-- arrow -->
+    <line x1="532" y1="110" x2="668" y2="110" class="flow" marker-end="url(#e4)"/>
+
+    <!-- v2: Rust -->
+    <g transform="translate(680 35)">
+      <rect width="380" height="150" rx="18" class="win"/>
+      <text x="26" y="34" class="ony" font-size="13" font-weight="800" letter-spacing="1.5">PANDA 2.0</text>
+      <text x="26" y="98" class="ony" font-size="42" font-weight="800">Rust</text>
+      <text x="26" y="126" class="ony" font-size="14.5" opacity="0.75">compiles anywhere</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## 📝 Description

Reworked the blog post for better clarity, accuracy and tone. 

Also worked on the overall layout, added in svgs where necessary

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63181285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the missing migration guidance for the public `Css*` type rename is restored; the prose and unused-asset issues should also be cleaned up.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Awebsite%2Fcontent%2Fblog%2Fpanda-css-v2.mdx%3A399-402%0AThe%20upgrade%20post%20no%20longer%20documents%20that%20the%20public%20generated%20types%20%60PositionValue%60%2C%20%60LengthValue%60%2C%20and%20%60Globals%60%20were%20renamed%20to%20%60CssPosition%60%2C%20%60CssLength%60%2C%20and%20%60CssGlobals%60.%20Existing%20users%20who%20import%20the%20old%20names%20will%20get%20TypeScript%20build%20errors%20after%20upgrading%2C%20and%20the%20linked%20v2%20upgrade%20guide%20does%20not%20provide%20this%20migration%20step.%20Please%20restore%20the%20rename%20notice%20in%20the%20upgrade%20checklist.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%202%0Awebsite%2Fcontent%2Fblog%2Fpanda-css-v2.mdx%3A301%0AThis%20bullet%20accidentally%20combines%20tree-shaking%20with%20support%20for%20symlinks%20and%20Docker%20layers%2C%20producing%20the%20incomplete%20sentence%20%E2%80%9CShip%20only%20what%20you%20use%20symlinks%2C%20and%20Docker%20layers%20all%20work.%E2%80%9D%20This%20obscures%20both%20benefits%20in%20the%20published%20post.%0A%0A%60%60%60suggestion%0A-%20Ship%20only%20what%20you%20use%0A%60%60%60%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%203%0Awebsite%2Fpublic%2Fblog%2Fpanda-v2-engine.svg%3A1%0AThis%20SVG%20was%20substantially%20redesigned%2C%20but%20the%20PR%20also%20removes%20its%20only%20MDX%20reference.%20Public%20assets%20are%20not%20rendered%20automatically%2C%20and%20no%20repository%20reference%20remains%2C%20so%20this%20artwork%20will%20not%20appear%20on%20any%20page.%20Either%20include%20it%20in%20the%20post%20or%20drop%20the%20modification%20to%20avoid%20maintaining%20a%20dead%20asset.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fpanda&pr=3812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Breaking Type Rename Omitted** <a href="https://github.com/chakra-ui/panda/pull/3812#discussion_r3991957517">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Unrelated Benefits Merged** <a href="https://github.com/chakra-ui/panda/pull/3812#discussion_r3991957531">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Redesigned Asset Is Unused** <a href="https://github.com/chakra-ui/panda/pull/3812#discussion_r3991957558">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
website/content/blog/panda-css-v2.mdx:399-402
The upgrade post no longer documents that the public generated types `PositionValue`, `LengthValue`, and `Globals` were renamed to `CssPosition`, `CssLength`, and `CssGlobals`. Existing users who import the old names will get TypeScript build errors after upgrading, and the linked v2 upgrade guide does not provide this migration step. Please restore the rename notice in the upgrade checklist.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
website/content/blog/panda-css-v2.mdx:301
This bullet accidentally combines tree-shaking with support for symlinks and Docker layers, producing the incomplete sentence “Ship only what you use symlinks, and Docker layers all work.” This obscures both benefits in the published post.

```suggestion
- Ship only what you use
```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 3
website/public/blog/panda-v2-engine.svg:1
This SVG was substantially redesigned, but the PR also removes its only MDX reference. Public assets are not rendered automatically, and no repository reference remains, so this artwork will not appear on any page. Either include it in the post or drop the modification to avoid maintaining a dead asset.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Reorganizes explanations of the Rust compiler, performance results, features, and migration steps.
- Adds diagrams for compiler bindings, performance, static CSS generation, and the v1-to-v2 transition.
- Leaves one breaking type migration undocumented, introduces a malformed feature-list item, and modifies one diagram that is no longer referenced.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs: refine announcement blog post, add..."](https://github.com/chakra-ui/panda/commit/a9ee25739ce1b4e11e3b6ce045975f30ead14e0a)</sub>

<!-- /greptile_comment -->